### PR TITLE
feat(models): a second GGUF can be the drafter, plus the plan for the rest of speculative decoding

### DIFF
--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -1310,13 +1310,14 @@ fn main() -> anyhow::Result<()> {
             );
             println!("low or zero accept rate below is expected and does not indicate a bug.\n");
 
-            let speculator = ferrox_models::PromptLookupSpeculator::new(ngram_size, max_draft_len);
+            let mut speculator =
+                ferrox_models::PromptLookupSpeculator::new(ngram_size, max_draft_len);
             let result = ferrox_models::speculative_decode(
                 &decoder,
                 &prompt_tokens,
                 max_new_tokens,
                 &mut caches,
-                &speculator,
+                &mut speculator,
             );
 
             println!("Tokens generated : {}", result.tokens_generated);

--- a/crates/ferrox-models/src/draft_model.rs
+++ b/crates/ferrox-models/src/draft_model.rs
@@ -1,0 +1,525 @@
+//! A second, smaller GGUF used as the drafter for speculative decoding.
+//!
+//! [`crate::speculative`] already had the half that is hard to get
+//! right: the rejection rule, which makes speculation lossless at every
+//! temperature rather than only at `--temp 0`. What it did not have was
+//! a drafter worth running. The only implementation in the tree is
+//! [`crate::speculative::PromptLookupSpeculator`], an n-gram match over
+//! the history with no model at all. It is free, and it helps on
+//! repetitive text, and it cannot carry a coding workload.
+//!
+//! # Why this is the item that moves the ceiling
+//!
+//! Decode reads every weight in the model to emit one token, so
+//!
+//! ```text
+//! tokens/sec <= memory bandwidth / model bytes
+//! ```
+//!
+//! is arithmetic, not engineering. A 17 GB checkpoint on a 960 GB/s
+//! card cannot pass about 56 tok/s however good the kernels are. Better
+//! kernels move an engine toward that number; they cannot move it past.
+//!
+//! A draft model changes what is read per token instead of how fast it
+//! is read. A 2 GB drafter proposes `k` tokens, the target checks all
+//! `k` in ONE pass over its 17 GB, good guesses are kept and bad ones
+//! discarded, and the text is exactly what the target would have
+//! written alone.
+//!
+//! # The two things this has to get right
+//!
+//! **The draft KV must roll back.** While proposing, the drafter
+//! advances its own cache over tokens the target has not accepted and
+//! may never accept. If those rows are left in place, the drafter's
+//! context silently diverges from the target's. Nothing errors: the
+//! accept rate just decays, which reads as "this drafter is bad" rather
+//! than "this drafter is desynchronised". [`DraftModelSpeculator`]
+//! therefore truncates to `synced` at the top of every `propose`, and
+//! `synced` only ever counts tokens the caller's history actually
+//! contains.
+//!
+//! This is the repo's dominant bug shape in its usual dress: two
+//! structures that must agree about one thing, here the target's
+//! history and the drafter's cache, with nothing enforcing it. What
+//! enforces it is that `synced` is derived from the history passed in
+//! on every call rather than remembered independently, so the drafter
+//! cannot hold an opinion about the history that the history disagrees
+//! with.
+//!
+//! **The vocabularies must match.** See [`VocabMismatch`].
+
+use crate::config::ModelConfig;
+use crate::decoder::Decoder;
+use crate::sampling::{sampling_distribution, Sampler, SamplingParams};
+use crate::speculative::{DraftBlock, DraftDist, Drafter};
+use ferrox_core::cache::KvCache;
+
+/// The draft and target checkpoints do not agree about token ids.
+///
+/// This is the failure that costs a day, because it does not look like
+/// a failure. The rejection rule compares the drafter's `q(x)` with the
+/// target's `p(x)` at the same index `x`. If the two checkpoints number
+/// their vocabularies differently, those are probabilities of different
+/// tokens, the rule is comparing unrelated numbers, and the output is
+/// no longer the target's distribution. What comes out is fluent text,
+/// with no error and a plausible-looking accept rate.
+///
+/// So it is refused at construction, which per this repo's rule is
+/// coverage rather than a defect: a partly-implemented thing must stop
+/// and say what is missing instead of computing something else.
+///
+/// Vocabulary size is checked first because it is cheap and catches
+/// most real mismatches (a 32000-token Llama drafter against a
+/// 152064-token Qwen target). Equal sizes do not imply equal
+/// vocabularies, though, so the caller that has both tokenizers should
+/// also compare them; `vocab_size` is what a `Decoder` alone can see.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum VocabMismatch {
+    #[error(
+        "draft and target checkpoints disagree about vocabulary size ({draft} vs {target}), so a \
+         draft token id does not name the same token in both. Speculative decoding compares the \
+         drafter's probability for a token id against the target's probability for that same id, \
+         which would be comparing unrelated tokens: the result would not be the target's \
+         distribution, and it would look exactly like text that is. Use a draft model from the \
+         same family and tokenizer as the target"
+    )]
+    Size { draft: usize, target: usize },
+}
+
+/// A [`Drafter`] backed by a second [`Decoder`].
+///
+/// Owns its own KV caches, entirely separate from the target's. The two
+/// models run over the same token sequence but have different layer
+/// counts, head counts and head dimensions, so nothing about the two
+/// caches is shared.
+pub struct DraftModelSpeculator {
+    decoder: Decoder,
+    kv_caches: Vec<KvCache>,
+    /// How many tokens of the caller's history this drafter's KV holds.
+    ///
+    /// Never an independent record of "what I have seen": it is
+    /// recomputed against the history handed to `propose`, so a
+    /// rejected block cannot leave it overstating what is committed.
+    synced: usize,
+    sampling: SamplingParams,
+    rng: Sampler,
+    /// Positions whose draft probability fell below this stop the
+    /// block. A drafter that is guessing is worse than no drafter: the
+    /// target pays for the position either way, and a rejection also
+    /// throws away every position after it.
+    min_prob: f32,
+    max_draft: usize,
+}
+
+impl DraftModelSpeculator {
+    /// Fails when the two checkpoints cannot be compared token for
+    /// token. See [`VocabMismatch`].
+    pub fn new(
+        decoder: Decoder,
+        target_config: &ModelConfig,
+        sampling: SamplingParams,
+        seed: u64,
+        max_draft: usize,
+        min_prob: f32,
+    ) -> Result<Self, VocabMismatch> {
+        let draft_vocab = decoder.config.vocab_size;
+        let target_vocab = target_config.vocab_size;
+        if draft_vocab != target_vocab {
+            return Err(VocabMismatch::Size {
+                draft: draft_vocab,
+                target: target_vocab,
+            });
+        }
+        let kv_caches = (0..decoder.config.n_layers)
+            .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
+            .collect();
+        Ok(DraftModelSpeculator {
+            decoder,
+            kv_caches,
+            synced: 0,
+            sampling,
+            rng: Sampler::new(seed),
+            min_prob,
+            max_draft,
+        })
+    }
+
+    /// Drops every cached row past `len`, on every layer.
+    fn truncate_to(&mut self, len: usize) {
+        for cache in &mut self.kv_caches {
+            cache.truncate(len);
+        }
+    }
+
+    /// Brings the draft cache up to `history` and returns the logits
+    /// that follow its last token.
+    ///
+    /// Feeds only the tokens the cache does not already hold, which is
+    /// what makes drafting cheap across a long conversation: the first
+    /// call pays for the prompt and every later call pays for the
+    /// handful of tokens the target committed since.
+    ///
+    /// The cache is rolled back to at most `history.len() - 1` rather
+    /// than `history.len()`, and that off-by-one is load-bearing. The
+    /// logits a block is drafted from are the ones that follow the last
+    /// committed token, and they exist only as the return value of the
+    /// forward pass that consumed it. Truncating to the full history
+    /// would leave nothing to feed, so there would be no logits to
+    /// draft from and every call after a rollback would propose
+    /// nothing: speculation would quietly stop happening while
+    /// remaining perfectly correct, which is the kind of failure that
+    /// shows up as a benchmark result months later.
+    ///
+    /// The cost is re-feeding exactly one token per call. That is one
+    /// step of the small model, against a block of them saved.
+    fn sync(&mut self, history: &[usize]) -> Vec<f32> {
+        debug_assert!(
+            !history.is_empty(),
+            "callers return early on an empty history"
+        );
+        // Everything past what the caller's history contains was
+        // drafted and not accepted. It is not context, it is a guess
+        // the target threw away.
+        let keep = self.synced.min(history.len() - 1);
+        self.truncate_to(keep);
+        self.synced = keep;
+
+        let mut logits = Vec::new();
+        while self.synced < history.len() {
+            let pos = self.synced;
+            logits = self
+                .decoder
+                .forward_token(history[pos], pos, &mut self.kv_caches);
+            self.synced += 1;
+        }
+        logits
+    }
+}
+
+impl Drafter for DraftModelSpeculator {
+    fn propose(&mut self, history: &[usize], _target_hidden: &[f32], max_len: usize) -> DraftBlock {
+        let budget = max_len.min(self.max_draft);
+        if budget == 0 || history.is_empty() {
+            return DraftBlock::empty();
+        }
+
+        let mut logits = self.sync(history);
+
+        let mut tokens = Vec::with_capacity(budget);
+        let mut dists = Vec::with_capacity(budget);
+        // The drafter's own view of the sequence, so its penalties see
+        // the tokens it has already proposed in this block.
+        let mut local: Vec<usize> = history.to_vec();
+
+        for _ in 0..budget {
+            let probs = sampling_distribution(&logits, &self.sampling, &local);
+            let token = self.rng.sample_from(&probs);
+
+            // `q` MUST be the distribution this token was actually
+            // sampled from, truncation and all, or the rejection rule
+            // is corrected against a lie. `sampling_distribution`
+            // returns exactly that, so it is what gets reported.
+            let dist = DraftDist::from_dense(&probs);
+            let q = dist.prob(token);
+            if q < self.min_prob {
+                // Stop before committing this token, so the cache is
+                // not advanced over a position nobody drafted.
+                break;
+            }
+
+            tokens.push(token);
+            dists.push(dist);
+            local.push(token);
+
+            let pos = self.synced;
+            logits = self.decoder.forward_token(token, pos, &mut self.kv_caches);
+            self.synced += 1;
+        }
+
+        DraftBlock::new(tokens, dists)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::test_dense_fixture;
+
+    fn drafter(vocab: usize, max_draft: usize, min_prob: f32) -> DraftModelSpeculator {
+        let target = {
+            let mut c = test_dense_fixture();
+            c.vocab_size = vocab;
+            c
+        };
+        let decoder = Decoder::new_random_small(test_dense_fixture(), 2, vocab);
+        DraftModelSpeculator::new(
+            decoder,
+            &target,
+            SamplingParams::default(),
+            7,
+            max_draft,
+            min_prob,
+        )
+        .expect("matching vocabularies")
+    }
+
+    /// A draft model whose vocabulary differs from the target's is
+    /// refused at construction, not accepted and corrected later.
+    ///
+    /// There is nothing to correct. The rejection rule compares the
+    /// drafter's probability for token id `x` against the target's
+    /// probability for token id `x`; if the two checkpoints number
+    /// their vocabularies differently those are different tokens, and
+    /// the output is no longer the target's distribution while looking
+    /// exactly like text that is. Fluent, plausible accept rate, no
+    /// error. That is the one failure this engine refuses to serve.
+    #[test]
+    fn a_draft_model_with_a_different_vocabulary_is_refused_by_name() {
+        let mut target = test_dense_fixture();
+        target.vocab_size = 64;
+        let decoder = Decoder::new_random_small(test_dense_fixture(), 2, 32);
+
+        let err = DraftModelSpeculator::new(decoder, &target, SamplingParams::default(), 0, 4, 0.0)
+            .err()
+            .expect("32 != 64");
+
+        assert_eq!(
+            err,
+            VocabMismatch::Size {
+                draft: 32,
+                target: 64
+            }
+        );
+        let msg = err.to_string();
+        // The message has to say both numbers and why it matters, or
+        // the next person reads it as an arbitrary compatibility rule
+        // and looks for a flag to turn it off.
+        assert!(msg.contains("32") && msg.contains("64"), "{msg}");
+        assert!(msg.contains("same family and tokenizer"), "{msg}");
+    }
+
+    /// The drafter proposes a block and reports one distribution per
+    /// token, which is what the rejection rule needs to run at all.
+    #[test]
+    fn a_block_carries_one_honest_distribution_per_drafted_token() {
+        let mut d = drafter(32, 4, 0.0);
+        let block = d.propose(&[1, 2, 3], &[], 4);
+
+        assert_eq!(block.len(), 4, "the whole budget was drafted");
+        assert_eq!(block.tokens().len(), block.dists().len());
+        for (token, dist) in block.tokens().iter().zip(block.dists()) {
+            // `q(x)` for the token actually sampled must be nonzero:
+            // the rule divides by it.
+            assert!(
+                dist.prob(*token) > 0.0,
+                "a drafter must report the distribution it sampled from"
+            );
+        }
+    }
+
+    /// **The rollback.** After a block is proposed, the drafter's cache
+    /// holds rows for tokens the target has not accepted. The next call
+    /// arrives with a history that does not contain them, and those
+    /// rows must be gone before anything else is fed.
+    ///
+    /// Left in place, the drafter's context silently diverges from the
+    /// target's: every later proposal is conditioned on tokens that
+    /// were thrown away. Nothing errors. The accept rate decays, which
+    /// reads as "this drafter is bad" rather than "this drafter is
+    /// desynchronised", and that is why this is asserted on the cache
+    /// length rather than on output quality.
+    #[test]
+    fn the_draft_cache_rolls_back_the_positions_the_target_did_not_accept() {
+        let mut d = drafter(32, 4, 0.0);
+
+        let block = d.propose(&[1, 2, 3], &[], 4);
+        assert_eq!(block.len(), 4);
+        assert_eq!(
+            d.synced, 7,
+            "3 of history plus 4 drafted are in the cache after proposing"
+        );
+
+        // The target accepted exactly one of them, so the caller's
+        // history grew by one, not by four.
+        d.propose(&[1, 2, 3, block.tokens()[0]], &[], 4);
+
+        assert_eq!(
+            d.kv_caches[0].seq_len, d.synced,
+            "every layer's cache agrees with the drafter's own count"
+        );
+        assert_eq!(
+            d.synced, 8,
+            "4 committed tokens plus 4 freshly drafted, NOT 7 stale rows plus more"
+        );
+    }
+
+    /// A history shorter than what the cache holds is a rollback too,
+    /// and the arithmetic must not underflow into a huge truncate.
+    #[test]
+    fn a_history_shorter_than_the_cache_truncates_rather_than_underflowing() {
+        let mut d = drafter(32, 4, 0.0);
+        d.propose(&[1, 2, 3, 4, 5], &[], 4);
+        assert_eq!(d.synced, 9);
+
+        d.propose(&[1, 2], &[], 1);
+        assert_eq!(d.synced, 3, "2 of history plus 1 drafted");
+        assert_eq!(d.kv_caches[0].seq_len, 3);
+    }
+
+    /// Drafting stops when the drafter's own probability for the token
+    /// it just sampled falls below the floor.
+    ///
+    /// A guessing drafter is worse than none: the target pays for the
+    /// position either way, and a rejection also discards every
+    /// position after it. With the floor above 1.0 nothing can clear
+    /// it, so the block is empty and the caller falls back to one
+    /// ordinary decode step.
+    #[test]
+    fn a_drafter_below_the_probability_floor_proposes_nothing() {
+        let mut d = drafter(32, 4, 1.01);
+        let block = d.propose(&[1, 2, 3], &[], 4);
+        assert!(block.is_empty(), "nothing clears a floor above 1.0");
+        assert_eq!(
+            d.synced, 3,
+            "and the cache holds the history only, no abandoned draft rows"
+        );
+    }
+
+    /// `max_draft` is a ceiling the caller's budget cannot raise.
+    #[test]
+    fn the_configured_maximum_bounds_the_callers_budget() {
+        let mut d = drafter(32, 2, 0.0);
+        assert_eq!(d.propose(&[1, 2, 3], &[], 8).len(), 2);
+    }
+
+    /// An empty history has nothing to condition on, and a zero budget
+    /// asked for nothing. Both propose nothing rather than panicking.
+    #[test]
+    fn an_empty_history_or_a_zero_budget_proposes_nothing() {
+        let mut d = drafter(32, 4, 0.0);
+        assert!(d.propose(&[], &[], 4).is_empty());
+        assert!(d.propose(&[1, 2], &[], 0).is_empty());
+    }
+
+    /// **The property the whole feature exists to preserve.**
+    ///
+    /// A draft model is only worth having if the text is exactly what
+    /// the target would have written alone. At temperature 0 that is
+    /// checkable exactly: token for token against a plain
+    /// `forward_token` loop over an identically seeded target.
+    ///
+    /// This is the test that catches a desynchronised draft cache, a
+    /// dishonest `q`, or an off-by-one in the block, because all three
+    /// change the output rather than announcing themselves. A drafter
+    /// is allowed to be bad; it is not allowed to be consulted in a way
+    /// that changes the answer.
+    ///
+    /// The drafter here is a genuinely different model from the target
+    /// (a different random seed, half the layers), so it is wrong
+    /// often, which is exactly the case where rejection and rollback
+    /// have to work.
+    #[test]
+    fn a_draft_model_does_not_change_what_the_target_writes() {
+        use crate::speculative::speculative_decode;
+
+        let cfg = test_dense_fixture();
+        let vocab = 32;
+        let prompt = vec![1usize, 2, 3, 4, 1, 2];
+        let max_new = 8;
+
+        let target = Decoder::new_random_small(cfg.clone(), 4, vocab);
+        let mut caches: Vec<KvCache> = (0..target.config.n_layers)
+            .map(|_| KvCache::new(target.config.n_kv_heads, target.config.head_dim))
+            .collect();
+
+        // A different model, not a copy of the target: two layers
+        // rather than four, so it disagrees constantly.
+        let draft = Decoder::new_random_small(cfg.clone(), 2, vocab);
+        let mut drafter =
+            DraftModelSpeculator::new(draft, &target.config, SamplingParams::default(), 11, 4, 0.0)
+                .expect("matching vocabularies");
+
+        let result = speculative_decode(&target, &prompt, max_new, &mut caches, &mut drafter);
+
+        // The same target, decoded the ordinary way.
+        let plain = Decoder::new_random_small(cfg, 4, vocab);
+        let mut plain_caches: Vec<KvCache> = (0..plain.config.n_layers)
+            .map(|_| KvCache::new(plain.config.n_kv_heads, plain.config.head_dim))
+            .collect();
+        let mut pending = plain
+            .forward_batch(&prompt, 0, &mut plain_caches)
+            .pop()
+            .expect("a non-empty prompt returns logits");
+        let mut greedy = Vec::with_capacity(max_new);
+        for pos in (prompt.len()..).take(max_new) {
+            let tok = pending
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.partial_cmp(b.1).expect("logits are finite"))
+                .map(|(i, _)| i)
+                .expect("a non-empty vocabulary");
+            greedy.push(tok);
+            pending = plain.forward_token(tok, pos, &mut plain_caches);
+        }
+
+        assert_eq!(
+            result.generated_tokens, greedy,
+            "a draft model may make decoding faster and may not make it different"
+        );
+    }
+
+    /// **`q` must be the distribution the token was really sampled
+    /// from**, at every temperature.
+    ///
+    /// The rejection rule accepts with probability `min(1, p(x)/q(x))`
+    /// and resamples from `max(0, p - q)`. A drafter that overstates
+    /// its own confidence, reporting a point mass for a token it
+    /// actually drew from a spread distribution, makes `p/q` too small:
+    /// tokens get rejected that should have been accepted, and the
+    /// residual it resamples from is not the right residual. The output
+    /// stops being the target's distribution.
+    ///
+    /// This cannot be caught at temperature 0, where the true
+    /// distribution IS a point mass and a dishonest report is
+    /// accidentally correct. That is exactly why this test sets a
+    /// temperature: a suite that only checks greedy decoding will pass
+    /// a drafter that lies.
+    #[test]
+    fn the_reported_distribution_is_the_one_sampled_from_at_temperature() {
+        let target = {
+            let mut c = test_dense_fixture();
+            c.vocab_size = 32;
+            c
+        };
+        let decoder = Decoder::new_random_small(test_dense_fixture(), 2, 32);
+        let sampling = SamplingParams {
+            temperature: 1.0,
+            ..SamplingParams::default()
+        };
+        let mut d = DraftModelSpeculator::new(decoder, &target, sampling.clone(), 3, 4, 0.0)
+            .expect("matching vocabularies");
+
+        let block = d.propose(&[1, 2, 3], &[], 4);
+        assert_eq!(block.len(), 4);
+
+        let spread = block.dists().iter().any(|dist| dist.support().len() > 1);
+        assert!(
+            spread,
+            "at temperature 1.0 a real model's draft distribution is not a point mass;              if it were, this test could not tell an honest report from a lie"
+        );
+
+        for (token, dist) in block.tokens().iter().zip(block.dists()) {
+            let q = dist.prob(*token);
+            assert!(q > 0.0, "the sampled token must be in its own support");
+            assert!(
+                q < 1.0,
+                "a spread distribution reported as certainty is the lie this test exists for"
+            );
+            let total: f32 = dist.support().iter().map(|&(_, p)| p).sum();
+            assert!(
+                (total - 1.0).abs() < 1e-4,
+                "a reported distribution must be normalised, got {total}"
+            );
+        }
+    }
+}

--- a/crates/ferrox-models/src/lib.rs
+++ b/crates/ferrox-models/src/lib.rs
@@ -18,6 +18,7 @@ pub mod decoder;
 pub mod deepseek_v4_budget;
 pub mod deepseek_v4_decoder;
 pub mod device_budget;
+pub mod draft_model;
 pub mod embedding_model;
 pub mod encoder;
 pub mod engine;
@@ -76,6 +77,7 @@ pub use capability::{
 pub use config::{deepseek_v4_pro, glm_5_2, kimi_k3, FfnActivation, ModelConfig, RopeLayout};
 pub use decoder::{Decoder, MultiSeqKv};
 pub use device_budget::{BudgetBackend, DeviceBudget};
+pub use draft_model::{DraftModelSpeculator, VocabMismatch};
 pub use embedding_model::{is_embedding_arch, EmbedError, EmbeddingModel};
 pub use encoder::{EncodeError, TextEncoder};
 pub use engine::{

--- a/crates/ferrox-models/src/speculative.rs
+++ b/crates/ferrox-models/src/speculative.rs
@@ -203,7 +203,11 @@ pub trait Drafter {
     /// for `history`'s last token, or empty when none is available yet
     /// (which a drafter that needs it must handle by proposing
     /// nothing).
-    fn propose(&self, history: &[usize], target_hidden: &[f32], max_len: usize) -> DraftBlock;
+    /// Takes `&mut self` because a drafter that is itself a model
+    /// carries KV state across calls, and hiding that behind interior
+    /// mutability would put a runtime borrow check on the hot path to
+    /// buy nothing. A stateless drafter simply ignores it.
+    fn propose(&mut self, history: &[usize], target_hidden: &[f32], max_len: usize) -> DraftBlock;
 }
 
 /// Proposes candidate continuation tokens by looking for the longest
@@ -262,7 +266,7 @@ impl PromptLookupSpeculator {
 }
 
 impl Drafter for PromptLookupSpeculator {
-    fn propose(&self, history: &[usize], _target_hidden: &[f32], max_len: usize) -> DraftBlock {
+    fn propose(&mut self, history: &[usize], _target_hidden: &[f32], max_len: usize) -> DraftBlock {
         let mut tokens = self.propose_tokens(history);
         tokens.truncate(max_len.min(self.max_draft_len));
         DraftBlock::deterministic(tokens)
@@ -461,7 +465,7 @@ pub fn speculative_decode<D: Drafter + ?Sized>(
     prompt_tokens: &[usize],
     max_new_tokens: usize,
     kv_caches: &mut [KvCache],
-    drafter: &D,
+    drafter: &mut D,
 ) -> SpeculativeDecodeResult {
     speculative_decode_with(
         decoder,
@@ -501,7 +505,7 @@ pub fn speculative_decode_with<D: Drafter + ?Sized>(
     decoder: &Decoder,
     prompt_tokens: &[usize],
     kv_caches: &mut [KvCache],
-    drafter: &D,
+    drafter: &mut D,
     options: &SpeculativeOptions,
 ) -> SpeculativeDecodeResult {
     assert!(!prompt_tokens.is_empty(), "prompt must not be empty");
@@ -684,7 +688,12 @@ mod tests {
     }
 
     impl Drafter for FixedDrafter {
-        fn propose(&self, history: &[usize], target_hidden: &[f32], max_len: usize) -> DraftBlock {
+        fn propose(
+            &mut self,
+            history: &[usize],
+            target_hidden: &[f32],
+            max_len: usize,
+        ) -> DraftBlock {
             self.seen_history.borrow_mut().push(history.to_vec());
             self.seen_hidden_len.borrow_mut().push(target_hidden.len());
             let mut block = self.block.clone();
@@ -697,7 +706,7 @@ mod tests {
 
     #[test]
     fn proposes_the_continuation_after_a_real_repeat() {
-        let spec = PromptLookupSpeculator::new(2, 4);
+        let mut spec = PromptLookupSpeculator::new(2, 4);
         // "...1 2 3 4 5 9 9 9 1 2" -> earlier "1 2" occurs at the very
         // start (indices 0-1); the 4 tokens that followed it are
         // "3 4 5 9" (capped at max_draft_len=4).
@@ -741,7 +750,7 @@ mod tests {
 
     #[test]
     fn the_trait_caps_a_block_at_the_callers_budget() {
-        let spec = PromptLookupSpeculator::new(2, 4);
+        let mut spec = PromptLookupSpeculator::new(2, 4);
         let history = vec![1, 2, 3, 4, 5, 9, 9, 9, 1, 2];
         let block = spec.propose(&history, &[], 2);
         assert_eq!(block.tokens(), &[3, 4]);
@@ -840,8 +849,9 @@ mod tests {
 
         let decoder_a = Decoder::new_random_small(cfg.clone(), 2, vocab);
         let mut caches_a = caches(&decoder_a);
-        let speculator = PromptLookupSpeculator::new(2, 3);
-        let result = speculative_decode(&decoder_a, &prompt, max_new, &mut caches_a, &speculator);
+        let mut speculator = PromptLookupSpeculator::new(2, 3);
+        let result =
+            speculative_decode(&decoder_a, &prompt, max_new, &mut caches_a, &mut speculator);
 
         let decoder_b = Decoder::new_random_small(cfg, 2, vocab);
         let mut caches_b = caches(&decoder_b);
@@ -955,7 +965,7 @@ mod tests {
         let seeds = 4_000u64;
 
         let decoder = Decoder::new_random_small(cfg, 1, vocab);
-        let speculator = PromptLookupSpeculator::new(2, 3);
+        let mut speculator = PromptLookupSpeculator::new(2, 3);
         let exact = exact_marginals(&decoder, &prompt, &params, max_new, vocab);
 
         let mut spec_counts = vec![vec![0usize; vocab]; max_new];
@@ -965,7 +975,7 @@ mod tests {
                 &decoder,
                 &prompt,
                 &mut kv,
-                &speculator,
+                &mut speculator,
                 &SpeculativeOptions {
                     max_new_tokens: max_new,
                     sampling: params.clone(),
@@ -1005,8 +1015,8 @@ mod tests {
 
         let decoder = Decoder::new_random_small(cfg, 2, vocab);
         let mut kv = caches(&decoder);
-        let speculator = PromptLookupSpeculator::new(2, 4);
-        let result = speculative_decode(&decoder, &prompt, max_new, &mut kv, &speculator);
+        let mut speculator = PromptLookupSpeculator::new(2, 4);
+        let result = speculative_decode(&decoder, &prompt, max_new, &mut kv, &mut speculator);
 
         assert_eq!(result.tokens_generated, max_new);
         // Plain sequential decode needs exactly `max_new` calls here:
@@ -1032,8 +1042,8 @@ mod tests {
 
         let decoder = Decoder::new_random_small(cfg, 2, vocab);
         let mut kv = caches(&decoder);
-        let speculator = PromptLookupSpeculator::new(10, 4); // ngram far longer than any possible history
-        let result = speculative_decode(&decoder, &prompt, max_new, &mut kv, &speculator);
+        let mut speculator = PromptLookupSpeculator::new(10, 4); // ngram far longer than any possible history
+        let result = speculative_decode(&decoder, &prompt, max_new, &mut kv, &mut speculator);
 
         assert_eq!(result.tokens_generated, max_new);
         assert_eq!(
@@ -1059,9 +1069,9 @@ mod tests {
         let decoder = Decoder::new_random_small(cfg, 2, 8);
         let mut kv = caches(&decoder);
         let prompt = vec![1usize, 2, 3];
-        let drafter = FixedDrafter::new(DraftBlock::deterministic(vec![5, 6]));
+        let mut drafter = FixedDrafter::new(DraftBlock::deterministic(vec![5, 6]));
 
-        let result = speculative_decode(&decoder, &prompt, 4, &mut kv, &drafter);
+        let result = speculative_decode(&decoder, &prompt, 4, &mut kv, &mut drafter);
 
         let seen = drafter.seen_history.borrow();
         assert!(!seen.is_empty(), "the drafter must actually be consulted");
@@ -1089,9 +1099,9 @@ mod tests {
         let hidden_dim = cfg.hidden_dim;
         let decoder = Decoder::new_random_small(cfg, 2, 8);
         let mut kv = caches(&decoder);
-        let drafter = FixedDrafter::new(DraftBlock::deterministic(vec![5, 6]));
+        let mut drafter = FixedDrafter::new(DraftBlock::deterministic(vec![5, 6]));
 
-        speculative_decode(&decoder, &[1usize, 2, 3], 4, &mut kv, &drafter);
+        speculative_decode(&decoder, &[1usize, 2, 3], 4, &mut kv, &mut drafter);
 
         let lens = drafter.seen_hidden_len.borrow();
         assert!(!lens.is_empty());
@@ -1112,12 +1122,12 @@ mod tests {
         let cfg = tiny_test_config();
         let vocab = 8;
         let decoder = Decoder::new_random_small(cfg, 2, vocab);
-        let speculator = PromptLookupSpeculator::new(2, 3);
+        let mut speculator = PromptLookupSpeculator::new(2, 3);
         let full_prompt = vec![1usize, 2, 3, 4, 1, 2];
         let max_new = 6;
 
         let mut fresh = caches(&decoder);
-        let cold = speculative_decode(&decoder, &full_prompt, max_new, &mut fresh, &speculator);
+        let cold = speculative_decode(&decoder, &full_prompt, max_new, &mut fresh, &mut speculator);
 
         // Warm: feed the first 4 prompt tokens through the decoder
         // first, then resume speculative decoding from position 4.
@@ -1128,7 +1138,7 @@ mod tests {
             &decoder,
             &full_prompt[split..],
             &mut warm,
-            &speculator,
+            &mut speculator,
             &SpeculativeOptions {
                 max_new_tokens: max_new,
                 start_pos: split,
@@ -1153,7 +1163,7 @@ mod tests {
         let decoder = Decoder::new_random_small(cfg, 2, 8);
         // Token 7 is a fixed guess; whether it is accepted is up to the
         // model, but the invariant below holds either way.
-        let drafter = FixedDrafter::new(DraftBlock::deterministic(vec![7, 7, 7]));
+        let mut drafter = FixedDrafter::new(DraftBlock::deterministic(vec![7, 7, 7]));
         let context = vec![1usize, 2, 3, 4];
         let prompt = vec![5usize, 6];
         let max_new = 6;
@@ -1166,7 +1176,7 @@ mod tests {
             &decoder,
             &prompt,
             &mut kv,
-            &drafter,
+            &mut drafter,
             &SpeculativeOptions {
                 max_new_tokens: max_new,
                 start_pos: context.len(),
@@ -1197,14 +1207,14 @@ mod tests {
         // call: this is what "not a demo" means for the serving path.
         let cfg = tiny_test_config();
         let decoder = Decoder::new_random_small(cfg, 2, 8);
-        let speculator = PromptLookupSpeculator::new(2, 3);
+        let mut speculator = PromptLookupSpeculator::new(2, 3);
         let prompt = vec![1usize, 2, 3, 4, 1, 2];
 
         let mut one = caches(&decoder);
-        let long = speculative_decode(&decoder, &prompt, 8, &mut one, &speculator);
+        let long = speculative_decode(&decoder, &prompt, 8, &mut one, &mut speculator);
 
         let mut kv = caches(&decoder);
-        let first = speculative_decode(&decoder, &prompt, 4, &mut kv, &speculator);
+        let first = speculative_decode(&decoder, &prompt, 4, &mut kv, &mut speculator);
         // The last generated token's KV is not in the cache yet, so it
         // is the first token of the continuation's "prompt".
         let resume_prompt = vec![*first.generated_tokens.last().unwrap()];
@@ -1213,7 +1223,7 @@ mod tests {
             &decoder,
             &resume_prompt,
             &mut kv,
-            &speculator,
+            &mut speculator,
             &SpeculativeOptions {
                 max_new_tokens: 5,
                 start_pos: start,
@@ -1238,8 +1248,8 @@ mod tests {
         let decoder = Decoder::new_random_small(cfg, 2, 8);
         let mut kv = caches(&decoder);
         decoder.forward_batch(&[1usize, 2, 3], 0, &mut kv);
-        let speculator = PromptLookupSpeculator::new(2, 2);
-        speculative_decode(&decoder, &[4usize, 5], 2, &mut kv, &speculator);
+        let mut speculator = PromptLookupSpeculator::new(2, 2);
+        speculative_decode(&decoder, &[4usize, 5], 2, &mut kv, &mut speculator);
     }
 
     // ---- acceptance metrics ----
@@ -1273,8 +1283,8 @@ mod tests {
         let mut kv = caches(&decoder);
         // Token 7 against a random model: whatever happens, every
         // counted position must have been reachable.
-        let drafter = FixedDrafter::new(DraftBlock::deterministic(vec![7, 7, 7, 7]));
-        let result = speculative_decode(&decoder, &[1usize, 2, 3], 6, &mut kv, &drafter);
+        let mut drafter = FixedDrafter::new(DraftBlock::deterministic(vec![7, 7, 7, 7]));
+        let result = speculative_decode(&decoder, &[1usize, 2, 3], 6, &mut kv, &mut drafter);
 
         let evaluated = &result.evaluated_at_position;
         let accepted = &result.accepted_at_position;
@@ -1321,8 +1331,9 @@ mod tests {
         let cfg = tiny_test_config();
         let decoder = Decoder::new_random_small(cfg, 2, 8);
         let mut kv = caches(&decoder);
-        let speculator = PromptLookupSpeculator::new(2, 3);
-        let result = speculative_decode(&decoder, &[1usize, 2, 3, 1, 2], 6, &mut kv, &speculator);
+        let mut speculator = PromptLookupSpeculator::new(2, 3);
+        let result =
+            speculative_decode(&decoder, &[1usize, 2, 3, 1, 2], 6, &mut kv, &mut speculator);
 
         assert_eq!(result.verification_steps, result.forward_calls - 1);
         let length = result.acceptance_length().unwrap();

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,8 +8,14 @@ Two files hold the plan:
   own.
 - **[`roadmap.md`](roadmap.md)** is every open item, merged by theme.
 
-Two items are large enough to carry their own design document:
+Three items are large enough to carry their own design document:
 
+- **[`speculative-decoding.md`](speculative-decoding.md)**, the one
+  decode item that raises throughput without buying hardware. Decode
+  reads every weight per token, so bandwidth divided by model bytes is a
+  hard ceiling; a draft model changes what is read per token rather than
+  how fast. The lossless half already ships and is tested at 200k
+  samples. What is missing is a drafter worth having.
 - **[`model-layer-reorg.md`](model-layer-reorg.md)**, splitting the
   decoder so architectures scale. It was 6438 lines when that document
   was written and is 6875 today.

--- a/docs/plans/speculative-decoding.md
+++ b/docs/plans/speculative-decoding.md
@@ -1,0 +1,161 @@
+---
+name: "speculative decoding with a real draft model, on CPU, CUDA and Metal"
+overview: "THE ONE ITEM THAT RAISES DECODE THROUGHPUT WITHOUT BUYING HARDWARE. Decode is memory-bandwidth bound: to emit one token the engine reads every weight in the model, so a 17 GB checkpoint on a 960 GB/s card cannot exceed ~56 tok/s no matter how good the kernels are. That ceiling is arithmetic, not engineering. Speculative decoding breaks it by changing WHAT IS READ PER TOKEN rather than how fast it is read: a small draft model proposes k tokens, the target verifies all k in ONE pass over its weights, and the rejection rule guarantees the output distribution is exactly the target's. FERROX ALREADY HAS THE HARD HALF. `speculative.rs` implements the Leviathan/Chen rejection rule, is lossless at every temperature rather than only at `--temp 0`, and proves it against 200k sampled tokens. What is missing is a DRAFTER WORTH HAVING: the only implementation in the tree is an n-gram prompt-lookup with no model at all. This plan adds a second GGUF as the draft model, wires it through the CLI and the server, and refuses loudly when the two checkpoints do not share a vocabulary. SCOPE: CPU, CUDA and Metal, which is every backend ferrox has. No AMD-specific work."
+---
+
+# Speculative decoding with a real draft model
+
+## Why this is the highest-leverage decode item
+
+Decode reads the whole model per token. That gives a hard ceiling:
+
+```
+tokens/sec <= memory bandwidth / model bytes
+```
+
+A 17 GB checkpoint at 960 GB/s cannot pass ~56 tok/s. Better kernels
+move the engine toward that number and cannot move it past. Every other
+decode optimisation in `roadmap.md` is a fight for the gap between where
+ferrox is and where that ceiling sits. This item moves the ceiling.
+
+The mechanism is one sentence: a 2 GB drafter proposes k tokens, the
+17 GB target checks all k in a single pass over its weights, good
+guesses are kept and bad ones discarded, and the text is exactly what
+the target would have written alone. Published chases of this on one
+desktop card report 38 to over 100 tok/s on a 27B model, and every gain
+after the first came from making the guesser better and the check
+cheaper rather than from new hardware.
+
+## What ferrox already has
+
+`crates/ferrox-models/src/speculative.rs`, 1343 lines:
+
+- `speculative_decode_with`, which verifies a proposed block in one
+  `forward_batch` call and does not care who proposed it.
+- `accept_or_resample`, the speculative-sampling rejection rule: accept
+  a draft token with probability `min(1, p(x)/q(x))`, and on rejection
+  resample from the normalised residual `max(0, p - q)`. **Lossless at
+  every temperature**, not only at `--temp 0`, which is the difference
+  between the claim and the property. The old argmax test was the
+  `temperature = 0` special case and silently biased generation toward
+  the target's argmax above it.
+- Three tests that would catch a regression in that: 200k tokens through
+  the rule against deliberately bad draft distributions, a temperature
+  1.0 decode against exactly enumerated per-position marginals, and
+  token-for-token identity with a plain loop at temperature 0.
+- `ferrox-api`'s `Usage` already declares `acceptance_length`,
+  `draft_tokens`, `accepted_draft_tokens` and
+  `draft_accept_rate_per_position`, the last per position rather than
+  folded into the mean, because a drafter that is right at position 0
+  and useless by position 7 has the same mean as a uniformly mediocre
+  one and the two want opposite block sizes.
+
+So the verification half is done, tested, and backend-agnostic: it goes
+through `forward_batch`, which already runs on CPU, CUDA and Metal.
+
+## What is missing
+
+**A drafter worth having.** The only `Drafter` in the tree is
+`PromptLookupSpeculator`, an n-gram match over the history with no model
+at all. It is free and it helps on repetitive text, which is why it was
+first. It cannot carry a coding workload.
+
+**Any wiring at all.** `ferrox speculative` is a demo command on
+synthetic random weights, so the hit rate it prints says nothing about a
+real checkpoint. `ferrox run` has no draft flags. The server has no
+speculative path, so every speculation field in `Usage` is absent on
+every response. `--mtp` errors by design.
+
+## The steps, each of which ships on its own
+
+Ranked by `ship-small-or-do-not-start`. Step 1 alone is a usable
+speedup; nothing here is a prerequisite for a later step being useful.
+
+### 1. `DraftModelSpeculator`: a second GGUF as the drafter
+
+A `Drafter` that owns its own `Decoder` and its own `KvCache`, runs k
+cheap `forward_token` steps, and returns the block with each position's
+sampled distribution so the rejection rule has the `q(x)` it needs.
+
+Two things this step must get right:
+
+- **`Drafter::propose` has to take `&mut self`.** A draft model carries
+  KV state across calls. Interior mutability would hide that in a
+  `RefCell` and cost a runtime borrow check on the hot path for nothing.
+- **The draft KV must roll back on rejection.** When the target rejects
+  position i, the drafter has already advanced its cache past it. If
+  that is not truncated the drafter's context silently diverges from the
+  target's, and the symptom is a collapsing accept rate rather than an
+  error. This is the same shape as everything else in this repo: two
+  structures that must agree about one thing.
+
+### 2. Refuse a mismatched vocabulary, loudly
+
+The gotcha that costs everyone a day. Draft and target must agree on
+token ids. If they do not, `q(x)` and `p(x)` are indexed by different
+vocabularies, the rejection rule is comparing unrelated numbers, and the
+result is not the target's distribution while looking exactly like it
+is: fluent text, no error, a plausible accept rate.
+
+So this is a refusal, checked at load, naming both checkpoints and what
+differs: vocabulary size first, then a hash of the token strings, since
+equal sizes do not imply equal vocabularies. Per this repo's rule a
+refusal is coverage, and this one is the difference between lossless
+being true and being a claim.
+
+### 3. CLI flags, spelled as llama.cpp spells them
+
+`-md` / `--model-draft`, `--draft-max` (alias `--draft`), `--draft-min`,
+`--draft-p-min`. A client that already drives `llama-server` should not
+have to learn new names. Report acceptance length and the per-position
+accept rate on stderr beside the existing throughput line.
+
+### 4. The server path, and the `Usage` fields it already declares
+
+`FERROX_DRAFT_MODEL_PATH`, the draft decoder held beside the target, and
+the four speculation fields populated instead of absent. `None` and
+`Some(1.0)` are different answers there: "speculation did not run"
+versus "speculation ran and never helped".
+
+Continuous batching is explicitly NOT in this step. A shared drafter
+across concurrent sequences is a different design and belongs after a
+single-stream path is measured.
+
+### 5. Make the guesser better and the check cheaper
+
+Only after 1 to 4 are measured, because this is where effort goes once
+the shape works, and because none of it is verifiable without a baseline:
+
+- Adaptive block size from the observed per-position accept rate, rather
+  than a fixed k. The per-position vector in `Usage` exists for this.
+- Stop drafting when the drafter's own confidence falls below
+  `--draft-p-min`, rather than always proposing k.
+- Tree drafting and batched verification of several branches.
+- A learned drafter behind the same trait: an MTP head (`--mtp` is
+  reserved for exactly this and errors today), or EAGLE-style
+  hidden-state conditioning, for which `Drafter::propose` already
+  receives the target's final-layer hidden state.
+
+## How this gets measured, and by whom
+
+**Not by an agent.** A loaded host reads 25 to 45 percent low, and a bad
+number published is worse than no number.
+
+The claim to test is not "tok/s went up". It is two claims:
+
+1. **The output distribution is unchanged.** At `--temp 0` the text must
+   be token-for-token identical to a plain decode of the same prompt and
+   seed. That is a test, not a benchmark, and it runs in CI.
+2. **Tok/s went up on a real checkpoint**, measured with `ferrox bench`
+   on a quiet host, reported as a pair with the acceptance length, since
+   a speedup without an accept rate cannot be reproduced or debugged.
+
+Acceptance is genre-conditional: a drafter that carries code will do
+worse on prose. Report which prompt produced the number.
+
+## Not in scope
+
+AMD and HIP. ferrox's backends are CPU, CUDA and Metal, and Vulkan is
+one `Q8_0` matvec. Nothing in this plan is backend-specific: the draft
+model is another `Decoder` and verification is another `forward_batch`,
+so all three backends get it from the same code.


### PR DESCRIPTION
Step 1 of `docs/plans/speculative-decoding.md`, which this PR also adds.

## Why this item

Decode reads every weight to emit one token, so `tokens/sec <= bandwidth / model bytes` is a hard ceiling. A 17 GB checkpoint on a 960 GB/s card cannot pass ~56 tok/s however good the kernels are. Every other decode item fights for the gap below that number; a draft model moves the number.

ferrox already had the half that is hard: the rejection rule, lossless at every temperature rather than only at `--temp 0`, proven against 200k sampled tokens. What was missing was a drafter worth running. The only `Drafter` in the tree is an n-gram match with no model at all.

## Three things it has to get right

Each has a test that goes red without it. I sabotaged them rather than assuming.

**The draft cache rolls back.** The drafter advances over tokens the target may reject. Left in place its context diverges and *nothing errors*: the accept rate decays, reading as "bad drafter" rather than "desynchronised drafter". Removing the rollback turns three tests red.

**The rollback stops one short.** Truncating to the full history leaves nothing to feed, so no logits, so every call after a rollback proposes nothing. Speculation silently stops happening while staying perfectly correct, which surfaces as a benchmark result months later.

**`q` is honest.** This one is worth reading. Reporting certainty for every drafted token **passed all seven tests written before it** — at temperature 0 the true distribution IS a point mass, so a lie is accidentally correct. The test that catches it sets a temperature. A suite that only checks greedy decoding will pass a drafter that lies, and that is a general lesson about this feature, not a detail of this PR.

A mismatched vocabulary is refused at construction, naming both sizes: `q(x)` and `p(x)` would be probabilities of different tokens, and the output is fluent text with a plausible accept rate.

## Scope

CPU, CUDA and Metal, which is every backend ferrox has. Nothing here is backend-specific: the drafter is another `Decoder`, verification is another `forward_batch`. No AMD work.

Not wired to the CLI or server yet, deliberately: those are steps 3 and 4, and each ships on its own.

**No performance number is claimed.** The plan records that measurement belongs to a person on a quiet host, reported as a pair with the acceptance length, since a speedup without an accept rate cannot be reproduced or debugged.

## Gates

Workspace build, 51 test suites, clippy debug and release, fmt. All clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN