### PR TITLE
feat(server): /v1/rerank runs the checkpoint's own classification head

### DIFF
--- a/crates/ferrox-api/src/routes.rs
+++ b/crates/ferrox-api/src/routes.rs
@@ -56,6 +56,26 @@ pub const TOKENIZE: &str = "/tokenize";
 pub const DETOKENIZE: &str = "/detokenize";
 pub const V1_EMBEDDINGS: &str = "/v1/embeddings";
 
+/// Cross-encoder reranking: one query against N documents, scored by
+/// the checkpoint's own classification head (`cls` / `cls.output`), not
+/// by the cosine similarity of two embeddings.
+///
+/// The path Cohere and Jina clients use, and one of the four llama.cpp
+/// mounts. Not an OpenAI endpoint at all -- OpenAI has no reranker --
+/// so the request and response shapes follow Jina/Cohere, which is what
+/// every existing client already speaks.
+pub const V1_RERANK: &str = "/v1/rerank";
+
+/// llama.cpp's unprefixed spelling of [`V1_RERANK`], mounted on the
+/// same handler (`tools/server/server.cpp` registers `/rerank`,
+/// `/reranking`, `/v1/rerank` and `/v1/reranking`).
+///
+/// Same reasoning as [`TOKENIZE`]: the client's configured URL should
+/// work unchanged rather than 404 on a prefix ferrox chose. Unlike
+/// [`COMPLETION`], this one really is an alias -- same dialect, same
+/// body, same response.
+pub const RERANK: &str = "/rerank";
+
 /// Anthropic-compatible messages endpoint.
 pub const V1_MESSAGES: &str = "/v1/messages";
 
@@ -210,6 +230,8 @@ pub const ALL: &[&str] = &[
     TOKENIZE,
     DETOKENIZE,
     V1_EMBEDDINGS,
+    V1_RERANK,
+    RERANK,
     V1_MESSAGES,
     V1_MESSAGES_COUNT_TOKENS,
     V1_CANCEL,
@@ -246,7 +268,11 @@ mod tests {
     /// removed and nothing else changed.
     #[test]
     fn the_llama_cpp_aliases_are_the_v1_paths_without_the_prefix() {
-        for (alias, v1) in [(TOKENIZE, V1_TOKENIZE), (DETOKENIZE, V1_DETOKENIZE)] {
+        for (alias, v1) in [
+            (TOKENIZE, V1_TOKENIZE),
+            (DETOKENIZE, V1_DETOKENIZE),
+            (RERANK, V1_RERANK),
+        ] {
             assert_eq!(v1, format!("/v1{alias}"));
             assert!(ALL.contains(&alias), "{alias} must be enumerable");
         }

--- a/crates/ferrox-models/src/bert_encoder.rs
+++ b/crates/ferrox-models/src/bert_encoder.rs
@@ -229,6 +229,29 @@ impl TextEncoder for BertEncoder {
         out
     }
 
+    /// `[CLS] a [SEP] b [SEP]` — what HuggingFace's
+    /// `tokenizer(query, document)` builds for a BERT cross-encoder,
+    /// which is the input these checkpoints were trained on.
+    ///
+    /// The **segment ids** that pairing normally carries are not here,
+    /// and that is deliberate rather than forgotten: this graph adds
+    /// row 0 of `token_types.weight` to every position, because
+    /// llama.cpp does the same (`token types are hardcoded to zero`,
+    /// its `bert.cpp`; see [`BertEncoder::type_embd_row0`]). A reranker
+    /// scored here therefore differs from the HF reference by the
+    /// second segment's type embedding, on both engines equally. It is
+    /// recorded in the ferrox rerank docs and is the first thing to
+    /// check if an ordering disagrees with `transformers`.
+    fn wrap_special_pair(&self, a: &[u32], b: &[u32]) -> Option<Vec<u32>> {
+        let mut out = Vec::with_capacity(a.len() + b.len() + 3);
+        out.push(self.hp.cls_id);
+        out.extend_from_slice(a);
+        out.push(self.hp.sep_id);
+        out.extend_from_slice(b);
+        out.push(self.hp.sep_id);
+        Some(out)
+    }
+
     fn encode_tokens(&self, tokens: &[u32]) -> Result<Vec<f32>, EncodeError> {
         let n = tokens.len();
         if n == 0 {
@@ -615,6 +638,29 @@ mod tests {
         let m = fixture(1);
         assert_eq!(m.wrap_special(&[7, 8]), vec![1, 7, 8, 2]);
         assert_eq!(m.wrap_special(&[]), vec![1, 2]);
+    }
+
+    /// The cross-encoder input is `[CLS] a [SEP] b [SEP]` — the
+    /// boundary between the two halves is the whole reason a reranker
+    /// scores differently from an embedding model. Concatenating
+    /// without it, or dropping the trailing `[SEP]`, produces a
+    /// perfectly plausible ranking that is not the model's, so the
+    /// exact sequence is asserted rather than its length.
+    #[test]
+    fn the_pair_form_separates_the_two_halves_and_closes_the_second() {
+        let m = fixture(1);
+        assert_eq!(
+            m.wrap_special_pair(&[7, 8], &[9]).unwrap(),
+            vec![1, 7, 8, 2, 9, 2]
+        );
+        // An empty half is still a half: the boundary stays.
+        assert_eq!(m.wrap_special_pair(&[], &[]).unwrap(), vec![1, 2, 2]);
+        // And it is NOT the single-sequence form of the two texts run
+        // together, which is what a defaulted implementation would give.
+        assert_ne!(
+            m.wrap_special_pair(&[7, 8], &[9]).unwrap(),
+            m.wrap_special(&[7, 8, 9])
+        );
     }
 
     /// `embed_tokens` must return the CLS row of the hidden states this

--- a/crates/ferrox-models/src/embedding_model.rs
+++ b/crates/ferrox-models/src/embedding_model.rs
@@ -13,10 +13,11 @@
 
 use thiserror::Error;
 
-use crate::bert_gguf_loader::{load_bert_encoder, BERT_ARCH};
+use crate::bert_gguf_loader::{load_bert_encoder, read_bert_hparams, BERT_ARCH};
 use crate::encoder::{EncodeError, TextEncoder};
 use crate::loader::LoadError;
-use crate::pooling::{l2_normalize, PoolingType};
+use crate::pooling::{l2_normalize, pool, PoolingType};
+use crate::rank_head::{load_rank_head, RankHead};
 use crate::tokenizer::{GgufWordPieceTokenizer, TokenizerLoadError};
 
 /// Encoder architectures upstream builds from `bert.cpp` and the other
@@ -90,6 +91,18 @@ pub enum EmbedError {
          WordPiece (\"bert\")"
     )]
     UnsupportedTokenizer { arch: String, model: String },
+    #[error(
+        "the embedding model {name:?} ({arch}) carries no reranker classification head: the \
+         checkpoint has no cls / cls.output tensors, so it has no relevance score to \
+         report. It can only produce embeddings"
+    )]
+    NoRankHead { name: String, arch: String },
+    #[error(
+        "the encoder for {arch:?} has no two-segment (query, document) input form, which a \
+         cross-encoder rerank needs. Concatenating the two texts would score fluently and \
+         wrongly, so this refuses instead"
+    )]
+    NoPairInput { arch: String },
 }
 
 /// A loaded embedding model: tokenizer + encoder + the checkpoint's own
@@ -97,6 +110,10 @@ pub enum EmbedError {
 pub struct EmbeddingModel {
     encoder: Box<dyn TextEncoder + Send + Sync>,
     tokenizer: GgufWordPieceTokenizer,
+    /// The reranker classification head, when the checkpoint carries
+    /// one. `None` for a plain embedding model, and that is what makes
+    /// `/v1/rerank` refuse rather than substitute a cosine similarity.
+    rank_head: Option<RankHead>,
     arch: String,
     name: String,
 }
@@ -128,10 +145,23 @@ impl EmbeddingModel {
             .map(str::to_string)
             .unwrap_or_else(|| arch.clone());
         let tokenizer = GgufWordPieceTokenizer::from_gguf(&file)?;
+
+        // ORDER IS LOAD-BEARING. `load_rank_head` MUST run before
+        // `load_bert_encoder`, which ends in
+        // `assert_every_tensor_consumed`: `cls.weight`, `cls.output.*`
+        // and `cls.norm.weight` are read by nothing else in this crate,
+        // so with the two lines swapped every reranker checkpoint dies
+        // with an `UnconsumedTensors` refusal listing tensors ferrox
+        // does in fact read. `read_bert_hparams` touches metadata only,
+        // so asking for the geometry twice costs nothing.
+        let hp = read_bert_hparams(&file)?;
+        let rank_head = load_rank_head(&file, &hp.arch, hp.n_embd, hp.layer_norm_eps)?;
         let encoder = load_bert_encoder(&file)?;
+
         Ok(Self {
             encoder: Box::new(encoder),
             tokenizer,
+            rank_head,
             arch,
             name,
         })
@@ -184,6 +214,60 @@ impl EmbeddingModel {
     /// wants to pool differently (or not at all).
     pub fn hidden_states(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
         Ok(self.encoder.encode_tokens(&self.token_ids(text))?)
+    }
+
+    /// The checkpoint's reranker classification head, or `None` for a
+    /// plain embedding model. What `/v1/rerank` checks before it
+    /// promises a caller a relevance score.
+    pub fn rank_head(&self) -> Option<&RankHead> {
+        self.rank_head.as_ref()
+    }
+
+    /// The exact ids [`Self::rerank_score`] will see for one
+    /// `(query, document)` pair: `[CLS] query [SEP] document [SEP]`.
+    ///
+    /// Separate from the scoring call for the same reason
+    /// [`Self::token_ids`] is separate from [`Self::embed`] — a route
+    /// has to report `usage.prompt_tokens`, and that number is this
+    /// length.
+    pub fn rerank_token_ids(&self, query: &str, document: &str) -> Result<Vec<u32>, EmbedError> {
+        self.encoder
+            .wrap_special_pair(
+                &self.tokenizer.encode(query),
+                &self.tokenizer.encode(document),
+            )
+            .ok_or_else(|| EmbedError::NoPairInput {
+                arch: self.arch.clone(),
+            })
+    }
+
+    /// The head's relevance score for a pair sequence built by
+    /// [`Self::rerank_token_ids`].
+    ///
+    /// This is upstream's RANK path in full: encode, take the **CLS**
+    /// row, run the classification head, report output 0
+    /// (`send_rerank`'s `embd[0]`). The CLS row is taken here regardless
+    /// of what `{arch}.pooling_type` says, because the head was trained
+    /// on that position — `pooling_type = RANK` is the checkpoint
+    /// *declaring* this path, not naming a pooling rule, which is why
+    /// [`crate::pooling::pool`] still refuses RANK and must keep
+    /// refusing it.
+    ///
+    /// No L2 normalization and no sigmoid: upstream reports the raw
+    /// logit, so a score is comparable only against other scores from
+    /// the same head, and this must not quietly squash it into `0..1`.
+    pub fn rerank_score(&self, pair_ids: &[u32]) -> Result<f32, EmbedError> {
+        let head = self
+            .rank_head
+            .as_ref()
+            .ok_or_else(|| EmbedError::NoRankHead {
+                name: self.name.clone(),
+                arch: self.arch.clone(),
+            })?;
+        let hidden = self.encoder.encode_tokens(pair_ids)?;
+        let cls = pool(&hidden, self.encoder.n_embd(), PoolingType::Cls)
+            .map_err(|e| EmbedError::Encode(EncodeError::Pooling(e)))?;
+        Ok(head.score(&cls))
     }
 }
 

--- a/crates/ferrox-models/src/encoder.rs
+++ b/crates/ferrox-models/src/encoder.rs
@@ -84,6 +84,21 @@ pub trait TextEncoder {
         pieces.to_vec()
     }
 
+    /// The two-segment input a **cross-encoder** scores: one sequence
+    /// holding a query and a document with the model's own boundary
+    /// between them. For BERT that is `[CLS] a [SEP] b [SEP]`.
+    ///
+    /// `None` — the default — means this encoder has no two-segment
+    /// form, and a caller that needs one must refuse. Deliberately NOT
+    /// defaulted to `wrap_special(a ++ b)`: a cross-encoder was trained
+    /// with a separator between the halves, and one that never sees it
+    /// still returns a plausible float. That is the "computes something
+    /// else" failure, and it is invisible — a rerank with no boundary
+    /// produces an ordering, just not the model's.
+    fn wrap_special_pair(&self, _a: &[u32], _b: &[u32]) -> Option<Vec<u32>> {
+        None
+    }
+
     /// `n_tokens × n_embd` hidden states, in row order.
     fn encode_tokens(&self, tokens: &[u32]) -> Result<Vec<f32>, EncodeError>;
 

--- a/crates/ferrox-models/src/pooling.rs
+++ b/crates/ferrox-models/src/pooling.rs
@@ -16,14 +16,19 @@
 //!
 //! # What is implemented, and what refuses
 //!
-//! `NONE`, `MEAN`, `CLS` and `LAST` are here. `RANK` is **not**: it is
-//! not a pooling rule at all but a classification head — upstream runs
-//! `cls`/`cls_out` matrices, a `tanh`, and an optional head norm over
-//! the pooled row, and reports the result through `/v1/rerank` against
-//! `classifier.output_labels`. None of that exists in ferrox yet, so
-//! [`PoolingType::Rank`] parses (so the refusal can name it) and
-//! [`pool`] returns [`PoolingError::Unimplemented`] rather than
-//! quietly handing back a CLS row that means something else.
+//! `NONE`, `MEAN`, `CLS` and `LAST` are here. `RANK` is **not**, and
+//! never will be: it is not a pooling rule at all but a classification
+//! head — upstream runs `cls`/`cls_out` matrices, a `tanh`, and an
+//! optional head norm over the pooled row, and reports the result
+//! through `/v1/rerank` against `classifier.output_labels`. That head
+//! is [`crate::rank_head`] and that route exists, but neither is
+//! reachable from here: [`pool`] sees hidden states and a width, so the
+//! head's matrices are not a thing it *could* apply. So
+//! [`PoolingType::Rank`] parses (which is how the refusal can name it)
+//! and [`pool`] returns [`PoolingError::Unimplemented`] rather than
+//! quietly handing back a CLS row that means something else. An
+//! `/v1/embeddings` request against a reranker checkpoint refuses here,
+//! deliberately, and that is what sends the caller to `/v1/rerank`.
 
 use thiserror::Error;
 
@@ -55,9 +60,10 @@ pub enum PoolingError {
     NotAnInteger { key: String, value: String },
     #[error(
         "pooling type RANK is a reranker classification head (cls / cls_out / \
-         classifier.output_labels), which ferrox does not implement — there is no /v1/rerank \
-         route and the head tensors are unread. Refusing rather than returning a CLS row \
-         that is not what RANK means"
+         classifier.output_labels), not a pooling rule: pooling sees hidden states and a \
+         width, and cannot reach those matrices. POST /v1/rerank with a query and \
+         documents, which runs the head this checkpoint carries. Refusing rather than \
+         returning a CLS row that is not what RANK means"
     )]
     Unimplemented,
     #[error("cannot pool an empty sequence")]

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -57,6 +57,7 @@ mod model;
 mod openai_extra;
 mod output;
 mod policy;
+mod rerank;
 mod response_cache;
 pub(crate) mod responses;
 mod resume;
@@ -102,6 +103,7 @@ use ferrox_models::{Decoder, Gemma4Engine, KimiEngine, MlaEngine, PrefixCache};
 use generate::{FinishReason, GenerationParams};
 pub(crate) use loaded::{ActiveModel, Loaded};
 use model::ServerTokenizer;
+use rerank::encoder_endpoints;
 use response_cache::{CacheKey, ResponseCache};
 use sampling_knobs::SamplingKnobs;
 
@@ -1897,15 +1899,29 @@ async fn health(State(state): State<Arc<AppState>>) -> Response {
         // is `available` -- but a supervisor reading "serving X" and
         // then getting 501 from /v1/chat/completions learned nothing.
         // The detail says which endpoint this checkpoint is for.
-        Some(active) if active.encoder().is_some() => ferrox_api::Capability::available(
-            ferrox_api::health::capability::REAL_WEIGHTS,
-            format!(
-                "Serving the real embedding checkpoint '{}'. This is an ENCODER: {} serves \
-                 it, generation endpoints refuse it.",
-                active.name(),
-                ferrox_api::routes::V1_EMBEDDINGS,
-            ),
-        ),
+        // NOT a hard-coded /v1/embeddings any more: a reranker is an
+        // encoder too, and its pooling_type is RANK, which
+        // /v1/embeddings refuses and /v1/rerank is for. See
+        // `rerank::encoder_endpoints`, which `/v1/models` reads as well
+        // so the two cannot disagree.
+        Some(active) if active.encoder().is_some() => {
+            let endpoints = active
+                .encoder()
+                .map(|e| encoder_endpoints(e))
+                .unwrap_or_default();
+            let served_by = match endpoints.is_empty() {
+                true => "no endpoint in this build serves it".to_string(),
+                false => format!("served by {}", endpoints.join(" and ")),
+            };
+            ferrox_api::Capability::available(
+                ferrox_api::health::capability::REAL_WEIGHTS,
+                format!(
+                    "Serving the real embedding checkpoint '{}'. This is an ENCODER, \
+                     {served_by}; generation endpoints refuse it.",
+                    active.name(),
+                ),
+            )
+        }
         Some(active) => ferrox_api::Capability::available(
             ferrox_api::health::capability::REAL_WEIGHTS,
             format!("Serving the real checkpoint '{}'.", active.name()),
@@ -2006,7 +2022,7 @@ async fn list_models(State(state): State<Arc<AppState>>) -> Json<serde_json::Val
     // it never has to send the request to find out.
     if let Some(encoder) = active.encoder() {
         model_entry["ferrox_model_kind"] = serde_json::json!("embedding");
-        model_entry["ferrox_endpoints"] = serde_json::json!([ferrox_api::routes::V1_EMBEDDINGS]);
+        model_entry["ferrox_endpoints"] = serde_json::json!(encoder_endpoints(encoder));
         model_entry["ferrox_n_embd"] = serde_json::json!(encoder.n_embd());
         model_entry["ferrox_pooling"] = serde_json::json!(encoder.pooling_type().name());
         model_entry["ferrox_context_length"] = serde_json::json!(encoder.n_ctx_train());
@@ -4559,6 +4575,11 @@ async fn run(mcp_config_path: Option<PathBuf>, exit_on_stdin_close: bool) -> any
         .route(routes::TOKENIZE, post(openai_extra::tokenize))
         .route(routes::DETOKENIZE, post(openai_extra::detokenize))
         .route(routes::V1_EMBEDDINGS, post(embeddings::embeddings))
+        // Cross-encoder reranking, under the `/v1` spelling Cohere and
+        // Jina clients use and the unprefixed one llama.cpp mounts.
+        // Same handler: this really is an alias, not a second dialect.
+        .route(routes::V1_RERANK, post(rerank::rerank))
+        .route(routes::RERANK, post(rerank::rerank))
         .route(routes::CACHE_STATS, get(cache_stats))
         .route(routes::METRICS, get(metrics))
         // The control surface. Registered inside `protected` on

--- a/crates/ferrox-server/src/rerank.rs
+++ b/crates/ferrox-server/src/rerank.rs
@@ -1,0 +1,533 @@
+//! `/v1/rerank` (and llama.cpp's `/rerank`): one query, N documents,
+//! ordered by the checkpoint's **own** classification head.
+//!
+//! # Why this is not `/v1/embeddings` with a cosine
+//!
+//! The obvious cheap implementation — embed the query, embed each
+//! document, sort by cosine similarity — is a different model. A
+//! bi-encoder embeds the two texts independently and can only compare
+//! them afterwards; a cross-encoder reranker reads the pair *together*,
+//! `[CLS] query [SEP] document [SEP]`, so every layer's attention runs
+//! across the boundary, and it reports a relevance logit from a trained
+//! classification head ([`ferrox_models::RankHead`]) rather than an
+//! angle between two vectors. Reranking exists precisely because the
+//! two disagree. Serving a cosine here would return a plausible
+//! ordering under a name that promises the model's, which is this
+//! engine's one prohibited failure — so a checkpoint with no head
+//! **refuses** (501) instead, and never substitutes a similarity.
+//!
+//! # What the checkpoint has to be
+//!
+//! A `bert` GGUF carrying `cls` / `cls.output` (see
+//! [`ferrox_models::load_rank_head`]), reached the same two ways an
+//! embedding model is: as `FERROX_MODEL_PATH`, or as the
+//! `FERROX_EMBEDDING_MODEL_PATH` side-car. Such a checkpoint declares
+//! `pooling_type = RANK`, and `/v1/embeddings` against it still refuses
+//! in [`ferrox_models::pooling::pool`] — deliberately. RANK is not a
+//! pooling rule, and the refusal is what sends the caller here.
+//!
+//! # The wire shape
+//!
+//! Jina's and Cohere's, which is what every existing rerank client
+//! speaks (OpenAI has no reranker endpoint to be compatible with):
+//! `{"query": …, "documents": [...], "top_n": N, "return_documents":
+//! bool}` in, `{"results": [{"index": i, "relevance_score": f}]}` out,
+//! best first.
+//!
+//! `index` is the position in the **caller's** `documents` array, not
+//! in the sorted output. That is the standing bug in this route shape
+//! and it is invisible in the easy cases — a one-document request, or
+//! any input that happened to arrive already ordered — so
+//! [`ranking`] carries it and is tested directly.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+
+use ferrox_models::{EmbedError, EmbeddingModel};
+
+use crate::openai_extra::Call;
+use crate::{join_error_response, unsupported_feature, ApiError, AppState};
+
+/// Jina/Cohere's request body. Every field declared here is honoured;
+/// a field of another dialect (`rank_fields`, `return_text`) is ignored
+/// rather than refused, the same way [`crate::embeddings`] treats one.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RerankRequest {
+    /// Echoed back. Purely cosmetic: this server serves whatever is
+    /// loaded, and does not route on a model name.
+    #[serde(default)]
+    model: Option<String>,
+    query: String,
+    documents: Vec<String>,
+    /// Keep only the best `top_n`. Absent means "all of them".
+    #[serde(default)]
+    top_n: Option<usize>,
+    /// Echo each document's text back inside its result.
+    #[serde(default)]
+    return_documents: bool,
+}
+
+/// Which routes an encoder checkpoint actually answers.
+///
+/// `/health` and `/v1/models` both tell a client this, and before this
+/// route existed both simply said `/v1/embeddings` — true while an
+/// encoder was necessarily an embedding model. A reranker checkpoint is
+/// an encoder too, and it is the *opposite* case: its `pooling_type` is
+/// RANK, which [`ferrox_models::pooling::pool`] refuses, so
+/// `/v1/embeddings` answers it with a 400 while `/v1/rerank` serves it.
+/// Two reporting surfaces restating one list is this repo's dominant
+/// bug shape, so they read it from here instead.
+///
+/// Each line is derived from the refusal it mirrors, not from a guess
+/// about what a "reranker" is: embeddings is listed exactly when `pool`
+/// would accept the checkpoint's pooling type, and rerank exactly when
+/// there is a head for [`rerank_inner`] to run. A checkpoint that
+/// satisfies neither is listed as answering neither, which is true.
+pub(crate) fn encoder_endpoints(encoder: &EmbeddingModel) -> Vec<&'static str> {
+    let mut out = Vec::with_capacity(2);
+    if encoder.pooling_type() != ferrox_models::pooling::PoolingType::Rank {
+        out.push(ferrox_api::routes::V1_EMBEDDINGS);
+    }
+    if encoder.rank_head().is_some() {
+        out.push(ferrox_api::routes::V1_RERANK);
+    }
+    out
+}
+
+fn bad_request(message: String) -> ApiError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": { "message": message } })),
+    )
+}
+
+/// The output order: indices into the caller's `documents`, best first.
+///
+/// Two properties, and this route shape gets both wrong by default:
+///
+/// * **The values are the caller's indices.** A client joins the
+///   results back onto what it sent, so reporting the position in the
+///   sorted list instead silently mislabels every document whenever the
+///   input was not already in score order — and it *is* already in
+///   score order for a single-document request and for any test that
+///   does not deliberately shuffle.
+/// * **Ties keep the caller's order.** `sort_by` is stable and equal
+///   scores are ordinary here: duplicate documents score identically,
+///   and a head whose `tanh` saturates flattens whole runs of them. An
+///   unstable sort would make the same request answer differently on
+///   different days.
+///
+/// `total_cmp` rather than `partial_cmp(..).unwrap()`: a total order
+/// cannot panic on a score the head produced. Non-finite scores are
+/// refused before they get here (see [`finite_score`]), so this is
+/// belt-and-braces, not the check.
+///
+/// Truncation is one rule with no special cases: `top_n` absent keeps
+/// everything, `top_n` past the end keeps everything (`Vec::truncate`
+/// is a no-op then), `top_n` of 0 keeps nothing.
+fn ranking(scores: &[f32], top_n: Option<usize>) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..scores.len()).collect();
+    order.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]));
+    order.truncate(top_n.unwrap_or(order.len()));
+    order
+}
+
+/// Refuses a score that JSON cannot carry.
+///
+/// `serde_json` has no NaN and no infinity: `json!(f32::NAN)` is
+/// `null`, silently. A client reading `relevance_score` would get a
+/// null where it expected a number, or — worse — a JSON parser that
+/// coerces null to 0 would rank that document last with no error
+/// anywhere. A non-finite score means the head or the encoder went
+/// wrong, which is the server's fault and so a 500.
+fn finite_score(score: f32, index: usize) -> Result<f32, ApiError> {
+    if score.is_finite() {
+        return Ok(score);
+    }
+    Err((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": {
+            "message": format!(
+                "the classification head produced a non-finite relevance score ({score}) \
+                 for document {index}. JSON cannot carry it, and reporting it as null \
+                 would read as a valid score of zero"
+            ),
+            "type": "internal_error",
+        }})),
+    ))
+}
+
+/// 501 for an embedding model that carries no classification head.
+///
+/// The sentence itself is [`EmbedError::NoRankHead`], which lives
+/// beside the head loader rather than being restated here, and the 501
+/// comes from [`unsupported_feature`] — the server's one constructor
+/// for "ferrox does not implement this". Both halves are borrowed on
+/// purpose: a second wording of either is a second thing to keep true.
+fn no_rank_head(name: &str, arch: &str) -> ApiError {
+    let why = EmbedError::NoRankHead {
+        name: name.to_string(),
+        arch: arch.to_string(),
+    };
+    unsupported_feature(&format!(
+        "{why}. POST {} to use it for embeddings, or load a reranker checkpoint",
+        ferrox_api::routes::V1_EMBEDDINGS,
+    ))
+}
+
+/// 501 for a generative model, which is the mirror image of the
+/// refusal [`crate::loaded`] gives an encoder on a generation route:
+/// same status, same reason (this endpoint is not implemented *for
+/// this model*), same rule that it names the checkpoint rather than
+/// blaming a tensor.
+fn not_a_reranker(model: &str) -> ApiError {
+    unsupported_feature(&format!(
+        "the loaded model '{model}' is not a reranker. {} needs a cross-encoder checkpoint \
+         carrying a classification head (a `bert` GGUF with `cls` / `cls.output` tensors), \
+         loaded as FERROX_MODEL_PATH or beside this one as FERROX_EMBEDDING_MODEL_PATH. A \
+         generative model cannot answer this route, and the cosine of its embeddings is \
+         not a substitute for a rerank score",
+        ferrox_api::routes::V1_RERANK,
+    ))
+}
+
+/// The encoder that can actually answer this route, or the refusal
+/// naming what is loaded instead.
+///
+/// Three different answers, and none of them may be given for another:
+/// nothing loaded is 503 (from [`AppState::require_active`], the one
+/// place this server says that), a generative model is
+/// [`not_a_reranker`], and an embedding model with no head is
+/// [`no_rank_head`].
+fn require_reranker(state: &AppState) -> Result<Arc<EmbeddingModel>, ApiError> {
+    let Some(encoder) = state.embedding_model() else {
+        return Err(state.require_active().err().unwrap_or_else(|| {
+            not_a_reranker(&state.active_model_name().unwrap_or_else(|| "?".to_string()))
+        }));
+    };
+    if encoder.rank_head().is_none() {
+        return Err(no_rank_head(encoder.name(), encoder.architecture()));
+    }
+    Ok(encoder)
+}
+
+/// What a rerank needs before it is worth loading a model for.
+///
+/// Both refusals run before the encoder is touched, which is the point
+/// of them: an empty `documents` has nothing to rank, and an empty
+/// `query` would pay one full encoder pass per document to score them
+/// all against nothing.
+fn validate(query: &str, documents: &[String]) -> Result<(), ApiError> {
+    if documents.is_empty() {
+        return Err(bad_request(
+            "documents must be a non-empty array of strings".to_string(),
+        ));
+    }
+    if query.is_empty() {
+        return Err(bad_request(
+            "query must be a non-empty string; a rerank scores each document against it"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// A load-time refusal from the model, given the status it deserves.
+///
+/// `NoRankHead` / `NoPairInput` are "ferrox cannot do this at all" and
+/// stay 501 even though [`require_reranker`] has already ruled the
+/// first one out; anything else here is a property of this particular
+/// document (too long for the position table, an out-of-range id) and
+/// is the caller's 400, named with the document it came from.
+fn embed_error(index: usize, e: EmbedError) -> ApiError {
+    match e {
+        EmbedError::NoRankHead { .. } | EmbedError::NoPairInput { .. } => {
+            unsupported_feature(&e.to_string())
+        }
+        other => bad_request(format!("document {index}: {other}")),
+    }
+}
+
+/// One encoder pass per document, on the blocking pool.
+///
+/// Every document is scored even when `top_n` is small, and there is no
+/// way around that: the top N cannot be known without scoring all of
+/// them. `top_n` truncates the answer, it does not shorten the work.
+async fn score_documents(
+    encoder: Arc<EmbeddingModel>,
+    query: String,
+    documents: Arc<Vec<String>>,
+) -> Result<(Vec<f32>, usize), ApiError> {
+    tokio::task::spawn_blocking(move || {
+        let mut scores = Vec::with_capacity(documents.len());
+        let mut prompt_tokens = 0usize;
+        for (i, doc) in documents.iter().enumerate() {
+            let ids = encoder
+                .rerank_token_ids(&query, doc)
+                .map_err(|e| embed_error(i, e))?;
+            prompt_tokens += ids.len();
+            let score = encoder.rerank_score(&ids).map_err(|e| embed_error(i, e))?;
+            scores.push(finite_score(score, i)?);
+        }
+        Ok::<_, ApiError>((scores, prompt_tokens))
+    })
+    .await
+    .map_err(join_error_response)?
+}
+
+/// The `results` array, in `order`. Pure, so the index property above
+/// is testable without a checkpoint.
+fn results_json(
+    order: &[usize],
+    scores: &[f32],
+    documents: &[String],
+    return_documents: bool,
+) -> Vec<serde_json::Value> {
+    order
+        .iter()
+        .map(|&i| {
+            let mut row = serde_json::json!({
+                "index": i,
+                "relevance_score": scores[i],
+            });
+            if return_documents {
+                row["document"] = serde_json::json!({ "text": documents[i] });
+            }
+            row
+        })
+        .collect()
+}
+
+pub async fn rerank(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<RerankRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let call = Call::new(&headers);
+    let result = rerank_inner(&state, req).await;
+    // Same accounting rule as `/v1/embeddings`: the encoder passes are
+    // real prompt tokens, and there is no decode loop, so the
+    // completion half is 0 rather than borrowing from the total.
+    let usage = result
+        .as_ref()
+        .ok()
+        .map(|(_, prompt_tokens)| ferrox_api::Usage::new(*prompt_tokens, 0));
+    // Recorded under the `/v1` spelling for both mounts, the way
+    // `/tokenize` is: one route in the stats ring, two ways to reach it.
+    call.record(
+        &state,
+        ferrox_api::routes::V1_RERANK,
+        state.embedding_model_name(),
+        &result,
+        usage.as_ref(),
+    );
+    result.map(|(body, _)| Json(body))
+}
+
+async fn rerank_inner(
+    state: &AppState,
+    req: RerankRequest,
+) -> Result<(serde_json::Value, usize), ApiError> {
+    validate(&req.query, &req.documents)?;
+    let encoder = require_reranker(state)?;
+    let model_name = req
+        .model
+        .clone()
+        .unwrap_or_else(|| encoder.name().to_string());
+    // The label output 0 carries, when the head named its outputs.
+    // `RankHead::score` reports `embd[0]` the way upstream's
+    // `send_rerank` does, and `load_rank_head` refuses a multi-output
+    // head that names nothing -- so whenever there IS more than one
+    // output, there is a name for the one being reported, and saying it
+    // is cheaper than leaving the choice silent.
+    let score_label = encoder
+        .rank_head()
+        .and_then(|h| h.labels().first().cloned());
+
+    let documents = Arc::new(req.documents);
+    let (scores, prompt_tokens) =
+        score_documents(encoder, req.query, Arc::clone(&documents)).await?;
+
+    let order = ranking(&scores, req.top_n);
+    let mut body = serde_json::json!({
+        "object": "list",
+        "model": model_name,
+        "results": results_json(&order, &scores, &documents, req.return_documents),
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "total_tokens": prompt_tokens,
+        }
+    });
+    if let Some(label) = score_label {
+        body["ferrox_score_label"] = serde_json::json!(label);
+    }
+    Ok((body, prompt_tokens))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn docs(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("doc{i}")).collect()
+    }
+
+    /// **The classic bug in this route shape.** `index` must address
+    /// the caller's array, so a client can join the results back onto
+    /// what it sent; the position in the sorted output is a different
+    /// number that happens to agree whenever the input arrived already
+    /// ordered. The fixture is deliberately out of order in both
+    /// directions so neither reading passes by accident.
+    #[test]
+    fn the_index_is_the_position_in_the_request_not_in_the_sorted_output() {
+        let scores = [0.1f32, 0.9, 0.5];
+        assert_eq!(ranking(&scores, None), vec![1, 2, 0]);
+        let rows = results_json(&ranking(&scores, None), &scores, &docs(3), false);
+        assert_eq!(rows[0]["index"], 1);
+        assert_eq!(rows[1]["index"], 2);
+        assert_eq!(rows[2]["index"], 0);
+        // And the score travels with its own document, not with its
+        // rank: row 0 is document 1, so it carries document 1's score.
+        assert_eq!(rows[0]["relevance_score"], 0.9f32);
+        assert_eq!(rows[2]["relevance_score"], 0.1f32);
+    }
+
+    /// Equal scores are ordinary (duplicate documents, a saturating
+    /// `tanh`), so the tie-break has to be defined. It is the caller's
+    /// own order, which needs a STABLE sort -- an unstable one would
+    /// answer the same request differently on different days.
+    ///
+    /// The fixture is 64 documents over two distinct scores on purpose.
+    /// A four-element version of this test passes with
+    /// `sort_unstable_by` as well, because Rust's pattern-defeating
+    /// quicksort insertion-sorts anything under ~20 elements and is
+    /// accidentally stable there -- so the small version asserts the
+    /// property on paper and enforces nothing. Above that threshold the
+    /// real algorithm runs and permutes the tie groups.
+    #[test]
+    fn ties_keep_the_order_the_caller_sent() {
+        // Odd indices score 1.0, even indices 0.0: two tie groups of 32.
+        let scores: Vec<f32> = (0..64).map(|i| (i % 2) as f32).collect();
+        // The highs in the caller's order, then the lows in the
+        // caller's order. Any permutation inside either group is the
+        // failure this is here for.
+        let expected: Vec<usize> = (0..64)
+            .filter(|i| i % 2 == 1)
+            .chain((0..64).filter(|i| i % 2 == 0))
+            .collect();
+        assert_eq!(ranking(&scores, None), expected);
+    }
+
+    /// A `top_n` past the end is a clamp, not an error and not a panic:
+    /// asking for more than exists returns everything that exists.
+    #[test]
+    fn a_top_n_larger_than_the_document_list_returns_every_document() {
+        let scores = [0.1f32, 0.9];
+        assert_eq!(ranking(&scores, Some(1000)), vec![1, 0]);
+        assert_eq!(ranking(&scores, Some(2)), vec![1, 0]);
+        assert_eq!(ranking(&scores, None), vec![1, 0]);
+    }
+
+    /// `top_n: 0` is the same truncation rule with a smaller argument:
+    /// the top nothing is nothing. It is NOT read as "unset" -- that
+    /// would silently return every document to a caller who asked for
+    /// none.
+    #[test]
+    fn a_top_n_of_zero_returns_no_results() {
+        let scores = [0.1f32, 0.9, 0.5];
+        assert!(ranking(&scores, Some(0)).is_empty());
+        assert!(results_json(&ranking(&scores, Some(0)), &scores, &docs(3), true).is_empty());
+    }
+
+    /// An empty `documents` array is refused rather than answered with
+    /// an empty list: there is nothing to rank, and a 200 saying so is
+    /// indistinguishable from "your documents all scored badly". An
+    /// empty query is refused for the mirror reason -- it would pay one
+    /// full encoder pass per document to score them all against
+    /// nothing.
+    #[test]
+    fn an_empty_documents_array_and_an_empty_query_are_refused_by_name() {
+        assert!(validate("q", &docs(1)).is_ok());
+        // An empty document is a document: it is the LIST that must be
+        // non-empty, not each string in it.
+        assert!(validate("q", &[String::new()]).is_ok());
+
+        let (status, body) = validate("q", &[]).unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.0["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("documents"));
+
+        let (status, body) = validate("", &docs(1)).unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.0["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("query"));
+    }
+
+    /// A checkpoint with no classification head must be told apart
+    /// from a decoder, and both from "nothing is loaded". Each refusal
+    /// names the model it is about -- an operator reading "unsupported"
+    /// alone goes hunting a missing tensor, which is the exact failure
+    /// the encoder seam in `crate::loaded` already exists to prevent.
+    #[test]
+    fn the_two_501s_name_the_model_and_the_route_that_would_serve_it() {
+        let (status, body) = no_rank_head("bge-small-en-v1.5", "bert");
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        let msg = body.0["error"]["message"].as_str().unwrap().to_string();
+        for fact in ["bge-small-en-v1.5", "bert", "cls", "/v1/embeddings"] {
+            assert!(msg.contains(fact), "{msg} does not carry {fact}");
+        }
+
+        let (status, body) = not_a_reranker("llama-3.2-3b");
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        let msg = body.0["error"]["message"].as_str().unwrap().to_string();
+        for fact in ["llama-3.2-3b", "cross-encoder", "/v1/rerank"] {
+            assert!(msg.contains(fact), "{msg} does not carry {fact}");
+        }
+        // 501 and not 503: no amount of retrying turns either of these
+        // into a reranker, and a supervisor acts on that difference.
+        assert_ne!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// `serde_json` has no NaN: it serializes as `null`, which a client
+    /// reads as a missing score or coerces to 0. A head that produces
+    /// one is broken, and saying so is the only honest answer.
+    #[test]
+    fn a_non_finite_score_is_refused_rather_than_serialized_as_null() {
+        // The trap this guards, stated as an assertion so it cannot
+        // quietly stop being true.
+        assert!(serde_json::json!(f32::NAN).is_null());
+        assert!(serde_json::json!(f32::INFINITY).is_null());
+
+        assert_eq!(finite_score(0.0, 0).unwrap(), 0.0);
+        assert_eq!(finite_score(-12.5, 0).unwrap(), -12.5);
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let (status, body) = finite_score(bad, 3).unwrap_err();
+            assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+            let msg = body.0["error"]["message"].as_str().unwrap();
+            assert!(msg.contains("document 3"), "{msg}");
+        }
+    }
+
+    /// `return_documents` echoes the text of the document each row
+    /// refers to -- which is the index property again, from the other
+    /// side: row 0 must carry document 1's text, not document 0's.
+    #[test]
+    fn return_documents_echoes_the_row_s_own_document_and_omitting_it_omits_the_key() {
+        let scores = [0.1f32, 0.9, 0.5];
+        let order = ranking(&scores, None);
+        let rows = results_json(&order, &scores, &docs(3), true);
+        assert_eq!(rows[0]["document"]["text"], "doc1");
+        assert_eq!(rows[2]["document"]["text"], "doc0");
+
+        let bare = results_json(&order, &scores, &docs(3), false);
+        assert!(bare[0].get("document").is_none());
+    }
+}


### PR DESCRIPTION
## What changed

`crates/ferrox-models/src/rank_head.rs` loaded a reranker classification
head that **nothing called**, and there was no `/v1/rerank` route. Worse
than dead code: a reranker checkpoint could not load *at all*.
`load_bert_encoder` ends in `assert_every_tensor_consumed`, and `cls.*`
was read by nobody, so every such GGUF died with an `UnconsumedTensors`
refusal naming tensors ferrox does in fact know how to read.

This wires it.

* **`crates/ferrox-server/src/rerank.rs` (new).** `/v1/rerank` and
  llama.cpp's `/rerank`, same handler. Jina/Cohere request and response
  shape.
* **`crates/ferrox-models/src/embedding_model.rs`.** `EmbeddingModel`
  now loads and holds the head, and exposes `rank_head()`,
  `rerank_token_ids(query, doc)` and `rerank_score(pair_ids)`.
* **`crates/ferrox-models/src/encoder.rs` + `bert_encoder.rs`.** A new
  `TextEncoder::wrap_special_pair`, defaulting to `None`; BERT builds
  `[CLS] a [SEP] b [SEP]`.
* **`crates/ferrox-models/src/pooling.rs`.** The RANK refusal's wording,
  which said "there is no /v1/rerank route and the head tensors are
  unread" — both halves false after this PR.
* **`crates/ferrox-api/src/routes.rs`.** `V1_RERANK` / `RERANK`.
* **`crates/ferrox-server/src/lib.rs`.** `mod`, `use`, two route lines,
  and the `/health` + `/v1/models` endpoint reporting (below).

The score comes from the head or it does not come at all. A checkpoint
with no head answers **501 naming the model**, the way a generation
route already refuses an encoder; there is no cosine-of-two-embeddings
fallback. A bi-encoder similarity is a different model wearing the same
response shape, and reranking exists precisely because the two disagree.

`pooling_type = RANK` still refuses in `pool`, and must — RANK is a
classification head and `pool` sees hidden states and a width. An
`/v1/embeddings` request against a rank-head checkpoint is still a
refusal; that refusal is now the thing that sends the caller here.

## The three defined behaviours, and the classic bug

* **`index` addresses the caller's `documents`, not the sorted output.**
  This is the standing bug in this endpoint shape and it is invisible
  whenever the input arrived already in score order — which it does for
  a one-document request and for every test that does not deliberately
  shuffle. Tested from both sides (`index`, and the `return_documents`
  echo).
* **Ties keep the caller's order**, via a stable sort. The fixture is 64
  documents over two distinct scores on purpose: a four-element version
  passes with `sort_unstable_by` as well, because pdqsort insertion-sorts
  anything under ~20 elements and is accidentally stable there. The small
  version asserts the property and enforces nothing.
* **`top_n` is one truncation rule, no special cases.** Absent keeps
  everything; larger than `documents.len()` keeps everything
  (`Vec::truncate` is a no-op); `0` keeps nothing. An **empty
  `documents`** array is a 400, not a 200 with an empty list — the
  latter is indistinguishable from "they all scored badly". An empty
  `query` is a 400 too, before any document is encoded.

A **non-finite score is a 500 naming the document**. `serde_json` has no
NaN and no infinity: it serializes both as `null`, so a broken head
would have shipped `"relevance_score": null` silently, and a parser
coercing null to 0 would rank that document last with no error anywhere.
The test asserts the trap itself (`json!(f32::NAN).is_null()`) so it
cannot quietly stop being true.

## A disagreement this PR creates, and closes

`/health` and `/v1/models` hard-coded `/v1/embeddings` as the one route
an encoder answers. That was true until now — a reranker is an encoder
that `/v1/embeddings` refuses. Both surfaces now read
`rerank::encoder_endpoints`, which derives each entry from the refusal
it mirrors: embeddings is listed exactly when `pool` would accept the
checkpoint's pooling type, rerank exactly when there is a head to run.
Two reporting surfaces restating one list is this repo's dominant bug
shape.

## Evidence, and its honest limit

Gates, all green: `cargo build --workspace`, `cargo test --workspace`,
`cargo clippy --workspace --all-targets -- -D warnings`, the same
`--release`, `cargo fmt --all`.

Every new test was **sabotaged and confirmed red**:

| Sabotage | Test that went red |
|---|---|
| report the sorted position as `index` | `the_index_is_the_position_in_the_request_not_in_the_sorted_output`, `return_documents_echoes_…` |
| sort ascending | 4 tests |
| `sort_unstable_by` | `ties_keep_the_order_the_caller_sent` (only after the fixture grew to 64) |
| drop the `truncate` | `a_top_n_of_zero_returns_no_results` |
| drop the finiteness check | `a_non_finite_score_is_refused_rather_than_serialized_as_null` |
| drop the middle `[SEP]` | `the_pair_form_separates_the_two_halves_and_closes_the_second` |

**UNVERIFIED, and this is the limit worth reading:** there is no
reranker checkpoint on this machine, so **the route has never run end to
end and its ordering has never been compared to anything**. Every piece
is tested against a synthetic head (`rank_head.rs`) or synthetic scores
(`rerank.rs`); the *composition* — load a real GGUF, encode a pair, take
the CLS row, run the head, sort — is not. Do not read a green CI as "the
route works". Tracked as issue #43.

There is a second, narrower unknown: this graph adds **row 0** of
`token_types.weight` to every position, both halves of the pair, because
llama.cpp does the same (`token types are hardcoded to zero`, its
`bert.cpp`). HuggingFace gives the document half segment 1. Scores
therefore differ from `transformers` by that embedding, on both engines
equally. Tracked as issue #44.

## What this does NOT do

* No real-checkpoint run, no `ferrox parity` comparison, no benchmark.
* No `sentencepiece`/unigram tokenizer, so `bge-reranker-base` (XLM-R)
  still refuses at `EmbedError::UnsupportedTokenizer`. A BERT/WordPiece
  cross-encoder is what this path can load.
* `jina-reranker-v1-tiny-en` is `jina-bert-v2` and still refuses by name.
* No batching across documents: one encoder pass each, sequentially, on
  `spawn_blocking`.
* Docs untouched (another agent owns `docs/`). Delta below.

## Doc delta for whoever owns `docs/`

**`docs/API.md`** (~line 1119) lists `/rerank` as not implemented.
Replace with an implemented row:

> `POST /v1/rerank` (also `/rerank`) — **implemented.** Cross-encoder
> reranking against the loaded checkpoint's own classification head
> (`cls` / `cls.output`), not the cosine of two embeddings. Request
> `{"model"?, "query", "documents": [...], "top_n"?,
> "return_documents"?}`; response `{"object": "list", "model",
> "results": [{"index", "relevance_score", "document"?}], "usage"}`,
> best first. `index` is the position in the request's `documents`
> array. Ties keep request order. `top_n` clamps to `documents.len()`;
> `top_n: 0` returns no results; an empty `documents` array is a 400.
> Needs a `bert` GGUF carrying a rank head (`FERROX_MODEL_PATH` or
> `FERROX_EMBEDDING_MODEL_PATH`); anything else answers 501 naming the
> model. `/v1/embeddings` against a rank-head checkpoint still refuses —
> its `pooling_type` is RANK, which is a head and not a pooling rule.

**`docs/FEATURES.md`** (~line 160) says the rank head has no route.
Replace with: "Reranker classification head (`cls`, `cls.output`,
`cls.norm`, `classifier.output_labels`) — loaded, and served by
`POST /v1/rerank`. End-to-end ordering against a real reranker
checkpoint is unverified; see issue #43."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN

