### PR TITLE
feat(server): response_format json_schema is served, not refused

### DIFF
--- a/crates/ferrox-models/src/grammar/mod.rs
+++ b/crates/ferrox-models/src/grammar/mod.rs
@@ -42,9 +42,10 @@
 //! stricter than upstream by design -- a keyword it cannot honour is a
 //! typed refusal rather than a grammar that accepts too much -- and its
 //! module docs list what is ported, what is refused by name, and where its
-//! output differs from llama.cpp's. It is not wired into the server
-//! either; `ferrox-server` still answers `response_format: json_schema`
-//! with a 501.
+//! output differs from llama.cpp's. `ferrox-server` now answers
+//! `response_format: {"type": "json_schema"}` through it (see that crate's
+//! `grammar_request`), so a schema and a hand-written grammar reach the
+//! same machine.
 //!
 //! **Lazy grammars** ([`lazy`]) are ported: `trigger_tokens` and
 //! `trigger_patterns`, the accumulated trigger buffer, and the replay that

--- a/crates/ferrox-server/src/completion/mod.rs
+++ b/crates/ferrox-server/src/completion/mod.rs
@@ -294,9 +294,10 @@ pub(crate) struct CompletionRequest {
     /// GBNF, the same field and the same syntax `/v1/completions` takes.
     #[serde(default)]
     grammar: Option<String>,
-    /// Refused through the one site that refuses a JSON schema
-    /// everywhere else, so the converter that closes it has one place
-    /// to land.
+    /// upstream's bare JSON Schema, compiled to a grammar through the
+    /// one site that decides a schema everywhere else. Not a
+    /// `response_format`: llama.cpp's request has no such field, and
+    /// this one carries the schema directly.
     #[serde(default)]
     json_schema: Option<Value>,
     /// Upstream's default is `true`, and `true` is a PERMISSION to reuse
@@ -433,15 +434,6 @@ impl CompletionRequest {
             self.logit_bias.as_ref(),
             ferrox_api::routes::COMPLETION,
         )?;
-        if self.json_schema.is_some() {
-            // Routed through the single site that refuses a schema on
-            // every other surface, so the converter that closes this
-            // has one call site to land in. Its message names
-            // `response_format` because that is the OpenAI spelling;
-            // the remedy it gives -- send the equivalent `grammar` --
-            // is the same one that applies here.
-            crate::grammar_request::for_request(None, Some(&json!({"type": "json_schema"})))?;
-        }
         for option in UNSUPPORTED {
             let sent = self.extra.get(option.field);
             let asked_for_something = match sent {
@@ -470,10 +462,36 @@ impl CompletionRequest {
                  variable to serve requests that require a cold prompt",
             ));
         }
-        // Compiled here so an unparseable grammar is a 400 before any
-        // work happens.
-        crate::grammar_request::for_request(self.grammar.as_deref(), None)?;
+        // Compiled here so an unparseable grammar, or a schema with a
+        // keyword that has none, is a 400 before any work happens.
+        self.constraint()?;
         Ok(())
+    }
+
+    /// The grammar this request runs under, from either field that can
+    /// state one.
+    ///
+    /// One function, called by both [`Self::validate`] and the handler,
+    /// because the two of them disagreeing about which field wins is
+    /// exactly the shape that lets a request be validated against one
+    /// constraint and served under another.
+    ///
+    /// `grammar` and `json_schema` together are refused rather than
+    /// ranked: upstream silently prefers `grammar` and drops the schema,
+    /// which is a 200 whose answer need not match the schema the caller
+    /// sent.
+    fn constraint(&self) -> Result<Option<Arc<ferrox_models::grammar::Grammar>>, ApiError> {
+        match (&self.grammar, &self.json_schema) {
+            (Some(g), Some(_)) if !g.trim().is_empty() => Err(crate::invalid_request(
+                "a \"grammar\" and a \"json_schema\" are two different constraints on the same \
+                 generation; send one",
+                "json_schema",
+            )),
+            (_, Some(schema)) => {
+                crate::grammar_request::from_schema(schema, "json_schema").map(Some)
+            }
+            (grammar, None) => crate::grammar_request::for_request(grammar.as_deref(), None),
+        }
     }
 }
 pub(crate) async fn completion(
@@ -506,7 +524,7 @@ pub(crate) async fn completion(
         seed: req.seed(),
         stop: req.stop.clone().unwrap_or_default(),
         json_object: false,
-        grammar: crate::grammar_request::for_request(req.grammar.as_deref(), None)?,
+        grammar: req.constraint()?,
         stop_token_ids: Vec::new(),
         cancel: None,
         ignore_eos: req.ignore_eos.unwrap_or(false),
@@ -817,6 +835,87 @@ mod tests {
         stock
             .validate(false)
             .expect("every one of these asks for nothing");
+    }
+
+    /// Upstream's bare `json_schema` used to be routed into the 501 that
+    /// said the schema-to-grammar converter was missing. It is compiled
+    /// now, through the same module `response_format` goes through, and
+    /// the evidence is the machine rejecting a document the schema does.
+    #[test]
+    fn a_bare_json_schema_becomes_the_requests_grammar() {
+        let req = request(json!({
+            "prompt": "hi",
+            "json_schema": {
+                "type": "object",
+                "properties": {"ok": {"type": "boolean"}},
+                "required": ["ok"],
+                "additionalProperties": false,
+            },
+        }));
+        req.validate(false).expect("this schema converts");
+        let grammar = req
+            .constraint()
+            .expect("and compiles")
+            .expect("into a grammar");
+        let mut good = (*grammar).clone();
+        good.accept_token(0, br#"{"ok": true}"#)
+            .expect("a schema-valid document");
+        assert!(good.allows_eog(), "and it completes the parse");
+        let mut bad = (*grammar).clone();
+        assert!(
+            bad.accept_token(0, br#"{"ok": "yes""#).is_err(),
+            "a property's own type must be enforced"
+        );
+    }
+
+    /// A schema with no grammar is a 400 naming the keyword, at the same
+    /// seam an unparseable `grammar` is refused at.
+    #[test]
+    fn a_json_schema_with_no_grammar_is_a_400_naming_the_keyword() {
+        let (status, body) = request(json!({
+            "prompt": "hi",
+            "json_schema": {"type": "object", "patternProperties": {"^a": {}}},
+        }))
+        .validate(false)
+        .expect_err("patternProperties has no grammar");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            body.0["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("patternProperties"),
+            "the refusal must name the keyword: {body:?}"
+        );
+    }
+
+    /// Two constraints on one generation. Upstream silently prefers
+    /// `grammar` and drops the schema, which is a 200 whose answer need
+    /// not match the schema the caller sent.
+    #[test]
+    fn a_grammar_and_a_json_schema_together_are_refused() {
+        let (status, body) = request(json!({
+            "prompt": "hi",
+            "grammar": "root ::= \"a\"",
+            "json_schema": {"type": "boolean"},
+        }))
+        .validate(false)
+        .expect_err("two constraints, one generation");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body.0["error"]["param"], "json_schema");
+
+        // Each alone is still served, so the refusal is about the pair.
+        assert!(
+            request(json!({"prompt": "hi", "grammar": "root ::= \"a\""}))
+                .constraint()
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            request(json!({"prompt": "hi", "json_schema": {"type": "boolean"}}))
+                .constraint()
+                .unwrap()
+                .is_some()
+        );
     }
 
     /// And each one refused by name the moment it asks for something.

--- a/crates/ferrox-server/src/grammar_request.rs
+++ b/crates/ferrox-server/src/grammar_request.rs
@@ -1,42 +1,127 @@
 //! Where a request's stated constraint becomes a compiled grammar.
 //!
 //! Exactly one function answers "what grammar does this request run
-//! under", because a request can state the constraint two ways and only
-//! one of them may win:
+//! under", because a request can state the constraint several ways and
+//! only one of them may win:
 //!
 //! | Request field | Today |
 //! |---|---|
 //! | `"grammar": "<GBNF>"` | compiled and applied (llama.cpp's field, same spelling) |
-//! | `response_format: {"type": "json_schema", ...}` | refused, naming what is missing |
+//! | `response_format: {"type": "json_schema", …}` | the `schema` is compiled to GBNF and applied |
+//! | `response_format: {"type": "json_object"}` | not a grammar; the character-class mask in [`crate::json_mode`], decided by the caller of this module |
+//! | `response_format` naming any other `type` | 400, naming the type |
+//! | both a `grammar` and a `json_schema` | 400: two constraints on one generation, send one |
 //!
-//! The second is the one callers actually reach for, and it is one
-//! function away: a JSON schema becomes a GBNF grammar
-//! (`common/json-schema-to-grammar.cpp` upstream), and everything after
-//! that -- masking, accepting, both decode loops, the batcher -- is the
-//! same path `"grammar"` already takes. That converter is a separate
-//! piece of work and is NOT approximated here: emitting a grammar that
-//! is *nearly* the caller's schema would be served with a 200 and read
-//! as compliance.
+//! The schema half used to be a 501, because a JSON schema has to become
+//! a GBNF grammar before any of this can run and that converter did not
+//! exist. It does now --
+//! [`ferrox_models::grammar::json_schema`], a port of llama.cpp's
+//! `common/json-schema-to-grammar.cpp` -- so everything after the
+//! conversion (masking, accepting, both decode loops, the batcher) is the
+//! same path `"grammar"` already took.
 //!
-//! # Why the refusal is not a silent ignore
+//! # What inside `json_schema` is honoured, and what is refused
+//!
+//! The OpenAI object is `{"name": …, "description": …, "schema": {…},
+//! "strict": bool}` and [`JsonSchemaSpec`] is destructured exhaustively,
+//! so a field added to that struct cannot be dropped on the floor:
+//!
+//! | Member | Treatment |
+//! |---|---|
+//! | `schema` | compiled to GBNF; required, because there is nothing to enforce without it |
+//! | `name`, `description` | labels. They constrain nothing, so ignoring them cannot widen or narrow what is accepted |
+//! | `strict: true`, or absent | the schema is ENFORCED by the grammar |
+//! | `strict: false` | 400, naming the field |
+//! | anything else | 400, naming the field (`deny_unknown_fields`) |
+//!
+//! `strict: false` is a refusal rather than a shrug because OpenAI's two
+//! modes are not the same promise: `false` asks for best-effort guidance
+//! and permits schemas strict mode rejects, while this server has exactly
+//! one behaviour for a schema, which is to enforce it token by token.
+//! Serving that under `strict: false` is answering a question the caller
+//! did not ask, and doing it silently is how a client learns the wrong
+//! thing about what its schema bought it. An OMITTED `strict` is enforced
+//! (OpenAI defaults it to `false`, and this table is the notice): a caller
+//! who wrote nothing stated no preference, and the stronger guarantee is
+//! the only one this engine has.
+//!
+//! A schema the converter will not compile is a **400 naming the keyword
+//! and where it sits**, never a 500 and never a grammar that is only
+//! nearly the caller's schema: that would be served with a 200 and read
+//! as compliance. The converter is deliberately stricter than llama.cpp
+//! here -- upstream discards a keyword no branch tested, so
+//! `{"type": "string", "pattern": "^[a-z]+$"}` compiles upstream to a
+//! grammar for *any* string.
+//!
+//! # Property order, stated because it is observable
+//!
+//! The grammar requires an object's `required` members in a fixed order,
+//! the way llama.cpp's does. Upstream that order is the schema's
+//! declaration order; here it is LEXICOGRAPHIC, because a
+//! `response_format` reaches this module as a `serde_json::Value` and this
+//! workspace builds `serde_json` without `preserve_order`, so declaration
+//! order is gone before the converter is called. Both are valid grammars
+//! for the schema and neither accepts a document the schema rejects. This
+//! is the same order [`crate::tool_grammar`] already gives a forced tool
+//! call's `arguments`.
+//!
+//! # Why a refusal is never a silent ignore
 //!
 //! `logit_bias` was declared on these requests only so it could be
 //! refused by name, because serde dropped an undeclared field and the
 //! caller got a 200 whose answer was sampled from unbiased logits. A
-//! `json_schema` that is accepted and not applied is the same failure
-//! with more expensive consequences: the caller parses the answer.
+//! `json_schema` member that is accepted and not applied is the same
+//! failure with more expensive consequences: the caller parses the
+//! answer.
 
 use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum::Json;
-use ferrox_models::grammar::Grammar;
+use ferrox_models::grammar::json_schema::json_schema_to_grammar_value;
+use ferrox_models::grammar::{Grammar, SchemaError};
+use serde::Deserialize;
 
 use crate::ApiError;
 
 /// The root rule name every grammar here starts from. llama.cpp's
 /// convention, and the one every published `.gbnf` uses.
 const ROOT: &str = "root";
+
+/// `response_format`, as the wire spells it.
+///
+/// `deny_unknown_fields` is the point: a member this server does not act
+/// on must be refused by name rather than dropped by serde, and the
+/// derive is the only version of that rule which cannot fall out of date
+/// with the struct.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResponseFormat {
+    /// Optional here only so that its absence is answered with this
+    /// module's own message instead of a serde one.
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
+    #[serde(default)]
+    json_schema: Option<JsonSchemaSpec>,
+}
+
+/// The `json_schema` member of an OpenAI `response_format`.
+///
+/// Every field is destructured in [`schema_grammar`] with no `..`, so
+/// adding one here stops compiling until somebody decides whether it
+/// changes what is accepted.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JsonSchemaSpec {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    schema: Option<serde_json::Value>,
+    #[serde(default)]
+    strict: Option<bool>,
+}
 
 /// Compile GBNF text, or refuse with the parser's own diagnostic.
 ///
@@ -60,45 +145,177 @@ pub(crate) fn compile(src: &str) -> Result<Arc<Grammar>, ApiError> {
         })
 }
 
+/// Compile a bare JSON Schema value to a grammar.
+///
+/// `param` is the field the caller sent it in, so the 400 points at the
+/// request rather than at this module's idea of where a schema lives:
+/// `/v1/chat/completions` spells it `response_format.json_schema.schema`
+/// and llama.cpp's `/completion` spells it `json_schema`.
+pub(crate) fn from_schema(
+    schema: &serde_json::Value,
+    param: &str,
+) -> Result<Arc<Grammar>, ApiError> {
+    let text = json_schema_to_grammar_value(schema).map_err(|e| schema_refused(&e, param))?;
+    // The converter re-parses its own output before returning it, so a
+    // failure here is a defect in the converter and not a fact about
+    // the request. Saying 400 would send the caller looking at a schema
+    // that is fine.
+    Grammar::from_str_with_root(&text, ROOT)
+        .map(Arc::new)
+        .map_err(|e| {
+            internal(format!(
+                "the grammar generated from {param} does not compile: {e}"
+            ))
+        })
+}
+
 /// The grammar one request runs under, from every field that can state
 /// one.
 ///
-/// `response_format` is checked FIRST and refuses rather than falls
-/// through: a request that asked for a schema and also supplied a
-/// grammar has asked for two different constraints, and serving the one
-/// we happen to be able to compile is not answering the question.
+/// A request carrying BOTH a `grammar` and a `response_format` schema has
+/// stated two different constraints on one generation, and serving
+/// whichever we compiled last is not answering either question. That is a
+/// 400, the same way a forced `tool_choice` beside a `grammar` already
+/// is.
 pub(crate) fn for_request(
     grammar: Option<&str>,
     response_format: Option<&serde_json::Value>,
 ) -> Result<Option<Arc<Grammar>>, ApiError> {
-    if let Some(kind) = response_format
-        .and_then(|v| v.get("type"))
-        .and_then(|v| v.as_str())
-    {
-        if kind == "json_schema" {
-            return Err(json_schema_not_implemented());
-        }
-    }
-    match grammar.map(str::trim).filter(|s| !s.is_empty()) {
-        Some(src) => compile(src).map(Some),
-        None => Ok(None),
+    // Whitespace is not a grammar. Left as `None` rather than sent to
+    // the parser, which would 400 on an empty string a client library
+    // sent by defaulting the field.
+    let gbnf = grammar.map(str::trim).filter(|s| !s.is_empty());
+    let from_format = match response_format {
+        Some(fmt) => schema_grammar(fmt)?,
+        None => None,
+    };
+    match (gbnf, from_format) {
+        (Some(_), Some(_)) => Err(two_constraints()),
+        (Some(src), None) => compile(src).map(Some),
+        (None, from_format @ Some(_)) => Ok(from_format),
+        (None, None) => Ok(None),
     }
 }
 
-/// The one place `response_format: json_schema` is refused, so the
-/// converter that closes it has one call site to land in.
-fn json_schema_not_implemented() -> ApiError {
+/// The whole of what a `response_format` says about a grammar.
+///
+/// `Ok(None)` means "this format states no grammar", which today is
+/// `json_object`: that is a character-class mask in [`crate::json_mode`],
+/// decided by this module's caller, and it must not be caught by the
+/// schema arm.
+fn schema_grammar(fmt: &serde_json::Value) -> Result<Option<Arc<Grammar>>, ApiError> {
+    let parsed: ResponseFormat = serde_json::from_value(fmt.clone())
+        .map_err(|e| invalid(format!("response_format: {e}"), "response_format"))?;
+    let ResponseFormat { kind, json_schema } = parsed;
+    match kind.as_deref() {
+        Some("json_schema") => {}
+        Some("json_object") => {
+            if json_schema.is_some() {
+                return Err(invalid(
+                    "response_format carries a \"json_schema\" but asks for type \"json_object\", \
+                     which enforces nothing but the character class; send type \"json_schema\" to \
+                     have the schema enforced",
+                    "response_format",
+                ));
+            }
+            return Ok(None);
+        }
+        Some(other) => {
+            return Err(invalid(
+                format!(
+                    "response_format type {other:?} is not supported (only json_object and \
+                     json_schema)"
+                ),
+                "response_format",
+            ));
+        }
+        None => {
+            return Err(invalid(
+                "response_format must include \"type\" (only json_object and json_schema are \
+                 supported)",
+                "response_format",
+            ));
+        }
+    }
+    let spec = json_schema.ok_or_else(|| {
+        invalid(
+            "response_format type \"json_schema\" carries the schema in a \"json_schema\" object: \
+             {\"type\": \"json_schema\", \"json_schema\": {\"name\": \"…\", \"schema\": {…}}}",
+            "response_format.json_schema",
+        )
+    })?;
+    // Exhaustive, with no `..`: a member added to the wire struct must
+    // be decided here rather than silently accepted and ignored.
+    let JsonSchemaSpec {
+        // Labels. They name the schema for the caller's own logs and
+        // constrain no byte of the answer, so ignoring them cannot make
+        // the grammar accept or reject anything.
+        name: _name,
+        description: _description,
+        schema,
+        strict,
+    } = spec;
+    // `Some(true)` and `None` both enforce -- absent is enforced, and
+    // this module's table says so rather than leaving it to be
+    // discovered. Only the explicit contradiction is refused.
+    if strict == Some(false) {
+        return Err(invalid(
+            "response_format json_schema with \"strict\": false is not supported: this server has \
+             one behaviour for a schema, which is to enforce it with a grammar, and serving that \
+             under a flag asking for best-effort guidance would report a guarantee the caller \
+             declined. Send \"strict\": true to have the schema enforced, or response_format \
+             {\"type\": \"json_object\"} for the best-effort character-class mode.",
+            "response_format.json_schema.strict",
+        ));
+    }
+    let schema = schema.ok_or_else(|| {
+        invalid(
+            "response_format json_schema must carry a \"schema\"; there is nothing to enforce \
+             without one",
+            "response_format.json_schema.schema",
+        )
+    })?;
+    from_schema(&schema, "response_format.json_schema.schema").map(Some)
+}
+
+/// A schema the converter will not compile, reported as what it refused.
+///
+/// [`SchemaError`]'s own `Display` names the keyword and the subschema it
+/// sits in, which is the only thing that makes this fixable from the
+/// client side.
+fn schema_refused(err: &SchemaError, param: &str) -> ApiError {
+    invalid(format!("{param}: {err}"), param)
+}
+
+/// Two constraints, one generation.
+fn two_constraints() -> ApiError {
+    invalid(
+        "a \"grammar\" and a response_format \"json_schema\" are two different constraints on the \
+         same generation; send one",
+        "response_format",
+    )
+}
+
+fn invalid(message: impl Into<String>, param: &str) -> ApiError {
     (
-        StatusCode::NOT_IMPLEMENTED,
+        StatusCode::BAD_REQUEST,
         Json(serde_json::json!({
             "error": {
-                "message":
-                    "response_format json_schema is not implemented: the grammar engine and the \
-                     sampler hook are wired, but converting a JSON schema to a GBNF grammar is \
-                     not. Send the equivalent grammar in the \"grammar\" field, or use \
-                     response_format json_object for the best-effort character-class mode.",
+                "message": message.into(),
                 "type": "invalid_request_error",
-                "param": "response_format",
+                "param": param,
+            }
+        })),
+    )
+}
+
+fn internal(message: String) -> ApiError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({
+            "error": {
+                "message": message,
+                "type": "server_error",
             }
         })),
     )
