### PR TITLE
fix(server): build the response cache key from an exhaustive destructure of GenerationParams

### DIFF
--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -1703,18 +1703,27 @@ impl ChatCompletionRequest {
         self.temperature.unwrap_or(0.0) <= 0.0 || self.seed.is_some()
     }
 
-    fn cache_key(&self, prompt: &str) -> CacheKey {
+    /// The cache key for this request under the parameters it will
+    /// actually be generated with.
+    ///
+    /// `params` is taken rather than rebuilt because the RESOLVED
+    /// parameters are the only honest thing to key on: this function
+    /// used to re-state a handful of the request's fields, complete with
+    /// its own copy of every `unwrap_or` default, and then keyed on a
+    /// configuration that was only nearly the one that ran. Three fields
+    /// of that hand-written list were simply missing (#35).
+    ///
+    /// `params` must be the ones from
+    /// [`Self::generation_params_for_template`], not
+    /// [`Self::generation_params`]: the template's end-of-turn stop and
+    /// a forced `tool_choice`'s grammar are added there, and both change
+    /// the answer.
+    fn cache_key(&self, prompt: &str, params: &GenerationParams) -> CacheKey {
         CacheKey {
             model: self.model.clone(),
             prompt: prompt.to_string(),
-            max_tokens: self.max_tokens,
-            // Off the RESOLVED params, not off the request fields: this
-            // used to re-state every `unwrap_or` default a second time,
-            // so a default changed in one place and not the other would
-            // have keyed the cache on a configuration nothing ran.
-            sampling: response_cache::sampling_key(&self.sampling_params()),
+            generation: response_cache::generation_key(params),
             seed: self.seed,
-            stop: self.effective_stop_sequences(),
         }
     }
 
@@ -2947,7 +2956,15 @@ async fn chat_completions_full(
     let template = active.generative()?.chat_template();
     let kwargs = req.resolve_template_kwargs(&template);
     let prompt = prompt_from_messages(&history, &template, &req.tools, kwargs)?;
-    let key = req.is_cacheable().then(|| req.cache_key(&prompt));
+    // Resolved BEFORE the lookup, because the constraint is part of the
+    // key: a grammar, JSON mode and `ignore_eos` all change the answer
+    // and none of them changes the prompt, so a cache consulted first
+    // would answer a constrained request with an unconstrained
+    // completion (#35). It also means an unparseable grammar is a 400
+    // for the second caller too, rather than a 200 carrying prose
+    // generated under no grammar at all.
+    let params = req.generation_params_for_template(&template, active.name())?;
+    let key = req.is_cacheable().then(|| req.cache_key(&prompt, &params));
 
     let (completion, cache_status) = if let Some(cached) = key
         .as_ref()
@@ -2956,7 +2973,6 @@ async fn chat_completions_full(
         tracing::debug!("cache hit for key {}", key.as_ref().unwrap().digest());
         (cached, "hit")
     } else {
-        let params = req.generation_params_for_template(&template, active.name())?;
         let (chunks, finish, usage) = decode_task::buffered(
             decode_task::DecodeHandles::take(&state, &active)?,
             prompt.clone(),
@@ -4989,12 +5005,22 @@ mod tests {
     /// that render chat templates (ASCII role names) do not spuriously
     /// reject their own prompt prefixes.
     fn test_model_full_byte_vocab() -> Model {
+        test_model_full_byte_vocab_with_eos(None)
+    }
+
+    /// [`test_model_full_byte_vocab`] with an end-of-generation id, so a
+    /// test can tell a turn the MODEL ended from one that merely ran out
+    /// of budget -- which is the only way `ignore_eos` is observable.
+    ///
+    /// Parameterised rather than copied: a second `Model` literal here
+    /// is one more place a field has to be remembered.
+    fn test_model_full_byte_vocab_with_eos(eos: Option<usize>) -> Model {
         let mut cfg = test_dense_fixture();
         cfg.vocab_size = 256;
         Model::Gguf(GgufModel {
             decoder: Arc::new(Decoder::new_random_small(cfg, 2, 256)),
             tokenizer: Arc::new(ServerTokenizer::Byte),
-            stop_tokens: StopTokens::default(),
+            stop_tokens: StopTokens::from_eos(eos),
             bos_id: None,
             is_synthetic: true,
             chat_template: chat_template::PromptTemplate::plain(),
@@ -7600,6 +7626,179 @@ mod tests {
         assert_eq!(second["usage"]["completion_tokens"], 3);
     }
 
+    /// The whole of #35 through the real router: a request that adds a
+    /// GRAMMAR to a body already answered without one must be generated
+    /// afresh, under that grammar.
+    ///
+    /// The cache used to be consulted before
+    /// `generation_params_for_template` had even compiled the grammar,
+    /// and the key held no trace of it, so the constrained request was
+    /// handed the previous caller's unconstrained prose with a 200. The
+    /// answer is asserted, not the key: a key that differs proves
+    /// nothing if the lookup uses something else.
+    #[tokio::test]
+    async fn a_grammar_request_is_not_answered_from_an_unconstrained_cache_entry() {
+        let app = test_app();
+        let plain = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "\u{1}\u{2}"}],
+            "max_tokens": 3,
+            "temperature": 0,
+        });
+
+        let first = post_json(&app, plain.clone()).await;
+        assert_eq!(first["ferrox_cache"], "miss");
+        let unconstrained = first["choices"][0]["message"]["content"]
+            .as_str()
+            .expect("content")
+            .to_string();
+
+        let mut constrained = plain.clone();
+        constrained["grammar"] = serde_json::json!("root ::= \"yes\"");
+        let second = post_json(&app, constrained).await;
+        assert_eq!(
+            second["ferrox_cache"], "miss",
+            "a grammar is part of the key, so this body has never been answered"
+        );
+        // The synthetic demo model wraps its decode in a banner, so the
+        // assertion is on the decoded text inside it: `yes` is the only
+        // string this grammar admits, and it is there.
+        let constrained_answer = second["choices"][0]["message"]["content"]
+            .as_str()
+            .expect("content")
+            .to_string();
+        assert!(
+            constrained_answer.contains("-> \"yes\"]"),
+            "the grammar must have been compiled AND applied, not skipped \
+             by a cache hit: {constrained_answer}"
+        );
+        assert_ne!(
+            constrained_answer, unconstrained,
+            "the constrained request was served the unconstrained answer"
+        );
+
+        // And the entry the first request made is still the first
+        // request's: the miss above is the grammar, not a key that
+        // fails to repeat.
+        let third = post_json(&app, plain).await;
+        assert_eq!(third["ferrox_cache"], "hit");
+        assert_eq!(third["choices"][0]["message"]["content"], unconstrained);
+    }
+
+    /// The third of #35's fields, and the one whose old failure was
+    /// LOUD: `validate_json_object_output` runs against whatever came
+    /// back, so a `json_object` request answered from a cached prose
+    /// entry got a hard 400 for a body that had never been generated
+    /// under the JSON mask at all.
+    ///
+    /// The system message is what makes this reproducible, and it is the
+    /// repo's own bug shape underneath. `inject_json_object_system_hint`
+    /// usually leaves a fingerprint in the PROMPT, which happened to
+    /// split the two keys apart -- a correctness property nothing stated
+    /// or enforced, resting on a string edit made for a different
+    /// reason. Its `!s.contains("JSON")` arm is the hole: a caller who
+    /// already says "JSON" in their own system message gets NO hint
+    /// appended, so the two requests render byte-identical prompts and
+    /// the old key could not tell them apart.
+    ///
+    /// The synthetic model emits its demo banner under either mask, so
+    /// the 400 is the same on both sides of this fix and cannot be the
+    /// assertion; the cache-level twin in `response_cache` asserts the
+    /// answer. What is asserted here is that the answer did not come
+    /// from the other request's entry.
+    #[tokio::test]
+    async fn a_json_object_request_does_not_reuse_the_unconstrained_cache_entry() {
+        let state = Arc::new(test_state(
+            test_model_full_byte_vocab(),
+            ResponseCache::new(1000, Duration::from_secs(3600)),
+        ));
+        let app = test_app_with_state(state.clone());
+        let plain = serde_json::json!({
+            "model": "m",
+            "messages": [
+                {"role": "system", "content": "Answer in JSON when it helps."},
+                {"role": "user", "content": "\u{1}\u{2}"},
+            ],
+            "max_tokens": 3,
+            "temperature": 0,
+        });
+
+        let first = post_json(&app, plain.clone()).await;
+        assert_eq!(first["ferrox_cache"], "miss");
+        assert_eq!(state.cache_stats().entries, 1);
+
+        let mut as_json = plain.clone();
+        as_json["response_format"] = serde_json::json!({"type": "json_object"});
+        let (status, _) = post_json_uri(&app, "/v1/chat/completions", as_json).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "the demo banner is not a JSON object, whoever generated it"
+        );
+        assert_eq!(
+            state.cache_stats().hits,
+            0,
+            "a json_object request must not be answered from an entry the \
+             JSON mask never produced"
+        );
+        assert_eq!(
+            state.cache_stats().entries,
+            2,
+            "json_object must key its own entry, not reuse the unconstrained \
+             one it happens to render the same prompt as"
+        );
+    }
+
+    /// The same failure for `ignore_eos`, whose whole purpose is that a
+    /// benchmarking run produces EXACTLY `max_tokens`. Answered from a
+    /// cache entry the model's own EOS had cut short, it produced the
+    /// short answer instead -- the one outcome the field exists to rule
+    /// out (#35).
+    ///
+    /// `0x77` is the id this model greedily emits SECOND for the prompt
+    /// below, so with it as the EOS the plain request stops after one
+    /// token and the `ignore_eos` one runs the whole budget. Asserted on
+    /// the token count and the finish reason, which is where a replayed
+    /// answer shows.
+    #[tokio::test]
+    async fn an_ignore_eos_request_is_not_answered_from_a_cache_entry_that_stopped_at_eos() {
+        let app = test_app_with_state(Arc::new(test_state(
+            test_model_full_byte_vocab_with_eos(Some(0x77)),
+            ResponseCache::new(1000, Duration::from_secs(3600)),
+        )));
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "\u{1}\u{2}"}],
+            "max_tokens": 6,
+            "temperature": 0,
+        });
+
+        let stopped = post_json(&app, body.clone()).await;
+        assert_eq!(stopped["ferrox_cache"], "miss");
+        assert_eq!(
+            stopped["choices"][0]["finish_reason"], "stop",
+            "the fixture is only meaningful if the model's EOS really fires here"
+        );
+        assert_eq!(stopped["usage"]["completion_tokens"], 1);
+
+        let mut ignoring = body.clone();
+        ignoring["ignore_eos"] = serde_json::json!(true);
+        let ran_on = post_json(&app, ignoring).await;
+        assert_eq!(
+            ran_on["ferrox_cache"], "miss",
+            "ignore_eos is part of the key, so this body has never been answered"
+        );
+        assert_eq!(
+            ran_on["usage"]["completion_tokens"], 6,
+            "ignore_eos must run the full budget, not replay the EOS-terminated answer"
+        );
+        assert_eq!(ran_on["choices"][0]["finish_reason"], "length");
+        assert_ne!(
+            ran_on["choices"][0]["message"]["content"],
+            stopped["choices"][0]["message"]["content"]
+        );
+    }
+
     /// The real proof for session reuse:
     /// a two-request session where the second request sends only its
     /// new message must produce exactly the same output as manually
@@ -8069,7 +8268,12 @@ mod tests {
             "messages": [{"role": "user", "content": "hi"}],
             "seed": 1,
         });
-        let baseline = chat_request(base.clone()).cache_key("prompt");
+        let key_for = |body: serde_json::Value| {
+            let req = chat_request(body);
+            let params = req.generation_params().expect("params");
+            req.cache_key("prompt", &params)
+        };
+        let baseline = key_for(base.clone());
         for (knob, value) in [
             ("temperature", serde_json::json!(0.5)),
             ("top_p", serde_json::json!(0.9)),
@@ -8082,10 +8286,59 @@ mod tests {
             let mut body = base.clone();
             body[knob] = value;
             assert_ne!(
-                chat_request(body).cache_key("prompt"),
+                key_for(body),
                 baseline,
                 "`{knob}` is not in the cache key: two requests differing \
                  only in it would share one cached answer"
+            );
+        }
+    }
+
+    /// The sampler half's twin, for the constraints. Each of these
+    /// changes the answer and changes NOTHING about the rendered
+    /// prompt, so an omission is invisible until a caller compares two
+    /// answers it never sees side by side (#35).
+    ///
+    /// `grammar` here is the wire field; `response_format:
+    /// {"type":"json_schema"}` and a forced `tool_choice` compile to a
+    /// grammar through the same `GenerationParams::grammar`, so they are
+    /// keyed by the same field being keyed at all.
+    #[test]
+    fn no_constraint_is_missing_from_the_cache_key() {
+        let base = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "pick one"}],
+        });
+        let key_for = |body: serde_json::Value| {
+            let req = chat_request(body);
+            let params = req.generation_params().expect("params");
+            req.cache_key("prompt", &params)
+        };
+        let baseline = key_for(base.clone());
+        for (field, value) in [
+            ("grammar", serde_json::json!("root ::= \"yes\" | \"no\"")),
+            (
+                "response_format",
+                serde_json::json!({"type": "json_object"}),
+            ),
+            (
+                "response_format",
+                serde_json::json!({"type": "json_schema", "json_schema": {
+                    "name": "answer",
+                    "schema": {"type": "object", "properties": {"a": {"type": "string"}}}
+                }}),
+            ),
+            ("ignore_eos", serde_json::json!(true)),
+            ("stop", serde_json::json!(["\n"])),
+            ("max_tokens", serde_json::json!(7)),
+        ] {
+            let mut body = base.clone();
+            body[field] = value.clone();
+            assert_ne!(
+                key_for(body),
+                baseline,
+                "`{field}: {value}` is not in the cache key: two requests \
+                 differing only in it would share one cached answer"
             );
         }
     }

--- a/crates/ferrox-server/src/response_cache.rs
+++ b/crates/ferrox-server/src/response_cache.rs
@@ -14,31 +14,152 @@
 //! KV-prefix cache (reusing the shared prefix of two *different*
 //! prompts) is a separate, larger piece of work, tracked separately.
 
-use crate::generate::{FinishReason, Usage};
+use crate::generate::{FinishReason, GenerationParams, Usage};
+use ferrox_models::grammar::Grammar;
 use ferrox_models::sampling::SamplingParams;
 use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheKey {
     pub model: String,
     pub prompt: String,
-    pub max_tokens: usize,
-    /// Every sampling parameter that affects output. See
-    /// [`SamplingKey`] for why it is a struct built by one function
-    /// rather than a handful of fields written out here.
+    /// Every resolved generation parameter that decides the answer.
+    /// See [`GenerationKey`] for why it is a struct built by one
+    /// function rather than a handful of fields written out here.
+    pub generation: GenerationKey,
+    /// The seed **as the request spelled it**, not the resolved one.
     ///
-    /// Only requests with a deterministic outcome -- greedy
-    /// (temperature 0) or an explicit seed -- are ever looked up against
-    /// this cache at all; see `ChatCompletionRequest::is_cacheable`. A
-    /// request without a deterministic outcome must never populate or
-    /// read this cache, since a "hit" would silently replay one random
-    /// sample forever instead of producing fresh output each call,
-    /// defeating the entire point of sampling.
-    pub sampling: SamplingKey,
+    /// [`GenerationParams::seed`] is already resolved, and for a request
+    /// that named no seed that resolution is a nanosecond clock reading
+    /// (`ChatCompletionRequest::resolved_seed`). Keying on it would make
+    /// every greedy request a fresh key and switch this cache off
+    /// entirely, so the request's own `Option` is what is keyed here.
+    ///
+    /// That is sound only because of what is allowed in at all: only
+    /// requests with a deterministic outcome -- greedy (temperature 0)
+    /// or an explicit seed -- are ever looked up against this cache;
+    /// see `ChatCompletionRequest::is_cacheable`. A request without a
+    /// deterministic outcome must never populate or read this cache,
+    /// since a "hit" would silently replay one random sample forever
+    /// instead of producing fresh output each call, defeating the
+    /// entire point of sampling. Greedy ignores the seed, and a seeded
+    /// request carries its seed here, so the resolved value never
+    /// distinguishes two keys that this `Option` does not.
     pub seed: Option<u64>,
+}
+
+/// Every field of a resolved [`GenerationParams`] that can change the
+/// answer, in a form that can be hashed and compared for exact
+/// equality.
+///
+/// Same reason [`SamplingKey`] exists, one layer out: the interesting
+/// property is not what is in it, it is that nothing is left out. This
+/// struct is what shipped broken. `CacheKey` used to restate a few of
+/// the request's fields by hand, so `grammar`, `json_object` and
+/// `ignore_eos` -- three things that decide the answer and change
+/// nothing about the prompt -- hashed identically to their absence, and
+/// a grammar-constrained request was served the unconstrained answer a
+/// previous caller had cached, with a 200 and no way to tell (#35).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GenerationKey {
+    pub max_tokens: usize,
+    pub sampling: SamplingKey,
     pub stop: Vec<String>,
