### PR TITLE
fix(server): max_tokens from an HTTP body could reach Vec::with_capacity(usize::MAX)

### DIFF
--- a/crates/ferrox-models/src/kv_budget.rs
+++ b/crates/ferrox-models/src/kv_budget.rs
@@ -61,17 +61,31 @@ impl KvElem {
     /// Bytes needed to store `elems` cached scalars, rounding up to a
     /// whole block for the block-quantized wires (a partial block still
     /// costs a full one).
+    ///
+    /// Saturating rather than wrapping or panicking. This is a
+    /// REPORTING number: it exists to put bytes in a refusal message,
+    /// and it is reached with position counts that came off an HTTP
+    /// body. `max_tokens: u64::MAX / 64` does not overflow the position
+    /// sum, so it reaches here and multiplied past `u64::MAX`, panicking
+    /// the request thread while computing the text of the very refusal
+    /// that was about to reject it (#36).
+    ///
+    /// Saturating is right HERE and wrong for a bound. A saturated byte
+    /// count still reports "astronomically large", which is the only
+    /// thing the message needs to convey. A saturated position bound
+    /// would silently turn a nonsense request into a plausible one and
+    /// serve it.
     pub fn bytes_for(self, elems: u64) -> u64 {
         match self {
-            KvElem::F32 => elems * 4,
-            KvElem::F16 => elems * 2,
+            KvElem::F32 => elems.saturating_mul(4),
+            KvElem::F16 => elems.saturating_mul(2),
             KvElem::Q8_0 => {
                 let blocks = elems.div_ceil(ferrox_quant::Q8_0_BLOCK_ELEMS as u64);
-                blocks * ferrox_quant::Q8_0_BLOCK_BYTES as u64
+                blocks.saturating_mul(ferrox_quant::Q8_0_BLOCK_BYTES as u64)
             }
             KvElem::Turbo4 => {
                 let blocks = elems.div_ceil(ferrox_quant::TURBO4_KV_GROUP as u64);
-                blocks * ferrox_quant::TURBO4_KV_BLOCK_BYTES as u64
+                blocks.saturating_mul(ferrox_quant::TURBO4_KV_BLOCK_BYTES as u64)
             }
         }
     }
@@ -327,19 +341,19 @@ impl KvShape {
     /// Bytes one request's KV costs at `tokens` of context, applying
     /// the sliding-window cap per layer class.
     pub fn kv_bytes_for_tokens(&self, tokens: usize) -> u64 {
+        // Every multiplication here saturates, for the reason on
+        // `KvElem::bytes_for`: `tokens` can arrive from an HTTP body.
         let per_layer = self.layout.elems_per_token_per_layer();
-        let full =
-            self.full_attention_layers() as u64 * self.elem.bytes_for(per_layer * tokens as u64);
+        let full = (self.full_attention_layers() as u64)
+            .saturating_mul(self.elem.bytes_for(per_layer.saturating_mul(tokens as u64)));
         let sliding = match self.sliding {
             None => 0,
-            Some(w) => {
-                self.sliding_layers() as u64
-                    * self
-                        .elem
-                        .bytes_for(per_layer * w.resident_positions(tokens) as u64)
-            }
+            Some(w) => (self.sliding_layers() as u64).saturating_mul(
+                self.elem
+                    .bytes_for(per_layer.saturating_mul(w.resident_positions(tokens) as u64)),
+            ),
         };
-        full + sliding
+        full.saturating_add(sliding)
     }
 
     /// The sentence a user should be able to read and reproduce with a

--- a/crates/ferrox-server/src/budget.rs
+++ b/crates/ferrox-server/src/budget.rs
@@ -132,6 +132,49 @@ impl ContextCeiling {
         })
     }
 
+    /// The typed refusal for a `prompt + max_tokens` that cannot be
+    /// represented at all, or `None` when the sum is a real number.
+    ///
+    /// The wrap was the whole bug in #36. `prompt_tokens +
+    /// params.max_tokens` is a `usize` addition on a value read
+    /// straight off the wire, so `max_tokens: 18446744073709551615`
+    /// produced `prompt_tokens - 1`, which is BELOW any ceiling. The
+    /// clamp that existed to bound this was therefore skipped by
+    /// exactly the requests that needed it most, and the value went on
+    /// to size a `Vec::with_capacity`.
+    ///
+    /// A wrapping sum is refused even when there is NO ceiling
+    /// configured, because it is not a request any deployment could
+    /// serve: no machine holds `usize::MAX` positions. That is the
+    /// derived invariant doing the work rather than a chosen constant.
+    ///
+    /// `saturating_add` would have been the wrong tool. It silently
+    /// clamps a nonsense value into a plausible one and serves it,
+    /// which answers a question the caller did not ask.
+    pub fn overflow_refusal(&self, prompt_tokens: usize, max_tokens: usize) -> Option<DecodeError> {
+        match prompt_tokens.checked_add(max_tokens) {
+            // It fits in a `usize`, so it is a real request. Whether it
+            // fits the CEILING is the clamp's business, and answering
+            // it here would count a clamp as a refusal.
+            Some(_) => None,
+            None => {
+                self.refused.fetch_add(1, Ordering::Relaxed);
+                Some(DecodeError::KvBudgetExceeded {
+                    binding: Ceiling::ContextLength.code(),
+                    estimated_bytes: 0,
+                    limit_bytes: 0,
+                    positions: usize::MAX,
+                    positions_limit: self.limit.unwrap_or(usize::MAX),
+                    detail: format!(
+                        "prompt of {prompt_tokens} tokens plus max_tokens of {max_tokens} \
+                         overflows the position counter, so this request cannot be served by \
+                         any deployment. Send a max_tokens that fits the model's context"
+                    ),
+                })
+            }
+        }
+    }
+
     /// The typed refusal for a request of `positions` positions, or
     /// `None` when it fits.
     ///
@@ -530,5 +573,97 @@ mod tests {
         });
         let derived = derive_limits(&b, 8192, 256).expect("a bounded KV always fits");
         assert_eq!(derived.max_context, 8192);
+    }
+
+    /// **The wrap that skipped the clamp.** `max_tokens` arrives as a
+    /// `usize` straight off an HTTP body, and `prompt + max_tokens` was
+    /// an unchecked addition. At `usize::MAX` it wrapped to
+    /// `prompt - 1`, which is BELOW any ceiling, so the guard that
+    /// existed to bound the value was skipped by exactly the requests
+    /// that needed bounding. The value then went on to size a
+    /// `Vec::with_capacity`.
+    #[test]
+    fn a_max_tokens_that_wraps_the_position_sum_is_refused() {
+        let ceiling = ContextCeiling::new(Some(100), shape());
+        let err = ceiling
+            .overflow_refusal(10, usize::MAX)
+            .expect("usize::MAX must be refused");
+        assert!(
+            format!("{err}").contains("max_tokens"),
+            "the refusal must name the field the caller sent"
+        );
+
+        // This is the comparison that used to let it through: below the
+        // limit, and not a real request.
+        assert!(
+            10usize.wrapping_add(usize::MAX) < 100,
+            "the wrap this refusal exists to catch"
+        );
+    }
+
+    /// A deployment with NO ceiling is the other half of the hole. It
+    /// cannot clamp, so it must still refuse a sum that cannot exist,
+    /// rather than treating "no ceiling" as "unbounded".
+    #[test]
+    fn a_wrapping_sum_is_refused_even_with_no_ceiling_configured() {
+        let ceiling = ContextCeiling::new(None, shape());
+        assert!(
+            ceiling.overflow_refusal(10, usize::MAX).is_some(),
+            "no ceiling is not a licence to accept a request no machine could serve"
+        );
+        assert!(ceiling.overflow_refusal(10, 100).is_none());
+    }
+
+    /// This guard refuses the IMPOSSIBLE, not the merely oversized.
+    ///
+    /// A request past the ceiling is servable and is clamped by the
+    /// caller. Refusing it here would turn a servable long-prompt
+    /// request into a 400 over a `max_tokens` the caller very likely
+    /// never set, and would count a clamp as a refusal in the stats.
+    #[test]
+    fn an_ordinary_request_past_the_ceiling_is_left_for_the_clamp() {
+        let ceiling = ContextCeiling::new(Some(100), shape());
+        assert!(ceiling.overflow_refusal(10, 50).is_none(), "10 + 50 fits");
+        assert!(
+            ceiling.overflow_refusal(10, 200).is_none(),
+            "over the ceiling but representable: the clamp handles it"
+        );
+        assert_eq!(ceiling.refused(), 0, "a clamp is not a refusal");
+    }
+
+    /// **A `max_tokens` that does NOT wrap still reached an overflow**,
+    /// one layer down, while computing the byte count for the refusal
+    /// message. `u64::MAX / 64` positions multiplied past `u64::MAX` in
+    /// `KvShape::kv_bytes_for_tokens` and panicked the request thread.
+    ///
+    /// Sized past the lazy-allocation threshold on purpose: a test at
+    /// `500_000_000` would pass whatever the code does, because a large
+    /// `Vec::with_capacity` is reserved lazily on macOS and the loop
+    /// fails on the first read. `u64::MAX / 64` fails deterministically.
+    #[test]
+    fn a_huge_but_representable_max_tokens_reports_bytes_instead_of_panicking() {
+        let ceiling = ContextCeiling::new(Some(100), shape());
+        // 10 + u64::MAX/64, which is what a 10-token prompt with
+        // `max_tokens: u64::MAX / 64` really produces. Exactly
+        // `u64::MAX / 64` lands just UNDER the overflow and would make
+        // this test pass whatever the code does, which is the same trap
+        // as sizing an allocation test below the lazy-reserve
+        // threshold: the number has to be chosen to fail.
+        let positions = 10 + (u64::MAX / 64) as usize;
+
+        // The byte count saturates rather than overflowing. It is a
+        // reporting number, and "astronomically large" is all the
+        // message needs to convey.
+        // Asserted as "astronomically large" rather than as an exact
+        // number: whether it saturates or merely lands just under
+        // `u64::MAX` depends on the shape, and the property that matters
+        // is that it is produced at all.
+        assert!(ceiling.bytes_for(positions) > u64::MAX / 2);
+
+        // And the refusal it feeds is produced, not panicked through.
+        let err = ceiling
+            .refusal(positions)
+            .expect("far past a 100-position ceiling");
+        assert!(format!("{err}").contains("100"));
     }
 }

--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -1285,8 +1285,16 @@ pub fn generate(
             if let Some(err) = ceiling.prompt_refusal(prompt_tokens) {
                 return Err(err);
             }
+            // Checked BEFORE the clamp below, because the clamp's own
+            // comparison used to be the thing that wrapped: a
+            // `max_tokens` near `usize::MAX` summed to less than the
+            // limit and walked straight past the guard that existed to
+            // stop it. See `ContextCeiling::positions_refusal`.
+            if let Some(err) = ceiling.overflow_refusal(prompt_tokens, params.max_tokens) {
+                return Err(err);
+            }
             match ceiling.limit() {
-                Some(limit) if prompt_tokens + params.max_tokens > limit => {
+                Some(limit) if prompt_tokens.saturating_add(params.max_tokens) > limit => {
                     let mut p = params.clone();
                     p.max_tokens = limit - prompt_tokens;
                     tracing::debug!(
@@ -1302,7 +1310,24 @@ pub fn generate(
         }
         None => params,
     };
-    let max_seq_len = prompt_tokens + params.max_tokens;
+    // `params` is the clamped copy by now, so this cannot exceed the
+    // ceiling when one exists. `checked_add` covers the case where none
+    // does: an unbounded deployment must still not wrap into a small
+    // number and pass every check below it.
+    let Some(max_seq_len) = prompt_tokens.checked_add(params.max_tokens) else {
+        return Err(DecodeError::KvBudgetExceeded {
+            binding: ferrox_models::Ceiling::ContextLength.code(),
+            estimated_bytes: 0,
+            limit_bytes: 0,
+            positions: usize::MAX,
+            positions_limit: usize::MAX,
+            detail: format!(
+                "prompt of {prompt_tokens} tokens plus max_tokens of {} overflows the position \
+                 counter, so this request cannot be served by any deployment",
+                params.max_tokens
+            ),
+        });
+    };
 
     // A request whose worst case exceeds the *whole* pool is not a
     // request to retry: no amount of waiting frees blocks that do not
@@ -1591,7 +1616,15 @@ fn sample_until_stop(
 ) -> Result<(FinishReason, Vec<usize>, Vec<f32>), DecodeError> {
     let mut matcher = crate::stop::StopMatcher::new(&params.stop, &params.stop_token_ids);
     let mut state = crate::sample_step::SampleState::new(params.seed);
-    let mut generated_ids: Vec<usize> = Vec::with_capacity(params.max_tokens);
+    // NOT `with_capacity(params.max_tokens)`. That is a caller-supplied
+    // number sizing an allocation, and it reached
+    // `Vec::with_capacity(usize::MAX)` from one unauthenticated POST.
+    // The vector grows as tokens are produced, so the reservation only
+    // ever saved reallocations on a path that performs a full model
+    // forward pass per element. A cap keeps that saving for the sizes
+    // it was worth having for, and refuses to pre-size beyond them.
+    const PREALLOC_CAP: usize = 4096;
+    let mut generated_ids: Vec<usize> = Vec::with_capacity(params.max_tokens.min(PREALLOC_CAP));
     let mut finish = FinishReason::Length;
 
     for _ in 0..params.max_tokens {


### PR DESCRIPTION
Closes #36. One unauthenticated POST; auth is off unless `FERROX_API_KEY` is set.

`max_tokens` is a `usize` off the wire, validated only for `== 0`. The clamp that would bound it needs a ceiling that is often absent, and **even with a ceiling the clamp was bypassed**: its own `prompt + max_tokens` was unchecked, so `usize::MAX` wrapped to `prompt - 1`, below any limit. The guard was skipped by exactly the requests that needed it.

`ContextCeiling::overflow_refusal` sits in the one place all three entry points already pass through. It refuses only the *impossible*; a sum merely over the ceiling is still clamped, because refusing that turns a servable 100k-prompt request into a 400 over a `max_tokens` the caller never set. `saturating_add` would have been wrong: it makes nonsense plausible and serves it.

## Writing the test found a second bug

A `max_tokens` that does **not** wrap still overflowed one layer down — while computing the byte count *for the refusal message*. The request panicked inside the very refusal about to reject it. Those multiplies now saturate, which is correct for a reporting number and would be wrong for a bound.

## On the test values

Both are chosen to fail, not to look thorough. For the byte overflow I first used `u64::MAX / 64`, which lands just **under** the boundary and passed no matter what the code did; `10 + u64::MAX / 64` is what a 10-token prompt really produces. Same trap as sizing an allocation test below the lazy-reserve threshold. Sabotage-verified after correcting it.

Gates: workspace build, 51 suites, clippy debug and release, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN