### PR TITLE
perf(quant): i8mm 4x8 SMMLA tier for Q8_0 and Q4_0 (plan 1d)

### DIFF
--- a/crates/ferrox-core/src/weight_matrix.rs
+++ b/crates/ferrox-core/src/weight_matrix.rs
@@ -103,7 +103,7 @@ fn get_or_repack_q8x4(data: &[u8], rows: usize, cols: usize) -> Arc<[u8]> {
         }
     }
     let packed =
-        ferrox_quant::pack_q8_0_matrix_x4(data, rows, cols, ferrox_quant::Q8_0X4_INTERLEAVE);
+        ferrox_quant::pack_q8_0_matrix_x4(data, rows, cols, ferrox_quant::q8_0x4_interleave());
     let arc: Arc<[u8]> = Arc::from(packed.into_boxed_slice());
     let mut cache = q8x4_repack_cache().lock().unwrap();
     Arc::clone(cache.entry(key).or_insert_with(|| Arc::clone(&arc)))
@@ -124,7 +124,7 @@ fn get_or_repack_q4_0x4(data: &[u8], rows: usize, cols: usize) -> Arc<[u8]> {
         }
     }
     let packed =
-        ferrox_quant::pack_q4_0_matrix_x4(data, rows, cols, ferrox_quant::Q4_0X4_INTERLEAVE);
+        ferrox_quant::pack_q4_0_matrix_x4(data, rows, cols, ferrox_quant::q4_0x4_interleave());
     let arc: Arc<[u8]> = Arc::from(packed.into_boxed_slice());
     let mut cache = q4x4_repack_cache().lock().unwrap();
     Arc::clone(cache.entry(key).or_insert_with(|| Arc::clone(&arc)))
@@ -665,7 +665,12 @@ impl WeightMatrix {
                                         .enumerate()
                                     {
                                         ferrox_quant::gemv_q8_0x4_group(
-                                            &packed, g, &act, *cols, chunk,
+                                            &packed,
+                                            g,
+                                            &act,
+                                            *cols,
+                                            ferrox_quant::q8_0x4_interleave(),
+                                            chunk,
                                         );
                                     }
                                 } else {
@@ -675,7 +680,12 @@ impl WeightMatrix {
                                         .enumerate()
                                         .for_each(|(g, chunk)| {
                                             ferrox_quant::gemv_q8_0x4_group(
-                                                &packed, g, &act, *cols, chunk,
+                                                &packed,
+                                                g,
+                                                &act,
+                                                *cols,
+                                                ferrox_quant::q8_0x4_interleave(),
+                                                chunk,
                                             );
                                         });
                                 }
@@ -734,7 +744,12 @@ impl WeightMatrix {
                                         .enumerate()
                                     {
                                         ferrox_quant::gemv_q4_0x4_group(
-                                            &packed, g, &act, *cols, chunk,
+                                            &packed,
+                                            g,
+                                            &act,
+                                            *cols,
+                                            ferrox_quant::q4_0x4_interleave(),
+                                            chunk,
                                         );
                                     }
                                 } else {
@@ -744,7 +759,12 @@ impl WeightMatrix {
                                         .enumerate()
                                         .for_each(|(g, chunk)| {
                                             ferrox_quant::gemv_q4_0x4_group(
-                                                &packed, g, &act, *cols, chunk,
+                                                &packed,
+                                                g,
+                                                &act,
+                                                *cols,
+                                                ferrox_quant::q4_0x4_interleave(),
+                                                chunk,
                                             );
                                         });
                                 }
@@ -970,7 +990,14 @@ impl WeightMatrix {
                 let packed = get_or_repack_q8x4(data, *rows, *cols);
                 let serial = Self::prefer_serial_matvec(*rows, *cols);
                 let body = |g: usize, chunk: &mut [f32]| {
-                    ferrox_quant::gemv_q8_0x4_group(&packed, g, act, *cols, chunk);
+                    ferrox_quant::gemv_q8_0x4_group(
+                        &packed,
+                        g,
+                        act,
+                        *cols,
+                        ferrox_quant::q8_0x4_interleave(),
+                        chunk,
+                    );
                 };
                 if serial {
                     for (g, chunk) in out[..n_groups * ferrox_quant::Q8_0X4_NROWS]
@@ -1020,7 +1047,14 @@ impl WeightMatrix {
                 let packed = get_or_repack_q4_0x4(data, *rows, *cols);
                 let serial = Self::prefer_serial_matvec(*rows, *cols);
                 let body = |g: usize, chunk: &mut [f32]| {
-                    ferrox_quant::gemv_q4_0x4_group(&packed, g, act, *cols, chunk);
+                    ferrox_quant::gemv_q4_0x4_group(
+                        &packed,
+                        g,
+                        act,
+                        *cols,
+                        ferrox_quant::q4_0x4_interleave(),
+                        chunk,
+                    );
                 };
                 if serial {
                     for (g, chunk) in out[..n_groups * ferrox_quant::Q4_0X4_NROWS]
@@ -1303,35 +1337,73 @@ impl WeightMatrix {
                             if n_groups > 0 {
                                 let packed = get_or_repack_q8x4(data.as_slice(), *rows, cols);
                                 let nrows_g = ferrox_quant::Q8_0X4_NROWS;
-                                (0..n_groups)
-                                    .into_par_iter()
-                                    .with_min_len(Self::min_rows_per_task(n_groups).max(1))
-                                    .for_each_init(
-                                        // GEMM, not a GEMV per position:
-                                        // the batched kernel writes a
-                                        // `[row][batch]` group, and the
-                                        // group's weight vectors stay in
-                                        // registers across a tile of
-                                        // activations. The group is then
-                                        // scattered into the [batch][rows]
-                                        // output right here, in parallel.
-                                        || vec![0f32; nrows_g * batch_size],
-                                        |group, g| {
-                                            ferrox_quant::gemm_q8_0x4_group(
-                                                &packed, g, &acts, cols, group,
-                                            );
-                                            for b in 0..batch_size {
-                                                for r in 0..nrows_g {
-                                                    unsafe {
-                                                        out_w.set(
-                                                            b * rows + g * nrows_g + r,
-                                                            group[r * batch_size + b],
-                                                        );
+                                let interleave = ferrox_quant::q8_0x4_interleave();
+                                if ferrox_quant::q8_0x4_gemm_uses_acts_x4(interleave) {
+                                    // i8mm: interleave each quad of
+                                    // activations once per matmul (llama.cpp
+                                    // `ggml_quantize_mat_q8_0_4x8` into
+                                    // `wdata`); every row-group reuses it.
+                                    let nc = ferrox_quant::Q8K_ACTS_X4_NC;
+                                    let act_tiles: Vec<ferrox_quant::Q8ActsX4> = acts
+                                        .par_chunks(nc)
+                                        .map(|chunk| {
+                                            ferrox_quant::prepare_q8_acts_x4(chunk, cols)
+                                        })
+                                        .collect();
+                                    (0..n_groups)
+                                        .into_par_iter()
+                                        .with_min_len(Self::min_rows_per_task(n_groups).max(1))
+                                        .for_each(|g| {
+                                            let mut tmp = [0f32;
+                                                ferrox_quant::Q8_0X4_NROWS
+                                                    * ferrox_quant::Q8K_ACTS_X4_NC];
+                                            for (t, tile) in act_tiles.iter().enumerate() {
+                                                let n = tile.na;
+                                                let tmp = &mut tmp[..nrows_g * n];
+                                                ferrox_quant::gemm_q8_0x4_group_x4(
+                                                    &packed, g, tile, cols, interleave, tmp,
+                                                );
+                                                for j in 0..n {
+                                                    let col = (t * nc + j) * rows + g * nrows_g;
+                                                    for r in 0..nrows_g {
+                                                        unsafe {
+                                                            out_w.set(col + r, tmp[r * n + j]);
+                                                        }
                                                     }
                                                 }
                                             }
-                                        },
-                                    );
+                                        });
+                                } else {
+                                    (0..n_groups)
+                                        .into_par_iter()
+                                        .with_min_len(Self::min_rows_per_task(n_groups).max(1))
+                                        .for_each_init(
+                                            // GEMM, not a GEMV per position:
+                                            // the batched kernel writes a
+                                            // `[row][batch]` group, and the
+                                            // group's weight vectors stay in
+                                            // registers across a tile of
+                                            // activations. The group is then
+                                            // scattered into the [batch][rows]
+                                            // output right here, in parallel.
+                                            || vec![0f32; nrows_g * batch_size],
+                                            |group, g| {
+                                                ferrox_quant::gemm_q8_0x4_group(
+                                                    &packed, g, &acts, cols, interleave, group,
+                                                );
+                                                for b in 0..batch_size {
+                                                    for r in 0..nrows_g {
+                                                        unsafe {
+                                                            out_w.set(
+                                                                b * rows + g * nrows_g + r,
+                                                                group[r * batch_size + b],
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                        );
+                                }
                                 let data_slice = data.as_slice();
                                 let tail = *rows - n_groups * ferrox_quant::Q8_0X4_NROWS;
                                 (0..tail)
@@ -1381,27 +1453,63 @@ impl WeightMatrix {
                             if n_groups > 0 {
                                 let packed = get_or_repack_q4_0x4(data.as_slice(), *rows, cols);
                                 let nrows_g = ferrox_quant::Q4_0X4_NROWS;
-                                (0..n_groups)
-                                    .into_par_iter()
-                                    .with_min_len(Self::min_rows_per_task(n_groups).max(1))
-                                    .for_each_init(
-                                        || vec![0f32; nrows_g * batch_size],
-                                        |group, g| {
-                                            ferrox_quant::gemm_q4_0x4_group(
-                                                &packed, g, &acts, cols, group,
-                                            );
-                                            for b in 0..batch_size {
-                                                for r in 0..nrows_g {
-                                                    unsafe {
-                                                        out_w.set(
-                                                            b * rows + g * nrows_g + r,
-                                                            group[r * batch_size + b],
-                                                        );
+                                let interleave = ferrox_quant::q4_0x4_interleave();
+                                if ferrox_quant::q4_0x4_gemm_uses_acts_x4(interleave) {
+                                    // i8mm: same once-per-matmul activation
+                                    // quad hoist as the Q8_0 arm above.
+                                    let nc = ferrox_quant::Q8K_ACTS_X4_NC;
+                                    let act_tiles: Vec<ferrox_quant::Q8ActsX4> = acts
+                                        .par_chunks(nc)
+                                        .map(|chunk| {
+                                            ferrox_quant::prepare_q8_acts_x4(chunk, cols)
+                                        })
+                                        .collect();
+                                    (0..n_groups)
+                                        .into_par_iter()
+                                        .with_min_len(Self::min_rows_per_task(n_groups).max(1))
+                                        .for_each(|g| {
+                                            let mut tmp = [0f32;
+                                                ferrox_quant::Q4_0X4_NROWS
+                                                    * ferrox_quant::Q8K_ACTS_X4_NC];
+                                            for (t, tile) in act_tiles.iter().enumerate() {
+                                                let n = tile.na;
+                                                let tmp = &mut tmp[..nrows_g * n];
+                                                ferrox_quant::gemm_q4_0x4_group_x4(
+                                                    &packed, g, tile, cols, interleave, tmp,
+                                                );
+                                                for j in 0..n {
+                                                    let col = (t * nc + j) * rows + g * nrows_g;
+                                                    for r in 0..nrows_g {
+                                                        unsafe {
+                                                            out_w.set(col + r, tmp[r * n + j]);
+                                                        }
                                                     }
                                                 }
                                             }
-                                        },
-                                    );
+                                        });
+                                } else {
+                                    (0..n_groups)
+                                        .into_par_iter()
+                                        .with_min_len(Self::min_rows_per_task(n_groups).max(1))
+                                        .for_each_init(
+                                            || vec![0f32; nrows_g * batch_size],
+                                            |group, g| {
+                                                ferrox_quant::gemm_q4_0x4_group(
+                                                    &packed, g, &acts, cols, interleave, group,
+                                                );
+                                                for b in 0..batch_size {
+                                                    for r in 0..nrows_g {
+                                                        unsafe {
+                                                            out_w.set(
+                                                                b * rows + g * nrows_g + r,
+                                                                group[r * batch_size + b],
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                        );
+                                }
                                 let data_slice = data.as_slice();
                                 let tail = *rows - n_groups * ferrox_quant::Q4_0X4_NROWS;
                                 (0..tail)

--- a/crates/ferrox-quant/src/lib.rs
+++ b/crates/ferrox-quant/src/lib.rs
@@ -16,18 +16,20 @@ pub mod iq_tables;
 pub mod repack;
 
 pub use repack::{
-    gemm_q4_0x4_group, gemm_q4_kx8_group, gemm_q4_kx8_group_x4, gemm_q5_kx8_group,
-    gemm_q5_kx8_group_x4, gemm_q6_kx8_group, gemm_q6_kx8_group_x4, gemm_q8_0x4_group,
-    gemv_q4_0x4_group, gemv_q4_kx8_group, gemv_q4_kx8_q8_k, gemv_q5_kx8_group, gemv_q5_kx8_q8_k,
-    gemv_q6_kx8_group, gemv_q6_kx8_q8_k, gemv_q8_0x4_group, gemv_q8_0x4_q8_0, make_block_q4_0x4,
-    make_block_q4_kx8, make_block_q5_kx8, make_block_q6_kx8, make_block_q8_0x4, pack_q4_0_matrix_x4,
-    pack_q4_k_matrix_x8, pack_q5_k_matrix_x8, pack_q6_k_matrix_x8, pack_q8_0_matrix_x4,
-    prepare_q8_k_acts_x4, q4_kx8_gemm_uses_acts_x4, q4_kx8_interleave, q5_kx8_gemm_uses_acts_x4,
-    q5_kx8_interleave, q6_kx8_gemm_uses_acts_x4, q6_kx8_interleave, Q8KActsX4, Q8K_ACTS_X4_NC,
-    Q4_0X4_BLOCK_BYTES,
-    Q4_0X4_GEMM_NC, Q4_0X4_INTERLEAVE, Q4_0X4_NROWS, Q4_KX8_BLOCK_BYTES, Q4_KX8_GEMM_NC,
-    Q4_KX8_NROWS, Q5_KX8_BLOCK_BYTES, Q5_KX8_GEMM_NC, Q5_KX8_NROWS, Q6_KX8_BLOCK_BYTES,
-    Q6_KX8_GEMM_NC, Q6_KX8_NROWS, Q8_0X4_BLOCK_BYTES, Q8_0X4_INTERLEAVE, Q8_0X4_NROWS,
+    gemm_q4_0x4_group, gemm_q4_0x4_group_x4, gemm_q4_kx8_group, gemm_q4_kx8_group_x4,
+    gemm_q5_kx8_group, gemm_q5_kx8_group_x4, gemm_q6_kx8_group, gemm_q6_kx8_group_x4,
+    gemm_q8_0x4_group, gemm_q8_0x4_group_x4, gemv_q4_0x4_group, gemv_q4_kx8_group,
+    gemv_q4_kx8_q8_k, gemv_q5_kx8_group, gemv_q5_kx8_q8_k, gemv_q6_kx8_group, gemv_q6_kx8_q8_k,
+    gemv_q8_0x4_group, gemv_q8_0x4_q8_0, make_block_q4_0x4, make_block_q4_kx8, make_block_q5_kx8,
+    make_block_q6_kx8, make_block_q8_0x4, pack_q4_0_matrix_x4, pack_q4_k_matrix_x8,
+    pack_q5_k_matrix_x8, pack_q6_k_matrix_x8, pack_q8_0_matrix_x4, prepare_q8_acts_x4,
+    prepare_q8_k_acts_x4, q4_0x4_gemm_uses_acts_x4, q4_0x4_interleave, q4_kx8_gemm_uses_acts_x4,
+    q4_kx8_interleave, q5_kx8_gemm_uses_acts_x4, q5_kx8_interleave, q6_kx8_gemm_uses_acts_x4,
+    q6_kx8_interleave, q8_0x4_gemm_uses_acts_x4, q8_0x4_interleave, Q8ActsX4, Q8KActsX4,
+    Q8K_ACTS_X4_NC, Q4_0X4_BLOCK_BYTES, Q4_0X4_GEMM_NC, Q4_0X4_INTERLEAVE, Q4_0X4_NROWS,
+    Q4_KX8_BLOCK_BYTES, Q4_KX8_GEMM_NC, Q4_KX8_NROWS, Q5_KX8_BLOCK_BYTES, Q5_KX8_GEMM_NC,
+    Q5_KX8_NROWS, Q6_KX8_BLOCK_BYTES, Q6_KX8_GEMM_NC, Q6_KX8_NROWS, Q8_0X4_BLOCK_BYTES,
+    Q8_0X4_INTERLEAVE, Q8_0X4_NROWS,
 };
 
 use half::f16;

--- a/crates/ferrox-quant/src/repack.rs
+++ b/crates/ferrox-quant/src/repack.rs
@@ -383,8 +383,23 @@ pub fn gemv_q4_kx8_group(
 pub const Q8_0X4_BLOCK_BYTES: usize = 136;
 /// Number of Q8_0 rows packed into one interleaved block.
 pub const Q8_0X4_NROWS: usize = 4;
-/// qs interleave width for `ggml_gemv_q8_0_4x4_q8_0` (NEON SDOT).
+/// qs interleave width for `ggml_gemv_q8_0_4x4_q8_0` (NEON SDOT). The
+/// DotProd-only default; [`q8_0x4_interleave`] picks 8 on i8mm hosts.
 pub const Q8_0X4_INTERLEAVE: usize = 4;
+
+/// Preferred qs interleave width: 8 on ARM i8mm (`ggml_gemm_q8_0_4x8_q8_0`
+/// via `ggml_repack_get_optimal_repack_type`), 4 on DotProd-only NEON and
+/// everywhere else (the scalar fallback handles either).
+#[inline]
+pub fn q8_0x4_interleave() -> usize {
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("i8mm") {
+            return 8;
+        }
+    }
+    Q8_0X4_INTERLEAVE
+}
 
 /// Pack four canonical Q8_0 blocks (same column-block) into one
 /// `block_q8_0x4`. `interleave` is 4 (ARM 4x4) or 8 (4x8).
@@ -436,16 +451,17 @@ pub fn pack_q8_0_matrix_x4(data: &[u8], rows: usize, cols: usize, interleave: us
     out
 }
 
-/// Scalar GEMV for interleave=4 (`ggml_gemv_q8_0_4x4_q8_0_generic`).
+/// Scalar GEMV (`ggml_gemv_q8_0_4x{4,8}_q8_0_generic`); `blocklen` is the
+/// interleave the matrix was packed with.
 fn gemv_q8_0x4_q8_0_scalar(
     packed: &[u8],
     act: &Q8Activations,
     n_cols: usize,
     n_row_groups: usize,
+    blocklen: usize,
     out: &mut [f32],
 ) {
     let nb = n_cols / Q8_0_BLOCK_ELEMS;
-    let blocklen = Q8_0X4_INTERLEAVE;
     let ncols = Q8_0X4_NROWS;
     debug_assert_eq!(act.n_blocks(), nb);
     debug_assert_eq!(out.len(), n_row_groups * ncols);
@@ -476,25 +492,44 @@ fn gemv_q8_0x4_q8_0_scalar(
 }
 
 /// GEMV: interleaved Q8_0 weights × Q8 activation → `n_row_groups * 4` f32s.
+/// `interleave` must match the packing (4: NEON SDOT `4x4`; 8: NEON `4x8`).
 pub fn gemv_q8_0x4_q8_0(
     packed: &[u8],
     act: &Q8Activations,
     n_cols: usize,
     n_row_groups: usize,
+    interleave: usize,
     out: &mut [f32],
 ) {
     assert!(n_cols.is_multiple_of(Q8_0_BLOCK_ELEMS));
     assert_eq!(out.len(), n_row_groups * Q8_0X4_NROWS);
-    #[cfg(target_arch = "aarch64")]
-    {
-        if std::arch::is_aarch64_feature_detected!("dotprod") {
-            unsafe {
-                neon::gemv_q8_0x4_q8_0_neon_sdot(packed, act, n_cols, n_row_groups, out);
+    match interleave {
+        4 => {
+            #[cfg(target_arch = "aarch64")]
+            {
+                if std::arch::is_aarch64_feature_detected!("dotprod") {
+                    unsafe {
+                        neon::gemv_q8_0x4_q8_0_neon_sdot(packed, act, n_cols, n_row_groups, out);
+                    }
+                    return;
+                }
             }
-            return;
+            gemv_q8_0x4_q8_0_scalar(packed, act, n_cols, n_row_groups, 4, out);
         }
+        8 => {
+            #[cfg(target_arch = "aarch64")]
+            {
+                if std::arch::is_aarch64_feature_detected!("dotprod") {
+                    unsafe {
+                        neon::gemv_q8_0x4_q8_0_neon_4x8(packed, act, n_cols, n_row_groups, out);
+                    }
+                    return;
+                }
+            }
+            gemv_q8_0x4_q8_0_scalar(packed, act, n_cols, n_row_groups, 8, out);
+        }
+        _ => panic!("q8_0x4 interleave must be 4 or 8, got {interleave}"),
     }
-    gemv_q8_0x4_q8_0_scalar(packed, act, n_cols, n_row_groups, out);
 }
 
 /// How many activations one [`gemm_q8_0x4_group`] pass keeps in flight.
@@ -521,6 +556,7 @@ pub fn gemm_q8_0x4_group(
     group: usize,
     acts: &[Q8Activations],
     n_cols: usize,
+    interleave: usize,
     out: &mut [f32],
 ) {
     assert_eq!(out.len(), Q8_0X4_NROWS * acts.len());
@@ -534,7 +570,31 @@ pub fn gemm_q8_0x4_group(
 
     #[cfg(target_arch = "aarch64")]
     {
-        if std::arch::is_aarch64_feature_detected!("dotprod") {
+        if interleave == 8 && std::arch::is_aarch64_feature_detected!("i8mm") {
+            // Compatibility entry: interleaves the quads here, once per
+            // call. Batch callers should prepare them once per matmul and
+            // use [`gemm_q8_0x4_group_x4`] instead.
+            for (t, chunk) in acts.chunks(Q8K_ACTS_X4_NC).enumerate() {
+                let tile = prepare_q8_acts_x4(chunk, n_cols);
+                let mut tmp = [0f32; Q8_0X4_NROWS * Q8K_ACTS_X4_NC];
+                let n = chunk.len();
+                unsafe {
+                    neon::gemm_q8_0x4_q8_0_neon_i8mm(
+                        slice,
+                        &tile,
+                        n_cols,
+                        &mut tmp[..Q8_0X4_NROWS * n],
+                    );
+                }
+                for r in 0..Q8_0X4_NROWS {
+                    for j in 0..n {
+                        out[r * acts.len() + t * Q8K_ACTS_X4_NC + j] = tmp[r * n + j];
+                    }
+                }
+            }
+            return;
+        }
+        if interleave == 4 && std::arch::is_aarch64_feature_detected!("dotprod") {
             unsafe {
                 neon::gemm_q8_0x4_q8_0_neon_sdot(slice, acts, n_cols, out);
             }
@@ -545,9 +605,143 @@ pub fn gemm_q8_0x4_group(
     // none of the reuse.
     let mut tmp = [0f32; Q8_0X4_NROWS];
     for (j, act) in acts.iter().enumerate() {
-        gemv_q8_0x4_q8_0(slice, act, n_cols, 1, &mut tmp);
+        gemv_q8_0x4_q8_0(slice, act, n_cols, 1, interleave, &mut tmp);
         for (r, v) in tmp.iter().enumerate() {
             out[r * acts.len() + j] = *v;
+        }
+    }
+}
+
+/// A quad of up to [`Q8K_ACTS_X4_NC`] Q8_0 activations, pre-interleaved
+/// into the layout llama.cpp's `ggml_quantize_mat_q8_0_4x8` writes into
+/// `block_q8_0x4` (`arch/arm/repack.cpp`): every 32-element block's qs in
+/// 8-byte runs, plus the per-block per-row scales. Consumed by the i8mm
+/// `4x8` GEMMs; prepared once per matmul, same hoist as [`Q8KActsX4`].
+pub struct Q8ActsX4 {
+    /// Real activations in the quad (≤ 4); rows `na..4` are zero padding.
+    pub na: usize,
+    /// Q8_0 blocks per activation (`n_cols / 32`).
+    pub n_blocks: usize,
+    /// Interleaved quants, `n_blocks * 128` long. Block `b`, 8-element run
+    /// `c`, quad row `a`, lane `k` ↦
+    /// `qs[b*128 + c*32 + a*8 + k] = acts[a].q[b*32 + c*8 + k]`.
+    pub qs: Vec<i8>,
+    /// Activation scales, `n_blocks * 4` long: `d[b*4 + a] = acts[a].d[b]`.
+    pub d: Vec<f32>,
+}
+
+/// Interleave a quad of Q8_0 activations for the `4x8` i8mm GEMMs
+/// (llama.cpp `ggml_quantize_mat_q8_0_4x8`, minus the quantization we
+/// already did). Zero-pads when `acts.len() < 4`. Available on every
+/// target so the portable GEMMs — and the tests pinning the NEON kernels
+/// to them — run anywhere.
+pub fn prepare_q8_acts_x4(acts: &[Q8Activations], n_cols: usize) -> Q8ActsX4 {
+    assert!(acts.len() <= Q8K_ACTS_X4_NC);
+    assert!(n_cols.is_multiple_of(Q8_0_BLOCK_ELEMS));
+    let na = acts.len();
+    let nb = n_cols / Q8_0_BLOCK_ELEMS;
+    let mut qs = vec![0i8; nb * Q8_0_BLOCK_ELEMS * 4];
+    let mut d = vec![0f32; nb * 4];
+    for (a, act) in acts.iter().enumerate() {
+        debug_assert_eq!(act.d.len(), nb);
+        for b in 0..nb {
+            let src = &act.q[b * Q8_0_BLOCK_ELEMS..(b + 1) * Q8_0_BLOCK_ELEMS];
+            let dst = &mut qs[b * Q8_0_BLOCK_ELEMS * 4..(b + 1) * Q8_0_BLOCK_ELEMS * 4];
+            for (c, run) in src.chunks_exact(8).enumerate() {
+                dst[c * 32 + a * 8..c * 32 + a * 8 + 8].copy_from_slice(run);
+            }
+            d[b * 4 + a] = act.d[b];
+        }
+    }
+    Q8ActsX4 {
+        na,
+        n_blocks: nb,
+        qs,
+        d,
+    }
+}
+
+/// Whether [`gemm_q8_0x4_group_x4`] is the fast Q8_0 batch path on this
+/// CPU: ARM i8mm with the interleave-8 layout (`ggml_gemm_q8_0_4x8_q8_0`).
+#[inline]
+pub fn q8_0x4_gemm_uses_acts_x4(interleave: usize) -> bool {
+    #[cfg(target_arch = "aarch64")]
+    {
+        interleave == 8 && std::arch::is_aarch64_feature_detected!("i8mm")
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let _ = interleave;
+        false
+    }
+}
+
+/// [`gemm_q8_0x4_group`] against a pre-interleaved activation quad;
+/// interleave-8 packing only, quad prepared once per matmul by
+/// [`prepare_q8_acts_x4`]. `out` is `[row][act]`: `out[r * tile.na + a]`.
+pub fn gemm_q8_0x4_group_x4(
+    packed: &[u8],
+    group: usize,
+    tile: &Q8ActsX4,
+    n_cols: usize,
+    interleave: usize,
+    out: &mut [f32],
+) {
+    assert_eq!(interleave, 8, "the x4 GEMM only exists for interleave-8 packing");
+    assert_eq!(out.len(), Q8_0X4_NROWS * tile.na);
+    assert!(n_cols.is_multiple_of(Q8_0_BLOCK_ELEMS));
+    debug_assert_eq!(tile.n_blocks, n_cols / Q8_0_BLOCK_ELEMS);
+    if tile.na == 0 {
+        return;
+    }
+    let nb = n_cols / Q8_0_BLOCK_ELEMS;
+    let off = group * nb * Q8_0X4_BLOCK_BYTES;
+    let slice = &packed[off..off + nb * Q8_0X4_BLOCK_BYTES];
+
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("i8mm") {
+        unsafe {
+            neon::gemm_q8_0x4_q8_0_neon_i8mm(slice, tile, n_cols, out);
+        }
+        return;
+    }
+    gemm_q8_0x4_acts_x4_scalar_8(slice, tile, n_cols, out);
+}
+
+/// Portable reference for the Q8_0 ×4 GEMM: the same math as
+/// [`gemv_q8_0x4_q8_0_scalar`] at blocklen 8, per quad row, reading qs and
+/// d out of the pre-interleaved [`Q8ActsX4`]. Bit-identical to running
+/// that GEMV per activation, which is what the tests assert.
+fn gemm_q8_0x4_acts_x4_scalar_8(packed: &[u8], tile: &Q8ActsX4, n_cols: usize, out: &mut [f32]) {
+    let nb = n_cols / Q8_0_BLOCK_ELEMS;
+    let blocklen = 8;
+    let ncols = Q8_0X4_NROWS;
+    let na = tile.na;
+    let mut sumf = [[0f32; Q8_0X4_NROWS]; Q8K_ACTS_X4_NC];
+    for l in 0..nb {
+        let blk = &packed[l * Q8_0X4_BLOCK_BYTES..][..Q8_0X4_BLOCK_BYTES];
+        let qs = &blk[8..];
+        let q8 = &tile.qs[l * Q8_0_BLOCK_ELEMS * 4..][..Q8_0_BLOCK_ELEMS * 4];
+        for a in 0..na {
+            let da = tile.d[l * 4 + a];
+            for k in 0..(Q8_0_BLOCK_ELEMS / blocklen) {
+                for j in 0..ncols {
+                    let mut sumi = 0i32;
+                    for i in 0..blocklen {
+                        let v0 = qs[k * ncols * blocklen + j * blocklen + i] as i8 as i32;
+                        // Canonical q8 element `e` lives at run `e/8`, row
+                        // `a`, lane `e%8` of the interleaved block.
+                        let e = k * blocklen + i;
+                        sumi += v0 * q8[(e / 8) * 32 + a * 8 + (e % 8)] as i32;
+                    }
+                    sumf[a][j] += sumi as f32 * f16_from_bytes(&blk[j * 2..]) * da;
+                }
+            }
+        }
+    }
+    for j in 0..ncols {
+        for (a, row) in sumf.iter().take(na).enumerate() {
+            out[j * na + a] = row[j];
         }
     }
 }
@@ -1916,8 +2110,23 @@ fn gemm_q6_kx8_acts_x4_scalar_8(packed: &[u8], tile: &Q8KActsX4, n_cols: usize, 
 pub const Q4_0X4_BLOCK_BYTES: usize = 72;
 /// Number of Q4_0 rows packed into one interleaved block.
 pub const Q4_0X4_NROWS: usize = 4;
-/// qs interleave width for `ggml_gemv_q4_0_4x4_q8_0` (NEON SDOT).
+/// qs interleave width for `ggml_gemv_q4_0_4x4_q8_0` (NEON SDOT). The
+/// DotProd-only default; [`q4_0x4_interleave`] picks 8 on i8mm hosts.
 pub const Q4_0X4_INTERLEAVE: usize = 4;
+
+/// Preferred qs interleave width: 8 on ARM i8mm (`ggml_gemm_q4_0_4x8_q8_0`
+/// via `ggml_repack_get_optimal_repack_type`), 4 on DotProd-only NEON and
+/// everywhere else (the scalar fallback handles either).
+#[inline]
+pub fn q4_0x4_interleave() -> usize {
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("i8mm") {
+            return 8;
+        }
+    }
+    Q4_0X4_INTERLEAVE
+}
 
 const Q4_0X4_XOR_MASK_U32: u32 = 0x8888_8888;
 const Q4_0X4_XOR_MASK_U64: u64 = 0x8888_8888_8888_8888;
@@ -1995,16 +2204,17 @@ fn q4_0x4_nibble_dot(byte: u8, q8_lo: i32, q8_hi: i32) -> i32 {
     ((v0 * q8_lo) + (v1 * q8_hi)) >> 4
 }
 
-/// Scalar GEMV for interleave=4 (`ggml_gemv_q4_0_4x4_q8_0_generic`).
+/// Scalar GEMV (`ggml_gemv_q4_0_4x{4,8}_q8_0_generic`); `blocklen` is the
+/// interleave the matrix was packed with.
 fn gemv_q4_0x4_q8_0_scalar(
     packed: &[u8],
     act: &Q8Activations,
     n_cols: usize,
     n_row_groups: usize,
+    blocklen: usize,
     out: &mut [f32],
 ) {
     let nb = n_cols / Q4_0_BLOCK_ELEMS;
-    let blocklen = Q4_0X4_INTERLEAVE;
     let ncols = Q4_0X4_NROWS;
     debug_assert_eq!(act.n_blocks(), nb);
     debug_assert_eq!(out.len(), n_row_groups * ncols);
@@ -2038,25 +2248,44 @@ fn gemv_q4_0x4_q8_0_scalar(
 }
 
 /// GEMV: interleaved Q4_0 weights × Q8 activation → `n_row_groups * 4` f32s.
+/// `interleave` must match the packing (4: NEON SDOT `4x4`; 8: NEON `4x8`).
 pub fn gemv_q4_0x4_q8_0(
     packed: &[u8],
     act: &Q8Activations,
     n_cols: usize,
     n_row_groups: usize,
+    interleave: usize,
     out: &mut [f32],
 ) {
     assert!(n_cols.is_multiple_of(Q4_0_BLOCK_ELEMS));
     assert_eq!(out.len(), n_row_groups * Q4_0X4_NROWS);
-    #[cfg(target_arch = "aarch64")]
-    {
-        if std::arch::is_aarch64_feature_detected!("dotprod") {
-            unsafe {
-                neon::gemv_q4_0x4_q8_0_neon_sdot(packed, act, n_cols, n_row_groups, out);
+    match interleave {
+        4 => {
+            #[cfg(target_arch = "aarch64")]
+            {
+                if std::arch::is_aarch64_feature_detected!("dotprod") {
+                    unsafe {
+                        neon::gemv_q4_0x4_q8_0_neon_sdot(packed, act, n_cols, n_row_groups, out);
+                    }
+                    return;
+                }
             }
-            return;
+            gemv_q4_0x4_q8_0_scalar(packed, act, n_cols, n_row_groups, 4, out);
         }
+        8 => {
+            #[cfg(target_arch = "aarch64")]
+            {
+                if std::arch::is_aarch64_feature_detected!("dotprod") {
+                    unsafe {
+                        neon::gemv_q4_0x4_q8_0_neon_4x8(packed, act, n_cols, n_row_groups, out);
+                    }
+                    return;
+                }
+            }
+            gemv_q4_0x4_q8_0_scalar(packed, act, n_cols, n_row_groups, 8, out);
+        }
+        _ => panic!("q4_0x4 interleave must be 4 or 8, got {interleave}"),
     }
-    gemv_q4_0x4_q8_0_scalar(packed, act, n_cols, n_row_groups, out);
 }
 
 /// How many activations one [`gemm_q4_0x4_group`] pass keeps in flight.
@@ -2070,6 +2299,7 @@ pub fn gemm_q4_0x4_group(
     group: usize,
     acts: &[Q8Activations],
     n_cols: usize,
+    interleave: usize,
     out: &mut [f32],
 ) {
     assert_eq!(out.len(), Q4_0X4_NROWS * acts.len());
@@ -2083,7 +2313,31 @@ pub fn gemm_q4_0x4_group(
 
     #[cfg(target_arch = "aarch64")]
     {
-        if std::arch::is_aarch64_feature_detected!("dotprod") {
+        if interleave == 8 && std::arch::is_aarch64_feature_detected!("i8mm") {
+            // Compatibility entry: interleaves the quads here, once per
+            // call. Batch callers should prepare them once per matmul and
+            // use [`gemm_q4_0x4_group_x4`] instead.
+            for (t, chunk) in acts.chunks(Q8K_ACTS_X4_NC).enumerate() {
+                let tile = prepare_q8_acts_x4(chunk, n_cols);
+                let mut tmp = [0f32; Q4_0X4_NROWS * Q8K_ACTS_X4_NC];
+                let n = chunk.len();
+                unsafe {
+                    neon::gemm_q4_0x4_q8_0_neon_i8mm(
+                        slice,
+                        &tile,
+                        n_cols,
+                        &mut tmp[..Q4_0X4_NROWS * n],
+                    );
+                }
+                for r in 0..Q4_0X4_NROWS {
+                    for j in 0..n {
+                        out[r * acts.len() + t * Q8K_ACTS_X4_NC + j] = tmp[r * n + j];
+                    }
+                }
+            }
+            return;
+        }
+        if interleave == 4 && std::arch::is_aarch64_feature_detected!("dotprod") {
             unsafe {
                 neon::gemm_q4_0x4_q8_0_neon_sdot(slice, acts, n_cols, out);
             }
@@ -2092,9 +2346,98 @@ pub fn gemm_q4_0x4_group(
     }
     let mut tmp = [0f32; Q4_0X4_NROWS];
     for (j, act) in acts.iter().enumerate() {
-        gemv_q4_0x4_q8_0(slice, act, n_cols, 1, &mut tmp);
+        gemv_q4_0x4_q8_0(slice, act, n_cols, 1, interleave, &mut tmp);
         for (r, v) in tmp.iter().enumerate() {
             out[r * acts.len() + j] = *v;
+        }
+    }
+}
+
+/// Whether [`gemm_q4_0x4_group_x4`] is the fast Q4_0 batch path on this
+/// CPU: ARM i8mm with the interleave-8 layout (`ggml_gemm_q4_0_4x8_q8_0`).
+#[inline]
+pub fn q4_0x4_gemm_uses_acts_x4(interleave: usize) -> bool {
+    #[cfg(target_arch = "aarch64")]
+    {
+        interleave == 8 && std::arch::is_aarch64_feature_detected!("i8mm")
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let _ = interleave;
+        false
+    }
+}
+
+/// [`gemm_q4_0x4_group`] against a pre-interleaved activation quad;
+/// interleave-8 packing only, quad prepared once per matmul by
+/// [`prepare_q8_acts_x4`]. `out` is `[row][act]`: `out[r * tile.na + a]`.
+pub fn gemm_q4_0x4_group_x4(
+    packed: &[u8],
+    group: usize,
+    tile: &Q8ActsX4,
+    n_cols: usize,
+    interleave: usize,
+    out: &mut [f32],
+) {
+    assert_eq!(interleave, 8, "the x4 GEMM only exists for interleave-8 packing");
+    assert_eq!(out.len(), Q4_0X4_NROWS * tile.na);
+    assert!(n_cols.is_multiple_of(Q4_0_BLOCK_ELEMS));
+    debug_assert_eq!(tile.n_blocks, n_cols / Q4_0_BLOCK_ELEMS);
+    if tile.na == 0 {
+        return;
+    }
+    let nb = n_cols / Q4_0_BLOCK_ELEMS;
+    let off = group * nb * Q4_0X4_BLOCK_BYTES;
+    let slice = &packed[off..off + nb * Q4_0X4_BLOCK_BYTES];
+
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("i8mm") {
+        unsafe {
+            neon::gemm_q4_0x4_q8_0_neon_i8mm(slice, tile, n_cols, out);
+        }
+        return;
+    }
+    gemm_q4_0x4_acts_x4_scalar_8(slice, tile, n_cols, out);
+}
+
+/// Portable reference for the Q4_0 ×4 GEMM: the same math as
+/// [`gemv_q4_0x4_q8_0_scalar`] at blocklen 8, per quad row, reading qs and
+/// d out of the pre-interleaved [`Q8ActsX4`]. Bit-identical to running
+/// that GEMV per activation, which is what the tests assert.
+fn gemm_q4_0x4_acts_x4_scalar_8(packed: &[u8], tile: &Q8ActsX4, n_cols: usize, out: &mut [f32]) {
+    let nb = n_cols / Q4_0_BLOCK_ELEMS;
+    let blocklen = 8;
+    let ncols = Q4_0X4_NROWS;
+    let na = tile.na;
+    let mut sumf = [[0f32; Q4_0X4_NROWS]; Q8K_ACTS_X4_NC];
+    for l in 0..nb {
+        let blk = &packed[l * Q4_0X4_BLOCK_BYTES..][..Q4_0X4_BLOCK_BYTES];
+        let q8 = &tile.qs[l * Q4_0_BLOCK_ELEMS * 4..][..Q4_0_BLOCK_ELEMS * 4];
+        for a in 0..na {
+            let da = tile.d[l * 4 + a];
+            for k in 0..(Q4_0_BLOCK_ELEMS / (2 * blocklen)) {
+                for j in 0..ncols {
+                    let mut sumi = 0i32;
+                    for i in 0..blocklen {
+                        let byte = blk[8 + k * ncols * blocklen + j * blocklen + i];
+                        // Canonical q8 element `e` lives at run `e/8`, row
+                        // `a`, lane `e%8` of the interleaved block.
+                        let e0 = k * blocklen + i;
+                        let e1 = e0 + Q4_0_BLOCK_ELEMS / 2;
+                        sumi += q4_0x4_nibble_dot(
+                            byte,
+                            q8[(e0 / 8) * 32 + a * 8 + (e0 % 8)] as i32,
+                            q8[(e1 / 8) * 32 + a * 8 + (e1 % 8)] as i32,
+                        );
+                    }
+                    sumf[a][j] += sumi as f32 * f16_from_bytes(&blk[j * 2..]) * da;
+                }
+            }
+        }
+    }
+    for j in 0..ncols {
+        for (a, row) in sumf.iter().take(na).enumerate() {
+            out[j * na + a] = row[j];
         }
     }
 }
@@ -2106,13 +2449,14 @@ pub fn gemv_q4_0x4_group(
     group: usize,
     act: &Q8Activations,
     n_cols: usize,
+    interleave: usize,
     out4: &mut [f32],
 ) {
     debug_assert_eq!(out4.len(), Q4_0X4_NROWS);
     let nb = n_cols / Q4_0_BLOCK_ELEMS;
     let off = group * nb * Q4_0X4_BLOCK_BYTES;
     let slice = &packed[off..off + nb * Q4_0X4_BLOCK_BYTES];
-    gemv_q4_0x4_q8_0(slice, act, n_cols, 1, out4);
+    gemv_q4_0x4_q8_0(slice, act, n_cols, 1, interleave, out4);
 }
 
 /// One row-group (4 outputs) starting at `group` within a packed Q8_0x4 matrix.
@@ -2122,13 +2466,14 @@ pub fn gemv_q8_0x4_group(
     group: usize,
     act: &Q8Activations,
     n_cols: usize,
+    interleave: usize,
     out4: &mut [f32],
 ) {
     debug_assert_eq!(out4.len(), Q8_0X4_NROWS);
     let nb = n_cols / Q8_0_BLOCK_ELEMS;
     let off = group * nb * Q8_0X4_BLOCK_BYTES;
     let slice = &packed[off..off + nb * Q8_0X4_BLOCK_BYTES];
-    gemv_q8_0x4_q8_0(slice, act, n_cols, 1, out4);
+    gemv_q8_0x4_q8_0(slice, act, n_cols, 1, interleave, out4);
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -4154,6 +4499,277 @@ mod neon {
             j0 += tile;
         }
     }
+
+    /// NEON DotProd GEMV for interleave-8 packed Q8_0 weights (llama.cpp
+    /// `ggml_gemv_q8_0_4x8_q8_0` in `arch/arm/repack.cpp`). Each 8-byte
+    /// activation run is broadcast to both vector halves so one `sdot`
+    /// covers two interleaved rows.
+    #[target_feature(enable = "neon,dotprod")]
+    pub unsafe fn gemv_q8_0x4_q8_0_neon_4x8(
+        packed: &[u8],
+        act: &Q8Activations,
+        n_cols: usize,
+        n_row_groups: usize,
+        out: &mut [f32],
+    ) {
+        let nb = n_cols / Q8_0_BLOCK_ELEMS;
+
+        for x in 0..n_row_groups {
+            let mut acc = vdupq_n_f32(0.0);
+            let group_off = x * nb * Q8_0X4_BLOCK_BYTES;
+
+            for b in 0..nb {
+                let blk = packed.as_ptr().add(group_off + b * Q8_0X4_BLOCK_BYTES);
+                let qs = blk.add(8) as *const i8;
+                let mut d_arr = [0f32; 4];
+                for (j, slot) in d_arr.iter_mut().enumerate() {
+                    *slot = f16_from_bytes(std::slice::from_raw_parts(blk.add(j * 2), 2));
+                }
+                let b_d = vld1q_f32(d_arr.as_ptr());
+                let a_base = act.q.as_ptr().add(b * Q8_0_BLOCK_ELEMS);
+
+                let mut ret0 = vdupq_n_s32(0);
+                let mut ret1 = vdupq_n_s32(0);
+                for c in 0..4 {
+                    let a = vreinterpretq_s8_s64(vld1q_dup_s64(a_base.add(c * 8) as *const i64));
+                    ret0 = sdot(ret0, vld1q_s8(qs.add(c * 32)), a);
+                    ret1 = sdot(ret1, vld1q_s8(qs.add(c * 32 + 16)), a);
+                }
+                let ret = vpaddq_s32(ret0, ret1);
+
+                acc = vfmaq_f32(acc, vcvtq_f32_s32(ret), vmulq_n_f32(b_d, act.d[b]));
+            }
+
+            vst1q_f32(out.as_mut_ptr().add(x * Q8_0X4_NROWS), acc);
+        }
+    }
+
+    /// NEON DotProd GEMV for interleave-8 packed Q4_0 weights (llama.cpp
+    /// `ggml_gemv_q4_0_4x8_q8_0` in `arch/arm/repack.cpp`). Nibbles are
+    /// consumed at 16× their value (`<< 4` for the low half, `& 0xf0` for
+    /// the high half — the pack's 0x88 XOR already folded in the -8), and
+    /// the fixed-point convert divides the 16 back out.
+    #[target_feature(enable = "neon,dotprod")]
+    pub unsafe fn gemv_q4_0x4_q8_0_neon_4x8(
+        packed: &[u8],
+        act: &Q8Activations,
+        n_cols: usize,
+        n_row_groups: usize,
+        out: &mut [f32],
+    ) {
+        let nb = n_cols / Q4_0_BLOCK_ELEMS;
+        let m4b = vdupq_n_u8(0xf0);
+
+        for x in 0..n_row_groups {
+            let mut acc = vdupq_n_f32(0.0);
+            let group_off = x * nb * Q4_0X4_BLOCK_BYTES;
+
+            for b in 0..nb {
+                let blk = packed.as_ptr().add(group_off + b * Q4_0X4_BLOCK_BYTES);
+                let qs = blk.add(8);
+                let mut d_arr = [0f32; 4];
+                for (j, slot) in d_arr.iter_mut().enumerate() {
+                    *slot = f16_from_bytes(std::slice::from_raw_parts(blk.add(j * 2), 2));
+                }
+                let b_d = vld1q_f32(d_arr.as_ptr());
+                let a_base = act.q.as_ptr().add(b * Q4_0_BLOCK_ELEMS);
+
+                let b0 = vld1q_u8(qs);
+                let b1 = vld1q_u8(qs.add(16));
+                let b2 = vld1q_u8(qs.add(32));
+                let b3 = vld1q_u8(qs.add(48));
+
+                let mut a = [vdupq_n_s8(0); 4];
+                for (c, slot) in a.iter_mut().enumerate() {
+                    *slot =
+                        vreinterpretq_s8_s64(vld1q_dup_s64(a_base.add(c * 8) as *const i64));
+                }
+
+                let mut ret0 = vdupq_n_s32(0);
+                let mut ret1 = vdupq_n_s32(0);
+                ret0 = sdot(ret0, vreinterpretq_s8_u8(vshlq_n_u8(b0, 4)), a[0]);
+                ret1 = sdot(ret1, vreinterpretq_s8_u8(vshlq_n_u8(b1, 4)), a[0]);
+                ret0 = sdot(ret0, vreinterpretq_s8_u8(vshlq_n_u8(b2, 4)), a[1]);
+                ret1 = sdot(ret1, vreinterpretq_s8_u8(vshlq_n_u8(b3, 4)), a[1]);
+                ret0 = sdot(ret0, vreinterpretq_s8_u8(vandq_u8(b0, m4b)), a[2]);
+                ret1 = sdot(ret1, vreinterpretq_s8_u8(vandq_u8(b1, m4b)), a[2]);
+                ret0 = sdot(ret0, vreinterpretq_s8_u8(vandq_u8(b2, m4b)), a[3]);
+                ret1 = sdot(ret1, vreinterpretq_s8_u8(vandq_u8(b3, m4b)), a[3]);
+                let ret = vpaddq_s32(ret0, ret1);
+
+                acc = vfmaq_f32(
+                    acc,
+                    vcvtq_n_f32_s32::<4>(ret),
+                    vmulq_n_f32(b_d, act.d[b]),
+                );
+            }
+
+            vst1q_f32(out.as_mut_ptr().add(x * Q4_0X4_NROWS), acc);
+        }
+    }
+
+    /// NEON i8mm **GEMM** for interleave-8 packed Q8_0 weights (llama.cpp
+    /// `ggml_gemm_q8_0_4x8_q8_0` in `arch/arm/repack.cpp`, NEON branch).
+    /// The activation quad arrives pre-interleaved as [`Q8ActsX4`], so
+    /// every `vmmlaq_s32` covers a 2×2 (activation × weight-row) tile.
+    #[target_feature(enable = "neon,i8mm")]
+    pub unsafe fn gemm_q8_0x4_q8_0_neon_i8mm(
+        packed: &[u8],
+        tile: &Q8ActsX4,
+        n_cols: usize,
+        out: &mut [f32],
+    ) {
+        let na = tile.na;
+        debug_assert!(na <= Q8K_ACTS_X4_NC);
+        let nb = n_cols / Q8_0_BLOCK_ELEMS;
+        debug_assert_eq!(tile.n_blocks, nb);
+
+        // acc_f32[a] holds activation row a's 4 weight-row outputs.
+        let mut acc_f32 = [vdupq_n_f32(0.0); Q8K_ACTS_X4_NC];
+
+        for b in 0..nb {
+            let blk = packed.as_ptr().add(b * Q8_0X4_BLOCK_BYTES);
+            let qs = blk.add(8) as *const i8;
+            let a_base = tile.qs.as_ptr().add(b * Q8_0_BLOCK_ELEMS * 4);
+
+            let mut acc = [vdupq_n_s32(0); 4];
+            for chunk in 0..4 {
+                let a01 = vld1q_s8(a_base.add(chunk * 32));
+                let a23 = vld1q_s8(a_base.add(chunk * 32 + 16));
+                let b01 = vld1q_s8(qs.add(chunk * 32));
+                let b23 = vld1q_s8(qs.add(chunk * 32 + 16));
+
+                acc[0] = vmmla_s32(acc[0], a01, b01);
+                acc[1] = vmmla_s32(acc[1], a01, b23);
+                acc[2] = vmmla_s32(acc[2], a23, b01);
+                acc[3] = vmmla_s32(acc[3], a23, b23);
+            }
+
+            // 2×2 tiles → per-activation-row vectors of 4 weight rows.
+            let rows = [
+                vcombine_s32(vget_low_s32(acc[0]), vget_low_s32(acc[1])),
+                vcombine_s32(vget_high_s32(acc[0]), vget_high_s32(acc[1])),
+                vcombine_s32(vget_low_s32(acc[2]), vget_low_s32(acc[3])),
+                vcombine_s32(vget_high_s32(acc[2]), vget_high_s32(acc[3])),
+            ];
+
+            let mut d_arr = [0f32; 4];
+            for (j, slot) in d_arr.iter_mut().enumerate() {
+                *slot = f16_from_bytes(std::slice::from_raw_parts(blk.add(j * 2), 2));
+            }
+            let b_d = vld1q_f32(d_arr.as_ptr());
+
+            for a in 0..na {
+                acc_f32[a] = vfmaq_f32(
+                    acc_f32[a],
+                    vcvtq_f32_s32(rows[a]),
+                    vmulq_n_f32(b_d, *tile.d.as_ptr().add(b * 4 + a)),
+                );
+            }
+        }
+
+        for a in 0..na {
+            let mut lanes = [0f32; Q8_0X4_NROWS];
+            vst1q_f32(lanes.as_mut_ptr(), acc_f32[a]);
+            for (r, v) in lanes.iter().enumerate() {
+                out[r * na + a] = *v;
+            }
+        }
+    }
+
+    /// NEON i8mm **GEMM** for interleave-8 packed Q4_0 weights. llama.cpp
+    /// ships `ggml_gemm_q4_0_4x8_q8_0` (`arch/arm/repack.cpp`) as raw
+    /// inline asm; this is the same computation with intrinsics, following
+    /// the `4x8` GEMV's nibble handling and the Q8_0 GEMM's MMLA tiling.
+    #[target_feature(enable = "neon,i8mm")]
+    pub unsafe fn gemm_q4_0x4_q8_0_neon_i8mm(
+        packed: &[u8],
+        tile: &Q8ActsX4,
+        n_cols: usize,
+        out: &mut [f32],
+    ) {
+        let na = tile.na;
+        debug_assert!(na <= Q8K_ACTS_X4_NC);
+        let nb = n_cols / Q4_0_BLOCK_ELEMS;
+        debug_assert_eq!(tile.n_blocks, nb);
+        let m4b = vdupq_n_u8(0xf0);
+
+        let mut acc_f32 = [vdupq_n_f32(0.0); Q8K_ACTS_X4_NC];
+
+        for b in 0..nb {
+            let blk = packed.as_ptr().add(b * Q4_0X4_BLOCK_BYTES);
+            let qs = blk.add(8);
+            let a_base = tile.qs.as_ptr().add(b * Q4_0_BLOCK_ELEMS * 4);
+
+            let bv = [
+                vld1q_u8(qs),
+                vld1q_u8(qs.add(16)),
+                vld1q_u8(qs.add(32)),
+                vld1q_u8(qs.add(48)),
+            ];
+            // Weight vectors per activation chunk: lo nibbles cover elems
+            // 0..16 (chunks 0,1), hi nibbles elems 16..32 (chunks 2,3),
+            // all at 16× their value until the fixed-point convert.
+            let w = [
+                [
+                    vreinterpretq_s8_u8(vshlq_n_u8(bv[0], 4)),
+                    vreinterpretq_s8_u8(vshlq_n_u8(bv[1], 4)),
+                ],
+                [
+                    vreinterpretq_s8_u8(vshlq_n_u8(bv[2], 4)),
+                    vreinterpretq_s8_u8(vshlq_n_u8(bv[3], 4)),
+                ],
+                [
+                    vreinterpretq_s8_u8(vandq_u8(bv[0], m4b)),
+                    vreinterpretq_s8_u8(vandq_u8(bv[1], m4b)),
+                ],
+                [
+                    vreinterpretq_s8_u8(vandq_u8(bv[2], m4b)),
+                    vreinterpretq_s8_u8(vandq_u8(bv[3], m4b)),
+                ],
+            ];
+
+            let mut acc = [vdupq_n_s32(0); 4];
+            for (chunk, w_pair) in w.iter().enumerate() {
+                let a01 = vld1q_s8(a_base.add(chunk * 32));
+                let a23 = vld1q_s8(a_base.add(chunk * 32 + 16));
+
+                acc[0] = vmmla_s32(acc[0], a01, w_pair[0]);
+                acc[1] = vmmla_s32(acc[1], a01, w_pair[1]);
+                acc[2] = vmmla_s32(acc[2], a23, w_pair[0]);
+                acc[3] = vmmla_s32(acc[3], a23, w_pair[1]);
+            }
+
+            let rows = [
+                vcombine_s32(vget_low_s32(acc[0]), vget_low_s32(acc[1])),
+                vcombine_s32(vget_high_s32(acc[0]), vget_high_s32(acc[1])),
+                vcombine_s32(vget_low_s32(acc[2]), vget_low_s32(acc[3])),
+                vcombine_s32(vget_high_s32(acc[2]), vget_high_s32(acc[3])),
+            ];
+
+            let mut d_arr = [0f32; 4];
+            for (j, slot) in d_arr.iter_mut().enumerate() {
+                *slot = f16_from_bytes(std::slice::from_raw_parts(blk.add(j * 2), 2));
+            }
+            let b_d = vld1q_f32(d_arr.as_ptr());
+
+            for a in 0..na {
+                acc_f32[a] = vfmaq_f32(
+                    acc_f32[a],
+                    vcvtq_n_f32_s32::<4>(rows[a]),
+                    vmulq_n_f32(b_d, *tile.d.as_ptr().add(b * 4 + a)),
+                );
+            }
+        }
+
+        for a in 0..na {
+            let mut lanes = [0f32; Q4_0X4_NROWS];
+            vst1q_f32(lanes.as_mut_ptr(), acc_f32[a]);
+            for (r, v) in lanes.iter().enumerate() {
+                out[r * na + a] = *v;
+            }
+        }
+    }
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -4405,19 +5021,21 @@ mod tests {
             reference[r] = dot_q4_0_q8_scalar(&matrix[r * row_bytes..(r + 1) * row_bytes], &act);
         }
 
-        let packed = pack_q4_0_matrix_x4(&matrix, rows, cols, Q4_0X4_INTERLEAVE);
-        let n_groups = rows / Q4_0X4_NROWS;
-        let mut out = vec![0f32; rows];
-        gemv_q4_0x4_q8_0(&packed, &act, cols, n_groups, &mut out);
-        for r in 0..rows {
-            let err = (out[r] - reference[r]).abs();
-            let scale = reference[r].abs().max(1.0);
-            assert!(
-                err / scale < 1e-4 || err < 1e-3,
-                "Q4_0x4 row {r}: got {} want {} err={err}",
-                out[r],
-                reference[r]
-            );
+        for &interleave in &[4usize, 8] {
+            let packed = pack_q4_0_matrix_x4(&matrix, rows, cols, interleave);
+            let n_groups = rows / Q4_0X4_NROWS;
+            let mut out = vec![0f32; rows];
+            gemv_q4_0x4_q8_0(&packed, &act, cols, n_groups, interleave, &mut out);
+            for r in 0..rows {
+                let err = (out[r] - reference[r]).abs();
+                let scale = reference[r].abs().max(1.0);
+                assert!(
+                    err / scale < 1e-4 || err < 1e-3,
+                    "Q4_0x4 interleave={interleave} row {r}: got {} want {} err={err}",
+                    out[r],
+                    reference[r]
+                );
+            }
         }
     }
 
@@ -4444,11 +5062,11 @@ mod tests {
 
         for group in 0..rows / Q4_0X4_NROWS {
             let mut gemm_out = vec![0f32; Q4_0X4_NROWS * n_acts];
-            gemm_q4_0x4_group(&packed, group, &acts, cols, &mut gemm_out);
+            gemm_q4_0x4_group(&packed, group, &acts, cols, Q4_0X4_INTERLEAVE, &mut gemm_out);
 
             for (j, act) in acts.iter().enumerate() {
                 let mut gemv_out = [0f32; Q4_0X4_NROWS];
-                gemv_q4_0x4_group(&packed, group, act, cols, &mut gemv_out);
+                gemv_q4_0x4_group(&packed, group, act, cols, Q4_0X4_INTERLEAVE, &mut gemv_out);
                 for r in 0..Q4_0X4_NROWS {
                     assert_eq!(
                         gemm_out[r * n_acts + j],
@@ -4470,7 +5088,7 @@ mod tests {
         }
         let packed = pack_q4_0_matrix_x4(&matrix, Q4_0X4_NROWS, cols, Q4_0X4_INTERLEAVE);
         let mut out: Vec<f32> = Vec::new();
-        gemm_q4_0x4_group(&packed, 0, &[], cols, &mut out);
+        gemm_q4_0x4_group(&packed, 0, &[], cols, Q4_0X4_INTERLEAVE, &mut out);
         assert!(out.is_empty());
     }
 
@@ -4494,19 +5112,21 @@ mod tests {
             reference[r] = dot_q8_0_q8_scalar(&matrix[r * row_bytes..(r + 1) * row_bytes], &act);
         }
 
-        let packed = pack_q8_0_matrix_x4(&matrix, rows, cols, Q8_0X4_INTERLEAVE);
-        let n_groups = rows / Q8_0X4_NROWS;
-        let mut out = vec![0f32; rows];
-        gemv_q8_0x4_q8_0(&packed, &act, cols, n_groups, &mut out);
-        for r in 0..rows {
-            let err = (out[r] - reference[r]).abs();
-            let scale = reference[r].abs().max(1.0);
-            assert!(
-                err / scale < 1e-4 || err < 1e-3,
-                "Q8_0x4 row {r}: got {} want {} err={err}",
-                out[r],
-                reference[r]
-            );
+        for &interleave in &[4usize, 8] {
+            let packed = pack_q8_0_matrix_x4(&matrix, rows, cols, interleave);
+            let n_groups = rows / Q8_0X4_NROWS;
+            let mut out = vec![0f32; rows];
+            gemv_q8_0x4_q8_0(&packed, &act, cols, n_groups, interleave, &mut out);
+            for r in 0..rows {
+                let err = (out[r] - reference[r]).abs();
+                let scale = reference[r].abs().max(1.0);
+                assert!(
+                    err / scale < 1e-4 || err < 1e-3,
+                    "Q8_0x4 interleave={interleave} row {r}: got {} want {} err={err}",
+                    out[r],
+                    reference[r]
+                );
+            }
         }
     }
 
@@ -4540,11 +5160,11 @@ mod tests {
 
         for group in 0..rows / Q8_0X4_NROWS {
             let mut gemm_out = vec![0f32; Q8_0X4_NROWS * n_acts];
-            gemm_q8_0x4_group(&packed, group, &acts, cols, &mut gemm_out);
+            gemm_q8_0x4_group(&packed, group, &acts, cols, Q8_0X4_INTERLEAVE, &mut gemm_out);
 
             for (j, act) in acts.iter().enumerate() {
                 let mut gemv_out = [0f32; Q8_0X4_NROWS];
-                gemv_q8_0x4_group(&packed, group, act, cols, &mut gemv_out);
+                gemv_q8_0x4_group(&packed, group, act, cols, Q8_0X4_INTERLEAVE, &mut gemv_out);
                 for r in 0..Q8_0X4_NROWS {
                     assert_eq!(
                         gemm_out[r * n_acts + j],
@@ -5061,6 +5681,234 @@ mod tests {
         }
     }
 
+    fn synth_q8_0_acts(n: usize, cols: usize) -> Vec<Q8Activations> {
+        (0..n)
+            .map(|j| {
+                let x: Vec<f32> = (0..cols)
+                    .map(|i| (((i + j * 13) as f32) * 0.021 - 0.9).sin() * 1.7)
+                    .collect();
+                quantize_activations_q8(&x)
+            })
+            .collect()
+    }
+
+    /// llama.cpp `ggml_quantize_mat_q8_0_4x8`'s qs ordering, as the
+    /// reference `prepare_q8_acts_x4` must reproduce.
+    #[test]
+    fn prepare_q8_acts_x4_matches_interleave_reference() {
+        let n_blocks = 3;
+        let cols = n_blocks * Q8_0_BLOCK_ELEMS;
+        for na in 1..=Q8K_ACTS_X4_NC {
+            let acts = synth_q8_0_acts(na, cols);
+            let tile = prepare_q8_acts_x4(&acts, cols);
+            assert_eq!(tile.na, na);
+            assert_eq!(tile.n_blocks, n_blocks);
+            for b in 0..n_blocks {
+                for (j, got) in tile.qs[b * 128..(b + 1) * 128].iter().enumerate() {
+                    let src_offset = (j / 32) * 8 + (j % 8);
+                    let src_id = (j % 32) / 8;
+                    let want = if src_id < na {
+                        acts[src_id].q[b * Q8_0_BLOCK_ELEMS + src_offset]
+                    } else {
+                        0
+                    };
+                    assert_eq!(*got, want, "qs mismatch, block {b} pos {j} na {na}");
+                }
+                for a in 0..4 {
+                    let want_d = acts.get(a).map_or(0.0, |act| act.d[b]);
+                    assert_eq!(tile.d[b * 4 + a], want_d, "d mismatch, block {b} row {a}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn q8_0x4_gemm_x4_portable_is_bit_exact_vs_scalar_gemv() {
+        let n_blocks = 3;
+        let cols = n_blocks * Q8_0_BLOCK_ELEMS;
+        let rows = Q8_0X4_NROWS;
+        let mut matrix = Vec::new();
+        for r in 0..rows {
+            matrix.extend_from_slice(&synth_q8_0_row(n_blocks, (r * 7 + 3) as u8));
+        }
+        let packed = pack_q8_0_matrix_x4(&matrix, rows, cols, 8);
+
+        for na in 1..=Q8K_ACTS_X4_NC {
+            let acts = synth_q8_0_acts(na, cols);
+            let tile = prepare_q8_acts_x4(&acts, cols);
+            let mut got = vec![0f32; Q8_0X4_NROWS * na];
+            gemm_q8_0x4_acts_x4_scalar_8(&packed, &tile, cols, &mut got);
+
+            for (j, act) in acts.iter().enumerate() {
+                let mut want = [0f32; Q8_0X4_NROWS];
+                gemv_q8_0x4_q8_0_scalar(&packed, act, cols, 1, 8, &mut want);
+                for r in 0..Q8_0X4_NROWS {
+                    assert_eq!(
+                        got[r * na + j].to_bits(),
+                        want[r].to_bits(),
+                        "row {r} act {j} na {na}: x4 {} vs GEMV {}",
+                        got[r * na + j],
+                        want[r]
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn q4_0x4_gemm_x4_portable_is_bit_exact_vs_scalar_gemv() {
+        let n_blocks = 3;
+        let cols = n_blocks * Q4_0_BLOCK_ELEMS;
+        let rows = Q4_0X4_NROWS;
+        let mut matrix = Vec::new();
+        for r in 0..rows {
+            matrix.extend_from_slice(&synth_q4_0_row(n_blocks, (r * 5 + 1) as u8));
+        }
+        let packed = pack_q4_0_matrix_x4(&matrix, rows, cols, 8);
+
+        for na in 1..=Q8K_ACTS_X4_NC {
+            let acts = synth_q8_0_acts(na, cols);
+            let tile = prepare_q8_acts_x4(&acts, cols);
+            let mut got = vec![0f32; Q4_0X4_NROWS * na];
+            gemm_q4_0x4_acts_x4_scalar_8(&packed, &tile, cols, &mut got);
+
+            for (j, act) in acts.iter().enumerate() {
+                let mut want = [0f32; Q4_0X4_NROWS];
+                gemv_q4_0x4_q8_0_scalar(&packed, act, cols, 1, 8, &mut want);
+                for r in 0..Q4_0X4_NROWS {
+                    assert_eq!(
+                        got[r * na + j].to_bits(),
+                        want[r].to_bits(),
+                        "row {r} act {j} na {na}: x4 {} vs GEMV {}",
+                        got[r * na + j],
+                        want[r]
+                    );
+                }
+            }
+        }
+    }
+
+    /// The interleave-8 NEON paths (DotProd `4x8` GEMV, i8mm GEMM) against
+    /// the scalar interleave-8 references, plus the x4 entries against the
+    /// compat entries (bit-exact -- they share the kernels).
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn q8_0_q4_0_interleave8_neon_matches_references_when_available() {
+        if !std::arch::is_aarch64_feature_detected!("dotprod") {
+            return;
+        }
+        let n_blocks = 3;
+        let n_groups = 2;
+
+        // Q8_0
+        let cols = n_blocks * Q8_0_BLOCK_ELEMS;
+        let rows = n_groups * Q8_0X4_NROWS;
+        let mut matrix = Vec::new();
+        for r in 0..rows {
+            matrix.extend_from_slice(&synth_q8_0_row(n_blocks, (r * 3 + 2) as u8));
+        }
+        let packed = pack_q8_0_matrix_x4(&matrix, rows, cols, 8);
+        let acts = synth_q8_0_acts(4, cols);
+        for act in &acts {
+            let mut got = vec![0f32; rows];
+            gemv_q8_0x4_q8_0(&packed, act, cols, n_groups, 8, &mut got);
+            let mut want = vec![0f32; rows];
+            gemv_q8_0x4_q8_0_scalar(&packed, act, cols, n_groups, 8, &mut want);
+            for r in 0..rows {
+                let err = (got[r] - want[r]).abs();
+                assert!(
+                    err / want[r].abs().max(1.0) < 1e-5 || err < 1e-3,
+                    "q8_0 gemv row {r}: NEON 4x8 {} vs scalar {}",
+                    got[r],
+                    want[r]
+                );
+            }
+        }
+        // Q4_0
+        let q4_cols = n_blocks * Q4_0_BLOCK_ELEMS;
+        let q4_rows = n_groups * Q4_0X4_NROWS;
+        let mut q4_matrix = Vec::new();
+        for r in 0..q4_rows {
+            q4_matrix.extend_from_slice(&synth_q4_0_row(n_blocks, (r * 9 + 1) as u8));
+        }
+        let q4_packed = pack_q4_0_matrix_x4(&q4_matrix, q4_rows, q4_cols, 8);
+        let q4_acts = synth_q8_0_acts(4, q4_cols);
+        for act in &q4_acts {
+            let mut got = vec![0f32; q4_rows];
+            gemv_q4_0x4_q8_0(&q4_packed, act, q4_cols, n_groups, 8, &mut got);
+            let mut want = vec![0f32; q4_rows];
+            gemv_q4_0x4_q8_0_scalar(&q4_packed, act, q4_cols, n_groups, 8, &mut want);
+            for r in 0..q4_rows {
+                let err = (got[r] - want[r]).abs();
+                assert!(
+                    err / want[r].abs().max(1.0) < 1e-5 || err < 1e-3,
+                    "q4_0 gemv row {r}: NEON 4x8 {} vs scalar {}",
+                    got[r],
+                    want[r]
+                );
+            }
+        }
+
+        if !std::arch::is_aarch64_feature_detected!("i8mm") {
+            return;
+        }
+        for na in 1..=Q8K_ACTS_X4_NC {
+            let acts = synth_q8_0_acts(na, cols);
+            let tile = prepare_q8_acts_x4(&acts, cols);
+            for group in 0..n_groups {
+                let mut x4_out = vec![0f32; Q8_0X4_NROWS * na];
+                gemm_q8_0x4_group_x4(&packed, group, &tile, cols, 8, &mut x4_out);
+
+                let mut group_out = vec![0f32; Q8_0X4_NROWS * na];
+                gemm_q8_0x4_group(&packed, group, &acts, cols, 8, &mut group_out);
+                assert_eq!(
+                    x4_out.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                    group_out.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                    "q8_0 x4 entry diverged from the compat entry, group {group} na {na}"
+                );
+
+                let slice = &packed[group * n_blocks * Q8_0X4_BLOCK_BYTES..]
+                    [..n_blocks * Q8_0X4_BLOCK_BYTES];
+                let mut want = vec![0f32; Q8_0X4_NROWS * na];
+                gemm_q8_0x4_acts_x4_scalar_8(slice, &tile, cols, &mut want);
+                for (got, want) in x4_out.iter().zip(want.iter()) {
+                    let err = (got - want).abs();
+                    assert!(
+                        err / want.abs().max(1.0) < 1e-5 || err < 1e-3,
+                        "q8_0 group {group} na {na}: i8mm GEMM {got} vs portable {want}"
+                    );
+                }
+            }
+
+            let q4_acts = synth_q8_0_acts(na, q4_cols);
+            let q4_tile = prepare_q8_acts_x4(&q4_acts, q4_cols);
+            for group in 0..n_groups {
+                let mut x4_out = vec![0f32; Q4_0X4_NROWS * na];
+                gemm_q4_0x4_group_x4(&q4_packed, group, &q4_tile, q4_cols, 8, &mut x4_out);
+
+                let mut group_out = vec![0f32; Q4_0X4_NROWS * na];
+                gemm_q4_0x4_group(&q4_packed, group, &q4_acts, q4_cols, 8, &mut group_out);
+                assert_eq!(
+                    x4_out.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                    group_out.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                    "q4_0 x4 entry diverged from the compat entry, group {group} na {na}"
+                );
+
+                let slice = &q4_packed[group * n_blocks * Q4_0X4_BLOCK_BYTES..]
+                    [..n_blocks * Q4_0X4_BLOCK_BYTES];
+                let mut want = vec![0f32; Q4_0X4_NROWS * na];
+                gemm_q4_0x4_acts_x4_scalar_8(slice, &q4_tile, q4_cols, &mut want);
+                for (got, want) in x4_out.iter().zip(want.iter()) {
+                    let err = (got - want).abs();
+                    assert!(
+                        err / want.abs().max(1.0) < 1e-5 || err < 1e-3,
+                        "q4_0 group {group} na {na}: i8mm GEMM {got} vs portable {want}"
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn q4_kx8_gemm_with_no_activations_is_a_no_op() {
         let n_blocks = 2;
@@ -5085,7 +5933,7 @@ mod tests {
         }
         let packed = pack_q8_0_matrix_x4(&matrix, Q8_0X4_NROWS, cols, Q8_0X4_INTERLEAVE);
         let mut out: Vec<f32> = Vec::new();
-        gemm_q8_0x4_group(&packed, 0, &[], cols, &mut out);
+        gemm_q8_0x4_group(&packed, 0, &[], cols, Q8_0X4_INTERLEAVE, &mut out);
         assert!(out.is_empty());
     }
 


### PR DESCRIPTION
Plan item **1d** (`cpu-i8mm-q8_0-q4_0`) from `docs/plans/llama-cpp-parity-push.md` (on the `docs/parity-push-plan` branch): `Q8_0X4_INTERLEAVE`/`Q4_0X4_INTERLEAVE` were hardcoded to 4, so no SMMLA path could exist for either format — the plan identifies this as the structural source of the widest remaining CPU pp512 gaps (SmolLM2 10.68×, Qwen3-0.6B 6.57×, Qwen2.5-0.5B 5.84×, Gemma-3-1B 5.14×, TinyLlama 3.52×). llama's `ggml_repack_get_optimal_repack_type` picks the 4x8 shapes whenever `neon && matmul_int8` — always on the M2.

## Ported (`ggml/src/ggml-cpu/arch/arm/repack.cpp`)

| llama.cpp symbol | ferrox | notes |
|---|---|---|
| `ggml_quantize_mat_q8_0_4x8` | `prepare_q8_acts_x4` / `Q8ActsX4` | activation quad interleaved **once per matmul**, same hoist as `Q8KActsX4` |
| `ggml_gemm_q8_0_4x8_q8_0` | `gemm_q8_0x4_q8_0_neon_i8mm` | 4 `vmmlaq_s32` per block over 2×2 tiles |
| `ggml_gemm_q4_0_4x8_q8_0` | `gemm_q4_0x4_q8_0_neon_i8mm` | upstream ships this as **raw inline asm**; port is the same computation with intrinsics — nibbles at 16× (`<<4` / `&0xf0`, the pack's 0x88 XOR already folds the −8), fixed-point convert divides the 16 out |
| `ggml_gemv_q8_0_4x8_q8_0` / `ggml_gemv_q4_0_4x8_q8_0` | `gemv_*_neon_4x8` | decode through the repack path stays NEON at interleave 8 |

## Wiring

- `q8_0x4_interleave()` / `q4_0x4_interleave()` → 8 on ARM i8mm, 4 everywhere else — **x86 and DotProd-only ARM are byte-for-byte unchanged**.
- The six public entry points gain an `interleave` argument (it was baked in); scalar GEMVs parametrized over blocklen. All callers live in `weight_matrix.rs`.
- `apply_batch`'s Q8_0/Q4_0 arms build the quads once per matmul and use the new `gemm_*_group_x4` entries on i8mm hosts; compat branches keep the old entries correct for direct callers.

## Verification

- **Ran green on x86 here:** `prepare_q8_acts_x4` pinned to llama's 4x8 qs ordering (incl. `na < 4` padding); portable x4 GEMMs **bit-exact** vs the scalar interleave-8 GEMVs for both formats; the pack-and-gemv tests now sweep both interleaves vs canonical row dots; both crates' suites green in both `FERROX_CPU_INT_DOT` modes (only the known pre-existing `dequant_row…` failure under `=1`).
- **Cross-compiled only:** the four NEON kernels (`--target aarch64-unknown-linux-gnu --all-targets` clean). The aarch64-gated test pins the GEMVs to the scalar references and the GEMMs to both the compat entries (bit-exact) and portable references — it runs on your first `cargo test -p ferrox-quant` on the M2 Pro.
- Clippy at baseline on both targets (2 / 6 pre-existing).

## ⚠️ Not benchmark-validated

No ARM hardware here; the kernels were never executed. Per the plan's validation rule:

```
cargo test -p ferrox-quant -p ferrox-core     # aarch64-gated kernel tests first
ferrox bench -m <SmolLM2-135M-Q8_0.gguf> -p 512 -n 128 -r 3 --n-gpu-layers 0 --compare
ferrox bench --suite --fit-host --skip-missing && ferrox bench --render
```

This is the fourth unmeasured change stacked since PR #2 — the full ledger diff is due before the next kernel lands.

Remaining Phase 1 after this: 1e (de-nest activation quantization), 1f (chunked work-stealing), 1g (blocked prefill attention). Also outstanding: your `d337602` (Q6_K DotProd 8x4) on the plan branch — superseded on i8mm hosts by #3, still valuable as the DotProd-only fallback tier if rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013g9h89y6jwpfHX6tcV6wQp

---
_Generated by [Claude Code](https://claude.ai/code/session_013g9h89y6jwpfHX6tcV6wQp)_