+    pub stop_token_ids: Vec<usize>,
+    pub json_object: bool,
+    pub grammar: Option<GrammarKey>,
+    pub ignore_eos: bool,
+}
+
+/// A compiled grammar, in a form a hashed cache key can hold.
+///
+/// [`Grammar`] is `Eq` but not `Hash`, and it belongs to
+/// `ferrox-models`, so equality here is the grammar's own -- exact and
+/// structural -- and only the hash is supplied. It is taken over the
+/// derived `Debug` rendering, which is a total dump of the same fields
+/// derived `PartialEq` compares, so equal grammars render equally and
+/// hash equally: the one law `Hash` owes `Eq`.
+///
+/// Two *different* grammars that happened to render the same would only
+/// share a hash bucket, never an entry, because `Eq` still separates
+/// them. So the failure this could produce is a slower lookup, not a
+/// wrong answer.
+///
+/// The rendering is transient -- built inside `hash` and dropped there
+/// -- so a large schema-derived grammar costs a hash rather than a
+/// second copy of itself in every cache key.
+#[derive(Debug, Clone)]
+pub struct GrammarKey(pub Arc<Grammar>);
+
+impl PartialEq for GrammarKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for GrammarKey {}
+
+impl Hash for GrammarKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        format!("{:?}", self.0).hash(state);
+    }
+}
+
+/// The cache-key form of a resolved generation configuration.
+///
+/// The destructure below is exhaustive ON PURPOSE, for the same reason
+/// [`sampling_key`]'s is: a field added to `GenerationParams` stops this
+/// crate compiling, HERE, until someone decides whether it belongs in
+/// the cache key. Two of the nine fields are deliberately NOT keyed and
+/// each says why at its `_` binding -- an exclusion on the record is a
+/// decision; a field nobody looked at is the bug in #35.
+pub fn generation_key(params: &GenerationParams) -> GenerationKey {
+    let GenerationParams {
+        max_tokens,
+        sampling,
+        // NOT KEYED. The resolved seed is a clock reading for any
+        // request that named none, which would give every greedy
+        // request a unique key. `CacheKey::seed` carries the request's
+        // own `Option<u64>` instead, and its doc comment argues why the
+        // two never disagree about which answers may be shared.
+        seed: _,
+        stop,
+        stop_token_ids,
+        json_object,
+        grammar,
+        // NOT KEYED. A cancel token is this request's own handle, not a
+        // parameter of the answer: two identical requests hold two
+        // different tokens, so keying on it would give every request a
+        // unique key and switch the cache off.
+        //
+        // Cancellation does change what comes back -- a `Cancelled`
+        // partial -- but it is `None` on the only path that reaches
+        // this key: `chat_completions_full` registers no token (the
+        // STREAMING handler is the one that does, and it does not
+        // cache). If that ever changes, the guard belongs on the PUT,
+        // as "do not cache a partial answer", and not on this key.
+        // Tracked in #57.
+        cancel: _,
+        ignore_eos,
+    } = params;
+    GenerationKey {
+        max_tokens: *max_tokens,
+        sampling: sampling_key(sampling),
+        stop: stop.clone(),
+        // Keyed even though it is EMPTY at every current call site (the
+        // ids are resolved later, by the layer holding the tokenizer).
+        // It is derived from `stop` and the model's vocabulary, both of
+        // which are already in the key, so keying it can never split
+        // two answers that are the same -- and "empty here" is a fact
+        // about today's call order, not a property of the field.
+        stop_token_ids: stop_token_ids.clone(),
+        json_object: *json_object,
+        grammar: grammar.clone().map(GrammarKey),
+        ignore_eos: *ignore_eos,
+    }
 }
 
 /// Every field of a resolved [`SamplingParams`], in a form that can be
@@ -235,14 +356,47 @@ mod tests {
     use super::*;
 
     fn key(prompt: &str) -> CacheKey {
+        key_under(prompt, |_| {})
+    }
+
+    /// A key built the way the server builds one: from
+    /// [`GenerationParams`], through [`generation_key`]. `tweak` is the
+    /// single parameter under test.
+    ///
+    /// Going through the real builder is the point. Reaching into
+    /// [`CacheKey`] and setting `generation.grammar` by hand would test
+    /// this module's `Eq`/`Hash` and nothing else -- it passes happily
+    /// against the broken key that shipped, because the broken part was
+    /// the BUILDER dropping the field on its way in.
+    fn key_under(prompt: &str, tweak: impl FnOnce(&mut GenerationParams)) -> CacheKey {
+        let mut params = params();
+        tweak(&mut params);
         CacheKey {
             model: "test-model".to_string(),
             prompt: prompt.to_string(),
-            max_tokens: 16,
-            sampling: sampling_key(&SamplingParams::default()),
+            generation: generation_key(&params),
             seed: None,
-            stop: Vec::new(),
         }
+    }
+
+    /// The `GenerationParams` these cache-mechanics tests key on: every
+    /// field at its do-nothing value.
+    fn params() -> GenerationParams {
+        GenerationParams {
+            max_tokens: 16,
+            sampling: SamplingParams::default(),
+            seed: 0,
+            stop: Vec::new(),
+            stop_token_ids: Vec::new(),
+            json_object: false,
+            grammar: None,
+            cancel: None,
+            ignore_eos: false,
+        }
+    }
+
+    fn grammar(src: &str) -> Arc<Grammar> {
+        Arc::new(Grammar::from_str_with_root(src, "root").expect("grammar"))
     }
 
     /// Wraps plain text into a `CachedCompletion` with fixed
@@ -281,10 +435,8 @@ mod tests {
     #[test]
     fn different_max_tokens_is_a_different_key_even_for_the_same_prompt() {
         let mut cache = ResponseCache::new(10, Duration::from_secs(60));
-        let mut k1 = key("same prompt");
-        k1.max_tokens = 16;
-        let mut k2 = key("same prompt");
-        k2.max_tokens = 32;
+        let k1 = key_under("same prompt", |p| p.max_tokens = 16);
+        let k2 = key_under("same prompt", |p| p.max_tokens = 32);
 
         cache.put(k1.clone(), cc("short response"));
         assert_eq!(
@@ -293,6 +445,112 @@ mod tests {
             "different max_tokens must be a cache miss even with identical prompt text"
         );
         assert_eq!(cache.get(&k1), Some(cc("short response")));
+    }
+
+    /// A grammar is a logit mask: it changes the answer and changes
+    /// nothing about the prompt. It was outside the key, so the second
+    /// request here used to be SERVED THE FIRST ONE'S UNCONSTRAINED
+    /// PROSE -- a 200 that looks like compliance with a constraint that
+    /// was never even compiled (#35).
+    ///
+    /// Asserted on the answer that comes back rather than on key
+    /// inequality, because a key that differs is only interesting if the
+    /// lookup the server performs is the one using it.
+    #[test]
+    fn a_grammar_request_is_not_served_the_unconstrained_answer() {
+        let mut cache = ResponseCache::new(10, Duration::from_secs(60));
+
+        let plain = key("same prompt");
+        cache.put(plain.clone(), cc("Sure! Here are a few options..."));
+
+        let constrained = key_under("same prompt", |p| {
+            p.grammar = Some(grammar("root ::= \"yes\" | \"no\""))
+        });
+
+        assert_eq!(
+            cache.get(&constrained),
+            None,
+            "a grammar-constrained request must not be answered with prose \
+             generated under no grammar"
+        );
+        assert_eq!(
+            cache.get(&plain),
+            Some(cc("Sure! Here are a few options...")),
+            "the unconstrained entry is still there: the miss above is the \
+             grammar, not an unstable key"
+        );
+    }
+
+    /// Two different grammars are two different constraints, so one's
+    /// answer is not the other's. The strictly-stronger half of the test
+    /// above: keying on "is there a grammar at all" would pass that one
+    /// and fail this one.
+    #[test]
+    fn two_different_grammars_do_not_share_an_answer() {
+        let mut cache = ResponseCache::new(10, Duration::from_secs(60));
+        let keyed =
+            |src: &'static str| key_under("same prompt", move |p| p.grammar = Some(grammar(src)));
+
+        let yes_no = keyed("root ::= \"yes\" | \"no\"");
+        let digits = keyed("root ::= [0-9]+");
+        cache.put(yes_no.clone(), cc("yes"));
+
+        assert_eq!(
+            cache.get(&digits),
+            None,
+            "a request constrained to digits must not be served an answer \
+             produced under a yes/no grammar"
+        );
+        assert_eq!(cache.get(&yes_no), Some(cc("yes")));
+    }
+
+    /// JSON-object mode is the other logit mask, and its failure is
+    /// louder than the grammar one: `validate_json_object_output` runs
+    /// against whatever the cache handed back, so a `json_object`
+    /// request that hit a cached prose answer got a hard 400 for a body
+    /// that would have succeeded (#35).
+    #[test]
+    fn a_json_object_request_is_not_served_the_unconstrained_answer() {
+        let mut cache = ResponseCache::new(10, Duration::from_secs(60));
+
+        let plain = key("same prompt");
+        cache.put(plain.clone(), cc("Sure! Here are a few options..."));
+
+        let json = key_under("same prompt", |p| p.json_object = true);
+
+        assert_eq!(
+            cache.get(&json),
+            None,
+            "a json_object request must not be answered with prose the JSON \
+             mask never saw"
+        );
+        assert_eq!(
+            cache.get(&plain),
+            Some(cc("Sure! Here are a few options..."))
+        );
+    }
+
+    /// `ignore_eos` suppresses the model's own end-of-generation set so
+    /// a benchmarking run produces EXACTLY `max_tokens`. Served from a
+    /// cache entry populated without it, it returns the short
+    /// EOS-terminated answer instead -- the field's one stated purpose,
+    /// defeated silently (#35).
+    #[test]
+    fn an_ignore_eos_request_is_not_served_the_eos_terminated_answer() {
+        let mut cache = ResponseCache::new(10, Duration::from_secs(60));
+
+        let stops_at_eos = key("same prompt");
+        cache.put(stops_at_eos.clone(), cc("short"));
+
+        let runs_on = key_under("same prompt", |p| p.ignore_eos = true);
+
+        assert_eq!(
+            cache.get(&runs_on),
+            None,
+            "ignore_eos must not be answered with a completion that stopped \
+             at the model's EOS"
+        );
+        assert_eq!(cache.get(&stops_at_eos), Some(cc("short")));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

The whole-response cache key is now built from an **exhaustive destructure of `GenerationParams`**, with no `..`, the way `sampling_key` has always been built from `SamplingParams`.

The bug was never the three missing fields. It was that one struct had the guard and its sibling did not: `CacheKey` hand-wrote four of the request's fields and called the set complete, so `grammar`, `json_object` and `ignore_eos` -- three parameters that decide the answer and change nothing about the prompt -- hashed identically to their absence. Adding them by hand would have recreated the same gap for the fourth. A tenth field on `GenerationParams` now stops this crate compiling (verified: `error[E0027]: pattern does not mention field`).

## Which fields are in the key, and which are not

| Field | Keyed | Why |
|---|---|---|
| `max_tokens` | yes | already was |
| `sampling` | yes | via `sampling_key`, unchanged |
| `stop` | yes | already was |
| `stop_token_ids` | yes | **new.** Empty at every current call site (resolved later, by the layer holding the tokenizer), but derived from `stop` + vocabulary, both already keyed -- so keying it can never split two identical answers, and "empty here" is a fact about today's call order, not a property of the field |
| `json_object` | yes | **new** |
| `grammar` | yes | **new** |
| `ignore_eos` | yes | **new** |
| `seed` | **no** | it is the RESOLVED seed, which is a clock reading for any request that named none -- keying it would give every greedy request a unique key and switch the cache off. `CacheKey::seed` carries the request's own `Option<u64>` instead, which is sound because `is_cacheable` admits only greedy (seed irrelevant) or explicitly seeded requests |
| `cancel` | **no** | a per-request handle, not a parameter: two identical requests hold two different tokens. Cancellation *does* change the answer, but it cannot reach this key -- `chat_completions_full` is the cache's only caller and registers no token. If that changes, the guard belongs on the PUT, not the key. Filed as #57 |

Both exclusions are stated at their `_` binding in `generation_key`. An exclusion on the record is a decision; a field nobody looked at is the bug being fixed.

## The lookup moved

It ran *before* `generation_params_for_template`, so on a hit the grammar was never even compiled -- and that function is where a template's end-of-turn stop and a forced `tool_choice`'s grammar get added. Resolving the parameters first is what lets the key see them.

Two consequences worth reviewing:

- An unparseable grammar is now a 400 for a repeat request too, instead of a 200 carrying prose generated under no grammar at all.
- A cacheable request pays its grammar compile even on a hit. That is the price of the constraint being part of the key.

`GrammarKey` supplies only `Hash` (over the derived `Debug` rendering, built transiently and not stored); equality is `Grammar`'s own, so two grammars that rendered alike would share a hash bucket and never an entry.

## One claim in the issue needed correcting, and it is the interesting part

`json_object` **does** usually change the rendered prompt: `inject_json_object_system_hint` prepends a system instruction, which split the two keys apart by accident. Its `!s.contains("JSON")` arm is the hole -- a caller whose own system message already says "JSON" gets no hint appended, renders a byte-identical prompt, and hit the shared entry. The HTTP test is written on exactly that path. Cache correctness was resting on a string edit made for an unrelated reason: the same bug shape, one level out.

`grammar` and `ignore_eos` were mis-keyed unconditionally, as described.

## Evidence

Every test below was sabotaged once and confirmed red (each of `grammar`, `json_object`, `ignore_eos`, `max_tokens` and `stop` neutralised in `generation_key` in turn).

- `response_cache`: four tests that PUT an answer under one request's key and assert the varied request's lookup does **not** return it -- grammar, two *different* grammars, `json_object`, `ignore_eos`. They build keys through the real `generation_key`; setting `generation.grammar` on the key by hand would test this module's `Eq` and pass happily against the broken builder, which is how the first draft of these tests failed to fail.
- `lib`, through the real router: the grammar one asserts the constrained answer is the grammar's and not the cached prose; the `ignore_eos` one gives the fixture model an EOS it actually hits, so the plain request stops at one token and the `ignore_eos` request runs the full budget.
- `no_constraint_is_missing_from_the_cache_key`, the twin of the existing sampler-knob test, walking `grammar`, both `response_format` spellings, `ignore_eos`, `stop` and `max_tokens`.

## What would have to be true for this to be wrong

- That the derived `Debug` of two *unequal* `Grammar`s can be equal. It would cost a bucket collision, not a wrong answer, because `Eq` is the grammar's own.
- That some caller wants a cache hit for a body whose grammar cannot compile. It now gets the 400 instead.
- That `stop_token_ids` can ever vary for a fixed (`stop`, model) pair. It cannot; keying it is conservative.

## Gates

`cargo build --workspace`, `cargo test --workspace` (0 failures, 52 suites), `cargo clippy --workspace --all-targets -- -D warnings`, the same `--release`, `cargo fmt --all`.

## Doc delta

**None.** No doc states the cache key's composition. `docs/THIRD_PARTY_NOTICES.md` describes *Shimmy's* cache as "keying a cache by prompt + model + generation params", which is a statement about the upstream design and stays accurate.

## Not done

- Did not fix the cancelled-partial PUT (#57), which is a latent gap rather than a live defect and is not this key's problem.
- Did not touch `budget.rs`, `generate.rs`'s ceiling logic, `ferrox-gguf`, `ferrox-models`, or `docs/`.
- Did not benchmark the grammar-compile-on-hit cost; an agent may not benchmark on this host.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
