### PR TITLE
fix(server): the batched prefill re-ran the whole prompt on top of the prefix it had just adopted

### DIFF
--- a/crates/ferrox-core/src/cache.rs
+++ b/crates/ferrox-core/src/cache.rs
@@ -605,7 +605,17 @@ impl PagedKvCache {
     ///
     /// This is how a sequence starts life on top of a cached prefix:
     /// the blocks are somebody else's, already full, and this sequence
-    /// appends past them. `seq_len` MUST be a whole number of blocks,
+    /// appends past them.
+    ///
+    /// The `seq_len` installed here is therefore also the POSITION the
+    /// caller's next forward pass must run at, and the caller has no
+    /// second source for that number: [`Self::push`] writes at `seq_len`
+    /// and ignores whatever position its caller believes it is at. A
+    /// prefill that started from zero over an adopted prefix put the
+    /// prompt in the rows *after* the prefix while carrying positions
+    /// `0..n`, which is a wrong answer served with a 200.
+    ///
+    /// `seq_len` MUST be a whole number of blocks,
     /// because the first append writes at `seq_len` and a shared block
     /// must never be written -- another sequence is attending over it.
     /// A ragged length would put that write inside the last shared

--- a/crates/ferrox-server/src/serving/batch/prefill.rs
+++ b/crates/ferrox-server/src/serving/batch/prefill.rs
@@ -37,6 +37,9 @@ pub struct PrefillState {
     /// forward pass is still required to produce the logits the first
     /// sampled token comes from.
     tokens: Vec<usize>,
+    /// How far through `tokens` this prefill has got. Never assigned a
+    /// literal: it is seeded from, and re-checked against,
+    /// [`RowKv::positions_written`] -- see [`PrefillState::over`].
     tokens_processed: usize,
     logits: Vec<f32>,
     chunk_size: usize,
@@ -44,7 +47,6 @@ pub struct PrefillState {
 
 impl PrefillState {
     pub fn new(decoder: Arc<Decoder>, prompt_tokens: &[usize], chunk_size: usize) -> Self {
-        assert!(chunk_size > 0, "prefill chunk size must be positive");
         let kv = RowKv::Contiguous(
             decoder
                 .layers
@@ -52,19 +54,7 @@ impl PrefillState {
                 .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
                 .collect(),
         );
-        let tokens = if prompt_tokens.is_empty() {
-            vec![0]
-        } else {
-            prompt_tokens.to_vec()
-        };
-        PrefillState {
-            decoder,
-            kv,
-            tokens,
-            tokens_processed: 0,
-            logits: Vec::new(),
-            chunk_size,
-        }
+        PrefillState::over(decoder, kv, prompt_tokens, chunk_size)
     }
 
     /// A prefill whose KV lives in a shared paged store, with its
@@ -73,11 +63,35 @@ impl PrefillState {
     /// Reserved for `prompt + max_tokens` at admission for the same
     /// reason the private path does it: the decode step has nowhere to
     /// report a store that ran dry mid-answer.
+    ///
+    /// The lease may arrive with a radix prefix already installed. That
+    /// is not this constructor's business to know: [`Self::over`] reads
+    /// the starting position off the KV, so a pre-seeded lease and a
+    /// cold one take the same path.
     pub fn new_paged(
         decoder: Arc<Decoder>,
         prompt_tokens: &[usize],
         chunk_size: usize,
         lease: PagedLease,
+    ) -> Self {
+        PrefillState::over(decoder, RowKv::Paged(lease), prompt_tokens, chunk_size)
+    }
+
+    /// The ONE place a prefill's starting position is decided, for
+    /// every kind of KV a row can have.
+    ///
+    /// It is read off the KV rather than assumed, because the KV is the
+    /// only thing that knows: `push` writes at its cache's `seq_len`
+    /// whatever position the caller names. A second constructor that
+    /// wrote `tokens_processed: 0` beside this one is exactly how issue
+    /// #37 happened -- a paged lease that had adopted a cached prefix
+    /// re-ran the whole prompt on top of it -- so there is no second
+    /// constructor, and no literal to get wrong.
+    fn over(
+        decoder: Arc<Decoder>,
+        mut kv: RowKv,
+        prompt_tokens: &[usize],
+        chunk_size: usize,
     ) -> Self {
         assert!(chunk_size > 0, "prefill chunk size must be positive");
         let tokens = if prompt_tokens.is_empty() {
@@ -85,17 +99,33 @@ impl PrefillState {
         } else {
             prompt_tokens.to_vec()
         };
+        let tokens_processed = kv.positions_written();
+        // `acquire_paged_caches` backs the adopted prefix off by a page
+        // so that at least one token is left to run: a prefill with
+        // nothing to run produces no logits, and the first sampled
+        // token has nowhere to come from. This is the assertion that
+        // holds that back-off and this loop to the same story.
+        debug_assert!(
+            tokens_processed < tokens.len(),
+            "a prefill must have at least one token left to run, \
+             got {tokens_processed} already done of {} -- the adopted \
+             prefix was not backed off",
+            tokens.len()
+        );
         PrefillState {
             decoder,
-            kv: RowKv::Paged(lease),
+            kv,
             tokens,
-            tokens_processed: 0,
+            tokens_processed,
             logits: Vec::new(),
             chunk_size,
         }
     }
 
-    /// Prompt tokens already through the model.
+    /// Prompt positions already in this row's KV. Includes any prefix
+    /// the lease adopted from the radix tree: those positions are
+    /// computed and resident, they were just computed by an earlier
+    /// request.
     pub fn tokens_processed(&self) -> usize {
         self.tokens_processed
     }
@@ -113,25 +143,35 @@ impl PrefillState {
     /// once the whole prompt has been processed. Calling it again after
     /// that is a no-op that still returns `true`.
     ///
-    /// The KV position of each token is its index in the prompt, so
-    /// resuming across chunk boundaries is exactly the sequential
-    /// `forward_token` loop it replaces, split at different points.
+    /// The KV position of each token is the row the KV will write it
+    /// into, so resuming across chunk boundaries is exactly the
+    /// sequential `forward_token` loop it replaces, split at different
+    /// points.
     pub fn step_chunk(&mut self) -> bool {
         let end = (self.tokens_processed + self.chunk_size).min(self.tokens.len());
-        for pos in self.tokens_processed..end {
+        while self.tokens_processed < end {
+            // The position comes from the KV every step, never from a
+            // counter kept alongside it. `push` writes at `seq_len` and
+            // discards this argument, so any other value pairs a row
+            // with a RoPE angle that does not belong to it -- fluent,
+            // wrong, and silent.
+            let pos = self.kv.positions_written();
+            debug_assert_eq!(
+                pos, self.tokens_processed,
+                "the KV write cursor and the prompt cursor diverged"
+            );
+            let token = self.tokens[self.tokens_processed];
             self.logits = match &mut self.kv {
-                RowKv::Contiguous(caches) => {
-                    self.decoder.forward_token(self.tokens[pos], pos, caches)
-                }
+                RowKv::Contiguous(caches) => self.decoder.forward_token(token, pos, caches),
                 RowKv::Paged(lease) => {
                     let store = Arc::clone(lease.store());
                     self.decoder
-                        .forward_token_paged(self.tokens[pos], pos, lease.caches_mut(), &store)
+                        .forward_token_paged(token, pos, lease.caches_mut(), &store)
                         .expect("the row's pages were reserved at admission")
                 }
             };
+            self.tokens_processed += 1;
         }
-        self.tokens_processed = end;
         self.is_done()
     }
 

--- a/crates/ferrox-server/src/serving/batch/row.rs
+++ b/crates/ferrox-server/src/serving/batch/row.rs
@@ -32,6 +32,36 @@ pub(super) enum RowKv {
     Paged(PagedLease),
 }
 
+impl RowKv {
+    /// Positions already written into this row's KV, and therefore the
+    /// only position a forward pass over it may run at next.
+    ///
+    /// This is a READ of the cursor, not a second derivation of it.
+    /// `KvCache::push` and `PagedKvCache::push` both write at their own
+    /// `seq_len` and IGNORE the position their caller passes alongside,
+    /// so the KV's length is the one true answer and everybody else's is
+    /// a guess that has to be kept in step.
+    ///
+    /// A paged row does not start at zero. `acquire_paged_caches` seeds
+    /// its lease with whatever prefix the radix tree already held
+    /// (`PagedKvCache::adopt_blocks` installs those blocks and sets
+    /// `seq_len` to the prefix length), so a prefill that assumed zero
+    /// re-ran the whole prompt ON TOP of the adopted prefix: the tokens
+    /// landed in rows past it while carrying RoPE positions `0..n`, and
+    /// the answer came back wrong with a 200 on it. That was issue #37,
+    /// and it existed because the batched prefill kept its own copy of
+    /// this number while the private generate loop derived one.
+    ///
+    /// `&mut self` only because [`PagedLease`] exposes its caches
+    /// mutably; nothing here is modified.
+    pub(super) fn positions_written(&mut self) -> usize {
+        match self {
+            RowKv::Contiguous(caches) => caches.first().map_or(0, |c| c.seq_len),
+            RowKv::Paged(lease) => lease.caches_mut().first().map_or(0, |c| c.seq_len()),
+        }
+    }
+}
+
 pub(super) struct Job {
     pub(super) prompt_tokens: Vec<usize>,
     pub(super) params: GenerationParams,

--- a/crates/ferrox-server/src/serving/batch/tests/radix.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/radix.rs
@@ -17,6 +17,7 @@ use std::sync::Mutex;
 
 use ferrox_core::cache::{PageGroup, SharedPagedKv};
 
+use crate::generate::acquire_paged_caches;
 use crate::policy::radix::RadixCache;
 
 use super::super::row::{Job, RowKv, Rows};
@@ -191,6 +192,141 @@ fn a_second_batched_request_adopts_the_pages_the_first_published() {
             store.group_refs(PageGroup(g)),
             1,
             "the row's hold goes back on Drop; the tree's survives"
+        );
+    }
+}
+
+/// A cache HIT must not re-run the prompt on top of the prefix it hit.
+///
+/// The failure this pins down (issue #37): the batched prefill started
+/// at token 0 whatever its lease had already adopted, so the second of
+/// two identical requests wrote its eight prompt tokens into rows
+/// `4..11` of a cache that already held `0..3`, while handing the model
+/// RoPE positions `0..7`. The KV ended `prompt + cached` long instead of
+/// `prompt` long, decode then pushed past the block table the lease
+/// reserved (a per-request page leak, and `PagedStoreExhausted` into an
+/// `.expect` on a tight pool), and the answer was simply different.
+///
+/// `seq_len` is the assertion because it is the one number that cannot
+/// be right by accident: it is where `push` writes, so a cache that is
+/// `cached_len` too long has put every prompt token in the wrong row.
+/// The existing tests here assert page REFCOUNTS, which the bug left
+/// perfectly correct.
+#[test]
+fn a_batched_prefill_over_an_adopted_prefix_ends_exactly_at_the_prompt_length() {
+    let decoder = tiny_decoder();
+    let (config, _store, _radix) = paged_with_radix(&decoder, 64);
+    let prompt = vec![1usize, 2, 3, 4, 5, 6, 7, 8];
+
+    let (first, _rx1) = admit_prefilled(&decoder, &config, prompt.clone(), 4).expect("admitted");
+    finish_row(first);
+
+    let (job, _rx2) = paged_job(prompt.clone(), 4);
+    let mut prefill = accept(&decoder, job, /* chunk_size = */ 3, Some(&config)).expect("admitted");
+
+    // The starting cursor is the adopted prefix, not zero.
+    let adopted = prefill.state.tokens_processed();
+    assert_eq!(
+        adopted, BLOCK,
+        "the second request must start where the prefix it adopted ends"
+    );
+    assert_eq!(prefill.state.tokens_remaining(), prompt.len() - BLOCK);
+
+    while !prefill.state.step_chunk() {}
+    let mut slot = prefill.into_slot();
+    assert_eq!(
+        slot.pos,
+        prompt.len(),
+        "the first generated token sits at the end of the prompt"
+    );
+    let RowKv::Paged(lease) = &mut slot.kv else {
+        panic!("a paged config must produce a paged row");
+    };
+    for (layer, cache) in lease.caches_mut().iter().enumerate() {
+        assert_eq!(
+            cache.seq_len(),
+            prompt.len(),
+            "layer {layer}: a warm prefill left {} KV rows for a {}-token \
+             prompt, so it re-ran the prompt on top of the adopted prefix",
+            cache.seq_len(),
+            prompt.len()
+        );
+    }
+}
+
+/// A warm request must produce the SAME logits as a cold one.
+///
+/// The user-visible half of issue #37: same model, same body, a
+/// different answer, 200 OK, no log line. Bit-identical is the right
+/// bar here -- both runs go through the same paged kernel over the same
+/// page contents, so the only thing that can differ is which row a
+/// token was written into and which position it was told it had.
+#[test]
+fn a_warm_batched_request_produces_the_same_logits_as_a_cold_one() {
+    let decoder = tiny_decoder();
+    let (config, _store, _radix) = paged_with_radix(&decoder, 64);
+    let prompt = vec![1usize, 2, 3, 4, 5, 6, 7, 8];
+
+    let cold = {
+        let (job, _rx) = paged_job(prompt.clone(), 4);
+        let mut prefill = accept(&decoder, job, 3, Some(&config)).expect("admitted");
+        assert_eq!(
+            prefill.state.tokens_processed(),
+            0,
+            "the first request has nothing to adopt"
+        );
+        while !prefill.state.step_chunk() {}
+        let (_kv, logits, _pos, _ids) = prefill.state.into_decode_start();
+        logits
+    };
+    // Publish, so the second request has something to adopt.
+    let (first, _rx1) = admit_prefilled(&decoder, &config, prompt.clone(), 4).expect("admitted");
+    finish_row(first);
+
+    let (job, _rx2) = paged_job(prompt.clone(), 4);
+    let mut prefill = accept(&decoder, job, 3, Some(&config)).expect("admitted");
+    assert!(
+        prefill.state.tokens_processed() > 0,
+        "this test proves nothing unless the second request adopted a prefix"
+    );
+    while !prefill.state.step_chunk() {}
+    let (_kv, warm, _pos, _ids) = prefill.state.into_decode_start();
+
+    assert_eq!(
+        warm, cold,
+        "a prefix-cache hit changed the answer: the warm request's logits \
+         differ from the cold request's for the same prompt"
+    );
+}
+
+/// The lease's own count of adopted positions and the KV rows it was
+/// seeded with must be the same number.
+///
+/// Two structures that have to agree, walked against each other. The
+/// batched prefill reads the cursor off the KV and the private generate
+/// loop derives it from `PagedLease::adopted_positions`; if
+/// `acquire_paged_caches` ever seeds one without the other, this goes
+/// red here rather than as a wrong answer in production.
+#[test]
+fn the_leases_adopted_count_and_its_seeded_kv_rows_agree() {
+    let decoder = tiny_decoder();
+    let (config, _store, _radix) = paged_with_radix(&decoder, 64);
+    let prompt = vec![1usize, 2, 3, 4, 5, 6, 7, 8];
+
+    let (first, _rx1) = admit_prefilled(&decoder, &config, prompt.clone(), 4).expect("admitted");
+    finish_row(first);
+
+    let mut lease = acquire_paged_caches(&decoder, &config, &prompt, prompt.len() + 4)
+        .expect("the store has pages to spare");
+    let claimed = lease.adopted_positions(BLOCK);
+    assert!(claimed > 0, "the second request must adopt something");
+    for (layer, cache) in lease.caches_mut().iter().enumerate() {
+        assert_eq!(
+            cache.seq_len(),
+            claimed,
+            "layer {layer}: the lease says {claimed} positions were adopted \
+             but its KV was seeded with {} rows",
+            cache.seq_len()
         );
     }
 }


### PR DESCRIPTION
Closes #37.

Every continuous-batching prefix-cache hit returned **wrong logits**, served with a 200 and no log line. Two identical requests were enough.

`adopt_blocks` installs the radix prefix and sets `seq_len`. The private generate loop started at `lease.adopted_positions(..)`; the batched twin wrote `tokens_processed: 0`. Since `push` writes at its own `seq_len` and ignores the position its caller passes, the re-run tokens landed *after* the prefix while carrying positions `0..n`. Also leaked a block per request, and could panic the batch worker on a tight pool.

**The fix is not the literal.** Two consumers of one pre-seeded lease each carried their own answer to "where does prefill begin". Writing `adopted_positions(..)` in the second place too would have been a third copy waiting to drift. Instead the number is read off the KV, and `new` and `new_paged` both route through one `PrefillState::over` — there is no literal left to get wrong.

Restoring `tokens_processed = 0` turns two of the three new tests red, including the one comparing warm and cold logits.

Gates: workspace build, 51 suites, clippy debug and release, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN