### PR TITLE
fix(tokenizer): a short tokenizer.ggml.scores array loaded and then panicked once per request

### DIFF
--- a/crates/ferrox-models/src/tokenizer.rs
+++ b/crates/ferrox-models/src/tokenizer.rs
@@ -29,10 +29,12 @@
 //! Still missing: `rwkv`, which needs a trie tokenizer, and `none`.
 
 mod pretokenize;
+mod scored_vocab;
 mod unicode;
 mod unicode_data;
 mod wordpiece;
 
+use scored_vocab::ScoredVocab;
 pub use wordpiece::{GgufWordPieceTokenizer, NormalizerOptions};
 
 /// The `tokenizer.ggml.pre` values whose llama.cpp arm sets
@@ -381,6 +383,14 @@ pub enum TokenizerLoadError {
     MissingTokens,
     #[error("'tokenizer.ggml.tokens' is present but is not a string array")]
     TokensNotStringArray,
+    #[error("'tokenizer.ggml.tokens' is present but empty: a vocabulary with no entries cannot tokenize anything, and its scores have no minimum")]
+    EmptyVocabulary,
+    #[error(
+        "vocabulary and scores disagree about the vocabulary size: 'tokenizer.ggml.tokens' has \
+         {tokens} entries but 'tokenizer.ggml.scores' has {scores}. A score-carrying vocabulary \
+         needs one score per token; this checkpoint cannot be tokenized"
+    )]
+    ScoresVocabLengthMismatch { tokens: usize, scores: usize },
 }
 
 /// GGUF's real `tokenizer.ggml.token_type` per-token integer tag,
@@ -892,9 +902,11 @@ fn spm_byte_fallback_value(token: &str) -> Option<u8> {
 /// covering ASCII, whitespace runs, control characters, CJK/Khmer/
 /// Vietnamese text, emoji, and byte-fallback. All 45 match exactly.
 pub struct GgufSpmTokenizer {
-    token_to_id: std::collections::HashMap<String, u32>,
-    id_to_token: Vec<String>,
-    scores: Vec<f32>,
+    /// The vocabulary and its per-token scores, checked against each
+    /// other at load -- see [`scored_vocab`]. Shared with
+    /// [`GgufUnigramTokenizer`] so that the score lookup exists once
+    /// rather than once per tokenizer.
+    vocab: ScoredVocab,
     /// Control/user-defined tokens from `tokenizer.ggml.token_type`,
     /// matched as atomic substrings before normal merging -- see
     /// `split_on_special_tokens`.
@@ -957,30 +969,8 @@ impl Ord for SpmMergeCandidate {
 
 impl GgufSpmTokenizer {
     pub fn from_gguf(file: &impl ferrox_gguf::TensorSource) -> Result<Self, TokenizerLoadError> {
-        let tokens_value = file
-            .metadata("tokenizer.ggml.tokens")
-            .ok_or(TokenizerLoadError::MissingTokens)?;
-        let id_to_token: Vec<String> = match tokens_value {
-            ferrox_gguf::GgufValue::Array(items) => items
-                .iter()
-                .map(|v| v.as_str().map(|s| s.to_string()))
-                .collect::<Option<Vec<_>>>()
-                .ok_or(TokenizerLoadError::TokensNotStringArray)?,
-            _ => return Err(TokenizerLoadError::TokensNotStringArray),
-        };
-        let token_to_id: std::collections::HashMap<String, u32> = id_to_token
-            .iter()
-            .enumerate()
-            .map(|(i, t)| (t.clone(), i as u32))
-            .collect();
-
-        let scores: Vec<f32> = match file.metadata("tokenizer.ggml.scores") {
-            Some(ferrox_gguf::GgufValue::Array(items)) => {
-                items.iter().map(|v| v.as_f32().unwrap_or(0.0)).collect()
-            }
-            _ => vec![0.0; id_to_token.len()],
-        };
-        let special_tokens = load_special_tokens(file, &id_to_token);
+        let vocab = ScoredVocab::from_gguf(file)?;
+        let special_tokens = load_special_tokens(file, vocab.tokens());
         // llama.cpp defaults SPM `add_space_prefix` to true, then lets
         // `tokenizer.ggml.add_space_prefix` override (Gemma sets false).
         let add_space_prefix = match file.metadata("tokenizer.ggml.add_space_prefix") {
@@ -989,16 +979,14 @@ impl GgufSpmTokenizer {
         };
 
         Ok(GgufSpmTokenizer {
-            token_to_id,
-            id_to_token,
-            scores,
+            vocab,
             special_tokens,
             add_space_prefix,
         })
     }
 
     pub fn vocab_size(&self) -> usize {
-        self.id_to_token.len()
+        self.vocab.len()
     }
 
     /// Encodes `text` using SentencePiece's space-replacement
@@ -1041,7 +1029,7 @@ impl GgufSpmTokenizer {
         let mut symbols: Vec<String> = Vec::new();
         for ch in normalized.chars() {
             let s = ch.to_string();
-            if self.token_to_id.contains_key(&s) {
+            if self.vocab.id_of(&s).is_some() {
                 symbols.push(s);
             } else {
                 for byte in s.as_bytes() {
@@ -1073,8 +1061,10 @@ impl GgufSpmTokenizer {
                              insertion_order: &mut u64| {
             let (Some(l), Some(r)) = (l, r) else { return };
             let merged = format!("{}{}", symbols[l], symbols[r]);
-            if let Some(&id) = self.token_to_id.get(&merged) {
-                let score = self.scores.get(id as usize).copied().unwrap_or(0.0);
+            // `lookup` hands back the score with the id it belongs to,
+            // so there is no second, separately-written id-to-score
+            // step here for the Unigram twin to spell differently.
+            if let Some((_id, score)) = self.vocab.lookup(&merged) {
                 *insertion_order += 1;
                 heap.push(SpmMergeCandidate {
                     score,
@@ -1126,7 +1116,7 @@ impl GgufSpmTokenizer {
         let mut i = Some(0usize);
         while let Some(idx) = i {
             if alive[idx] {
-                result.push(self.token_to_id.get(&symbols[idx]).copied().unwrap_or(0));
+                result.push(self.vocab.id_of(&symbols[idx]).unwrap_or(0));
             }
             i = nexts[idx];
         }
@@ -1156,7 +1146,7 @@ impl GgufSpmTokenizer {
         // "<0x0A>" instead of a newline).
         let mut bytes: Vec<u8> = Vec::new();
         for &id in ids {
-            let Some(token) = self.id_to_token.get(id as usize) else {
+            let Some(token) = self.vocab.token(id) else {
                 continue;
             };
             if let Some(b) = Self::byte_fallback_value(token) {
@@ -1233,9 +1223,13 @@ impl GgufSpmTokenizer {
 /// vocabulary substrings at all (exercising the unknown-token
 /// fallback repeatedly).
 pub struct GgufUnigramTokenizer {
-    token_to_id: std::collections::HashMap<String, u32>,
-    id_to_token: Vec<String>,
-    scores: Vec<f32>,
+    /// The vocabulary and its per-token scores, checked against each
+    /// other at load -- see [`scored_vocab`]. This used to be three
+    /// fields spelled out again here, with the Viterbi pass below
+    /// indexing `scores[id]` raw while the SPM twin guarded the same
+    /// lookup: a short `tokenizer.ggml.scores` array loaded and then
+    /// panicked once per request (issue #34).
+    vocab: ScoredVocab,
     unk_id: u32,
     /// Longest vocabulary piece, in characters -- bounds the Viterbi
     /// pass's inner loop so it only ever tries substrings that could
@@ -1254,29 +1248,7 @@ pub struct GgufUnigramTokenizer {
 
 impl GgufUnigramTokenizer {
     pub fn from_gguf(file: &impl ferrox_gguf::TensorSource) -> Result<Self, TokenizerLoadError> {
-        let tokens_value = file
-            .metadata("tokenizer.ggml.tokens")
-            .ok_or(TokenizerLoadError::MissingTokens)?;
-        let id_to_token: Vec<String> = match tokens_value {
-            ferrox_gguf::GgufValue::Array(items) => items
-                .iter()
-                .map(|v| v.as_str().map(|s| s.to_string()))
-                .collect::<Option<Vec<_>>>()
-                .ok_or(TokenizerLoadError::TokensNotStringArray)?,
-            _ => return Err(TokenizerLoadError::TokensNotStringArray),
-        };
-        let token_to_id: std::collections::HashMap<String, u32> = id_to_token
-            .iter()
-            .enumerate()
-            .map(|(i, t)| (t.clone(), i as u32))
-            .collect();
-
-        let scores: Vec<f32> = match file.metadata("tokenizer.ggml.scores") {
-            Some(ferrox_gguf::GgufValue::Array(items)) => {
-                items.iter().map(|v| v.as_f32().unwrap_or(0.0)).collect()
-            }
-            _ => vec![0.0; id_to_token.len()],
-        };
+        let vocab = ScoredVocab::from_gguf(file)?;
 
         let unk_id = file
             .metadata("tokenizer.ggml.unknown_token_id")
@@ -1284,20 +1256,20 @@ impl GgufUnigramTokenizer {
             .map(|v| v as u32)
             .unwrap_or(0);
 
-        let max_piece_chars = id_to_token
+        let max_piece_chars = vocab
+            .tokens()
             .iter()
             .map(|t| t.chars().count())
             .max()
             .unwrap_or(1)
             .max(1);
-        let min_score = scores.iter().copied().fold(f32::INFINITY, f32::min) as f64;
-        let unknown_token_score = min_score - 10.0;
-        let special_tokens = load_special_tokens(file, &id_to_token);
+        // A real score, not `+INFINITY`: `ScoredVocab` refuses an empty
+        // vocabulary, so this fold always sees at least one entry.
+        let unknown_token_score = vocab.min_score() as f64 - 10.0;
+        let special_tokens = load_special_tokens(file, vocab.tokens());
 
         Ok(GgufUnigramTokenizer {
-            token_to_id,
-            id_to_token,
-            scores,
+            vocab,
             unk_id,
             max_piece_chars,
             unknown_token_score,
@@ -1306,7 +1278,7 @@ impl GgufUnigramTokenizer {
     }
 
     pub fn vocab_size(&self) -> usize {
-        self.id_to_token.len()
+        self.vocab.len()
     }
 
     /// Encodes `text` via the real forward-Viterbi Unigram algorithm
@@ -1378,8 +1350,11 @@ impl GgufUnigramTokenizer {
             let max_len = self.max_piece_chars.min(n - i);
             for len in 1..=max_len {
                 let piece: String = chars[i..i + len].iter().collect();
-                if let Some(&id) = self.token_to_id.get(&piece) {
-                    let candidate = base + self.scores[id as usize] as f64;
+                // One lookup for id and score together: this line used
+                // to index `self.scores[id]` on its own, which is the
+                // out-of-bounds panic of issue #34.
+                if let Some((id, score)) = self.vocab.lookup(&piece) {
+                    let candidate = base + score as f64;
                     let j = i + len;
                     if candidate > dp[j].score {
                         dp[j] = Best {
@@ -1417,7 +1392,7 @@ impl GgufUnigramTokenizer {
     pub fn decode(&self, ids: &[u32]) -> String {
         let mut out = String::new();
         for &id in ids {
-            if let Some(token) = self.id_to_token.get(id as usize) {
+            if let Some(token) = self.vocab.token(id) {
                 out.push_str(&token.replace('\u{2581}', " "));
             }
         }
@@ -1893,6 +1868,78 @@ mod gguf_unigram_tests {
         // encode's leading dummy `▁` decodes back to a leading space,
         // same SentencePiece convention as GgufSpmTokenizer.
         assert_eq!(tok.decode(&ids), " hello world");
+    }
+
+    /// A hundred tokens and three scores.
+    fn short_scores_gguf() -> scored_vocab::MetadataOnlyGguf {
+        let tokens: Vec<String> = (0..100).map(|i| format!("\u{2581}piece{i}")).collect();
+        let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
+        scored_vocab::MetadataOnlyGguf::new()
+            .with_tokens(&refs)
+            .with_scores(&[-1.0, -2.0, -3.0])
+    }
+
+    /// Issue #34, and the reason the two tokenizers now share one
+    /// vocabulary type. This file used to LOAD CLEANLY -- accepted by
+    /// `/admin/models/load`, listed as the loaded model -- and then
+    /// panic with an index-out-of-bounds inside the generation task on
+    /// the first prompt whose Viterbi pass matched a piece with id >=
+    /// 3, once per request, forever. The SPM twin survived the same
+    /// file only because its copy of the lookup happened to be the
+    /// guarded spelling.
+    ///
+    /// Both must now refuse it at load, and refuse it the same way:
+    /// one lookup, one check, no room for the two to disagree again.
+    #[test]
+    fn a_scores_array_too_short_for_the_vocabulary_is_refused_at_load_by_both_tokenizers() {
+        let file = short_scores_gguf();
+        let unigram = GgufUnigramTokenizer::from_gguf(&file)
+            .err()
+            .expect("unigram must refuse a vocabulary its scores do not cover");
+        assert!(
+            matches!(
+                unigram,
+                TokenizerLoadError::ScoresVocabLengthMismatch {
+                    tokens: 100,
+                    scores: 3
+                }
+            ),
+            "unigram={unigram:?}"
+        );
+        let spm = GgufSpmTokenizer::from_gguf(&file)
+            .err()
+            .expect("spm must refuse the same file the same way");
+        assert!(
+            matches!(
+                spm,
+                TokenizerLoadError::ScoresVocabLengthMismatch {
+                    tokens: 100,
+                    scores: 3
+                }
+            ),
+            "spm={spm:?}"
+        );
+    }
+
+    /// The refusal above must be about the DISAGREEMENT, not about
+    /// synthetic vocabularies in general: the same 100 pieces with 100
+    /// scores load and encode, reaching ids far past the three the
+    /// broken file carried.
+    #[test]
+    fn the_same_vocabulary_with_one_score_per_token_loads_and_encodes() {
+        let tokens: Vec<String> = (0..100).map(|i| format!("\u{2581}piece{i}")).collect();
+        let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
+        let scores: Vec<f32> = (0..100).map(|i| -(i as f32)).collect();
+        let file = scored_vocab::MetadataOnlyGguf::new()
+            .with_tokens(&refs)
+            .with_scores(&scores);
+        let tok = GgufUnigramTokenizer::from_gguf(&file).expect("lengths agree");
+        assert_eq!(tok.vocab_size(), 100);
+        let ids = tok.encode("piece97");
+        assert!(
+            ids.contains(&97),
+            "the piece with the highest id must be reachable: ids={ids:?}"
+        );
     }
 }
 

--- a/crates/ferrox-models/src/tokenizer/scored_vocab.rs
+++ b/crates/ferrox-models/src/tokenizer/scored_vocab.rs
@@ -1,0 +1,316 @@
+//! The score-carrying vocabulary shared by the two SentencePiece
+//! tokenizers.
+//!
+//! `tokenizer.ggml.tokens` and `tokenizer.ggml.scores` are two arrays
+//! that must agree about one thing -- how many entries the vocabulary
+//! has -- and nothing used to relate them. Each tokenizer collected
+//! whatever the file happened to hold and then spelled the score lookup
+//! for itself: [`super::GgufSpmTokenizer`] guarded it with
+//! `.get(id).unwrap_or(0.0)`, [`super::GgufUnigramTokenizer`] indexed
+//! `scores[id]` raw. A GGUF carrying 100 tokens and a 3-element scores
+//! array therefore LOADED CLEANLY, was listed as a loaded model, and
+//! then panicked with an index-out-of-bounds inside the generation task
+//! on the first prompt whose Viterbi pass matched a piece with id >= 3
+//! -- once per request, forever (issue #34). The same missing check let
+//! an *empty* scores array through, whose `min_score` is `+INFINITY`,
+//! so Unigram's unknown-token transition (`min_score - 10.0`) won every
+//! comparison it took part in.
+//!
+//! Both spellings are gone. The two arrays are validated against each
+//! other ONCE, here, at load: a vocabulary whose scores do not cover it
+//! is a checkpoint this engine cannot run, so it is refused with both
+//! lengths named rather than accepted and paid for per request.
+//!
+//! There is deliberately no `score(id)` method to be the next copy of
+//! that lookup -- see [`ScoredVocab::lookup`].
+
+use std::collections::HashMap;
+
+use super::TokenizerLoadError;
+
+/// A GGUF vocabulary and its per-token scores, held together with the
+/// invariant that makes a score lookup infallible: `scores.len() ==
+/// id_to_token.len()`, and `id_to_token` is not empty.
+///
+/// Both invariants are established in [`ScoredVocab::from_gguf`], the
+/// only constructor, and the fields are private, so no other code can
+/// build one that violates them.
+pub(crate) struct ScoredVocab {
+    id_to_token: Vec<String>,
+    token_to_id: HashMap<String, u32>,
+    /// One score per entry of `id_to_token`, same order, same length.
+    scores: Vec<f32>,
+}
+
+impl ScoredVocab {
+    /// Reads `tokenizer.ggml.tokens` + `tokenizer.ggml.scores` and
+    /// checks them against each other.
+    ///
+    /// An absent scores key is not an error: llama.cpp's own loader
+    /// treats it as optional and scores every token `0.0`, and a
+    /// merge-table vocabulary converted with `tokenizer.ggml.model =
+    /// "llama"` really does ship without one. A scores key that is
+    /// PRESENT and does not cover the vocabulary is a different thing
+    /// entirely -- the file disagrees with itself about how big its own
+    /// vocabulary is, and there is no way to tell which half is right.
+    pub(crate) fn from_gguf(
+        file: &impl ferrox_gguf::TensorSource,
+    ) -> Result<Self, TokenizerLoadError> {
+        let tokens_value = file
+            .metadata("tokenizer.ggml.tokens")
+            .ok_or(TokenizerLoadError::MissingTokens)?;
+        let id_to_token: Vec<String> = match tokens_value {
+            ferrox_gguf::GgufValue::Array(items) => items
+                .iter()
+                .map(|v| v.as_str().map(|s| s.to_string()))
+                .collect::<Option<Vec<_>>>()
+                .ok_or(TokenizerLoadError::TokensNotStringArray)?,
+            _ => return Err(TokenizerLoadError::TokensNotStringArray),
+        };
+        if id_to_token.is_empty() {
+            return Err(TokenizerLoadError::EmptyVocabulary);
+        }
+
+        let scores: Vec<f32> = match file.metadata("tokenizer.ggml.scores") {
+            Some(ferrox_gguf::GgufValue::Array(items)) => {
+                items.iter().map(|v| v.as_f32().unwrap_or(0.0)).collect()
+            }
+            _ => vec![0.0; id_to_token.len()],
+        };
+        if scores.len() != id_to_token.len() {
+            return Err(TokenizerLoadError::ScoresVocabLengthMismatch {
+                tokens: id_to_token.len(),
+                scores: scores.len(),
+            });
+        }
+
+        let token_to_id: HashMap<String, u32> = id_to_token
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.clone(), i as u32))
+            .collect();
+
+        Ok(ScoredVocab {
+            id_to_token,
+            token_to_id,
+            scores,
+        })
+    }
+
+    /// Number of vocabulary entries, which is also the number of
+    /// scores.
+    pub(crate) fn len(&self) -> usize {
+        self.id_to_token.len()
+    }
+
+    /// The token texts in id order, for the callers that walk the
+    /// vocabulary itself (`load_special_tokens` zips it against
+    /// `tokenizer.ggml.token_type`; Unigram measures its longest
+    /// piece).
+    pub(crate) fn tokens(&self) -> &[String] {
+        &self.id_to_token
+    }
+
+    /// The id of an exact vocabulary entry, for the callers that need
+    /// the id and not the score.
+    pub(crate) fn id_of(&self, piece: &str) -> Option<u32> {
+        self.token_to_id.get(piece).copied()
+    }
+
+    /// The text of `id`, or `None` for an id this vocabulary did not
+    /// issue. Decode inputs are whatever a caller passes -- including a
+    /// sampled id from a model whose output head is wider than its
+    /// vocabulary -- so this one stays fallible on purpose.
+    pub(crate) fn token(&self, id: u32) -> Option<&str> {
+        self.id_to_token.get(id as usize).map(String::as_str)
+    }
+
+    /// The id of an exact vocabulary entry AND its score, together.
+    ///
+    /// This is the only way to reach a score, and it is why there is no
+    /// `score(id)`: an id-keyed score lookup is exactly what the two
+    /// tokenizers used to spell separately, one guarded and one not.
+    /// Handing the score back with the id it belongs to leaves no
+    /// id-to-score step for a caller to write a second time, and the
+    /// index here cannot go out of bounds -- every value in
+    /// `token_to_id` is an index into `id_to_token`, and `from_gguf`
+    /// refuses a file whose `scores` is not that same length.
+    pub(crate) fn lookup(&self, piece: &str) -> Option<(u32, f32)> {
+        let id = self.id_of(piece)?;
+        Some((id, self.scores[id as usize]))
+    }
+
+    /// The lowest score in the vocabulary. Unigram derives its
+    /// unknown-token penalty from this, so it matters that the fold is
+    /// over a non-empty set: `from_gguf` refuses an empty vocabulary,
+    /// which is the case that used to make this `+INFINITY`.
+    pub(crate) fn min_score(&self) -> f32 {
+        self.scores.iter().copied().fold(f32::INFINITY, f32::min)
+    }
+}
+
+/// A `TensorSource` that carries metadata and no tensors, so a
+/// tokenizer's loading rules can be tested against a vocabulary shaped
+/// exactly like the one in a bug report without writing a GGUF file.
+#[cfg(test)]
+pub(crate) struct MetadataOnlyGguf {
+    meta: HashMap<String, ferrox_gguf::GgufValue>,
+}
+
+#[cfg(test)]
+impl MetadataOnlyGguf {
+    pub(crate) fn new() -> Self {
+        MetadataOnlyGguf {
+            meta: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn with(mut self, key: &str, value: ferrox_gguf::GgufValue) -> Self {
+        self.meta.insert(key.to_string(), value);
+        self
+    }
+
+    pub(crate) fn with_tokens(self, tokens: &[&str]) -> Self {
+        let items = tokens
+            .iter()
+            .map(|t| ferrox_gguf::GgufValue::String((*t).to_string()))
+            .collect();
+        self.with(
+            "tokenizer.ggml.tokens",
+            ferrox_gguf::GgufValue::Array(items),
+        )
+    }
+
+    pub(crate) fn with_scores(self, scores: &[f32]) -> Self {
+        let items = scores
+            .iter()
+            .map(|s| ferrox_gguf::GgufValue::F32(*s))
+            .collect();
+        self.with(
+            "tokenizer.ggml.scores",
+            ferrox_gguf::GgufValue::Array(items),
+        )
+    }
+}
+
+#[cfg(test)]
+impl ferrox_gguf::TensorSource for MetadataOnlyGguf {
+    fn metadata(&self, key: &str) -> Option<&ferrox_gguf::GgufValue> {
+        self.meta.get(key)
+    }
+    fn find_tensor(&self, _name: &str) -> Option<&ferrox_gguf::TensorInfo> {
+        None
+    }
+    fn tensor_bytes(&self, name: &str) -> Result<&[u8], ferrox_gguf::GgufError> {
+        Err(ferrox_gguf::GgufError::TensorNotFound(name.to_string()))
+    }
+    fn tensor_mapped_range(
+        &self,
+        name: &str,
+    ) -> Result<
+        (
+            std::sync::Arc<ferrox_gguf::MmapHandle>,
+            std::ops::Range<usize>,
+        ),
+        ferrox_gguf::GgufError,
+    > {
+        Err(ferrox_gguf::GgufError::TensorNotFound(name.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shape of issue #34's file: a vocabulary of 100 tokens and a
+    /// scores array covering three of them.
+    fn short_scores_file() -> MetadataOnlyGguf {
+        let tokens: Vec<String> = (0..100).map(|i| format!("piece{i}")).collect();
+        let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
+        MetadataOnlyGguf::new()
+            .with_tokens(&refs)
+            .with_scores(&[-1.0, -2.0, -3.0])
+    }
+
+    /// What shipped broken: this file loaded, and every later score
+    /// lookup for an id >= 3 was an out-of-bounds index. The refusal
+    /// has to name both lengths, because "the scores are wrong" is not
+    /// something an operator can act on and "100 tokens, 3 scores" is.
+    #[test]
+    fn a_scores_array_shorter_than_the_vocabulary_is_refused_with_both_lengths_named() {
+        let err = ScoredVocab::from_gguf(&short_scores_file())
+            .err()
+            .expect("a 100-token vocabulary with 3 scores must not load");
+        assert!(
+            matches!(
+                err,
+                TokenizerLoadError::ScoresVocabLengthMismatch {
+                    tokens: 100,
+                    scores: 3
+                }
+            ),
+            "err={err:?}"
+        );
+        let text = err.to_string();
+        assert!(text.contains("100") && text.contains('3'), "text={text}");
+    }
+
+    /// A scores array LONGER than the vocabulary is refused by the same
+    /// check. It cannot panic, but the file still disagrees with itself
+    /// about its own vocabulary size, and guessing which half is right
+    /// is how a checkpoint gets tokenized with someone else's scores.
+    #[test]
+    fn a_scores_array_longer_than_the_vocabulary_is_refused_too() {
+        let file = MetadataOnlyGguf::new()
+            .with_tokens(&["a", "b"])
+            .with_scores(&[-1.0, -2.0, -3.0]);
+        assert!(matches!(
+            ScoredVocab::from_gguf(&file),
+            Err(TokenizerLoadError::ScoresVocabLengthMismatch {
+                tokens: 2,
+                scores: 3
+            })
+        ));
+    }
+
+    /// An absent scores key stays legal, because llama.cpp treats it as
+    /// optional and real converted vocabularies omit it. It must give
+    /// one zero per token, not zero scores.
+    #[test]
+    fn an_absent_scores_key_scores_every_token_zero_rather_than_refusing() {
+        let file = MetadataOnlyGguf::new().with_tokens(&["a", "b", "c"]);
+        let vocab = ScoredVocab::from_gguf(&file).expect("a scoreless vocabulary is legal");
+        assert_eq!(vocab.len(), 3);
+        assert_eq!(vocab.lookup("c"), Some((2, 0.0)));
+        assert_eq!(vocab.min_score(), 0.0);
+    }
+
+    /// The degenerate half of the same missing check: with an empty
+    /// vocabulary the scores fold has nothing to fold, `min_score` is
+    /// `+INFINITY`, and Unigram's `min_score - 10.0` unknown-token
+    /// penalty beats every real transition it is compared against.
+    #[test]
+    fn an_empty_vocabulary_is_refused_so_min_score_is_always_a_real_score() {
+        let file = MetadataOnlyGguf::new().with_tokens(&[]).with_scores(&[]);
+        assert!(matches!(
+            ScoredVocab::from_gguf(&file),
+            Err(TokenizerLoadError::EmptyVocabulary)
+        ));
+    }
+
+    #[test]
+    fn every_id_a_lookup_hands_back_indexes_its_own_score() {
+        let file = MetadataOnlyGguf::new()
+            .with_tokens(&["a", "bb", "ccc"])
+            .with_scores(&[-1.5, -2.5, -3.5]);
+        let vocab = ScoredVocab::from_gguf(&file).expect("lengths agree");
+        assert_eq!(vocab.lookup("a"), Some((0, -1.5)));
+        assert_eq!(vocab.lookup("bb"), Some((1, -2.5)));
+        assert_eq!(vocab.lookup("ccc"), Some((2, -3.5)));
+        assert_eq!(vocab.lookup("dddd"), None);
+        assert_eq!(vocab.min_score(), -3.5);
+        assert_eq!(vocab.token(2), Some("ccc"));
+        assert_eq!(vocab.token(3), None);
+        assert_eq!(vocab.id_of("bb"), Some(1));
+    }
+}


### PR DESCRIPTION
Closes #34.

## What was wrong

`GgufUnigramTokenizer` indexed `self.scores[id]` in its Viterbi inner loop; `GgufSpmTokenizer` wrote the identical lookup as `.get(id).unwrap_or(0.0)`. Two spellings of one lookup, and nothing related `tokenizer.ggml.scores` to `tokenizer.ggml.tokens` — each loader collected whatever the file held, and the `_ =>` arm covered only a *missing* key, not a short array.

A GGUF with `tokenizer.ggml.model = "t5"`, 100 tokens and a 3-element scores array loaded cleanly, was listed as the loaded model, and then panicked with an index-out-of-bounds inside the generation task on the first prompt whose Viterbi pass matched a piece with id >= 3 — once per request, on a checkpoint the engine had already accepted. Reachable from `POST /admin/models/load` plus any completion request.

## What changed

Not a second guard: adding one leaves two lookups that must agree, which is how this got here.

- New `crates/ferrox-models/src/tokenizer/scored_vocab.rs`. `ScoredVocab` owns the vocabulary and its scores together and is the only constructor of that pair, so the invariant `scores.len() == tokens.len()` (and a non-empty vocabulary) cannot be violated from outside.
- Both tokenizers now hold one `ScoredVocab` instead of restating `token_to_id` / `id_to_token` / `scores` each. That also collapses the two copies of the load prologue into one.
- The two arrays are validated against each other **once, at load**. A mismatch is a refusal naming both lengths: `'tokenizer.ggml.tokens' has 100 entries but 'tokenizer.ggml.scores' has 3`.
- There is deliberately no `score(id)` for the next copy of the lookup to be written against. `lookup(piece) -> Option<(u32, f32)>` returns the score with the id it belongs to, so no caller has an id-to-score step of its own, and its index is in bounds by construction.
- A **longer** scores array is refused by the same check. It cannot panic, but the file disagrees with itself about its own vocabulary size and nothing can say which half is right.
- An **empty** vocabulary is refused, which closes the degenerate half of the same missing check: it made `min_score` `+INFINITY`, so Unigram's `min_score - 10.0` unknown-token transition beat every real transition it was compared against.
- An absent scores key stays legal and still scores every token `0.0` (llama.cpp treats the key as optional and real converted vocabularies omit it). Only a *present* array that does not cover the vocabulary refuses — so the gate fires on files that exist rather than reading as coverage.

## What would have to be true for this to be wrong

That a real checkpoint ships a `tokenizer.ggml.scores` array of a different length than its `tokenizer.ggml.tokens` and is expected to work. llama.cpp reads `scores[i]` for every `i < n_tokens` unguarded, so such a file is already an out-of-bounds read there; every fixture in this repo, including the real llama-spm and trained-Unigram vocabularies, loads unchanged.

## Evidence

Every new test was sabotaged once and confirmed red:

- `if scores.len() != id_to_token.len()` replaced with `if false`: reddens `a_scores_array_shorter_than_the_vocabulary_is_refused_with_both_lengths_named`, `a_scores_array_longer_than_the_vocabulary_is_refused_too`, and `a_scores_array_too_short_for_the_vocabulary_is_refused_at_load_by_both_tokenizers`.
- Deleting the empty-vocabulary check: reddens `an_empty_vocabulary_is_refused_so_min_score_is_always_a_real_score`.
- `lookup` returning a wrong score, or a wrong id: reddens the unit tests and the round-trip against the real trained SentencePiece fixture.

`MetadataOnlyGguf` (test-only) is a metadata-carrying `TensorSource`, so a vocabulary shaped exactly like the bug report is built without writing a GGUF file.

Gates: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, the same `--release`, `cargo fmt --all` — all green.

## Doc delta

None. `docs/MODELS.md` and `docs/API.md` describe which checkpoints run; this changes only what happens to a malformed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
