### PR TITLE
fix(server): /v1/tokenize answered 501 on an encoder, which is the wrong refusal for a question about tokenizing

### DIFF
--- a/crates/ferrox-models/src/embedding_model.rs
+++ b/crates/ferrox-models/src/embedding_model.rs
@@ -197,6 +197,22 @@ impl EmbeddingModel {
         self.encoder.wrap_special(&self.tokenizer.encode(text))
     }
 
+    /// Text for `ids`, through this checkpoint's own vocabulary.
+    ///
+    /// The counterpart to [`Self::token_ids`], so `/v1/detokenize`
+    /// answers for an encoder rather than refusing. An embedding
+    /// model's whole contract is the vector it returns for a string,
+    /// and when that vector is surprising the first question is what
+    /// tokens it actually saw. Without this the only way to ask was to
+    /// load the checkpoint in a second tool.
+    ///
+    /// Not `wrap_special`'s inverse: it decodes exactly the ids given,
+    /// including specials if the caller passes them, because a caller
+    /// checking a tokenization wants to see what it sent.
+    pub fn decode_tokens(&self, ids: &[u32]) -> String {
+        self.tokenizer.decode(ids)
+    }
+
     /// Pooled embedding for `text`. `normalize` applies L2 normalization,
     /// which is what an OpenAI-compatible `/v1/embeddings` response is
     /// expected to carry and what llama.cpp's server does by default;

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -7017,6 +7017,53 @@ mod tests {
             .expect("a real-weights capability row");
         let detail = weights["detail"].as_str().unwrap_or_default();
         assert!(detail.contains("ENCODER"), "{detail}");
+        // 5. It tokenizes, and round-trips. An embedding model's whole
+        // contract is the vector it returns for a string, so when that
+        // vector surprises you the first question is what tokens it
+        // actually saw. These routes used to go through
+        // `generative()?` and answer 501 "not a generative model",
+        // which left no way to ask without loading the checkpoint in a
+        // second tool (issue #28).
+        let (status, body) = post_json_uri(
+            &app,
+            ferrox_api::routes::V1_TOKENIZE,
+            serde_json::json!({ "content": "hello world" }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "an encoder has a real tokenizer: {body}"
+        );
+        let tokens = body["tokens"].as_array().expect("tokens array").clone();
+        assert!(!tokens.is_empty(), "WordPiece produced nothing: {body}");
+
+        let (status, body) = post_json_uri(
+            &app,
+            ferrox_api::routes::V1_DETOKENIZE,
+            serde_json::json!({ "tokens": tokens }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let round_tripped = body["content"].as_str().expect("content").to_string();
+        assert!(
+            round_tripped.contains("hello") && round_tripped.contains("world"),
+            "the ids did not decode back through the encoder's own vocabulary: {round_tripped}"
+        );
+
+        // And the refusal that must NOT have been weakened: a decode is
+        // still a decode, and this checkpoint still cannot do one.
+        let (status, _) = post_json_uri(
+            &app,
+            "/v1/completions",
+            serde_json::json!({ "model": "m", "prompt": "hi", "max_tokens": 1 }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_IMPLEMENTED,
+            "tokenizing an encoder must not have opened a path to generating with one"
+        );
     }
 
     /// The /metrics endpoint must expose the bounded expert cache's

--- a/crates/ferrox-server/src/loaded.rs
+++ b/crates/ferrox-server/src/loaded.rs
@@ -116,6 +116,38 @@ impl ActiveModel {
         }
     }
 
+    /// Token ids for `text`, whichever kind of checkpoint is loaded.
+    ///
+    /// `/v1/tokenize` and `/v1/detokenize` went through
+    /// `require_model()`, which is `generative()?`, so on an
+    /// encoder-only server they answered 501 "not a generative model".
+    /// That is the right refusal for a decode and the wrong one for a
+    /// question about tokenization: an encoder has a real tokenizer,
+    /// and asking what tokens it saw is exactly what a surprising
+    /// embedding makes you want to do (issue #28).
+    ///
+    /// Deliberately NOT reached through `generative()`: routes that
+    /// need a decode still go through it and still refuse, and this
+    /// pair is the only thing that steps around it.
+    pub(crate) fn encode_any(&self, text: &str) -> Vec<usize> {
+        match &self.loaded {
+            Loaded::Generative(m) => m.encode(text),
+            Loaded::Encoder(e) => e.token_ids(text).into_iter().map(|t| t as usize).collect(),
+        }
+    }
+
+    /// Text for `ids`, whichever kind of checkpoint is loaded. The
+    /// counterpart to [`Self::encode_any`].
+    pub(crate) fn decode_any(&self, ids: &[usize]) -> String {
+        match &self.loaded {
+            Loaded::Generative(m) => m.decode(ids),
+            Loaded::Encoder(e) => {
+                let ids: Vec<u32> = ids.iter().map(|&i| i as u32).collect();
+                e.decode_tokens(&ids)
+            }
+        }
+    }
+
     /// What `/v1/models` and `/health` call this checkpoint. Both kinds
     /// have a real name.
     pub(crate) fn name(&self) -> &str {

--- a/crates/ferrox-server/src/openai_extra.rs
+++ b/crates/ferrox-server/src/openai_extra.rs
@@ -392,14 +392,23 @@ fn tokenize_inner(
     // Tokenizing needs the loaded vocabulary, so this is a 503 like any
     // other generation endpoint when nothing is loaded -- answering
     // with byte-fallback ids would silently be the wrong vocabulary.
-    let model = state.require_model()?;
-    let mut tokens = model.encode(text);
+    // `require_active`, not `require_model`. Tokenizing is a question
+    // about the tokenizer, and an encoder has a real one: routing this
+    // through `generative()` made `/v1/tokenize` answer 501 "not a
+    // generative model" on an encoder-only server, which is the right
+    // refusal for a decode and the wrong one for this (issue #28).
+    let active = state.require_active()?;
+    let mut tokens = active.encode_any(text);
     if req.add_special == Some(true) {
         // The same helper the generation path uses, so `add_special`
         // reports the prompt the model would actually be given --
         // including its no-op behaviour on a checkpoint whose metadata
-        // says not to add BOS.
-        ferrox_models::tokenizer::prepend_bos(&mut tokens, model.bos_id());
+        // says not to add BOS. An encoder wraps its own specials in
+        // `token_ids` already, so there is no BOS to prepend and
+        // `bos_id()` is `None` there: the helper is a no-op, which is
+        // the honest answer rather than a second special token.
+        let bos = active.generative_opt().and_then(|m| m.bos_id());
+        ferrox_models::tokenizer::prepend_bos(&mut tokens, bos);
     }
     let count = tokens.len();
     Ok(Json(serde_json::json!({
@@ -433,7 +442,10 @@ fn detokenize_inner(
     state: &AppState,
     req: DetokenizeRequest,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let text = state.require_model()?.decode(&req.tokens);
+    // Same reasoning as `tokenize_inner`: an encoder's vocabulary is a
+    // real vocabulary, and asking what a token id means is not asking
+    // for a decode.
+    let text = state.require_active()?.decode_any(&req.tokens);
     // Both keys, same string: llama.cpp's clients read `content`
     // (`server-context.cpp:4970`), ferrox's existing ones read `text`,
     // and there is only one answer to disagree about.


### PR DESCRIPTION
Closes #28.

Both routes went through `require_model()` = `generative()?`, so an encoder-only server answered "not a generative model". Right refusal for a decode, wrong one here: an encoder has a real tokenizer.

It is also exactly the question an embedding model provokes. When a vector surprises you, the first check is what tokens it saw — and WordPiece's `##` prefix does not survive GGUF conversion, so this is live. Until now the only way to ask was a second tool.

**The decode refusal is not weakened.** Every route needing a decode still goes through `generative()`, and the test asserts `/v1/completions` on this checkpoint is still a 501.

## Two corrections worth recording

**My issue was wrong.** #28 said there was no `/tokenize` or `/detokenize` route at all. There is, and has been, for decoder models — I filed it from the docs and a grep rather than from the code. The gap was real; the diagnosis was not.

**The test was silently skipping.** It resolves `../../models` relative to the crate, and a git worktree has no `models/` directory, so it passed in 0.00s — and my first two sabotage runs passed with it, which is the only reason I noticed. Both halves are confirmed red now with the checkpoint actually present. Any `#[ignore]`d fixture test in this repo has the same trap when run from a worktree.

Gates: workspace build, 52 suites, clippy debug and release, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN