### PR TITLE
perf(cpu): de-nest activation quantization + share it across q/k/v and gate/up (plan 1e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,6 @@ name = "ferrox-quant"
 version = "0.3.0"
 dependencies = [
  "half",
- "rayon",
  "thiserror",
 ]
 

--- a/crates/ferrox-core/src/lib.rs
+++ b/crates/ferrox-core/src/lib.rs
@@ -38,4 +38,4 @@ pub use tensor::Tensor;
 pub use weight_matrix::cuda_dense_enabled;
 #[cfg(feature = "metal")]
 pub use weight_matrix::metal_dense_enabled;
-pub use weight_matrix::{QuantKind, WeightMatrix};
+pub use weight_matrix::{BatchActs, QuantKind, WeightMatrix};

--- a/crates/ferrox-core/src/weight_matrix.rs
+++ b/crates/ferrox-core/src/weight_matrix.rs
@@ -319,6 +319,16 @@ pub unsafe fn default_cpu_int_dot_on() {
     }
 }
 
+/// A batch of activations quantized once for reuse across several
+/// [`WeightMatrix::apply_batch_with_acts`] calls that read the same input
+/// (q/k/v on one normed batch; gate/up on another). Build with
+/// [`WeightMatrix::quantize_batch_acts`]. Q8_0/Q4_0 matrices consume
+/// [`BatchActs::Q8`]; the K-quants consume [`BatchActs::Q8K`].
+pub enum BatchActs {
+    Q8(Vec<ferrox_quant::Q8Activations>),
+    Q8K(Vec<ferrox_quant::Q8KActivations>),
+}
+
 pub enum WeightMatrix {
     F32(Tensor),
     Quantized {
@@ -1217,6 +1227,76 @@ impl WeightMatrix {
     /// [`ferrox_metal::gpu::launch_matvec_batch`]. Falls back to
     /// per-row [`Self::apply`] if the batch launch fails.
     pub fn apply_batch(&self, x_batch: &[f32], batch_size: usize) -> Vec<f32> {
+        self.apply_batch_with_acts(x_batch, batch_size, None)
+    }
+
+    /// Quantize `x_batch` once, in the activation format this matrix's
+    /// INT_DOT batch path consumes, for sharing across every projection
+    /// that reads the same input (q/k/v on one normed batch; gate/up on
+    /// another). Returns `None` when [`Self::apply_batch`] would not use
+    /// quantized activations for this matrix — GPU dispatch, INT_DOT off,
+    /// unsupported kind or width — so callers can pass the result straight
+    /// to [`Self::apply_batch_with_acts`] unconditionally.
+    pub fn quantize_batch_acts(&self, x_batch: &[f32], batch_size: usize) -> Option<BatchActs> {
+        #[cfg(feature = "metal")]
+        {
+            if metal_dense_enabled()
+                && matches!(
+                    self,
+                    WeightMatrix::Quantized { kind, .. } if Self::metal_kind_supported(*kind)
+                )
+            {
+                return None;
+            }
+        }
+        #[cfg(feature = "cuda")]
+        {
+            if cuda_dense_enabled() && matches!(self, WeightMatrix::Quantized { .. }) {
+                return None;
+            }
+        }
+        let WeightMatrix::Quantized { cols, kind, .. } = self else {
+            return None;
+        };
+        if !cpu_int_dot_enabled() || x_batch.len() != batch_size * cols {
+            return None;
+        }
+        match kind {
+            QuantKind::Q8_0 | QuantKind::Q4_0 if cols.is_multiple_of(32) => Some(BatchActs::Q8(
+                (0..batch_size)
+                    .into_par_iter()
+                    .map(|b| {
+                        ferrox_quant::quantize_activations_q8(&x_batch[b * cols..(b + 1) * cols])
+                    })
+                    .collect(),
+            )),
+            QuantKind::Q4K | QuantKind::Q5K | QuantKind::Q6K if cols.is_multiple_of(256) => {
+                Some(BatchActs::Q8K(
+                    (0..batch_size)
+                        .into_par_iter()
+                        .map(|b| {
+                            ferrox_quant::quantize_activations_q8_k(
+                                &x_batch[b * cols..(b + 1) * cols],
+                            )
+                        })
+                        .collect(),
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    /// [`Self::apply_batch`], optionally reusing a shared pre-quantized
+    /// activation batch from [`Self::quantize_batch_acts`]. A `shared`
+    /// value whose format or length does not match this matrix is simply
+    /// ignored (the activations are re-quantized locally), so mixed-kind
+    /// projection groups stay correct.
+    pub fn apply_batch_with_acts(
+        &self,
+        x_batch: &[f32],
+        batch_size: usize,
+        shared: Option<&BatchActs>,
+    ) -> Vec<f32> {
         let cols = self.cols();
         assert_eq!(
             x_batch.len(),
@@ -1325,14 +1405,21 @@ impl WeightMatrix {
                 if cpu_int_dot_enabled() {
                     match *kind {
                         QuantKind::Q8_0 if cols.is_multiple_of(32) => {
-                            let acts: Vec<_> = (0..batch_size)
-                                .into_par_iter()
-                                .map(|b| {
-                                    ferrox_quant::quantize_activations_q8(
-                                        &x_batch[b * cols..(b + 1) * cols],
-                                    )
-                                })
-                                .collect();
+                            let acts_owned: Vec<_>;
+                            let acts: &[ferrox_quant::Q8Activations] = match shared {
+                                Some(BatchActs::Q8(a)) if a.len() == batch_size => a,
+                                _ => {
+                                    acts_owned = (0..batch_size)
+                                        .into_par_iter()
+                                        .map(|b| {
+                                            ferrox_quant::quantize_activations_q8(
+                                                &x_batch[b * cols..(b + 1) * cols],
+                                            )
+                                        })
+                                        .collect();
+                                    &acts_owned
+                                }
+                            };
                             let n_groups = *rows / ferrox_quant::Q8_0X4_NROWS;
                             if n_groups > 0 {
                                 let packed = get_or_repack_q8x4(data.as_slice(), *rows, cols);
@@ -1441,14 +1528,21 @@ impl WeightMatrix {
                             return out;
                         }
                         QuantKind::Q4_0 if cols.is_multiple_of(32) => {
-                            let acts: Vec<_> = (0..batch_size)
-                                .into_par_iter()
-                                .map(|b| {
-                                    ferrox_quant::quantize_activations_q8(
-                                        &x_batch[b * cols..(b + 1) * cols],
-                                    )
-                                })
-                                .collect();
+                            let acts_owned: Vec<_>;
+                            let acts: &[ferrox_quant::Q8Activations] = match shared {
+                                Some(BatchActs::Q8(a)) if a.len() == batch_size => a,
+                                _ => {
+                                    acts_owned = (0..batch_size)
+                                        .into_par_iter()
+                                        .map(|b| {
+                                            ferrox_quant::quantize_activations_q8(
+                                                &x_batch[b * cols..(b + 1) * cols],
+                                            )
+                                        })
+                                        .collect();
+                                    &acts_owned
+                                }
+                            };
                             let n_groups = *rows / ferrox_quant::Q4_0X4_NROWS;
                             if n_groups > 0 {
                                 let packed = get_or_repack_q4_0x4(data.as_slice(), *rows, cols);
@@ -1547,14 +1641,21 @@ impl WeightMatrix {
                             return out;
                         }
                         QuantKind::Q4K if cols.is_multiple_of(256) => {
-                            let acts: Vec<_> = (0..batch_size)
-                                .into_par_iter()
-                                .map(|b| {
-                                    ferrox_quant::quantize_activations_q8_k(
-                                        &x_batch[b * cols..(b + 1) * cols],
-                                    )
-                                })
-                                .collect();
+                            let acts_owned: Vec<_>;
+                            let acts: &[ferrox_quant::Q8KActivations] = match shared {
+                                Some(BatchActs::Q8K(a)) if a.len() == batch_size => a,
+                                _ => {
+                                    acts_owned = (0..batch_size)
+                                        .into_par_iter()
+                                        .map(|b| {
+                                            ferrox_quant::quantize_activations_q8_k(
+                                                &x_batch[b * cols..(b + 1) * cols],
+                                            )
+                                        })
+                                        .collect();
+                                    &acts_owned
+                                }
+                            };
                             let n_groups = *rows / ferrox_quant::Q4_KX8_NROWS;
                             if n_groups > 0 {
                                 let interleave = ferrox_quant::q4_kx8_interleave();
@@ -1646,14 +1747,21 @@ impl WeightMatrix {
                             return out;
                         }
                         QuantKind::Q5K if cols.is_multiple_of(256) => {
-                            let acts: Vec<_> = (0..batch_size)
-                                .into_par_iter()
-                                .map(|b| {
-                                    ferrox_quant::quantize_activations_q8_k(
-                                        &x_batch[b * cols..(b + 1) * cols],
-                                    )
-                                })
-                                .collect();
+                            let acts_owned: Vec<_>;
+                            let acts: &[ferrox_quant::Q8KActivations] = match shared {
+                                Some(BatchActs::Q8K(a)) if a.len() == batch_size => a,
+                                _ => {
+                                    acts_owned = (0..batch_size)
+                                        .into_par_iter()
+                                        .map(|b| {
+                                            ferrox_quant::quantize_activations_q8_k(
+                                                &x_batch[b * cols..(b + 1) * cols],
+                                            )
+                                        })
+                                        .collect();
+                                    &acts_owned
+                                }
+                            };
                             // Q5_Kx8 multi-act NEON GEMM amortizes weight unpack.
                             let use_kx8 = cfg!(target_arch = "aarch64");
                             let n_groups = if use_kx8 {
@@ -1757,14 +1865,21 @@ impl WeightMatrix {
                             return out;
                         }
                         QuantKind::Q6K if cols.is_multiple_of(256) => {
-                            let acts: Vec<_> = (0..batch_size)
-                                .into_par_iter()
-                                .map(|b| {
-                                    ferrox_quant::quantize_activations_q8_k(
-                                        &x_batch[b * cols..(b + 1) * cols],
-                                    )
-                                })
-                                .collect();
+                            let acts_owned: Vec<_>;
+                            let acts: &[ferrox_quant::Q8KActivations] = match shared {
+                                Some(BatchActs::Q8K(a)) if a.len() == batch_size => a,
+                                _ => {
+                                    acts_owned = (0..batch_size)
+                                        .into_par_iter()
+                                        .map(|b| {
+                                            ferrox_quant::quantize_activations_q8_k(
+                                                &x_batch[b * cols..(b + 1) * cols],
+                                            )
+                                        })
+                                        .collect();
+                                    &acts_owned
+                                }
+                            };
                             // Kx8 batch path only where the i8mm GEMM
                             // exists (the scalar Kx8 GEMM measured slower
                             // than the per-row NEON dot on Phi ffn_down,
@@ -3041,6 +3156,38 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    /// Sharing one quantized activation batch across projections must be
+    /// invisible in the results: a matching `BatchActs` produces exactly
+    /// what `apply_batch` produces (same quantization, same kernels), and
+    /// a mismatched variant is ignored rather than misused.
+    #[test]
+    fn apply_batch_with_shared_acts_matches_apply_batch() {
+        let rows = 19;
+        let cols = 512;
+        let batch_size = 6;
+        let x_batch: Vec<f32> = (0..batch_size * cols)
+            .map(|i| (((i * 29 + 11) % 89) as f32) * 0.023 - 1.0)
+            .collect();
+        for kind in [QuantKind::Q8_0, QuantKind::Q4_0, QuantKind::Q4K, QuantKind::Q6K] {
+            let matrix = synth_quant_matrix(kind, rows, cols);
+            let baseline = matrix.apply_batch(&x_batch, batch_size);
+
+            let shared = matrix.quantize_batch_acts(&x_batch, batch_size);
+            let with_shared = matrix.apply_batch_with_acts(&x_batch, batch_size, shared.as_ref());
+            assert_eq!(baseline, with_shared, "{kind:?}: shared acts changed the result");
+
+            let wrong = match kind {
+                QuantKind::Q8_0 | QuantKind::Q4_0 => BatchActs::Q8K(Vec::new()),
+                _ => BatchActs::Q8(Vec::new()),
+            };
+            let with_wrong = matrix.apply_batch_with_acts(&x_batch, batch_size, Some(&wrong));
+            assert_eq!(
+                baseline, with_wrong,
+                "{kind:?}: mismatched shared acts were not ignored"
+            );
         }
     }
 

--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -1067,8 +1067,13 @@ impl Decoder {
             #[cfg(not(feature = "metal"))]
             let down: Option<Vec<f32>> = None;
             let down = down.unwrap_or_else(|| {
-                let gate = shex.gate.apply_batch(normed2_batch, batch_size);
-                let up = shex.up.apply_batch(normed2_batch, batch_size);
+                let ffn_acts = shex.gate.quantize_batch_acts(normed2_batch, batch_size);
+                let gate =
+                    shex.gate
+                        .apply_batch_with_acts(normed2_batch, batch_size, ffn_acts.as_ref());
+                let up = shex
+                    .up
+                    .apply_batch_with_acts(normed2_batch, batch_size, ffn_acts.as_ref());
                 let activated = ferrox_core::matmul::swiglu(&gate, &up);
                 shex.down.apply_batch(&activated, batch_size)
             });
@@ -2769,8 +2774,13 @@ impl Decoder {
             }
         }
         Some(layer.moe.with_expert(0, |ex| {
-            let gate = ex.gate.apply_batch(normed2_batch, batch_size);
-            let up = ex.up.apply_batch(normed2_batch, batch_size);
+            let ffn_acts = ex.gate.quantize_batch_acts(normed2_batch, batch_size);
+            let gate = ex
+                .gate
+                .apply_batch_with_acts(normed2_batch, batch_size, ffn_acts.as_ref());
+            let up = ex
+                .up
+                .apply_batch_with_acts(normed2_batch, batch_size, ffn_acts.as_ref());
             let activated: Vec<f32> = match config.ffn_activation {
                 crate::config::FfnActivation::Swiglu
                 | crate::config::FfnActivation::SwigluFused => {
@@ -2865,8 +2875,9 @@ impl Decoder {
                     .copy_from_slice(&normed2_batch[tok * hidden_dim..(tok + 1) * hidden_dim]);
             }
             let ex = &experts[eid];
-            let gate = ex.gate.apply_batch(&gathered, n);
-            let up = ex.up.apply_batch(&gathered, n);
+            let ffn_acts = ex.gate.quantize_batch_acts(&gathered, n);
+            let gate = ex.gate.apply_batch_with_acts(&gathered, n, ffn_acts.as_ref());
+            let up = ex.up.apply_batch_with_acts(&gathered, n, ffn_acts.as_ref());
             let activated = ferrox_core::matmul::swiglu(&gate, &up);
             let down = ex.down.apply_batch(&activated, n);
             for (i, &(tok, w)) in toks.iter().enumerate() {
@@ -3241,9 +3252,27 @@ impl Decoder {
                 .flatten()
                 .collect();
 
-            let mut q_batch = layer.attn.q_proj.apply_batch(&normed_batch, batch_size);
-            let mut k_batch = layer.attn.k_proj.apply_batch(&normed_batch, batch_size);
-            let mut v_batch = layer.attn.v_proj.apply_batch(&normed_batch, batch_size);
+            // One shared activation-quant pass for q/k/v (plan 1e): the
+            // three projections read the same normed batch, so quantize it
+            // once instead of once per projection. A kind mismatch inside
+            // the group just re-quantizes locally.
+            let qkv_acts = layer.attn.q_proj.quantize_batch_acts(&normed_batch, batch_size);
+            let mut q_batch =
+                layer
+                    .attn
+                    .q_proj
+                    .apply_batch_with_acts(&normed_batch, batch_size, qkv_acts.as_ref());
+            let mut k_batch =
+                layer
+                    .attn
+                    .k_proj
+                    .apply_batch_with_acts(&normed_batch, batch_size, qkv_acts.as_ref());
+            let mut v_batch =
+                layer
+                    .attn
+                    .v_proj
+                    .apply_batch_with_acts(&normed_batch, batch_size, qkv_acts.as_ref());
+            drop(qkv_acts);
 
             if let Some(bias) = &layer.attn.q_bias {
                 for row in q_batch.chunks_mut(q_width) {
@@ -3774,9 +3803,27 @@ impl Decoder {
                 .flatten()
                 .collect();
 
-            let mut q_batch = layer.attn.q_proj.apply_batch(&normed_batch, batch_size);
-            let mut k_batch = layer.attn.k_proj.apply_batch(&normed_batch, batch_size);
-            let mut v_batch = layer.attn.v_proj.apply_batch(&normed_batch, batch_size);
+            // One shared activation-quant pass for q/k/v (plan 1e): the
+            // three projections read the same normed batch, so quantize it
+            // once instead of once per projection. A kind mismatch inside
+            // the group just re-quantizes locally.
+            let qkv_acts = layer.attn.q_proj.quantize_batch_acts(&normed_batch, batch_size);
+            let mut q_batch =
+                layer
+                    .attn
+                    .q_proj
+                    .apply_batch_with_acts(&normed_batch, batch_size, qkv_acts.as_ref());
+            let mut k_batch =
+                layer
+                    .attn
+                    .k_proj
+                    .apply_batch_with_acts(&normed_batch, batch_size, qkv_acts.as_ref());
+            let mut v_batch =
+                layer
+                    .attn
+                    .v_proj
+                    .apply_batch_with_acts(&normed_batch, batch_size, qkv_acts.as_ref());
+            drop(qkv_acts);
 
             let q_width = n_heads * head_dim;
             let kv_width = n_kv_heads * head_dim;

--- a/crates/ferrox-quant/Cargo.toml
+++ b/crates/ferrox-quant/Cargo.toml
@@ -10,5 +10,4 @@ readme = "README.md"
 
 [dependencies]
 half = { workspace = true }
-rayon = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ferrox-quant/src/lib.rs
+++ b/crates/ferrox-quant/src/lib.rs
@@ -33,7 +33,6 @@ pub use repack::{
 };
 
 use half::f16;
-use rayon::prelude::*;
 
 /// Q8_0: 32 int8 values sharing one f16 scale. 34 bytes per block.
 pub const Q8_0_BLOCK_BYTES: usize = 34;
@@ -686,23 +685,18 @@ pub fn quantize_activations_q8_k(x: &[f32]) -> Q8KActivations {
             bsum_slot[g] = s as i16;
         }
     };
-    if n_blocks >= 4 {
-        q.par_chunks_mut(Q4_K_BLOCK_ELEMS)
-            .zip(d.par_iter_mut())
-            .zip(bsums.par_chunks_mut(16))
-            .zip(x.par_chunks_exact(Q4_K_BLOCK_ELEMS))
-            .for_each(|(((q_slot, d_slot), bsum_slot), chunk)| {
-                quant_one((q_slot, d_slot, bsum_slot, chunk));
-            });
-    } else {
-        for (b, chunk) in x.chunks_exact(Q4_K_BLOCK_ELEMS).enumerate() {
-            quant_one((
-                &mut q[b * Q4_K_BLOCK_ELEMS..(b + 1) * Q4_K_BLOCK_ELEMS],
-                &mut d[b],
-                &mut bsums[b * 16..(b + 1) * 16],
-                chunk,
-            ));
-        }
+    // Serial on purpose: every batch caller is already inside a Rayon
+    // region (one task per activation), so an inner region here nested
+    // ~batch_size fork-joins per matmul; and one row's blocks are far too
+    // little work to amortize one. llama quantizes serially per thread
+    // chunk too (`ggml_compute_forward_mul_mat`, `ggml-cpu.c`).
+    for (b, chunk) in x.chunks_exact(Q4_K_BLOCK_ELEMS).enumerate() {
+        quant_one((
+            &mut q[b * Q4_K_BLOCK_ELEMS..(b + 1) * Q4_K_BLOCK_ELEMS],
+            &mut d[b],
+            &mut bsums[b * 16..(b + 1) * 16],
+            chunk,
+        ));
     }
     Q8KActivations { q, d, bsums }
 }
@@ -726,19 +720,15 @@ pub fn quantize_activations_q8(x: &[f32]) -> Q8Activations {
             q_slot[i] = qi.clamp(-127.0, 127.0) as i8;
         }
     };
-    if n_blocks >= 4 {
-        q.par_chunks_mut(Q8_0_BLOCK_ELEMS)
-            .zip(d.par_iter_mut())
-            .zip(x.par_chunks_exact(Q8_0_BLOCK_ELEMS))
-            .for_each(|((q_slot, d_slot), chunk)| quant_one((q_slot, d_slot, chunk)));
-    } else {
-        for (b, chunk) in x.chunks_exact(Q8_0_BLOCK_ELEMS).enumerate() {
-            quant_one((
-                &mut q[b * Q8_0_BLOCK_ELEMS..(b + 1) * Q8_0_BLOCK_ELEMS],
-                &mut d[b],
-                chunk,
-            ));
-        }
+    // Serial on purpose — see `quantize_activations_q8_k`. The parallel
+    // split this replaces was also 32-byte `q` chunks (two per cache
+    // line) with adjacent `d` writes: false sharing on every store.
+    for (b, chunk) in x.chunks_exact(Q8_0_BLOCK_ELEMS).enumerate() {
+        quant_one((
+            &mut q[b * Q8_0_BLOCK_ELEMS..(b + 1) * Q8_0_BLOCK_ELEMS],
+            &mut d[b],
+            chunk,
+        ));
     }
     Q8Activations { q, d }
 }


### PR DESCRIPTION
Plan item **1e** (`cpu-actquant-flat`), both halves, one commit each. Unlike the kernel PRs, everything here executes on x86, so both changes are fully test-verified in this environment.

## Commit 1 — serial quantization internals

`quantize_activations_q8` / `quantize_activations_q8_k` opened an inner Rayon region whenever a row had ≥ 4 blocks — but every batch caller already runs them from a parallel region with one task per activation, so a 512-position prefill nested ~512 fork-joins per matmul, five matmuls per layer. The Q8_0 split was 32-byte `q` chunks (two per cache line) zipped with `d.par_iter_mut()` writing adjacent f32s — the false sharing called out in the plan. llama quantizes serially per thread chunk (`ggml_compute_forward_mul_mat`); same here now: the serial branch that already existed becomes the only branch. Numerically identical (blocks independent, math unchanged). This leaves **ferrox-quant with zero rayon usage**, so the dependency is dropped from the crate.

## Commit 2 — one quant pass for q/k/v, one for gate/up

Each INT_DOT `apply_batch` quantized its input privately: five passes per dense layer where two suffice (q/k/v share `normed_batch`; gate/up share `normed2_batch`). llama quantizes `src1` once into `wdata` and every matmul over it reuses the bytes.

New API on `WeightMatrix`:
- `quantize_batch_acts(x, n) -> Option<BatchActs>` — quantizes once in the format this matrix's INT_DOT path consumes (`Q8` for Q8_0/Q4_0, `Q8K` for K-quants); `None` whenever `apply_batch` wouldn't use quantized activations (GPU dispatch, INT_DOT off, unsupported kind/width), so callers pass it through unconditionally.
- `apply_batch_with_acts(x, n, shared)` — reuses the shared batch when format and length match; a mismatch (mixed-kind groups, e.g. Q8_0 `k_proj` beside Q4_K `q_proj`) is ignored and the arm re-quantizes locally — results always identical to `apply_batch`.

Wired at all six sharing sites: both batched q/k/v triples and the three gate/up pairs (dense FFN, MoE expert loop, bucketed MoE).

## Verification (all ran here, on x86)

- New `apply_batch_with_shared_acts_matches_apply_batch` pins both behaviors (shared → bit-identical; mismatched → ignored) across Q8_0/Q4_0/Q4_K/Q6_K, green with `FERROX_CPU_INT_DOT` unset **and** `=1`.
- Full workspace: build green, `ferrox-quant` 98 / `ferrox-core` 99 / `ferrox-models` 193 tests green. Under `INT_DOT=1`, the two `loader` q5_k/q6_k end-to-end failures reproduce **identically at HEAD** (pre-existing; that suite documents running with INT_DOT off).
- aarch64 cross-compile clean (`--all-targets`); clippy at baseline both targets.

## Measurement

No kernels changed — this is scheduling/overhead work, so nothing needs the aarch64-gated tests. But it stacks on four unmeasured kernel PRs; per the plan's validation rule the full `ferrox bench --suite --fit-host --skip-missing && ferrox bench --render` ledger diff is due on the M2 Pro. Expected movement: CPU pp512 across the board (nested-region and quant-pass overhead scales with batch), plus a small tg effect via the serial internals on decode.

Remaining Phase 1 after this: 1f (chunked work-stealing over row+batch dims), 1g (blocked prefill attention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013g9h89y6jwpfHX6tcV6wQp

---
_Generated by [Claude Code](https://claude.ai/code/session_013g9h89y6jwpfHX6tcV6wQp)_