### PR TITLE
fix(gguf,safetensors): untrusted header arithmetic refuses instead of wrapping past its own checks

### DIFF
--- a/crates/ferrox-gguf/src/lib.rs
+++ b/crates/ferrox-gguf/src/lib.rs
@@ -51,6 +51,16 @@ pub enum GgufError {
          success"
     )]
     UnsizedTensor(String, GgmlType),
+    #[error(
+        "tensor '{0}' declares shape {1:?}, whose element count is larger than a {2}-byte \
+         file can hold: every element occupies at least one bit on the wire"
+    )]
+    ImplausibleShape(String, Vec<u64>, usize),
+    #[error(
+        "general.alignment is {0}: the GGUF spec requires a power of two, and it must be one \
+         a file can actually be aligned to"
+    )]
+    BadAlignment(u64),
 }
 
 /// A single scalar/array metadata value from the GGUF key-value header.
@@ -296,8 +306,34 @@ pub struct TensorInfo {
 }
 
 impl TensorInfo {
+    /// The declared element count, or `None` when folding the
+    /// file-supplied dims wraps or does not fit an address on this
+    /// machine.
+    ///
+    /// This is the ONLY place the shape is folded. It used to be a bare
+    /// `product()`, which made every downstream shape-vs-bytes check
+    /// agree with a lie: dims `[2^32, 2^32]` wrap to exactly 0, so the
+    /// tensor sized as 0 bytes and `tensor_bytes` returned `Ok(&[])` --
+    /// the very outcome [`GgufError::UnsizedTensor`] exists to prevent,
+    /// reached through a door it does not cover. `[2^63 + 2, 2]` wraps
+    /// to 4 and walked straight through `Tensor::new`'s own product
+    /// assert.
+    pub fn element_count(&self) -> Option<usize> {
+        let mut n: u64 = 1;
+        for &dim in &self.shape {
+            n = n.checked_mul(dim)?;
+        }
+        usize::try_from(n).ok()
+    }
+
+    /// The element count for REPORTING (a parameter-count sum, a log
+    /// line) -- never for sizing a read. [`GgufFile::parse`] refuses any
+    /// shape `element_count` cannot represent, so for a `TensorInfo` that
+    /// came out of a parsed file this is exact; the saturating arm exists
+    /// only for a hand-built one, and saturates UP, so it can still only
+    /// cause a refusal, never an over-read.
     pub fn n_elements(&self) -> usize {
-        self.shape.iter().product::<u64>() as usize
+        self.element_count().unwrap_or(usize::MAX)
     }
 
     /// Size on disk, or `None` for a dtype whose block layout this
@@ -313,8 +349,8 @@ impl TensorInfo {
         if block_bytes == 0 {
             return None;
         }
-        let n = self.n_elements();
-        Some((n / block_elems) * block_bytes)
+        let n = self.element_count()?;
+        (n / block_elems).checked_mul(block_bytes)
     }
 }
 
@@ -337,6 +373,7 @@ impl GgufFile {
     }
 
     fn parse(mmap: Mmap) -> Result<Self, GgufError> {
+        let file_len = mmap.len();
         let mut cursor = io::Cursor::new(&mmap[..]);
 
         let magic = cursor.read_u32::<LittleEndian>()?;
@@ -371,22 +408,53 @@ impl GgufFile {
             }
             let dtype_tag = cursor.read_u32::<LittleEndian>()?;
             let offset = cursor.read_u64::<LittleEndian>()?;
-            tensors.push(TensorInfo {
+            let info = TensorInfo {
                 name,
                 shape,
                 dtype: GgmlType::from_tag(dtype_tag),
                 offset,
-            });
+            };
+            // The bound is derived from the input, not chosen: every
+            // element occupies at least one bit on the wire (the densest
+            // format this build knows is Q1_0, at 1.125 bpw), so a
+            // tensor cannot declare more elements than eight times the
+            // bytes of the file that has to contain it. Refusing HERE,
+            // at the only place a `GgufFile`'s `TensorInfo`s are built,
+            // is what lets `n_elements` and `byte_len` be trusted by the
+            // consumers downstream that each had their own copy of the
+            // arithmetic.
+            let max_elements = file_len as u128 * 8;
+            if info
+                .element_count()
+                .is_none_or(|n| n as u128 > max_elements)
+            {
+                return Err(GgufError::ImplausibleShape(info.name, info.shape, file_len));
+            }
+            tensors.push(info);
         }
 
         // Tensor data begins at the next `general.alignment` boundary
         // (default 32) after the header. This matches the GGUF spec.
-        let alignment = metadata
+        // `general.alignment` comes off the wire and is used as a
+        // DIVISOR. Zero divided by zero, and `is_power_of_two()` is
+        // false for zero, so one predicate refuses both 0 and the
+        // spec-violating non-powers like 3. The panic this replaces
+        // defeated `admin.rs`'s deliberate
+        // `let Ok(file) = GgufFile::open(..) else { .. }` degradation
+        // arm, 500-ing the whole model listing over one malformed file.
+        let declared_alignment = metadata
             .get("general.alignment")
             .and_then(|v| v.as_u64())
-            .unwrap_or(32) as usize;
+            .unwrap_or(32);
+        let alignment = usize::try_from(declared_alignment)
+            .ok()
+            .filter(|a| a.is_power_of_two())
+            .ok_or(GgufError::BadAlignment(declared_alignment))?;
         let pos = cursor.position() as usize;
-        let data_start = pos.div_ceil(alignment) * alignment;
+        let data_start = pos
+            .div_ceil(alignment)
+            .checked_mul(alignment)
+            .ok_or(GgufError::BadAlignment(declared_alignment))?;
 
         Ok(GgufFile {
             version,
@@ -397,24 +465,40 @@ impl GgufFile {
         })
     }
 
-    pub fn tensor_bytes(&self, name: &str) -> Result<&[u8], GgufError> {
+    /// The single computation of a tensor's byte range in this file.
+    ///
+    /// It used to be three lines written out verbatim TWICE, once in
+    /// each accessor below, with wrapping `usize` arithmetic: a tensor
+    /// `offset` near `u64::MAX` wrapped `start` past the end of the
+    /// mmap, then wrapped `start + len` back down to something small, so
+    /// the `TruncatedTensor` refusal did not fire and the mmap was
+    /// sliced with `start > end`. Two copies is two places to forget,
+    /// and the twin forgot differently: it did not slice, so it returned
+    /// a bogus `Range` and the panic landed in whichever consumer sliced
+    /// it, far from the cause.
+    fn tensor_range(&self, name: &str) -> Result<std::ops::Range<usize>, GgufError> {
         let info = self
             .tensors
             .iter()
             .find(|t| t.name == name)
             .ok_or_else(|| GgufError::TensorNotFound(name.to_string()))?;
-        let start = self.data_start + info.offset as usize;
         let len = info
             .byte_len()
             .ok_or_else(|| GgufError::UnsizedTensor(name.to_string(), info.dtype))?;
-        if start + len > self.mmap.len() {
-            return Err(GgufError::TruncatedTensor(
-                name.to_string(),
-                len,
-                self.mmap.len().saturating_sub(start),
-            ));
-        }
-        Ok(&self.mmap[start..start + len])
+        let start = usize::try_from(info.offset)
+            .ok()
+            .and_then(|off| self.data_start.checked_add(off));
+        // `available` is for the message, not for the decision, so it
+        // may saturate. The decision below is `checked_add` only.
+        let available = start.map_or(0, |s| self.mmap.len().saturating_sub(s));
+        start
+            .and_then(|s| s.checked_add(len).map(|end| s..end))
+            .filter(|r| r.end <= self.mmap.len())
+            .ok_or_else(|| GgufError::TruncatedTensor(name.to_string(), len, available))
+    }
+
+    pub fn tensor_bytes(&self, name: &str) -> Result<&[u8], GgufError> {
+        Ok(&self.mmap[self.tensor_range(name)?])
     }
 
     /// Zero-copy accessor: returns a cheaply-cloneable handle to the
@@ -428,23 +512,7 @@ impl GgufFile {
         &self,
         name: &str,
     ) -> Result<(Arc<Mmap>, std::ops::Range<usize>), GgufError> {
-        let info = self
-            .tensors
-            .iter()
-            .find(|t| t.name == name)
-            .ok_or_else(|| GgufError::TensorNotFound(name.to_string()))?;
-        let start = self.data_start + info.offset as usize;
-        let len = info
-            .byte_len()
-            .ok_or_else(|| GgufError::UnsizedTensor(name.to_string(), info.dtype))?;
-        if start + len > self.mmap.len() {
-            return Err(GgufError::TruncatedTensor(
-                name.to_string(),
-                len,
-                self.mmap.len().saturating_sub(start),
-            ));
-        }
-        Ok((Arc::clone(&self.mmap), start..start + len))
+        Ok((Arc::clone(&self.mmap), self.tensor_range(name)?))
     }
 
     pub fn find_tensor(&self, name: &str) -> Option<&TensorInfo> {
@@ -595,43 +663,98 @@ mod tests {
         build_synthetic_gguf_with_dtype(0)
     }
 
+    /// The synthetic file, parameterised by every field a hostile
+    /// header varies rather than copied per case. One byte layout, so a
+    /// malformed-header case cannot drift from the well-formed file the
+    /// rest of these tests parse -- which is the same rule the parser
+    /// itself now follows for the tensor range.
+    struct Synthetic {
+        dtype_tag: u32,
+        alignment: u32,
+        shape: Vec<u64>,
+        offset: u64,
+    }
+
+    impl Default for Synthetic {
+        fn default() -> Self {
+            Self {
+                dtype_tag: 0, // F32
+                alignment: 32,
+                shape: vec![4, 8],
+                offset: 0,
+            }
+        }
+    }
+
+    impl Synthetic {
+        fn bytes(&self) -> Vec<u8> {
+            let mut buf = Vec::new();
+            buf.write_u32::<LittleEndian>(GGUF_MAGIC).unwrap();
+            buf.write_u32::<LittleEndian>(3).unwrap(); // version
+            buf.write_u64::<LittleEndian>(1).unwrap(); // tensor_count
+            buf.write_u64::<LittleEndian>(2).unwrap(); // kv_count
+
+            // kv 1: general.alignment (u32)
+            write_string(&mut buf, "general.alignment");
+            buf.write_u32::<LittleEndian>(4).unwrap(); // type = u32
+            buf.write_u32::<LittleEndian>(self.alignment).unwrap();
+
+            // kv 2: general.name = "synthetic-test"
+            write_string(&mut buf, "general.name");
+            buf.write_u32::<LittleEndian>(8).unwrap(); // type = string
+            write_string(&mut buf, "synthetic-test");
+
+            // tensor 0: "tok_embd.weight"
+            write_string(&mut buf, "tok_embd.weight");
+            buf.write_u32::<LittleEndian>(self.shape.len() as u32)
+                .unwrap();
+            for &dim in &self.shape {
+                buf.write_u64::<LittleEndian>(dim).unwrap();
+            }
+            buf.write_u32::<LittleEndian>(self.dtype_tag).unwrap();
+            buf.write_u64::<LittleEndian>(self.offset).unwrap();
+
+            // Pad to the declared alignment where that is a boundary a
+            // file can actually have; a hostile alignment gets the
+            // default padding, because what those cases assert is the
+            // refusal, not where the data landed.
+            let pad = if self.alignment.is_power_of_two() && self.alignment <= 4096 {
+                self.alignment as usize
+            } else {
+                32
+            };
+            while buf.len() % pad != 0 {
+                buf.push(0);
+            }
+            // tensor data: 32 f32 values
+            for i in 0..32u32 {
+                buf.write_f32::<LittleEndian>(i as f32 * 0.5).unwrap();
+            }
+            buf
+        }
+    }
+
     /// The synthetic file, parameterised by the tensor's dtype tag
     /// rather than copied per dtype: the byte layout is identical and a
     /// second copy would drift from this one.
     fn build_synthetic_gguf_with_dtype(dtype_tag: u32) -> Vec<u8> {
-        let mut buf = Vec::new();
-        buf.write_u32::<LittleEndian>(GGUF_MAGIC).unwrap();
-        buf.write_u32::<LittleEndian>(3).unwrap(); // version
-        buf.write_u64::<LittleEndian>(1).unwrap(); // tensor_count
-        buf.write_u64::<LittleEndian>(2).unwrap(); // kv_count
-
-        // kv 1: general.alignment = 32 (u32)
-        write_string(&mut buf, "general.alignment");
-        buf.write_u32::<LittleEndian>(4).unwrap(); // type = u32
-        buf.write_u32::<LittleEndian>(32).unwrap();
-
-        // kv 2: general.name = "synthetic-test"
-        write_string(&mut buf, "general.name");
-        buf.write_u32::<LittleEndian>(8).unwrap(); // type = string
-        write_string(&mut buf, "synthetic-test");
-
-        // tensor 0: "tok_embd.weight", shape [4, 8], F32
-        write_string(&mut buf, "tok_embd.weight");
-        buf.write_u32::<LittleEndian>(2).unwrap(); // n_dims
-        buf.write_u64::<LittleEndian>(4).unwrap();
-        buf.write_u64::<LittleEndian>(8).unwrap();
-        buf.write_u32::<LittleEndian>(dtype_tag).unwrap(); // dtype (0 = F32)
-        buf.write_u64::<LittleEndian>(0).unwrap(); // offset
-
-        // pad to 32-byte alignment
-        while buf.len() % 32 != 0 {
-            buf.push(0);
+        Synthetic {
+            dtype_tag,
+            ..Default::default()
         }
-        // tensor data: 32 f32 values
-        for i in 0..32u32 {
-            buf.write_f32::<LittleEndian>(i as f32 * 0.5).unwrap();
-        }
-        buf
+        .bytes()
+    }
+
+    /// Writes `bytes` to a uniquely named temp file, opens it, and
+    /// removes it. The returned `GgufFile` keeps its own mmap, so the
+    /// unlink is safe.
+    fn open_temp(bytes: &[u8], tag: &str) -> Result<GgufFile, GgufError> {
+        let tmp =
+            std::env::temp_dir().join(format!("ferrox_test_{tag}_{}.gguf", std::process::id()));
+        std::fs::write(&tmp, bytes).unwrap();
+        let res = GgufFile::open(&tmp);
+        std::fs::remove_file(&tmp).ok();
+        res
     }
 
     fn write_string(buf: &mut Vec<u8>, s: &str) {
@@ -826,6 +949,140 @@ mod tests {
             Ok((_, range)) => panic!("tensor_mapped_range returned Ok({range:?})"),
         }
         std::fs::remove_file(&tmp).ok();
+    }
+
+    /// A file-supplied shape must be REFUSED when its element count
+    /// cannot be what it claims, never folded with a wrapping
+    /// `product()` that makes every later shape-vs-bytes check agree
+    /// with the lie.
+    ///
+    /// What shipped: `[2^32, 2^32]` wrapped to exactly 0, so the tensor
+    /// sized as 0 bytes and `tensor_bytes` handed back `Ok(&[])` -- a
+    /// load that reads as success and yields an empty tensor, which is
+    /// the outcome `UnsizedTensor` exists to prevent, reached through a
+    /// door it does not cover. `[2^63 + 2, 2]` wrapped to 4, walked
+    /// through `Tensor::new`'s own product assert, and the first
+    /// `row(0)` then indexed `data[0..2^63 + 2]` on a 4-element `Vec`.
+    #[test]
+    fn a_shape_larger_than_the_file_could_hold_is_refused_rather_than_wrapped() {
+        // Chosen to fail rather than to be round. The first two wrap the
+        // u64 fold (to 0 and to 4); the third and fourth wrap nothing
+        // and are caught only by the bound derived from the input --
+        // one bit per element, so this ~288-byte file cannot hold more
+        // than 2304 of them.
+        for (i, shape) in [
+            vec![1u64 << 32, 1 << 32],
+            vec![(1u64 << 63) + 2, 2],
+            vec![u64::MAX / 64, 65],
+            vec![1u64 << 40],
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let bytes = Synthetic {
+                shape: shape.clone(),
+                ..Default::default()
+            }
+            .bytes();
+            match open_temp(&bytes, &format!("wrapshape{i}")) {
+                Err(GgufError::ImplausibleShape(name, got, _)) => {
+                    assert_eq!(name, "tok_embd.weight");
+                    assert_eq!(got, shape);
+                }
+                Err(other) => panic!("expected ImplausibleShape for {shape:?}, got {other}"),
+                Ok(f) => panic!(
+                    "shape {shape:?} parsed: n_elements={} byte_len={:?}",
+                    f.tensors[0].n_elements(),
+                    f.tensors[0].byte_len()
+                ),
+            }
+        }
+    }
+
+    /// A tensor `offset` near `u64::MAX` must be refused, by BOTH
+    /// accessors, rather than wrapping past the `TruncatedTensor` check
+    /// and slicing the mmap with `start > end`.
+    #[test]
+    fn a_tensor_offset_that_wraps_the_mmap_is_refused_by_both_accessors() {
+        // The offsets below are chosen against this exact file: 288
+        // bytes, `data_start` 160, a 128-byte F32 tensor. If the builder
+        // changes, they stop probing what they were chosen to probe, so
+        // the drift has to be the thing that fails.
+        let base = Synthetic::default().bytes();
+        assert_eq!(
+            base.len(),
+            288,
+            "the offsets below were chosen against a 288-byte file"
+        );
+
+        // With `start = data_start + offset` wrapping:
+        //   MAX - 232: `start` wrapped to 2^64 - 73 and `start + len`
+        //              wrapped back down to 55, under the file length,
+        //              so the refusal did not fire and the mmap was
+        //              sliced with start > end. That is the panic.
+        //   MAX -  98: `start` wrapped to 61 and `start + len` to 189,
+        //              both inside the file: no panic at all, just 128
+        //              bytes of the HEADER served as tensor data.
+        //   MAX:       `start` 159, `end` 287 -- same silent misread.
+        for (i, offset) in [u64::MAX - 232, u64::MAX - 98, u64::MAX]
+            .into_iter()
+            .enumerate()
+        {
+            let bytes = Synthetic {
+                offset,
+                ..Default::default()
+            }
+            .bytes();
+            let f =
+                open_temp(&bytes, &format!("wrapoffset{i}")).expect("the header itself is fine");
+            match f.tensor_bytes("tok_embd.weight") {
+                Err(GgufError::TruncatedTensor(name, len, _)) => {
+                    assert_eq!(name, "tok_embd.weight");
+                    assert_eq!(len, 128);
+                }
+                Err(other) => panic!("offset {offset}: expected TruncatedTensor, got {other}"),
+                Ok(b) => panic!("offset {offset}: tensor_bytes returned {} bytes", b.len()),
+            }
+            // The zero-copy accessor was a verbatim copy of the same
+            // three lines and forgot differently: it returned a bogus
+            // `Range` and let the panic land in whichever consumer
+            // sliced it. It cannot differ now -- there is one copy.
+            match f.tensor_mapped_range("tok_embd.weight") {
+                Err(GgufError::TruncatedTensor(..)) => {}
+                Err(other) => panic!("offset {offset}: expected TruncatedTensor, got {other}"),
+                Ok((_, r)) => panic!("offset {offset}: tensor_mapped_range returned {r:?}"),
+            }
+        }
+    }
+
+    /// `general.alignment` is a divisor read straight off the wire. Zero
+    /// divided by zero inside `parse`, and a panic there defeats
+    /// `admin.rs`'s deliberate `let Ok(file) = GgufFile::open(..) else`
+    /// degradation arm: one malformed file 500'd the whole model
+    /// listing instead of degrading its own row.
+    #[test]
+    fn a_zero_or_non_power_of_two_alignment_is_refused_rather_than_panicking() {
+        for (i, alignment) in [0u32, 3, 33, u32::MAX].into_iter().enumerate() {
+            let bytes = Synthetic {
+                alignment,
+                ..Default::default()
+            }
+            .bytes();
+            match open_temp(&bytes, &format!("align{i}")) {
+                Err(GgufError::BadAlignment(got)) => assert_eq!(got, u64::from(alignment)),
+                Err(other) => panic!("alignment {alignment}: expected BadAlignment, got {other}"),
+                Ok(_) => panic!("alignment {alignment} parsed"),
+            }
+        }
+        // A power of two other than the default still parses, so the
+        // refusal is not "anything unusual is refused".
+        let bytes = Synthetic {
+            alignment: 64,
+            ..Default::default()
+        }
+        .bytes();
+        let f = open_temp(&bytes, "align_ok").expect("alignment 64 is a valid alignment");
+        assert_eq!(f.tensor_bytes("tok_embd.weight").unwrap().len(), 128);
     }
 
     #[test]

--- a/crates/ferrox-safetensors/src/lib.rs
+++ b/crates/ferrox-safetensors/src/lib.rs
@@ -62,6 +62,11 @@ pub enum SafetensorsError {
     InvalidOffsets(String, (u64, u64)),
     #[error("tensor '{0}': shape/dtype imply {1} bytes but data_offsets span {2} bytes")]
     SizeMismatch(String, u64, u64),
+    #[error(
+        "tensor '{0}' declares shape {1:?}, whose size in bytes is not representable, so there \
+         is nothing for its data_offsets span to be checked against"
+    )]
+    ImplausibleShape(String, Vec<usize>),
     #[error("data section is {0} bytes but tensor offsets claim {1} bytes")]
     IncompleteBuffer(usize, usize),
     #[error("tensor '{0}' not found")]
@@ -137,9 +142,41 @@ pub struct TensorInfo {
     pub data_offsets: (u64, u64),
 }
 
+/// The single fold of a file-supplied shape into an element count.
+///
+/// It used to be a bare `product()` in two places, and that made
+/// [`SafetensorsError::SizeMismatch`] -- whose only job is to check a
+/// shape against the bytes the header says it occupies -- unable to fire
+/// for any overflowing shape, because the product it compared against
+/// had already wrapped to whatever would agree. A gate that cannot fire
+/// is worse than no gate.
+///
+/// No separate file-size bound is needed on top: `parse` already
+/// requires each span to equal this count times the dtype width, the
+/// spans to be contiguous from zero, and the last of them to end exactly
+/// at the end of the file. Once the fold cannot lie, that chain is the
+/// bound, and it is derived entirely from the input.
+fn fold_shape(shape: &[usize]) -> Option<u64> {
+    shape
+        .iter()
+        .try_fold(1u64, |n, &dim| n.checked_mul(dim as u64))
+}
+
 impl TensorInfo {
+    /// The declared element count, or `None` when folding the
+    /// file-supplied dims wraps or does not fit an address on this
+    /// machine.
+    pub fn element_count(&self) -> Option<usize> {
+        fold_shape(&self.shape).and_then(|n| usize::try_from(n).ok())
+    }
+
+    /// The element count for REPORTING -- never for sizing a read.
+    /// `parse` refuses any shape whose byte count is not representable,
+    /// so for a `TensorInfo` that came out of a parsed file this is
+    /// exact; the saturating arm exists only for a hand-built one, and
+    /// saturates UP, so it can only ever cause a refusal.
     pub fn n_elements(&self) -> usize {
-        self.shape.iter().product()
+        self.element_count().unwrap_or(usize::MAX)
     }
 
     pub fn byte_len(&self) -> u64 {
@@ -208,8 +245,11 @@ impl SafetensorsFile {
             if start != running_end || end < start {
                 return Err(SafetensorsError::InvalidOffsets(name, (start, end)));
             }
-            let n_elements: u64 = raw_info.shape.iter().map(|&d| d as u64).product();
-            let expected_bytes = n_elements * dtype.byte_size() as u64;
+            let expected_bytes = fold_shape(&raw_info.shape)
+                .and_then(|n| n.checked_mul(dtype.byte_size() as u64))
+                .ok_or_else(|| {
+                    SafetensorsError::ImplausibleShape(name.clone(), raw_info.shape.clone())
+                })?;
             if end - start != expected_bytes {
                 return Err(SafetensorsError::SizeMismatch(
                     name,
@@ -250,13 +290,28 @@ impl SafetensorsFile {
         self.tensors.iter().map(|t| t.name.as_str())
     }
 
-    pub fn tensor_bytes(&self, name: &str) -> Result<&[u8], SafetensorsError> {
+    /// The single computation of a tensor's byte range in this file,
+    /// rather than the verbatim copy each accessor used to hold -- the
+    /// same collapse `ferrox-gguf::GgufFile::tensor_range` got, and for
+    /// the same reason: two copies is two places for the reasoning that
+    /// makes them total to rot independently.
+    ///
+    /// Total by construction, and it is `parse` that makes it so: the
+    /// spans are contiguous from zero, each equals its shape's byte
+    /// count, and the last ends exactly at the end of the data section,
+    /// so `data_start + end` cannot exceed the mmap.
+    fn tensor_range(&self, name: &str) -> Result<Range<usize>, SafetensorsError> {
         let info = self
             .tensor_info(name)
             .ok_or_else(|| SafetensorsError::TensorNotFound(name.to_string()))?;
         let start = self.data_start + info.data_offsets.0 as usize;
         let end = self.data_start + info.data_offsets.1 as usize;
-        Ok(&self.mmap[start..end])
+        debug_assert!(start <= end && end <= self.mmap.len());
+        Ok(start..end)
+    }
+
+    pub fn tensor_bytes(&self, name: &str) -> Result<&[u8], SafetensorsError> {
+        Ok(&self.mmap[self.tensor_range(name)?])
     }
 
     /// Zero-copy accessor: a cheaply-cloneable handle to the underlying
@@ -267,12 +322,7 @@ impl SafetensorsFile {
         &self,
         name: &str,
     ) -> Result<(Arc<Mmap>, Range<usize>), SafetensorsError> {
-        let info = self
-            .tensor_info(name)
-            .ok_or_else(|| SafetensorsError::TensorNotFound(name.to_string()))?;
-        let start = self.data_start + info.data_offsets.0 as usize;
-        let end = self.data_start + info.data_offsets.1 as usize;
-        Ok((Arc::clone(&self.mmap), start..end))
+        Ok((Arc::clone(&self.mmap), self.tensor_range(name)?))
     }
 }
 
@@ -446,6 +496,74 @@ mod tests {
         );
         assert_eq!(file.tensor_bytes("a").unwrap(), &[10u8, 11]);
         assert_eq!(file.tensor_bytes("b").unwrap(), &[20u8, 21]);
+    }
+
+    /// `SizeMismatch` is the only thing standing between a
+    /// file-supplied shape and every consumer that trusts it, and it
+    /// compared two values that wrapped identically -- so for an
+    /// overflowing shape it could never fire. Executed before this fix,
+    /// shape `[2^63 + 2, 2]` with a 16-byte span parsed OK and reported
+    /// `n_elements=4`, and the wrapped count is what every downstream
+    /// bounds check then agreed with.
+    #[test]
+    fn a_shape_whose_byte_count_wraps_is_refused_rather_than_matched() {
+        // Chosen to fail rather than to be round:
+        //   [2^63 + 2, 2]           the element fold wraps to exactly 4
+        //   [2^32, 2^32]            it wraps to exactly 0, and a 0-byte
+        //                           span then agrees with it perfectly
+        //   [2^62]                  the count fits; it is the * 4 for
+        //                           F32 that wraps, to 0
+        //   [u64::MAX / 64, 65]     the fold wraps to a large nonsense
+        for (i, (shape, span)) in [
+            ("[9223372036854775810,2]", 16usize),
+            ("[4294967296,4294967296]", 0),
+            ("[4611686018427387904]", 0),
+            ("[288230376151711743,65]", 0),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let header =
+                format!(r#"{{"w":{{"dtype":"F32","shape":{shape},"data_offsets":[0,{span}]}}}}"#);
+            let bytes = build_file(&header, &vec![0u8; span]);
+            let tmp = std::env::temp_dir().join(format!(
+                "ferrox_st_wrapshape{i}_{}.safetensors",
+                std::process::id()
+            ));
+            std::fs::write(&tmp, &bytes).unwrap();
+            let result = SafetensorsFile::open(&tmp);
+            std::fs::remove_file(&tmp).ok();
+
+            match result {
+                Err(SafetensorsError::ImplausibleShape(name, _)) => assert_eq!(name, "w"),
+                Err(other) => panic!("shape {shape}: expected ImplausibleShape, got {other}"),
+                Ok(f) => panic!(
+                    "shape {shape} parsed: n_elements={} byte_len={}",
+                    f.tensors[0].n_elements(),
+                    f.tensors[0].byte_len()
+                ),
+            }
+        }
+
+        // And the gate it was hiding still fires when it CAN: a shape
+        // that does not overflow but does not match its span is a
+        // SizeMismatch, not an ImplausibleShape.
+        let header = r#"{"w":{"dtype":"F32","shape":[7],"data_offsets":[0,16]}}"#;
+        let bytes = build_file(header, &[0u8; 16]);
+        let tmp = std::env::temp_dir().join(format!(
+            "ferrox_st_plainmismatch_{}.safetensors",
+            std::process::id()
+        ));
+        std::fs::write(&tmp, &bytes).unwrap();
+        let result = SafetensorsFile::open(&tmp);
+        std::fs::remove_file(&tmp).ok();
+        match result {
+            Err(SafetensorsError::SizeMismatch(name, expected, got)) => {
+                assert_eq!((name.as_str(), expected, got), ("w", 28, 16));
+            }
+            Err(other) => panic!("expected SizeMismatch, got {other}"),
+            Ok(_) => panic!("expected SizeMismatch, got a parsed file"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three defects in the GGUF/safetensors header path, one class: a number read off the wire folded into a decision with wrapping arithmetic, so the check meant to catch it agreed with the wrapped value instead. `GgufFile::open` is reachable from `POST /admin/models/load` and from `GET /admin/models`' directory scan, and the safetensors path from a Kimi checkpoint directory, so all three are untrusted input.

Every claim in the three issues was reproduced against the code before anything was changed.

Closes #30
Closes #31
Closes #32

## What was wrong

**#30 — the shape product.** `TensorInfo::n_elements` folded file-supplied dims with a bare `product()`. `[2^32, 2^32]` wraps to exactly 0, so the tensor sized as 0 bytes and `tensor_bytes` returned `Ok(&[])` — the outcome `UnsizedTensor` exists to prevent, reached through a door it does not cover. `[2^63 + 2, 2]` wraps to 4 and walks through `Tensor::new`'s own product assert. On the safetensors side the same fold made `SizeMismatch` — whose only job is this check — unreachable for any overflowing shape, because the product it compares against had already agreed to whatever the file wanted.

**#31 — the tensor range.** `tensor_bytes` and `tensor_mapped_range` each held a verbatim copy of the same three-line range computation with wrapping `usize` adds. An `offset` near `u64::MAX` wrapped `start` past the mmap and wrapped `start + len` back under the file length, so `TruncatedTensor` did not fire and the mmap was sliced with `start > end`. The twin forgot differently: it does not slice, so it returned a bogus `Range` and the panic landed in whichever consumer sliced it — and that twin is the zero-copy path the loader actually uses. Nearer offsets did not even panic: they served bytes of the file's own header as tensor data.

**#32 — the divisor.** `general.alignment` was used as a divisor straight off the wire. `0` divided by zero inside `parse`, and a panic there defeats `admin.rs`'s deliberate `let Ok(file) = GgufFile::open(..) else { .. }` arm: one malformed file 500'd the whole model listing instead of degrading its own row.

## What it does now

- **One fold.** `TensorInfo::element_count() -> Option<usize>` (gguf) and `fold_shape` (safetensors) are the only places a file-supplied shape is folded, with `checked_mul`. `byte_len` goes through it; `n_elements` is documented as the reporting-only view and saturates UP, so it can only ever cause a refusal, never an over-read. In safetensors the `* dtype.byte_size()` is checked too — that one wraps on its own for `[2^62]` with F32.
- **A bound derived from the input, not chosen.** GGUF `parse` refuses an implausible shape at the one place a `GgufFile`'s `TensorInfo`s are built: every element occupies at least one bit on the wire (the densest format this build knows is Q1_0, at 1.125 bpw), so a tensor cannot declare more elements than eight times the bytes of the file that has to contain it. Safetensors needs no extra bound — `parse` already requires each span to equal its shape's byte count, the spans to be contiguous from zero, and the last to end exactly at the end of the file; once the fold cannot lie, that chain *is* the bound.
- **One range, not two copies.** A private `tensor_range` in each crate, which both accessors call, so a missing check cannot exist in only one of them. `checked_add` throughout on the GGUF side; `saturating_sub` survives only in the `available` figure that goes into an error message and into no decision.
- **One predicate for the divisor.** `is_power_of_two()` is false for zero, so `0` and the spec-violating `3` are refused in the same arm, with `BadAlignment` naming the value.

New refusals: `GgufError::ImplausibleShape`, `GgufError::BadAlignment`, `SafetensorsError::ImplausibleShape`.

## What would have to be true for this to be wrong

That some real GGUF declares a tensor with more elements than eight times its own byte count, or an alignment that is not a power of two — both forbidden by the format and emitted by no writer; that a safetensors checkpoint declares a tensor whose element count times its dtype width does not fit a `u64`, which its own `u64` `data_offsets` could not describe anyway; or that a consumer needs `n_elements` to be exact for a `TensorInfo` it built by hand rather than parsed, which nothing in the workspace does.

One behaviour change worth reviewing: `GgufFile::open` now refuses a file it previously parsed, in the three cases above. For `GET /admin/models` that means such a file takes the graceful-degradation arm and is listed with null fields — which is what that arm was written for, and strictly better than the 500 it produced before.

## Evidence

Each new test was sabotaged once and confirmed red, and each half of each fix was sabotaged separately (wrapping fold vs. removed bound; wrapping range; unchecked divisor).

Numbers are sized past the lazy-allocation threshold and **chosen to fail** rather than to be round — a round value can land just under an overflow boundary and pass whatever the code does:

- shapes `[2^32, 2^32]`, `[2^63 + 2, 2]`, `[u64::MAX / 64, 65]`, `[1 << 40]`, `[2^62]` — the first two exercise the fold, the rest the bound and the byte multiply
- offsets `u64::MAX - 232` (panicked), `u64::MAX - 98` and `u64::MAX` (served header bytes silently), asserted against **both** accessors
- `alignment ∈ {0, 3, 33, u32::MAX}` refused, and `64` still accepted, so the refusal is not "anything unusual is refused"
- a positive control asserting safetensors `SizeMismatch` still fires for a plain non-overflowing mismatch, so the new refusal did not swallow the old one

The GGUF synthetic-file builder is now one parameterised struct instead of a copy per case, and it asserts its own byte length, because the offsets above were chosen against it.

Gates: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, the same `--release`, and `cargo fmt --all`.

## Doc delta

None. No doc names `GgufError`, `TruncatedTensor`, `UnsizedTensor` or `general.alignment`, and no user-visible flag, env var or endpoint shape changed — only the error a malformed file produces instead of a panic.

## Not done

- `crates/ferrox-server/`, `crates/ferrox-models/` and `docs/` were left untouched (other agents own them), so `TensorInfo::n_elements()` keeps its `-> usize` signature for `admin.rs`'s parameter-count sum rather than becoming `Result`. It is now correct-by-construction for anything that came out of a parsed file, and documented as reporting-only; making it fallible is a follow-up for whoever owns `ferrox-server`.
- Tensor `offset` is still not validated at parse time, only at range time. Doing so would refuse a partially-downloaded checkpoint at `open` rather than letting it list and fail per tensor, which is a bigger behaviour change than these issues asked for.
- No benchmarks were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
