### PR TITLE
fix(server): Metal CB prefill host K/V (0.15.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-api"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cli"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-core"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cuda"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "cudarc",
  "ferrox-quant",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-gguf"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-inference"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "ferrox-api",
  "ferrox-core",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-metal"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "ferrox-quant",
  "half",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-models"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-moe"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "ferrox-core",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-quant"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "half",
  "thiserror",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-safetensors"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "byteorder",
  "memmap2",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-server"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-vulkan"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "ash",
  "ferrox-quant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/antonellof/ferrox"
@@ -57,19 +57,19 @@ minijinja = { version = "2.21", features = ["loop_controls", "json"] }
 libc = "0.2"
 
 # Internal crates — path for local builds, version for crates.io.
-ferrox-api = { version = "0.15.2", path = "crates/ferrox-api" }
-ferrox-gguf = { version = "0.15.2", path = "crates/ferrox-gguf" }
-ferrox-quant = { version = "0.15.2", path = "crates/ferrox-quant" }
-ferrox-safetensors = { version = "0.15.2", path = "crates/ferrox-safetensors" }
-ferrox-cuda = { version = "0.15.2", path = "crates/ferrox-cuda" }
-ferrox-metal = { version = "0.15.2", path = "crates/ferrox-metal" }
-ferrox-vulkan = { version = "0.15.2", path = "crates/ferrox-vulkan" }
-ferrox-core = { version = "0.15.2", path = "crates/ferrox-core" }
-ferrox-moe = { version = "0.15.2", path = "crates/ferrox-moe" }
-ferrox-models = { version = "0.15.2", path = "crates/ferrox-models" }
-ferrox-inference = { version = "0.15.2", path = "crates/ferrox-inference" }
+ferrox-api = { version = "0.15.3", path = "crates/ferrox-api" }
+ferrox-gguf = { version = "0.15.3", path = "crates/ferrox-gguf" }
+ferrox-quant = { version = "0.15.3", path = "crates/ferrox-quant" }
+ferrox-safetensors = { version = "0.15.3", path = "crates/ferrox-safetensors" }
+ferrox-cuda = { version = "0.15.3", path = "crates/ferrox-cuda" }
+ferrox-metal = { version = "0.15.3", path = "crates/ferrox-metal" }
+ferrox-vulkan = { version = "0.15.3", path = "crates/ferrox-vulkan" }
+ferrox-core = { version = "0.15.3", path = "crates/ferrox-core" }
+ferrox-moe = { version = "0.15.3", path = "crates/ferrox-moe" }
+ferrox-models = { version = "0.15.3", path = "crates/ferrox-models" }
+ferrox-inference = { version = "0.15.3", path = "crates/ferrox-inference" }
 # Only ferrox-cli depends on this, and only behind its optional `serve`
 # feature. The server's dependency set is a strict superset of the CLI's
 # (+98 crates, +6 MB), so an unconditional dependency would make
 # `cargo install ferrox-cli` compile an HTTP and TLS stack it never runs.
-ferrox-server = { version = "0.15.2", path = "crates/ferrox-server" }
+ferrox-server = { version = "0.15.3", path = "crates/ferrox-server" }

--- a/crates/ferrox-server/src/serving/batch/prefill.rs
+++ b/crates/ferrox-server/src/serving/batch/prefill.rs
@@ -1,9 +1,9 @@
 //! Chunked prefill: a prompt as a resumable state machine rather than
 //! one uninterruptible `forward_token` loop.
 //!
-//! Chunking is a *scheduling* boundary, not a numerical one. A chunk is
-//! still the same per-token sequence at the same positions, so chunk
-//! size never changes the logits or the sampled tokens (asserted by
+//! Chunking is a *scheduling* boundary, not a numerical one. Each chunk
+//! runs the same prompt slice at the same positions, so chunk size never
+//! changes the final logits or sampled tokens (asserted by
 //! `prefill_chunking_does_not_change_logits`).
 
 use std::sync::mpsc::Sender;
@@ -149,29 +149,33 @@ impl PrefillState {
     /// points.
     pub fn step_chunk(&mut self) -> bool {
         let end = (self.tokens_processed + self.chunk_size).min(self.tokens.len());
-        while self.tokens_processed < end {
-            // The position comes from the KV every step, never from a
-            // counter kept alongside it. `push` writes at `seq_len` and
-            // discards this argument, so any other value pairs a row
-            // with a RoPE angle that does not belong to it -- fluent,
-            // wrong, and silent.
-            let pos = self.kv.positions_written();
-            debug_assert_eq!(
-                pos, self.tokens_processed,
-                "the KV write cursor and the prompt cursor diverged"
-            );
-            let token = self.tokens[self.tokens_processed];
-            self.logits = match &mut self.kv {
-                RowKv::Contiguous(caches) => self.decoder.forward_token(token, pos, caches),
-                RowKv::Paged(lease) => {
-                    let store = Arc::clone(lease.store());
-                    self.decoder
-                        .forward_token_paged(token, pos, lease.caches_mut(), &store)
-                        .expect("the row's pages were reserved at admission")
-                }
-            };
-            self.tokens_processed += 1;
+        if self.tokens_processed >= end {
+            return self.is_done();
         }
+        // The position comes from the KV every chunk, never from a
+        // counter kept alongside it.
+        let pos = self.kv.positions_written();
+        debug_assert_eq!(
+            pos, self.tokens_processed,
+            "the KV write cursor and the prompt cursor diverged"
+        );
+        let chunk = &self.tokens[self.tokens_processed..end];
+        self.logits = match &mut self.kv {
+            // Batched decode reads host K/V via `forward_multi_seq`. Metal
+            // `forward_token` leaves host rows length-advanced but zero-filled;
+            // `sync_metal_attn_kv_to_host` cannot repair that once lengths
+            // match. Same contract as `forward_prompt_batch(..., host_kv: true)`.
+            RowKv::Contiguous(caches) => {
+                self.decoder.forward_batch_last_host_kv(chunk, pos, caches)
+            }
+            RowKv::Paged(lease) => {
+                let store = Arc::clone(lease.store());
+                self.decoder
+                    .forward_batch_last_paged(chunk, pos, lease.caches_mut(), &store)
+                    .expect("the row's pages were reserved at admission")
+            }
+        };
+        self.tokens_processed = end;
         self.is_done()
     }
 

--- a/crates/ferrox-server/src/serving/batch/tests/batching.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/batching.rs
@@ -437,10 +437,11 @@ fn empty_prompt_prefills_one_stand_in_token() {
 }
 
 /// Chunking is a scheduling boundary, not a numerical one: whatever
-/// the chunk size, the prompt runs through the same `forward_token`
-/// sequence at the same positions, so the logits are bit-identical
-/// to the sequential prefill this replaced. If this ever fails,
-/// every sampled token downstream is suspect.
+/// the chunk size, the prompt runs through the same prefill at the
+/// same positions, so the final logits match the sequential reference.
+/// Prefill uses `forward_batch_last_host_kv` so host K/V stays
+/// authoritative for batched Metal decode; tiny float drift vs
+/// per-token `forward_token` on CPU is expected and harmless.
 #[test]
 fn prefill_chunking_does_not_change_logits() {
     let decoder = tiny_decoder();
@@ -461,10 +462,13 @@ fn prefill_chunking_does_not_change_logits() {
         while !state.step_chunk() {}
         let (_caches, logits, pos, _ids) = state.into_decode_start();
         assert_eq!(pos, prompt.len());
-        assert_eq!(
-            logits, sequential,
-            "chunk size {chunk} changed the prefill logits"
-        );
+        assert_eq!(logits.len(), sequential.len());
+        for (i, (&got, &want)) in logits.iter().zip(sequential.iter()).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-3,
+                "chunk size {chunk}, logit {i}: got={got} want={want}"
+            );
+        }
     }
 }
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -198,7 +198,8 @@ OpenAI-compatible HTTP API:
   json_object` is still the best-effort character mask, and composes
 - Continuous batching and chunked prefill. On Metal, continuous batching
   is on by default when compatible; streaming emits tokens incrementally
-  under CB (0.15.2). CLI: `-cb`, `-np` / `--parallel N`
+  under CB (0.15.2). Metal CB prefill keeps host K/V authoritative for
+  batched decode (0.15.3). CLI: `-cb`, `-np` / `--parallel N`
 - Paged KV: shared page storage many requests read through a block
   table, with a radix tree over reference-counted page groups so
   conversations off one system prompt share its KV rather than each

--- a/docs/plans/metal-parallel-concurrency.md
+++ b/docs/plans/metal-parallel-concurrency.md
@@ -1,8 +1,19 @@
 # Metal parallel decode concurrency
 
-Status: **phase 1 shipped** in **0.15.2** ([PR #47](https://github.com/antonellof/ferrox/pull/47))
+Status: **phase 1 shipped** in **0.15.2** ([PR #47](https://github.com/antonellof/ferrox/pull/47)); **CB Metal prefill fix** in **0.15.3**
 
 Related defect: https://github.com/antonellof/ferrox/issues/46 (closed)
+
+## Hotfix (0.15.3)
+
+Continuous batching on Metal returned garbled HTTP responses (fluent
+nonsense) while the private CLI path was fine. Root cause: CB prefill
+used `forward_token` (Metal-resident KV) but batched decode reads host
+`KvCache` via `forward_multi_seq`. Host rows were length-advanced but
+zero-filled; `sync_metal_attn_kv_to_host` could not repair once lengths
+matched. Fix: prefill uses `forward_batch_last_host_kv` /
+`forward_batch_last_paged` — same contract as `forward_prompt_batch(...,
+host_kv: true)` on the private path.
 
 ## Phase 1 shipped (0.15.2)
 


### PR DESCRIPTION
## Summary
- Fix garbled HTTP responses when continuous batching is enabled on Metal
- CB prefill now uses `forward_batch_last_host_kv` / `forward_batch_last_paged` so host K/V matches what batched decode reads
- Bump workspace to **0.15.3**

## Root cause
Prefill used `forward_token` (Metal-resident KV) while batched decode reads host `KvCache`. Host rows were length-advanced but zero-filled.

## Test plan
- [x] `cargo test -p ferrox-server --features metal batch::` (60 passed)
- [x] `cargo clippy -p ferrox-server --features metal -- -D warnings`
- [x] Manual: `ferrox serve --cont-batching` on Metal — "Hi", "2+2", haiku prompts return valid text


Made with [Cursor](https://cursor.com)