@@ -107,6 +324,24 @@ fn json_schema_not_implemented() -> ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn schema_format(schema: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "type": "json_schema",
+            "json_schema": {"name": "answer", "schema": schema},
+        })
+    }
+
+    /// Drive `text` through the grammar the way a decode loop would and
+    /// report whether the parse is complete.
+    fn feed(grammar: &Grammar, pieces: &[&str]) -> Result<bool, String> {
+        let mut g = grammar.clone();
+        for (i, piece) in pieces.iter().enumerate() {
+            g.accept_token(i as u32, piece.as_bytes())
+                .map_err(|e| format!("piece {piece:?}: {e}"))?;
+        }
+        Ok(g.allows_eog())
+    }
 
     #[test]
     fn a_gbnf_grammar_compiles_and_starts_at_root() {
@@ -145,19 +380,171 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 
-    /// The seam. It must NOT quietly become "unconstrained", and it
-    /// must not be answered by the `grammar` field either.
+    /// The headline, and what used to be a 501: the schema is not merely
+    /// "some JSON", it is THIS schema. A required property cannot be
+    /// omitted and an `enum` member cannot be invented.
     #[test]
-    fn json_schema_is_refused_by_name_rather_than_ignored() {
-        let fmt = serde_json::json!({"type": "json_schema", "json_schema": {"schema": {}}});
-        let (status, Json(body)) = for_request(None, Some(&fmt)).expect_err("not implemented yet");
-        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
-        let message = body["error"]["message"].as_str().unwrap();
-        assert!(message.contains("JSON schema"), "{message}");
+    fn a_json_schema_compiles_to_a_grammar_that_constrains() {
+        let fmt = schema_format(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "hot": {"type": "boolean"},
+            },
+            "required": ["city", "hot"],
+            "additionalProperties": false,
+        }));
+        let g = for_request(None, Some(&fmt))
+            .expect("this schema converts")
+            .expect("and it states a grammar");
 
-        let (status, _) = for_request(Some(r#"root ::= "a""#), Some(&fmt))
-            .expect_err("two constraints, one of which cannot be honoured");
-        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        assert!(
+            feed(&g, &[r#"{"city": "Rome", "hot": true}"#]).expect("the document is schema-valid"),
+            "a complete document must finish the parse"
+        );
+        assert!(
+            feed(&g, &[r#"{"city": "Rome"}"#]).is_err(),
+            "a required property must not be droppable"
+        );
+        assert!(
+            feed(&g, &[r#"{"city": "Rome", "hot": true, "extra"#]).is_err(),
+            "additionalProperties: false must close the object"
+        );
+        assert!(
+            feed(&g, &[r#"{"city": 3"#]).is_err(),
+            "a property's own type must be enforced"
+        );
+    }
+
+    /// A schema the converter refuses is a 400 that says WHICH keyword,
+    /// not a 500 and not a grammar that is approximately the schema.
+    /// `allOf` is a real keyword with no grammar (schema intersection),
+    /// which is why upstream silently drops it.
+    #[test]
+    fn an_unconvertible_schema_is_a_400_naming_the_keyword() {
+        let fmt = schema_format(serde_json::json!({
+            "type": "object",
+            "properties": {"x": {"allOf": [{"type": "string"}]}},
+        }));
+        let (status, Json(body)) = for_request(None, Some(&fmt)).expect_err("allOf has no grammar");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let message = body["error"]["message"].as_str().expect("a message");
+        assert!(
+            message.contains("allOf"),
+            "the refusal must name the keyword: {message}"
+        );
+        assert_eq!(body["error"]["param"], "response_format.json_schema.schema");
+    }
+
+    /// Two constraints on one generation. Compiling both and serving
+    /// whichever came last answers neither question.
+    #[test]
+    fn a_grammar_and_a_schema_together_are_refused() {
+        let fmt = schema_format(serde_json::json!({"type": "string"}));
+        let (status, Json(body)) = for_request(Some(r#"root ::= "a""#), Some(&fmt))
+            .expect_err("two constraints, one generation");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let message = body["error"]["message"].as_str().expect("a message");
+        assert!(message.contains("two different constraints"), "{message}");
+
+        // Each alone is still fine, so the refusal is about the pair.
+        assert!(for_request(Some(r#"root ::= "a""#), None)
+            .unwrap()
+            .is_some());
+        assert!(for_request(None, Some(&fmt)).unwrap().is_some());
+    }
+
+    /// `strict: false` asks for best-effort guidance, which this server
+    /// does not have. Enforcing anyway and answering 200 would report a
+    /// guarantee the caller explicitly declined.
+    #[test]
+    fn strict_false_is_refused_rather_than_treated_as_strict_true() {
+        let mut fmt = schema_format(serde_json::json!({"type": "string"}));
+        fmt["json_schema"]["strict"] = serde_json::json!(false);
+        let (status, Json(body)) =
+            for_request(None, Some(&fmt)).expect_err("best-effort is not a mode here");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["param"], "response_format.json_schema.strict");
+
+        // `true` and absent both enforce, and absent is the OpenAI
+        // default -- which is why the table in the module docs says so
+        // out loud rather than leaving it to be discovered.
+        fmt["json_schema"]["strict"] = serde_json::json!(true);
+        assert!(for_request(None, Some(&fmt)).unwrap().is_some());
+        let absent = schema_format(serde_json::json!({"type": "string"}));
+        assert!(for_request(None, Some(&absent)).unwrap().is_some());
+    }
+
+    /// Anything inside `json_schema` this server does not act on is
+    /// refused BY NAME. Serde's `deny_unknown_fields` is what makes that
+    /// true of a field nobody has thought of yet.
+    #[test]
+    fn an_unknown_member_of_json_schema_is_refused_by_name() {
+        let mut fmt = schema_format(serde_json::json!({"type": "string"}));
+        fmt["json_schema"]["max_depth"] = serde_json::json!(3);
+        let (status, Json(body)) =
+            for_request(None, Some(&fmt)).expect_err("nothing honours max_depth");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let message = body["error"]["message"].as_str().expect("a message");
+        assert!(message.contains("max_depth"), "{message}");
+
+        // And the same at the top level of `response_format`.
+        let stray = serde_json::json!({"type": "json_object", "schema": {"type": "string"}});
+        let (status, Json(body)) = for_request(None, Some(&stray)).expect_err(
+            "`schema` is not a \
+             member of response_format",
+        );
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body["error"]["message"]
+            .as_str()
+            .expect("a message")
+            .contains("schema"));
+    }
+
+    /// `name` and `description` are labels; honouring them by ignoring
+    /// them is safe precisely because they constrain nothing, and the
+    /// grammar must be the same with or without them.
+    #[test]
+    fn the_label_members_do_not_change_the_grammar() {
+        let schema = serde_json::json!({"type": "boolean"});
+        let bare = serde_json::json!({"type": "json_schema", "json_schema": {"schema": schema}});
+        let labelled = serde_json::json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "yes_or_no",
+                "description": "whether the answer is yes",
+                "schema": schema,
+                "strict": true,
+            },
+        });
+        for fmt in [&bare, &labelled] {
+            let g = for_request(None, Some(fmt)).unwrap().expect("a grammar");
+            assert!(feed(&g, &["true"]).unwrap());
+            assert!(
+                feed(&g, &["\"true\""]).is_err(),
+                "a boolean is not a string"
+            );
+        }
+    }
+
+    /// A `json_schema` type with nothing to compile is a 400 naming the
+    /// member that is missing, not a grammar for "any JSON".
+    #[test]
+    fn a_json_schema_format_with_no_schema_is_refused() {
+        let empty = serde_json::json!({"type": "json_schema"});
+        let (status, Json(body)) =
+            for_request(None, Some(&empty)).expect_err("there is no schema here");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["param"], "response_format.json_schema");
+
+        let no_schema = serde_json::json!({
+            "type": "json_schema",
+            "json_schema": {"name": "answer"},
+        });
+        let (status, Json(body)) =
+            for_request(None, Some(&no_schema)).expect_err("still nothing to enforce");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["param"], "response_format.json_schema.schema");
     }
 
     /// `json_object` is a different feature (a character-class mask) and
@@ -166,5 +553,57 @@ mod tests {
     fn json_object_is_not_the_schema_arm() {
         let fmt = serde_json::json!({"type": "json_object"});
         assert!(for_request(None, Some(&fmt)).unwrap().is_none());
+        // And it composes with a `grammar` exactly as it did before the
+        // schema arm existed: the mask is not a grammar, so there is no
+        // pair of constraints to refuse.
+        assert!(for_request(Some(r#"root ::= "a""#), Some(&fmt))
+            .unwrap()
+            .is_some());
+    }
+
+    /// A `response_format` this server cannot honour is refused by the
+    /// type it named, and a `response_format` with no type at all says
+    /// so, rather than being read as "unconstrained".
+    #[test]
+    fn an_unknown_response_format_type_is_refused_by_name() {
+        let text = serde_json::json!({"type": "text"});
+        let (status, Json(body)) =
+            for_request(None, Some(&text)).expect_err("chat has no text arm");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body["error"]["message"]
+            .as_str()
+            .expect("a message")
+            .contains("\"text\""));
+
+        let typeless = serde_json::json!({});
+        let (status, Json(body)) =
+            for_request(None, Some(&typeless)).expect_err("there is no type");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body["error"]["message"]
+            .as_str()
+            .expect("a message")
+            .contains("must include"));
+    }
+
+    /// The bare-schema entry point llama.cpp's `/completion` uses names
+    /// the field the caller actually sent, so the 400 points at the
+    /// request rather than at an OpenAI path that request never had.
+    #[test]
+    fn the_bare_schema_entry_point_names_the_callers_own_field() {
+        let good = from_schema(&serde_json::json!({"type": "integer"}), "json_schema")
+            .expect("integers have a grammar");
+        assert!(feed(&good, &["42"]).unwrap());
+
+        let (status, Json(body)) = from_schema(
+            &serde_json::json!({"type": "object", "minProperties": 1}),
+            "json_schema",
+        )
+        .expect_err("minProperties has no grammar");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["param"], "json_schema");
+        assert!(body["error"]["message"]
+            .as_str()
+            .expect("a message")
+            .contains("minProperties"));
     }
 }

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -1188,10 +1188,11 @@ struct ChatCompletionRequest {
     ///
     /// llama.cpp's field, spelled the same way, because a client that
     /// already builds a grammar for `llama-server` should not have to
-    /// build a second one. Not an OpenAI field: OpenAI states this as
-    /// `response_format: {"type": "json_schema"}`, which needs a
-    /// schema-to-grammar converter that does not exist yet -- see
-    /// [`crate::grammar_request`], where both spellings are resolved.
+    /// build a second one. Not an OpenAI field: OpenAI states the same
+    /// constraint as `response_format: {"type": "json_schema"}`, which
+    /// is now compiled through the same grammar engine. Sending BOTH is
+    /// two constraints on one generation and is refused -- see
+    /// [`crate::grammar_request`], where every spelling is resolved.
     #[serde(default)]
     grammar: Option<String>,
 }
@@ -1491,44 +1492,22 @@ impl ChatCompletionRequest {
             ));
         }
         unsupported_sampling::refuse_logit_bias(self.logit_bias.as_ref(), "/v1/chat/completions")?;
-        // Both spellings of "constrain the output", resolved by the one
-        // function that knows the rule -- refusing `json_schema` by
-        // name, and compiling a `grammar` here so a grammar that does
-        // not parse is a 400 before any prompt is rendered. The result
-        // is thrown away and recompiled in `generation_params`, which
-        // is the only other caller: a grammar is a small parse, and one
-        // rule in two places would be two rules soon enough.
-        grammar_request::for_request(self.grammar.as_deref(), self.response_format.as_ref())?;
-        if let Some(fmt) = &self.response_format {
-            match fmt.get("type").and_then(|v| v.as_str()) {
-                Some("json_object") => {}
-                // `json_schema` never reaches here: `for_request` above
-                // refuses it with the 501 that names the missing
-                // converter, rather than the 400 this arm would give.
-                Some(other) => {
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        Json(serde_json::json!({
-                            "error": {
-                                "message": format!(
-                                    "response_format type {other:?} is not supported (only json_object)"
-                                )
-                            }
-                        })),
-                    ));
-                }
-                None => {
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        Json(serde_json::json!({
-                            "error": {
-                                "message": "response_format must include \"type\" (only json_object is supported)"
-                            }
-                        })),
-                    ));
-                }
-            }
-        }
+        // Every spelling of "constrain the output", resolved by the one
+        // function that knows the rule: `grammar` is compiled and a
+        // `response_format` is decided in full -- its schema converted,
+        // its unhonoured members refused by name, its unknown types
+        // refused by the type they named. Done here so all of that is a
+        // 400 before any prompt is rendered. The result is recompiled in
+        // `generation_params`, which is the only other caller: a grammar
+        // is a small parse, and one rule in two places would be two
+        // rules soon enough.
+        //
+        // Kept as ONE call rather than a second `match` on
+        // `response_format` beside it. The one that used to be here
+        // answered `json_schema` with "only json_object is supported"
+        // and had to be kept in step with the module by hand.
+        let stated_grammar =
+            grammar_request::for_request(self.grammar.as_deref(), self.response_format.as_ref())?;
         // A forced `tool_choice` is served by compiling the offered tools
         // into a grammar (`tool_grammar`). What can be checked without
         // knowing which checkpoint is loaded is checked here, so the
@@ -1555,10 +1534,17 @@ impl ChatCompletionRequest {
             }
             // Two different constraints on one generation. Serving the
             // one we happen to compile last is not answering either.
-            if self.grammar.is_some() {
+            //
+            // Asked of the RESOLVED grammar rather than of
+            // `self.grammar`: a `response_format` json_schema states one
+            // too, and a check spelled against one field would have let
+            // the other through -- `generation_params_for_template`
+            // overwrites `params.grammar` with the tool-call grammar on
+            // the strength of this refusal having happened.
+            if stated_grammar.is_some() {
                 return Err(invalid_request(
-                    "a forced tool_choice and a \"grammar\" are two different constraints on the \
-                     same generation; send one",
+                    "a forced tool_choice and a \"grammar\" or response_format \"json_schema\" \
+                     are two different constraints on the same generation; send one",
                     "tool_choice",
                 ));
             }
@@ -7770,29 +7756,87 @@ mod tests {
         assert!(req.generation_params().is_err(), "and again at params time");
     }
 
-    /// `response_format: json_schema` is refused by name, with the 501
-    /// that says which half is missing -- not the 400 that reads as
-    /// "this server does not do structured output", which is no longer
-    /// true, and not a 200 carrying unconstrained text.
+    /// `response_format: json_schema` used to be a 501 naming the
+    /// missing converter. It is served now, and the request-level
+    /// evidence is that the schema reaches `generation_params` as a
+    /// grammar -- there is exactly one place a `response_format` is
+    /// decided, so a route that validated it and then forgot to apply
+    /// it is the failure this asserts against.
     #[test]
-    fn response_format_json_schema_names_the_missing_converter() {
+    fn response_format_json_schema_becomes_the_requests_grammar() {
         let req = chat_request(serde_json::json!({
             "model": "m",
             "messages": [{"role": "user", "content": "hi"}],
             "response_format": {
                 "type": "json_schema",
-                "json_schema": {"name": "x", "schema": {"type": "object"}},
+                "json_schema": {"name": "x", "schema": {"type": "boolean"}},
+            },
+        }));
+        req.validate_supported_fields()
+            .expect("a boolean schema converts");
+        let params = req.generation_params().expect("and compiles");
+        let grammar = params.grammar.expect("the schema is the grammar");
+        let mut g = (*grammar).clone();
+        g.accept_token(0, b"true").expect("a boolean is accepted");
+        assert!(g.allows_eog(), "and completes the parse");
+        assert!(
+            !params.json_object,
+            "a schema is not the json_object character-class mask"
+        );
+    }
+
+    /// A schema the converter will not compile is a 400 naming the
+    /// keyword, at both the validation and the params seam -- never a
+    /// 500, and never a grammar that is approximately the schema.
+    #[test]
+    fn an_unconvertible_response_format_schema_is_a_400_naming_the_keyword() {
+        let req = chat_request(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "x", "schema": {"type": "integer", "minimum": 3}},
             },
         }));
         let (status, Json(body)) = req
             .validate_supported_fields()
-            .expect_err("not implemented yet");
-        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
-        let message = body["error"]["message"].as_str().expect("a message");
+            .expect_err("minimum has no grammar in this port");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(
-            message.contains("JSON schema") && message.contains("grammar"),
-            "the refusal must say what is missing: {message}"
+            body["error"]["message"]
+                .as_str()
+                .expect("a message")
+                .contains("minimum"),
+            "the refusal must name the keyword: {body}"
         );
+        assert!(req.generation_params().is_err(), "and again at params time");
+    }
+
+    /// A forced `tool_choice` and a `response_format` schema are two
+    /// constraints on one generation. The refusal used to be spelled
+    /// against `self.grammar` alone, so the schema spelling walked past
+    /// it and `generation_params_for_template` overwrote the schema's
+    /// grammar with the tool-call one.
+    #[test]
+    fn a_forced_tool_choice_and_a_schema_are_two_constraints() {
+        let req = chat_request(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "required",
+            "tools": [{
+                "type": "function",
+                "function": {"name": "f", "parameters": {"type": "object"}},
+            }],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "x", "schema": {"type": "boolean"}},
+            },
+        }));
+        let (status, Json(body)) = req
+            .validate_supported_fields()
+            .expect_err("two constraints, one generation");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["param"], "tool_choice");
     }
 
     /// A chat client that omits `max_tokens` wants an answer, not

--- a/crates/ferrox-server/src/tool_grammar.rs
+++ b/crates/ferrox-server/src/tool_grammar.rs
@@ -20,10 +20,10 @@
 //!
 //! `tool-<name>-args` is the tool's own `parameters` JSON Schema, run
 //! through [`ferrox_models::grammar::json_schema`] -- the same converter
-//! the CLI's `-j` / `--json-schema` uses, `pattern` included. (The HTTP
-//! `response_format: json_schema` field is still a 501; see
-//! `grammar_request`. The converter is not what is missing there.) So the
-//! arguments are not merely well-formed JSON: a `required` property that
+//! the CLI's `-j` / `--json-schema` uses, `pattern` included, and the same
+//! one `response_format: {"type": "json_schema"}` goes through in
+//! [`crate::grammar_request`]. So the arguments are not merely
+//! well-formed JSON: a `required` property that
 //! the schema declares is a property the model cannot omit, and an `enum`
 //! is a choice it cannot invent a member of.
 //!

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,6 +54,20 @@ fixture-away / one-match-arm / new-code / unknown.
 Landed but not reachable yet: the reranker classification head
 (`ferrox_models::rank_head`) has no `/v1/rerank` route.
 
+## Tracked as issues
+
+Open work now has a GitHub issue each, so nothing depends on a person
+remembering it. How work lands is written down in
+[`plans/contribution-workflow.md`](plans/contribution-workflow.md): a
+completed feature is a branch and a pull request, a defect is an issue,
+and the two are never the same artifact.
+
+| # | What |
+|---|---|
+| [#27](https://github.com/antonellof/ferrox/issues/27) | CPU decode is scheduling-bound. rayon fork-join per operation where llama.cpp parks a persistent pool on a spin barrier: ~75% of decode time at 135M, ~9% at 8B |
+| [#28](https://github.com/antonellof/ferrox/issues/28) | No `/tokenize` or `/detokenize`, so an encoder model's embedding cannot be debugged without a second tool |
+| [#29](https://github.com/antonellof/ferrox/issues/29) | A forced `tool_choice` works on 3 of the 11 wire formats ferrox already parses; the other 8 answer 501 |
+
 ## Speed gaps against llama.cpp
 
 Closed since the last pass over this list: bench last-token `lm_head`


### PR DESCRIPTION
## What was wrong

`response_format: {"type": "json_schema", ...}` was a **501** whose message said
the schema-to-GBNF converter did not exist. It does — `ferrox_models::grammar::json_schema`
ships, and `tool_grammar.rs` already compiles a tool's `parameters` through it,
`pattern` included. The refusal was naming a gap that had closed, so callers
reaching for the only structured-output field OpenAI has were told to hand-write
GBNF instead. `grammar_request.rs`'s module doc table said the same thing.

## What it does now

The schema is compiled to a grammar and applied by the same masking path
`"grammar"` already took. `grammar_request::for_request` stays **the one function
that decides what a request runs under**, and it now decides the *whole* of
`response_format` rather than half of it: the second `match` on
`response_format["type"]` in `ChatCompletionRequest::validate_supported_fields`
is deleted, because it answered `json_schema` with *"only json_object is
supported"* and had to be kept in step with this module by hand. Classic
two-structures-that-must-agree.

Refused **by name**, never ignored:

| Input | Result |
|---|---|
| an unknown member of `json_schema` | 400 naming it (`deny_unknown_fields` + an exhaustive destructure with no `..`) |
| `strict: false` | 400 naming the field |
| a schema the converter will not compile | 400 carrying `SchemaError`'s own text — the keyword *and* the subschema it sits in |
| a `grammar` **and** a schema | 400: two constraints on one generation, send one |
| any other `response_format` type / a missing `type` | 400 naming the type |

`strict: false` is a refusal rather than a shrug: OpenAI's two modes are not the
same promise (false asks for best-effort guidance and permits schemas strict mode
rejects), and this server has exactly one behaviour for a schema, which is to
enforce it token by token. Serving that under `strict: false` reports a guarantee
the caller declined. An **omitted** `strict` is enforced, and the module doc table
states that out loud rather than leaving it to be discovered.

A schema the converter refuses is never a 500 and never a grammar that is
*approximately* the caller's schema — that would be served with a 200 and read as
compliance.

`response_format: {"type": "json_object"}` is untouched: it is a character-class
mask, not a grammar, so it still returns no grammar here and still composes with
`grammar`.

### Two things carried along, because they were made wrong by this change

- The forced-`tool_choice` refusal is re-spelled against the **resolved** grammar
  instead of `self.grammar`. `generation_params_for_template` overwrites
  `params.grammar` with the tool-call grammar *on the strength of that refusal
  having happened*; asked of one field, the schema spelling would have walked
  past it and lost the caller's schema silently.
- llama.cpp's `/completion` carries a bare `json_schema` field that was routed
  into the same 501. It is compiled now, through the same module, and `grammar` +
  `json_schema` together is refused rather than ranked (upstream prefers `grammar`
  and drops the schema — a 200 whose answer need not match what the caller sent).
  `validate()` and the handler both go through one `constraint()`, so a request
  cannot be validated against one constraint and served under another.

Two doc comments that this change made false are corrected in place:
`tool_grammar.rs`'s "still a 501" and `ferrox-models/src/grammar/mod.rs`'s
"not wired into the server either".

## Evidence

14 new tests, **each sabotaged once and confirmed red**:

- schema ignored → 5 red; `deny_unknown_fields` dropped → 1; `strict:false` check
  removed → 1; refusal turned into a 500 → 2; `json_object` routed into the schema
  arm → 1; unknown/missing type ignored → 1; missing `schema` defaulted to `{}` → 1
- `generation_params` forgetting `response_format` → 2 red;
  `validate_supported_fields` not resolving → 2; the `tool_choice` check
  re-spelled against `self.grammar` → 1; `/completion` dropping `json_schema` → 3

The schema tests drive real documents through the compiled machine rather than
asserting on a status code: a dropped required property, an invented additional
property and a wrong-typed value all fail to parse.

## What would have to be true for this to be wrong

The converter's grammar would have to accept a document the schema rejects, or
reject one it accepts. Two things guard that and neither is "it compiles": the
converter re-parses its own output before returning, and it is stricter than
llama.cpp by design — a keyword no branch consumed is a typed refusal, where
upstream discards it and silently widens the grammar.

One observable difference from llama.cpp is stated in the module docs: `required`
members are enforced in **lexicographic** order, not declaration order, because a
`response_format` reaches this module as a `serde_json::Value` and this workspace
builds `serde_json` without `preserve_order`. Both are valid grammars for the
schema and neither accepts a document the schema rejects. It is the same order
`tool_grammar` already gives a forced call's `arguments`.

## Gates

`cargo build --workspace` · `cargo test --workspace` (51 suites ok, 0 failed) ·
`cargo clippy --workspace --all-targets -- -D warnings` · the same `--release` ·
`cargo fmt --all` — all run in an isolated worktree at this commit.

## Docs delta (NOT applied — another agent owns `docs/`)

**`docs/API.md:71`** — replace

```
| `response_format: json_schema` | **501**, naming the missing schema-to-grammar step |
```

with

```
| `response_format: json_schema` | Supported. The `json_schema.schema` is compiled to GBNF and enforced per token. `strict: false` and any unknown member of the `json_schema` object are refused **by name**; a schema the converter cannot compile is a 400 naming the keyword |
```

**`docs/API.md:~1072`** — replace the paragraph

```
`response_format: {"type": "json_schema"}` returns **501** naming the
schema-to-grammar conversion as the missing piece, rather than an
unexplained 400, and it refuses even when a `grammar` is supplied
alongside, rather than quietly honouring a different constraint than the
one asked for.
```

with

```
`response_format: {"type": "json_schema", "json_schema": {"name": …,
"schema": {…}, "strict": true}}` is compiled to GBNF by the same
converter `tool_choice` uses and enforced by the same stack machine, so
a `required` property cannot be omitted and an `enum` cannot be
invented. `name` and `description` are labels and constrain nothing.

Everything inside `json_schema` that this server does not act on is
refused **by name** rather than dropped: an unknown member is a 400
naming it, and `strict: false` is a 400 too. OpenAI's `strict: false`
asks for best-effort guidance and permits schemas strict mode rejects,
while ferrox has one behaviour for a schema — enforce it token by token
— so serving that under `strict: false` would report a guarantee the
caller declined. An **omitted** `strict` is enforced.

A schema the converter will not compile is a 400 naming the keyword and
the subschema it sits in, never a 500 and never a grammar that is only
nearly the caller's schema. The converter is stricter than llama.cpp's
on purpose: upstream discards a keyword no branch tested, so
`{"type": "string", "pattern": "^[a-z]+$"}` compiles upstream to a
grammar for *any* string.

A `grammar` and a `json_schema` in one request are two different
constraints on one generation and are refused (400), rather than one of
them being quietly honoured. A forced `tool_choice` beside either is
refused the same way.

One observable difference from llama.cpp: `required` members are
enforced in lexicographic order rather than the schema's declaration
order, because the request body reaches the converter as a parsed value
and this workspace builds `serde_json` without `preserve_order`. Both
are valid grammars for the schema.
```

**`docs/API.md:981-982`** — replace

```
Also refused: `logit_bias` (through the same rule both OpenAI routes
use), `json_schema` (through the same site that refuses
`response_format: json_schema`), token-id prompts, multiple prompts in
one request, and `prompt.multimodal_data`.
```

with

```
Also refused: `logit_bias` (through the same rule both OpenAI routes
use), token-id prompts, multiple prompts in one request, and
`prompt.multimodal_data`.

`json_schema` is llama.cpp's bare-schema field and is **supported**,
compiled through the same site as `response_format: json_schema`. A
`grammar` and a `json_schema` in one request are refused (400) rather
than ranked; upstream prefers `grammar` and drops the schema, which is
a 200 whose answer need not match the schema the caller sent.
```

**`docs/API.md:~1108` ("Not yet")** — delete the clause

```
`response_format: json_schema` (GBNF grammars
themselves *are* supported, see above, and `tool_choice` uses the
schema converter, only this wire spelling is unwired) ·
```

so the section reads `Image and audio input · MCP tool invocation …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
