### PR TITLE
Fold the last copy of project-and-softcap into logits_from_flat_hidden

### DIFF
--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -4487,23 +4487,12 @@ impl Decoder {
             }
         }
 
-        let vocab_size = self.output_head.rows();
         let final_normed_batch: Vec<f32> = hidden_batch
             .par_chunks(hidden_dim)
             .map(|h| rms_norm(h, &self.final_norm, self.config.rms_norm_eps))
             .flatten()
             .collect();
-        let mut logits_batch = self
-            .output_head
-            .apply_batch(&final_normed_batch, batch_size);
-        if let Some(sc) = self.config.final_logit_softcap {
-            softcap_inplace(&mut logits_batch, sc);
-        }
-
-        logits_batch
-            .chunks(vocab_size)
-            .map(|c| c.to_vec())
-            .collect()
+        self.logits_from_flat_hidden(final_normed_batch, batch_size)
     }
 }
 


### PR DESCRIPTION
Tail of #15, which merged before this commit landed on the branch.

`forward_batch_prefill_multi`'s tail was a fourth copy of the same
rule: `output_head.apply_batch`, then `final_logit_softcap`, then chunk
by vocab. It differs from `logits_from_flat_hidden` only in computing
the final RMS norm itself, which happens before the shared part starts.

With this, every path that turns hidden states into logits goes through
one of the two helpers — `logits_from_normed` for a single row,
`logits_from_flat_hidden` for a batch — so the softcap has one
implementation rather than four. That was the point of #15: the paged
path's missing softcap was a drifted copy, and leaving three more
copies in place leaves the same drift available.

- `cargo test --workspace` — 1803 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Note: #15 merged without CI ever running on it. `.github/workflows/ci.yml`
triggers on `pull_request: branches: [main]`, and #15 was opened against
#12's branch; retargeting it to `main` fires `edited`, which that
workflow does not run on, so no checks were queued. This PR is opened
against `main` from the start, so it gets the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VAuLssGUMmEhpac917e2x

---
_Generated by [Claude Code](https://claude.ai/code/session_015VAuLssGUMmEhpac917e2x)_