### PR TITLE
docs: response_format json_schema is served, so stop documenting the 501

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -68,7 +68,7 @@ conversation or a large `/v1/embeddings` batch past that comes back
 | `logprobs` / `top_logprobs` / `n` (>1) | **Reject** |
 | `response_format: json_object` | Supported (best-effort character mask + validate) |
 | `grammar` | Supported. llama.cpp's own field: a GBNF string, enforced per token by a real parser |
-| `response_format: json_schema` | **501**, naming the missing schema-to-grammar step |
+| `response_format: json_schema` | Supported. The `json_schema.schema` is compiled to GBNF and enforced per token. `strict: false` and any unknown member of the `json_schema` object are refused **by name**; a schema the converter cannot compile is a 400 naming the keyword |
 | Other `response_format` types | **Reject** |
 | `session_id` | Ferrox extension (server-side history) |
 | `chat_template_kwargs` | Supported (see [Chat templates](#chat-templates)) |
@@ -978,9 +978,14 @@ rather than shifting context, so there is nothing to protect) ·
 · `sse_ping_interval` (the keepalive is fixed at 15s).
 
 Also refused: `logit_bias` (through the same rule both OpenAI routes
-use), `json_schema` (through the same site that refuses
-`response_format: json_schema`), token-id prompts, multiple prompts in
-one request, and `prompt.multimodal_data`.
+use), token-id prompts, multiple prompts in one request, and
+`prompt.multimodal_data`.
+
+`json_schema` is llama.cpp's bare-schema field and is **supported**,
+compiled through the same site as `response_format: json_schema`. A
+`grammar` and a `json_schema` in one request are refused (400) rather
+than ranked; upstream prefers `grammar` and drops the schema, which is
+a 200 whose answer need not match the schema the caller sent.
 
 Options that only *parameterise* a switched-off sampler (
 `mirostat_tau`, `mirostat_eta`, `dry_base`, `dry_allowed_length`,
@@ -1069,11 +1074,37 @@ while still unsatisfied is an error, and it is a 400 with
 is scoped to the row that hit it; other requests in the batch keep
 running.
 
-`response_format: {"type": "json_schema"}` returns **501** naming the
-schema-to-grammar conversion as the missing piece, rather than an
-unexplained 400, and it refuses even when a `grammar` is supplied
-alongside, rather than quietly honouring a different constraint than the
-one asked for.
+`response_format: {"type": "json_schema", "json_schema": {"name": ...,
+"schema": {...}, "strict": true}}` is compiled to GBNF by the same
+converter `tool_choice` uses and enforced by the same stack machine, so
+a `required` property cannot be omitted and an `enum` cannot be
+invented. `name` and `description` are labels and constrain nothing.
+
+Everything inside `json_schema` that this server does not act on is
+refused **by name** rather than dropped: an unknown member is a 400
+naming it, and `strict: false` is a 400 too. OpenAI's `strict: false`
+asks for best-effort guidance and permits schemas that strict mode
+rejects. ferrox has one behaviour for a schema, which is to enforce it
+token by token, so serving that under `strict: false` would report a
+guarantee the caller declined. An **omitted** `strict` is enforced.
+
+A schema the converter will not compile is a 400 naming the keyword and
+the subschema it sits in, never a 500 and never a grammar that is only
+nearly the caller's schema. The converter is stricter than llama.cpp's
+on purpose: upstream discards a keyword no branch tested, so
+`{"type": "string", "pattern": "^[a-z]+$"}` compiles upstream to a
+grammar for *any* string.
+
+A `grammar` and a `json_schema` in one request are two different
+constraints on one generation and are refused (400), rather than one of
+them being quietly honoured. A forced `tool_choice` beside either is
+refused the same way.
+
+One observable difference from llama.cpp: `required` members are
+enforced in lexicographic order rather than the schema's declaration
+order, because the request body reaches the converter as a parsed value
+and this workspace builds `serde_json` without `preserve_order`. Both
+are valid grammars for the schema.
 
 `tool_choice: "required"` and a named `tool_choice` are supported, by a
 lazy grammar built from the request's own `tools`. Each tool's
@@ -1105,9 +1136,7 @@ cannot read back.
 
 ## Not yet
 
-Image and audio input · `response_format: json_schema` (GBNF grammars
-themselves *are* supported, see above, and `tool_choice` uses the
-schema converter, only this wire spelling is unwired) · MCP tool
+Image and audio input · MCP tool
 invocation
 (the config is read, nothing is called) · embedding architectures other
 than `bert` (they refuse by name, see above) ·

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -182,11 +182,14 @@ OpenAI-compatible HTTP API:
   truncation filters, as llama.cpp orders it, and the repetition penalty
   is applied once per candidate rather than once per occurrence. Both
   routes read the same knobs through one `SamplingKnobs::resolve`
-- Grammar-constrained decoding: llama.cpp's own `grammar` field, a GBNF
-  string enforced on every token by a stack machine, on chat and
-  completions and on all three decode paths. `response_format:
-  json_object` is still the best-effort character mask, and the two
-  compose
+- Grammar-constrained decoding, in every spelling: llama.cpp's own
+  `grammar` field, OpenAI's `response_format: json_schema`, llama.cpp's
+  bare `json_schema` field on `/completion`, and a forced `tool_choice`.
+  A schema is compiled to GBNF first, so all of them end at one stack
+  machine that masks every token which cannot continue a valid string,
+  on chat and completions and all three decode paths. Two constraints in
+  one request are refused rather than ranked. `response_format:
+  json_object` is still the best-effort character mask, and composes
 - Continuous batching and chunked prefill
 - Paged KV: shared page storage many requests read through a block
   table, with a radix tree over reference-counted page groups so

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,6 +44,11 @@ fixture-away / one-match-arm / new-code / unknown.
 - **Lazy grammars**, so `tool_choice: "required"` and a named
   `tool_choice` are enforced rather than asked for in the prompt
 - **`pattern` in the JSON-schema-to-GBNF converter**
+- **`response_format: json_schema`** is served rather than refused, and
+  the second decision site that answered it with "only json_object is
+  supported" is deleted. A forced `tool_choice` beside a schema is now
+  refused against the *resolved* grammar: the check asked `self.grammar`
+  and a schema would have walked past it
 - **The GGUF parser is bounded against a hostile file** (#24, #25, #26):
   every count, string length, array length and nesting depth is checked
   against what the file can actually contain, rather than against a
@@ -118,12 +123,12 @@ Beyond closing the measured gaps.
    dp4a/MMQ integer path and the other five quant kinds, is the work.
 5. **Tool calling and full OpenAI API compatibility.** See
    [`API.md`](API.md). GBNF grammars and the lazy grammars behind a
-   forced `tool_choice` both ship. What is left is
-   `response_format: json_schema` (a 501 today, though the
-   schema-to-GBNF converter it needs already exists, and is what a
-   forced `tool_choice` compiles its arguments with), a forced
+   forced `tool_choice` both ship, and so does
+   `response_format: json_schema`, through the same converter a forced
+   `tool_choice` compiles its arguments with. What is left is a forced
    `tool_choice` on the eight wire formats that are not JSON-object
-   shaped, and MCP invocation.
+   shaped ([#29](https://github.com/antonellof/ferrox/issues/29)), and
+   MCP invocation.
 6. **Docker images**, so evaluating any of this stops requiring a Rust
    toolchain.
 
@@ -152,10 +157,12 @@ Beyond closing the measured gaps.
   format. What is left here is those eight, argument deltas for the six
   JSON-payload formats, and streamed tool calls on the
   continuous-batching path
-- JSON-schema constrained decoding. The GBNF engine and the `grammar`
-  request field shipped on 2026-09-01, on chat, completions and all
-  three decode paths; `response_format: json_schema` still answers 501
-  naming the schema-to-grammar step
+- JSON-schema constrained decoding, **done**. The GBNF engine and the
+  `grammar` request field shipped on 2026-09-01, on chat, completions
+  and all three decode paths; `response_format: json_schema` and
+  llama.cpp's bare `json_schema` field followed on 2026-09-02, compiled
+  by the same converter and decided at the one site that resolves every
+  spelling of "constrain the output"
 - MCP tool invocation. Anthropic streaming and tools now ship
 - The rest of the OpenAI API surface (see [`API.md`](API.md))
 - Docker images (CPU, Metal and CUDA variants)


### PR DESCRIPTION
The doc half of #38, split out because that PR ran while another agent could have been in `docs/`, and two branches editing one file is this project's most reliable way to produce a merge nobody can review.

Applies the delta #38 stated in its body: the API.md matrix row, the paragraph naming the missing converter, `/completion`'s bare `json_schema` field, and the "Not yet" clause. Plus the two documents that had gone stale on their own: FEATURES.md's grammar bullet, which listed only llama.cpp's `grammar` field when four spellings now reach the same stack machine, and ROADMAP.md, which still had this as pending work in two places.

Two things recorded because they will otherwise be rediscovered as bugs. `strict: false` is a 400, not a downgrade to best-effort, since this server has exactly one behaviour for a schema. And `required` members are enforced in lexicographic rather than declaration order, because the body reaches the converter as a parsed value and this workspace builds `serde_json` without `preserve_order`; both are valid grammars for the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN