### PR TITLE
feat(cli): -d loads a draft model, and speculative decoding runs on a real checkpoint pair

### DIFF
--- a/crates/ferrox-cli/src/run.rs
+++ b/crates/ferrox-cli/src/run.rs
@@ -141,6 +141,36 @@ pub struct InferArgs {
     )]
     pub n_gpu_layers: GpuLayers,
 
+    /// Draft model for speculative decoding, llama.cpp's `-md`.
+    ///
+    /// A smaller checkpoint from the SAME family and tokenizer as the
+    /// target. Decode reads every weight of the target per token, so
+    /// bandwidth divided by model bytes is a hard ceiling; a drafter
+    /// proposes several tokens and the target checks them all in one
+    /// pass, which changes what is read per token rather than how fast.
+    /// The output is exactly what the target would have written alone.
+    #[arg(long = "model-draft", short = 'd', value_name = "FILE")]
+    pub model_draft: Option<String>,
+
+    /// Tokens the drafter proposes per verification step (llama.cpp's
+    /// `--draft-max`, also spelled `--draft`).
+    #[arg(
+        long = "draft-max",
+        visible_aliases = ["draft"],
+        value_name = "N",
+        default_value_t = 5
+    )]
+    pub draft_max: usize,
+
+    /// Stop drafting when the drafter's own probability for the token
+    /// it just sampled is below this (llama.cpp's `--draft-p-min`).
+    ///
+    /// A guessing drafter is worse than none: the target pays for the
+    /// position either way, and a rejection also discards every
+    /// position after it.
+    #[arg(long = "draft-p-min", value_name = "P", default_value_t = 0.75)]
+    pub draft_p_min: f32,
+
     /// Optional system prompt (chat mode only).
     #[arg(long = "system")]
     pub system: Option<String>,
@@ -1204,6 +1234,24 @@ pub fn run_infer(args: InferArgs) -> anyhow::Result<()> {
         .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
         .collect();
 
+    // Speculative decoding with a real draft model, when `-d` names
+    // one. The verification rule lives in `ferrox_models::speculative`
+    // and is lossless at every temperature; this is only the wiring.
+    if let Some(draft_path) = args.model_draft.as_deref() {
+        return run_infer_speculative(
+            &args,
+            &decoder,
+            draft_path,
+            &tokenizer,
+            &tokens,
+            max_new,
+            &sampling,
+            seed,
+            &stop_tokens,
+            &mut caches,
+        );
+    }
+
     let prefill_t = Instant::now();
     let mut pos;
     let mut logits = if tokens.is_empty() {
@@ -1645,6 +1693,163 @@ fn run_glm52_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow::
          predict {gen_n} tokens, {pred_tps:.2} t/s"
     );
 
+    Ok(())
+}
+
+/// `ferrox run` with a draft model, llama.cpp's `-md`.
+///
+/// The verification rule lives in `ferrox_models::speculative` and is
+/// lossless at every temperature, not only at `--temp 0`. Nothing here
+/// re-implements it: this function loads the second checkpoint, refuses
+/// the combinations speculation cannot honour, and streams the tokens
+/// the shared loop commits.
+#[allow(clippy::too_many_arguments)]
+fn run_infer_speculative(
+    args: &InferArgs,
+    decoder: &ferrox_models::Decoder,
+    draft_path: &str,
+    tokenizer: &CliTokenizer,
+    tokens: &[usize],
+    max_new: usize,
+    sampling: &ferrox_models::sampling::SamplingParams,
+    seed: u64,
+    stop_tokens: &ferrox_models::tokenizer::StopTokens,
+    caches: &mut [KvCache],
+) -> anyhow::Result<()> {
+    // A grammar masks the candidate set per token. Speculation compares
+    // the drafter's probability for a token against the target's for
+    // the same token, and neither of those distributions is the masked
+    // one, so running both would either break the constraint or break
+    // losslessness. Refused by name rather than silently dropping one
+    // of the two, which is the failure this engine exists not to have:
+    // a grammar that is accepted and not applied is served with a 200
+    // and read as compliance.
+    if args.grammar_source()?.is_some() {
+        anyhow::bail!(
+            "--model-draft cannot be combined with --grammar / --grammar-file / --json-schema \
+             yet: constrained decoding masks the candidate set per token, and the speculative \
+             rejection rule compares unmasked draft and target probabilities, so the two \
+             together would either drop the constraint or stop being lossless. Run with one or \
+             the other"
+        );
+    }
+    if tokens.is_empty() {
+        anyhow::bail!("--model-draft needs a prompt to continue");
+    }
+
+    let config =
+        ferrox_models::ModelConfig::from_gguf(&ferrox_gguf::ShardedGguf::open(draft_path)?)?;
+    let draft = ferrox_models::Decoder::from_gguf(draft_path, config)?;
+    eprintln!("ferrox: draft model {draft_path}");
+
+    // Refused at construction when the vocabularies differ. The two
+    // models must number their tokens identically or the rejection rule
+    // is comparing probabilities of different tokens, which produces
+    // fluent text with a plausible accept rate and no error at all.
+    let mut drafter = ferrox_models::DraftModelSpeculator::new(
+        draft,
+        &decoder.config,
+        sampling.clone(),
+        seed,
+        args.draft_max,
+        args.draft_p_min,
+    )?;
+
+    // One warm-up proposal, to find out whether this drafter's KV
+    // actually lands in the host caches it owns. A backend that keeps
+    // KV on the device leaves them empty, and a drafter that cannot see
+    // its own rows cannot roll back the ones the target rejected. Found
+    // by running it: on Metal this panicked mid-answer, after the first
+    // block had already been printed.
+    {
+        use ferrox_models::speculative::Drafter;
+        let _ = drafter.propose(tokens, &[], 1);
+    }
+    if !drafter.keeps_host_kv() {
+        anyhow::bail!(
+            "--model-draft needs the draft model's KV cache in host memory, and this \
+             backend keeps it on the device, so the drafter cannot roll back the \
+             positions the target rejects. Re-run with --device cpu, or without \
+             --model-draft. Speculative decoding on a device-resident KV cache is \
+             not implemented yet"
+        );
+    }
+
+    let mut stdout = io::stdout().lock();
+    let decode_t = Instant::now();
+    let mut emitted = 0usize;
+    let mut write_err = None;
+
+    let result = ferrox_models::speculative::speculative_decode_observed(
+        decoder,
+        tokens,
+        caches,
+        &mut drafter,
+        &mut |token| {
+            if !args.ignore_eos && stop_tokens.contains(token) {
+                return false;
+            }
+            let piece = tokenizer.decode(&[token]);
+            if let Err(e) = stdout
+                .write_all(piece.as_bytes())
+                .and_then(|()| stdout.flush())
+            {
+                write_err = Some(e);
+                return false;
+            }
+            emitted += 1;
+            true
+        },
+        &ferrox_models::speculative::SpeculativeOptions {
+            max_new_tokens: max_new,
+            start_pos: 0,
+            sampling: sampling.clone(),
+            seed,
+            // Match the ordinary decode loop, which penalises over the
+            // generated tokens only. A draft model must not change the
+            // output, and at the default --repeat-penalty 1.1 a
+            // different penalty window changes it on the first repeated
+            // token: verified by running the same prompt both ways.
+            penalty_history_start: tokens.len(),
+        },
+    );
+    if let Some(e) = write_err {
+        return Err(e.into());
+    }
+    let decode_secs = decode_t.elapsed().as_secs_f64();
+    writeln!(stdout)?;
+
+    let tps = if decode_secs > 0.0 {
+        emitted as f64 / decode_secs
+    } else {
+        0.0
+    };
+    eprintln!(
+        "ferrox: predict {emitted} tokens, {tps:.2} t/s over {} verification steps",
+        result.verification_steps
+    );
+    // Reported as a pair with the throughput, and per position rather
+    // than folded into the mean: a drafter that is right at position 0
+    // and useless by position 7 has the same mean as a uniformly
+    // mediocre one, and the two want opposite block sizes. A speedup
+    // without an accept rate cannot be reproduced or debugged.
+    match result.acceptance_length() {
+        Some(len) => eprintln!(
+            "ferrox: acceptance length {len:.2} tokens/step, accepted {} of {} drafted",
+            result.accepted_tokens, result.drafted_tokens
+        ),
+        // `None` and 1.00 are different answers: "the drafter never got
+        // to propose" is not "it proposed and never helped".
+        None => eprintln!("ferrox: the drafter proposed nothing, so no acceptance length exists"),
+    }
+    let per_pos: Vec<String> = result
+        .accept_rate_per_position()
+        .iter()
+        .map(|r| format!("{r:.2}"))
+        .collect();
+    if !per_pos.is_empty() {
+        eprintln!("ferrox: accept rate per position [{}]", per_pos.join(", "));
+    }
     Ok(())
 }
 

--- a/crates/ferrox-models/src/draft_model.rs
+++ b/crates/ferrox-models/src/draft_model.rs
@@ -112,6 +112,23 @@ pub struct DraftModelSpeculator {
 }
 
 impl DraftModelSpeculator {
+    /// True when this drafter's KV really lives in the host caches it
+    /// owns.
+    ///
+    /// A backend that keeps KV on the device leaves these at zero, and
+    /// a drafter cannot roll back rows it cannot see. Callers check
+    /// this after one warm-up rather than discovering it as a wrong
+    /// accept rate.
+    pub fn keeps_host_kv(&self) -> bool {
+        self.kv_caches.first().is_some_and(|c| c.seq_len > 0)
+    }
+
+    /// How many tokens of history this drafter's KV currently holds.
+    /// Exposed so a caller can assert the drafter kept up.
+    pub fn synced_len(&self) -> usize {
+        self.synced
+    }
+
     /// Fails when the two checkpoints cannot be compared token for
     /// token. See [`VocabMismatch`].
     pub fn new(
@@ -180,7 +197,15 @@ impl DraftModelSpeculator {
         // Everything past what the caller's history contains was
         // drafted and not accepted. It is not context, it is a guess
         // the target threw away.
-        let keep = self.synced.min(history.len() - 1);
+        // Derived from the CACHE, not only from `self.synced`. The
+        // cache is the authority on how many rows exist, and a backend
+        // that keeps its KV somewhere other than this host `KvCache`
+        // leaves it at zero however many tokens were fed. Trusting the
+        // counter there truncated to 7 rows of a cache holding 0 and
+        // panicked on a real Metal run. That is the same lesson as the
+        // batched prefill: read the cursor, do not keep a copy of it.
+        let held = self.kv_caches.first().map_or(0, |c| c.seq_len);
+        let keep = self.synced.min(history.len() - 1).min(held);
         self.truncate_to(keep);
         self.synced = keep;
 

--- a/crates/ferrox-models/src/speculative.rs
+++ b/crates/ferrox-models/src/speculative.rs
@@ -346,6 +346,23 @@ pub struct SpeculativeOptions {
     /// exactly these parameters (see [`accept_or_resample`]).
     pub sampling: SamplingParams,
     pub seed: u64,
+    /// Index into the history at which the repetition / presence /
+    /// frequency penalty window starts.
+    ///
+    /// `0` penalises over the prompt as well, which is what
+    /// llama-server does (it seeds the sampler with the prompt tokens).
+    /// `prompt_tokens.len()` penalises over the generated tokens only,
+    /// which is what `ferrox run`'s ordinary decode loop does.
+    ///
+    /// This is a knob because the two ferrox paths currently disagree,
+    /// and a caller must be able to make speculation match whichever
+    /// path it is standing in for. Speculation that changes the output
+    /// at default settings is not speculation, it is a different
+    /// decoder: the whole promise is that the text is what the target
+    /// would have written alone. The underlying divergence from
+    /// llama.cpp is tracked separately and is not this option's job to
+    /// decide.
+    pub penalty_history_start: usize,
 }
 
 /// Result of a speculative decode run, with the counters that make its
@@ -456,6 +473,16 @@ impl SpeculativeDecodeResult {
     }
 }
 
+/// The slice of history the penalties see, per
+/// [`SpeculativeOptions::penalty_history_start`].
+///
+/// Clamped rather than indexed directly: a caller that passes a start
+/// past the current history (a warm cache resumed oddly, say) should
+/// get an empty window, not a panic mid-generation.
+fn penalty_window<'a>(history: &'a [usize], options: &SpeculativeOptions) -> &'a [usize] {
+    &history[options.penalty_history_start.min(history.len())..]
+}
+
 /// Greedy speculative decode over a **fresh** KV cache, with
 /// prompt-lookup drafting. Thin wrapper over
 /// [`speculative_decode_with`], kept for callers that want the original
@@ -467,11 +494,12 @@ pub fn speculative_decode<D: Drafter + ?Sized>(
     kv_caches: &mut [KvCache],
     drafter: &mut D,
 ) -> SpeculativeDecodeResult {
-    speculative_decode_with(
+    speculative_decode_observed(
         decoder,
         prompt_tokens,
         kv_caches,
         drafter,
+        &mut |_| true,
         &SpeculativeOptions {
             max_new_tokens,
             ..SpeculativeOptions::default()
@@ -508,6 +536,41 @@ pub fn speculative_decode_with<D: Drafter + ?Sized>(
     drafter: &mut D,
     options: &SpeculativeOptions,
 ) -> SpeculativeDecodeResult {
+    speculative_decode_observed(
+        decoder,
+        prompt_tokens,
+        kv_caches,
+        drafter,
+        &mut |_| true,
+        options,
+    )
+}
+
+/// [`speculative_decode_with`], plus an observer called once per
+/// committed token, in order, which can end the run by returning
+/// `false`.
+///
+/// This exists so a caller that streams output, or that stops on an EOS
+/// or a stop string, does not have to write a second copy of the
+/// verification loop. Copying that loop to vary it is how this project
+/// lost five model features from one duplicated decode path, and the
+/// rejection rule is the last code in the tree that should be
+/// duplicated: a subtly different copy is still lossless-looking.
+///
+/// The observer sees a token only once it is COMMITTED, so it never
+/// sees a draft that was rejected. Returning `false` ends generation
+/// after the current verification block finishes, which keeps the KV
+/// caches in the single consistent state this function documents;
+/// `generated_tokens` is truncated at the token that said stop, so the
+/// caller's output and the returned tokens agree.
+pub fn speculative_decode_observed<D: Drafter + ?Sized>(
+    decoder: &Decoder,
+    prompt_tokens: &[usize],
+    kv_caches: &mut [KvCache],
+    drafter: &mut D,
+    on_token: &mut dyn FnMut(usize) -> bool,
+    options: &SpeculativeOptions,
+) -> SpeculativeDecodeResult {
     assert!(!prompt_tokens.is_empty(), "prompt must not be empty");
     for cache in kv_caches.iter() {
         assert_eq!(
@@ -539,14 +602,24 @@ pub fn speculative_decode_with<D: Drafter + ?Sized>(
     // fed as the anchor of the next batch, which is what lets one
     // forward call both commit it and verify a block after it.
     let mut pending = {
-        let probs = sampling_distribution(last, &options.sampling, &history);
+        let probs =
+            sampling_distribution(last, &options.sampling, penalty_window(&history, options));
         rng.sample_from(&probs)
     };
     let mut pos = options.start_pos + prompt_tokens.len();
 
+    // Set when the observer asks to stop. The current block still runs
+    // to completion so the caches end in the one state this function
+    // documents, and `generated` is cut back to this length afterwards.
+    let mut stop_at: Option<usize> = None;
+
     loop {
         generated.push(pending);
         history.push(pending);
+        if !on_token(pending) {
+            stop_at = Some(generated.len());
+            break;
+        }
         if generated.len() == options.max_new_tokens {
             break;
         }
@@ -580,13 +653,24 @@ pub fn speculative_decode_with<D: Drafter + ?Sized>(
         let mut accepted = 0usize;
         let mut replacement: Option<usize> = None;
         for (i, (&token, dist)) in draft.tokens().iter().zip(draft.dists()).enumerate() {
-            let target = sampling_distribution(&batch_logits[i], &options.sampling, &history);
+            let target = sampling_distribution(
+                &batch_logits[i],
+                &options.sampling,
+                penalty_window(&history, options),
+            );
             match accept_or_resample(&target, dist, token, &mut rng) {
                 None => {
                     result.record_position(i, true);
                     accepted += 1;
                     history.push(token);
                     generated.push(token);
+                    if stop_at.is_none() && !on_token(token) {
+                        // Keep verifying the rest of the block: the
+                        // loop below truncates the caches to exactly
+                        // what was committed, and leaving early here
+                        // would skip that.
+                        stop_at = Some(generated.len());
+                    }
                 }
                 Some(resampled) => {
                     result.record_position(i, false);
@@ -617,16 +701,29 @@ pub fn speculative_decode_with<D: Drafter + ?Sized>(
             // batch predicts a genuinely new position -- the free bonus
             // token that makes a fully-accepted block worth `k + 1`.
             None => {
-                let probs =
-                    sampling_distribution(&batch_logits[accepted], &options.sampling, &history);
+                let probs = sampling_distribution(
+                    &batch_logits[accepted],
+                    &options.sampling,
+                    penalty_window(&history, options),
+                );
                 rng.sample_from(&probs)
             }
         };
         pos = committed_len;
+        if stop_at.is_some() {
+            break;
+        }
         debug_assert!(generated.len() < options.max_new_tokens);
     }
 
-    debug_assert_eq!(generated.len(), options.max_new_tokens);
+    if let Some(len) = stop_at {
+        // The observer said stop at this token. Everything after it was
+        // produced by a block that had already been dispatched, and the
+        // caller never saw it.
+        generated.truncate(len);
+    } else {
+        debug_assert_eq!(generated.len(), options.max_new_tokens);
+    }
     result.tokens_generated = generated.len();
     result.generated_tokens = generated;
     result
@@ -1350,5 +1447,81 @@ mod tests {
         assert_eq!(result.acceptance_length(), None);
         assert_eq!(result.accept_rate(), None);
         assert_eq!(result.tokens_per_call(), 0.0);
+    }
+
+    /// The observer sees exactly the committed tokens, in order, and
+    /// stopping through it truncates the result to the token that said
+    /// so.
+    ///
+    /// This is what lets `ferrox run` stream and stop on an EOS without
+    /// a second copy of the verification loop. A copy is how this
+    /// project lost five model features from one duplicated decode
+    /// path, and the rejection rule is the last code in the tree that
+    /// should be duplicated: a subtly wrong copy still looks lossless.
+    #[test]
+    fn the_observer_sees_every_committed_token_and_can_end_the_run() {
+        let cfg = tiny_test_config();
+        let vocab = 8;
+        let prompt = vec![1usize, 2, 3, 4, 1, 2];
+
+        let decoder = Decoder::new_random_small(cfg.clone(), 2, vocab);
+        let mut kv = caches(&decoder);
+        let mut spec = PromptLookupSpeculator::new(2, 3);
+
+        let mut seen = Vec::new();
+        let result = speculative_decode_observed(
+            &decoder,
+            &prompt,
+            &mut kv,
+            &mut spec,
+            &mut |t| {
+                seen.push(t);
+                true
+            },
+            &SpeculativeOptions {
+                max_new_tokens: 6,
+                start_pos: 0,
+                sampling: SamplingParams::default(),
+                seed: 0,
+                penalty_history_start: 0,
+            },
+        );
+        assert_eq!(
+            seen, result.generated_tokens,
+            "the observer must see exactly what the run returns, in order"
+        );
+
+        // Now stop after three tokens.
+        let decoder = Decoder::new_random_small(cfg, 2, vocab);
+        let mut kv = caches(&decoder);
+        let mut spec = PromptLookupSpeculator::new(2, 3);
+        let mut count = 0usize;
+        let stopped = speculative_decode_observed(
+            &decoder,
+            &prompt,
+            &mut kv,
+            &mut spec,
+            &mut |_| {
+                count += 1;
+                count < 3
+            },
+            &SpeculativeOptions {
+                max_new_tokens: 6,
+                start_pos: 0,
+                sampling: SamplingParams::default(),
+                seed: 0,
+                penalty_history_start: 0,
+            },
+        );
+        assert_eq!(
+            stopped.generated_tokens.len(),
+            3,
+            "the run must end at the token that said stop, not at the end of its block"
+        );
+        assert_eq!(
+            stopped.generated_tokens,
+            result.generated_tokens[..3],
+            "and the tokens up to the stop must be the ones an unstopped run produced"
+        );
     }
 }


### PR DESCRIPTION
Step 3 of `docs/plans/speculative-decoding.md`. Flags spelled as llama.cpp spells them: `-d`/`--model-draft`, `--draft-max`, `--draft-p-min`.

**Measured, Llama-3.2-3B Q4_K_M with the 1B as drafter, 40 tokens:** 12 verification steps instead of 40 forward passes, acceptance length 3.33, per-position accept rate `[0.91, 0.70, 0.57, 0.75, 1.00]`. **No tok/s claimed** — another ferrox instance was serving on this host, so any timing beside it is noise.

## Three things the real run found that unit tests had not

**The output changed at `--temp 0`, and it was not the rejection rule.** With `--repeat-penalty 1.0` both runs are byte-identical, which located it: the ordinary loop penalises over *generated* tokens, `speculative_decode` over the whole history including the prompt. Two paths in one binary disagreeing about the penalty window, so turning speculation on changed the answer at default settings. Now a caller's choice, and the CLI matches its own loop — `-d` is output-neutral, verified by diffing.

*Separately:* llama-server seeds the sampler with prompt tokens, so ferrox's ordinary loop is the one diverging from llama.cpp. Filing that separately.

**Metal panicked mid-answer**, after the first block had printed: . A device-resident KV leaves the host cache empty, so the drafter's counter said 7 and its cache held 0. Same lesson as #37: read the cursor, do not keep a copy. It now derives from the cache, and the CLI probes once and refuses by name rather than running something that cannot be right.

**A grammar plus a draft model is refused.** Constrained decoding masks per token; the rejection rule compares unmasked probabilities. Together they either drop the constraint or stop being lossless.

Gates: workspace build, 52 suites, clippy debug and release, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN