### PR TITLE
fix(gemma): the 27B attention scale, and per-layer RoPE for sliding-window layers

### DIFF
--- a/crates/ferrox-models/src/capability.rs
+++ b/crates/ferrox-models/src/capability.rs
@@ -1940,6 +1940,59 @@ pub fn swa_rope_base_follows_model(arch: &str) -> bool {
     )
 }
 
+/// llama.cpp's `hparams.f_attention_scale`, but only when it DIFFERS
+/// from the `1/sqrt(head_dim)` every ferrox attention kernel already
+/// applies. `None` means "the kernels' own scale is already right", so
+/// a caller stores it straight into `ModelConfig::attention_scale`.
+///
+/// Only the Gemma-2 and Gemma-3 27B checkpoints answer `Some`:
+///
+/// ```cpp
+/// // src/models/gemma3.cpp:30-33 (src/models/gemma2.cpp:26-29 identical in shape)
+/// hparams.f_attention_scale = type == LLM_TYPE_27B
+///     ? 1.0f / std::sqrt(float(hparams.n_embd / hparams.n_head(0)))
+///     : 1.0f / std::sqrt(float(hparams.n_embd_head_k()));
+/// ```
+///
+/// and llama.cpp applies it as an explicit `ggml_scale` on Q followed by
+/// `build_attn(..., 1.0f)` (`gemma3.cpp:154`, `gemma2.cpp:110`), which is
+/// what [`crate::config::ModelConfig::attention_scale`] means here.
+///
+/// **The selector is the LAYER COUNT, not a comparison of the two
+/// widths.** `LLM_TYPE_27B` comes from `switch (hparams.n_layer())`
+/// (`gemma3.cpp:20-28` `case 62`, `gemma2.cpp:19-23` `case 46`), and
+/// deriving it instead from `n_embd / n_head != head_dim` would be
+/// wrong for EVERY other Gemma size -- all of them have
+/// `n_embd / n_head != head_dim` too, and all of them take llama.cpp's
+/// `1/sqrt(n_embd_head_k)` branch. See
+/// `gemma_27b_is_the_only_size_that_overrides_the_kernel_scale`.
+///
+/// `hidden_dim / n_heads` is integer division on purpose: llama.cpp
+/// divides two `uint32_t` and only then converts to float.
+pub fn attention_scale_override(
+    arch: &str,
+    n_layers: usize,
+    hidden_dim: usize,
+    n_heads: usize,
+    head_dim: usize,
+) -> Option<f32> {
+    // `case 62` / `case 46` in the `switch (hparams.n_layer())` that
+    // picks `LLM_TYPE_27B`. Every other Gemma architecture
+    // (`gemma-embedding`, `gemma3n`, `gemma4`) sets `f_attention_scale`
+    // unconditionally and has no 27B branch at all.
+    let is_27b = match arch {
+        "gemma2" => n_layers == 46,
+        "gemma3" => n_layers == 62,
+        _ => false,
+    };
+    if !is_27b || n_heads == 0 || head_dim == 0 {
+        return None;
+    }
+    let scale = 1.0 / ((hidden_dim / n_heads) as f32).sqrt();
+    let kernel_scale = 1.0 / (head_dim as f32).sqrt();
+    (scale != kernel_scale).then_some(scale)
+}
+
 /// Metadata keys that, when present with a nonzero value, require math
 /// ferrox's generic decoder does not implement *unless* the architecture
 /// profile opts into those features (Gemma family).
@@ -2013,7 +2066,14 @@ pub fn unsupported_feature_keys(arch: &str) -> Vec<(String, &'static str)> {
 /// "unset, use 1/sqrt(head_dim)" sentinel.
 pub fn unsupported_scaling_keys(arch: &str) -> Vec<(String, &'static str, f32)> {
     let profile = resolve_profile(arch);
-    // Gemma implements its own embedding scale and attention scale.
+    // Gemma implements its own embedding scale (`loader.rs`
+    // `embedding_scale`) and its own attention scale
+    // (`attention_scale_override`, including the 27B branch llama.cpp
+    // takes at `gemma3.cpp:30-33` / `gemma2.cpp:26-29`). That second
+    // half was an unimplemented claim until the 27B fix; the exemption
+    // is only honest while `attention_scale_override` covers it, which
+    // `gemma_27b_is_the_only_size_that_overrides_the_kernel_scale`
+    // pins.
     if matches!(profile.map(|p| p.family), Some(DecoderFamily::GemmaFamily)) {
         return Vec::new();
     }
@@ -2543,5 +2603,106 @@ mod tests {
             unsupported_feature_keys("gemma2").is_empty(),
             "the Gemma family implements softcap and the SWA pattern"
         );
+    }
+
+    /// llama.cpp picks Gemma's `f_attention_scale` on the LAYER COUNT
+    /// (`gemma3.cpp:20-33`, `gemma2.cpp:19-29`), and every published
+    /// Gemma size -- not just 27B -- has `n_embd / n_head != head_dim`.
+    /// An override derived from "the two widths disagree" would fire on
+    /// all eight rows below and mis-scale six of them, which is why this
+    /// walks the real sizes rather than asserting the 27B number alone.
+    ///
+    /// Shipped broken: `loader.rs` hardcoded `attention_scale = None`
+    /// beside a comment naming the 27B exception, so Gemma-2-27B scored
+    /// `sqrt(144/128)` and Gemma-3-27B `sqrt(168/128)` too large on
+    /// every layer -- a sharper softmax than the trained one, with no
+    /// error.
+    #[test]
+    fn gemma_27b_is_the_only_size_that_overrides_the_kernel_scale() {
+        /// One published Gemma size, as its GGUF header declares it.
+        struct Size {
+            arch: &'static str,
+            n_layers: usize,
+            n_embd: usize,
+            n_head: usize,
+            /// `attention.key_length`, llama.cpp's `n_embd_head_k()`.
+            head_dim: usize,
+            /// The denominator llama.cpp's 27B branch produces, or
+            /// `None` where it takes the `1/sqrt(n_embd_head_k)` branch.
+            want_denom: Option<f32>,
+        }
+        let size = |arch, n_layers, n_embd, n_head, head_dim, want_denom| Size {
+            arch,
+            n_layers,
+            n_embd,
+            n_head,
+            head_dim,
+            want_denom,
+        };
+        let sizes = [
+            size("gemma2", 26, 2304, 8, 256, None),         // Gemma-2-2B
+            size("gemma2", 42, 3584, 16, 256, None),        // Gemma-2-9B
+            size("gemma2", 46, 4608, 32, 128, Some(144.0)), // Gemma-2-27B
+            size("gemma3", 18, 640, 4, 256, None),          // Gemma-3-270M
+            size("gemma3", 26, 1152, 4, 256, None),         // Gemma-3-1B
+            size("gemma3", 34, 2560, 8, 256, None),         // Gemma-3-4B
+            size("gemma3", 48, 3840, 16, 256, None),        // Gemma-3-12B
+            size("gemma3", 62, 5376, 32, 128, Some(168.0)), // Gemma-3-27B
+        ];
+        for &Size {
+            arch,
+            n_layers,
+            n_embd,
+            n_head,
+            head_dim,
+            want_denom,
+        } in &sizes
+        {
+            // The premise of the whole test: no Gemma size has
+            // `n_embd / n_head == head_dim`, so "the widths disagree"
+            // cannot be the selector.
+            assert_ne!(
+                n_embd / n_head,
+                head_dim,
+                "{arch}/{n_layers}L: if this ever holds, re-read the derivation"
+            );
+            let got = attention_scale_override(arch, n_layers, n_embd, n_head, head_dim);
+            match want_denom {
+                None => assert_eq!(
+                    got, None,
+                    "{arch}/{n_layers}L takes llama.cpp's 1/sqrt(n_embd_head_k) branch, \
+                     which the attention kernels already apply"
+                ),
+                Some(denom) => {
+                    let want = 1.0 / denom.sqrt();
+                    let got = got.unwrap_or_else(|| {
+                        panic!("{arch}/{n_layers}L is llama.cpp's LLM_TYPE_27B; scale must be set")
+                    });
+                    assert!(
+                        (got - want).abs() < 1e-7,
+                        "{arch}/{n_layers}L: want 1/sqrt({denom}) = {want}, got {got}"
+                    );
+                    // The direction of the correction: the kernels' own
+                    // scale is the LARGER one, so the override shrinks
+                    // the scores rather than growing them.
+                    let kernel = 1.0f32 / (head_dim as f32).sqrt();
+                    assert!(
+                        kernel > got,
+                        "{arch}/{n_layers}L: kernel scale {kernel} must exceed {got}"
+                    );
+                }
+            }
+        }
+        // `gemma-embedding`, `gemma3n` and `gemma4` set
+        // `f_attention_scale` unconditionally in llama.cpp and have no
+        // `LLM_TYPE_27B` branch; nothing outside gemma2/gemma3 reaches
+        // this at all.
+        for arch in ["gemma-embedding", "gemma3n", "gemma4", "llama", "qwen3"] {
+            assert_eq!(
+                attention_scale_override(arch, 62, 5376, 32, 128),
+                None,
+                "{arch} has no LLM_TYPE_27B branch in llama.cpp"
+            );
+        }
     }
 }

--- a/crates/ferrox-models/src/capability.rs
+++ b/crates/ferrox-models/src/capability.rs
@@ -1940,6 +1940,48 @@ pub fn swa_rope_base_follows_model(arch: &str) -> bool {
     )
 }
 
+/// True when this architecture's SWA layers inherit the model's TRAINED
+/// RoPE position scale rather than llama.cpp's
+/// `rope_freq_scale_train_swa` default of `1.0`.
+///
+/// The sibling of [`swa_rope_base_follows_model`], and deliberately NOT
+/// derived from it: llama.cpp defaults both fields
+/// (`src/llama-hparams.h:127,129`) and each architecture assigns them
+/// independently, so the two lists differ. `olmo2.cpp:13-14` and
+/// `laguna.cpp:47-48` seed the BASE from the model and then pin the
+/// SCALE to `1.0` -- laguna's own comment is "SWA uses plain RoPE (no
+/// YaRN scaling); do NOT inherit full layers 1/factor". Collapsing the
+/// two tables into one would rope those two architectures wrong in
+/// exactly the way this function exists to stop.
+///
+/// The default matters more than the list. `gemma3.cpp:11` reads only
+/// `LLM_KV_ROPE_FREQ_BASE_SWA` and never touches
+/// `rope_freq_scale_train_swa`, so Gemma-3's sliding layers rope at
+/// scale `1.0` while its full-attention layers use the trained scale --
+/// and the converter agrees, writing `rope.scaling.factor` from
+/// `rope_parameters["full_attention"]` alone (`conversion/base.py:1222`,
+/// whose own comment is "TODO: Handle sliding_attention similarly when
+/// models start implementing it").
+///
+/// Every name here is a `hparams.rope_freq_scale_train_swa =
+/// hparams.rope_freq_scale_train;` in `src/models/`, at the line given.
+pub fn swa_rope_scale_follows_model(arch: &str) -> bool {
+    matches!(
+        arch,
+        "afmoe"          // afmoe.cpp:22
+            | "cohere2"     // cohere2.cpp:10
+            | "cohere2moe"  // cohere2moe.cpp:39
+            | "dflash"      // dflash.cpp:59, :71
+            | "exaone-moe"  // exaone-moe.cpp:10
+            | "exaone4"     // exaone4.cpp:12
+            | "gemma2"      // gemma2.cpp:11
+            | "llama4"      // llama4.cpp:24
+            | "mellum"      // mellum.cpp:20
+            | "gpt-oss"     // openai-moe.cpp:14
+            | "smallthinker" // smallthinker.cpp:14
+    )
+}
+
 /// llama.cpp's `hparams.f_attention_scale`, but only when it DIFFERS
 /// from the `1/sqrt(head_dim)` every ferrox attention kernel already
 /// applies. `None` means "the kernels' own scale is already right", so

--- a/crates/ferrox-models/src/config.rs
+++ b/crates/ferrox-models/src/config.rs
@@ -217,7 +217,10 @@ pub struct ModelConfig {
     /// (`ggml_rope_cache_init` divides by `freq_factors` and *then*
     /// runs `rope_yarn`). Consumers must therefore treat this as "the
     /// correction to apply", not as "the tensor this file shipped".
-    pub rope_freqs: Option<Vec<f32>>,
+    ///
+    /// Per-LAYER, because llama.cpp's is: see [`RopeFreqs`]. Read it
+    /// through [`Self::layer_rope`], never field-by-field.
+    pub rope_freqs: Option<RopeFreqs>,
     /// LongRoPE's two candidate factor sets, kept so the choice between
     /// them can be made when the *run's* context size is known rather
     /// than at parse time. llama.cpp picks per request
@@ -299,6 +302,72 @@ pub struct ModelConfig {
     pub best_effort_fields: &'static [&'static str],
 }
 
+/// The resolved per-band RoPE divisors, for BOTH kinds of layer.
+///
+/// llama.cpp splits RoPE per layer in two places, not one:
+///
+/// ```cpp
+/// // src/llama-model.cpp:2029-2035
+/// float llama_model::get_rope_freq_base (const llama_cparams & cparams, int il) const {
+///     return hparams.is_swa(il) ? hparams.rope_freq_base_train_swa  : cparams.rope_freq_base;
+/// }
+/// float llama_model::get_rope_freq_scale(const llama_cparams & cparams, int il) const {
+///     return hparams.is_swa(il) ? hparams.rope_freq_scale_train_swa : cparams.rope_freq_scale;
+/// }
+/// ```
+///
+/// and every alternating-SWA graph calls both, per layer
+/// (`gemma3.cpp:112-121`, `gemma2.cpp:79-80`, `laguna.cpp:182-183`).
+/// ferrox folds llama.cpp's `freq_scale` into these divisors -- linear
+/// scaling by `s` is exactly "divide every band by `s`" -- so the SCALE
+/// half of that split has to live here, beside the BASE half in
+/// [`ModelConfig::rope_theta_swa`].
+///
+/// It did not, and Gemma-3 4B/12B/27B paid for it: their headers declare
+/// `rope.scaling.type = linear, factor = 8`, `gemma3.cpp` never assigns
+/// `rope_freq_scale_train_swa` so it keeps its `1.0f` default
+/// (`src/llama-hparams.h:129`), and five layers in every six are sliding
+/// (`sliding_window_pattern = 6`, last-dense). ferrox rotated all of
+/// them at `p/8` where llama.cpp rotates at `p` -- fluent, and worse the
+/// longer the prompt. Invisible to the audit because the fixture is
+/// Gemma-3-1B, the one size with no `rope_scaling` at all.
+///
+/// The two fields are one struct so that answering the base question
+/// without answering the scale question does not compile.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RopeFreqs {
+    /// What the FULL-ATTENTION layers divide each band's theta by.
+    pub full: Vec<f32>,
+    /// What the SLIDING layers divide by, when the architecture does not
+    /// let them inherit the model's trained RoPE scale
+    /// (`capability::swa_rope_scale_follows_model`). `None` means they
+    /// inherit [`Self::full`], which is llama.cpp's behaviour for every
+    /// architecture that assigns `rope_freq_scale_train_swa` from
+    /// `rope_freq_scale_train`.
+    ///
+    /// "No divisors at all" is spelled as an all-ones vector rather than
+    /// a third state: dividing by one is exactly not dividing, and one
+    /// fewer state is one fewer thing two call sites can disagree about.
+    pub swa: Option<Vec<f32>>,
+}
+
+impl RopeFreqs {
+    /// The divisors layer `il` uses, given whether it slides.
+    pub fn for_layer(&self, sliding: bool) -> &[f32] {
+        match (sliding, &self.swa) {
+            (true, Some(swa)) => swa,
+            _ => &self.full,
+        }
+    }
+
+    /// True when the sliding layers use a different set from the full
+    /// ones, i.e. when one `freq_factors` buffer cannot serve a whole
+    /// stack of layers.
+    pub fn varies_by_layer(&self) -> bool {
+        self.swa.as_ref().is_some_and(|swa| *swa != self.full)
+    }
+}
+
 /// Dense / expert FFN non-linearity used by the generic decoder.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FfnActivation {
@@ -327,7 +396,9 @@ impl ModelConfig {
     /// [`Self::rope_freqs`]). No real checkpoint hits that: LongRoPE
     /// files declare `rope.scaling.type = "longrope"`, which the loader's
     /// YaRN arm deliberately does not claim, so the two never populate
-    /// the field on the same file.
+    /// the field on the same file. The same caveat now covers
+    /// [`RopeFreqs::swa`], and for the same reason: no LongRoPE
+    /// checkpoint has alternating SWA layers.
     pub fn apply_runtime_context(&mut self, ctx: usize) {
         let (Some(orig), true) = (
             self.rope_orig_ctx,
@@ -344,7 +415,10 @@ impl ModelConfig {
             .or(self.rope_freqs_long.as_ref())
             .or(self.rope_freqs_short.as_ref())
         {
-            self.rope_freqs = Some(f.clone());
+            self.rope_freqs = Some(RopeFreqs {
+                full: f.clone(),
+                swa: None,
+            });
         }
     }
 
@@ -429,12 +503,53 @@ impl ModelConfig {
             .expect("aligned_block_size returns a size BlockLayout accepts")
     }
 
-    /// RoPE frequency base for layer `il` (SWA layers may differ).
-    pub fn layer_rope_theta(&self, layer_idx: usize) -> f32 {
-        match (self.layer_sliding_window(layer_idx), self.rope_theta_swa) {
-            (Some(_), Some(theta)) => theta,
+    /// BOTH halves of layer `il`'s RoPE: the frequency base and the
+    /// per-band divisors, which llama.cpp varies per layer together
+    /// (`llama-model.cpp:2029-2035`, and see [`RopeFreqs`]).
+    ///
+    /// Every RoPE call site takes the pair from here. Splitting them was
+    /// the defect: `layer_rope_theta` varied the base per layer while
+    /// `rope_freqs` was one global vector, so Gemma-3 4B/12B/27B roped
+    /// their sliding layers at scaled positions llama.cpp leaves
+    /// unscaled.
+    pub fn layer_rope(&self, layer_idx: usize) -> (f32, Option<&[f32]>) {
+        let sliding = self.layer_sliding_window(layer_idx).is_some();
+        let theta = match (sliding, self.rope_theta_swa) {
+            (true, Some(theta)) => theta,
             _ => self.rope_theta,
-        }
+        };
+        (
+            theta,
+            self.rope_freqs.as_ref().map(|f| f.for_layer(sliding)),
+        )
+    }
+
+    /// RoPE frequency base for layer `il` (SWA layers may differ).
+    ///
+    /// Prefer [`Self::layer_rope`] anywhere the divisors are needed too,
+    /// which is every site that actually rotates something. This one is
+    /// for the callers that only report or compare the base.
+    pub fn layer_rope_theta(&self, layer_idx: usize) -> f32 {
+        self.layer_rope(layer_idx).0
+    }
+
+    /// Per-band RoPE divisors for layer `il`; see [`Self::layer_rope`].
+    pub fn layer_rope_freqs(&self, layer_idx: usize) -> Option<&[f32]> {
+        self.layer_rope(layer_idx).1
+    }
+
+    /// True when the sliding layers need different per-band divisors
+    /// from the full-attention ones, so a fused launch taking ONE
+    /// `freq_factors` buffer for a whole run of layers cannot serve this
+    /// model.
+    pub fn rope_freqs_vary_by_layer(&self) -> bool {
+        self.rope_freqs
+            .as_ref()
+            .is_some_and(RopeFreqs::varies_by_layer)
+            // A model whose every layer slides, or none, uses one set
+            // whatever the two vectors hold.
+            && (0..self.n_layers).any(|il| self.layer_sliding_window(il).is_some())
+            && (0..self.n_layers).any(|il| self.layer_sliding_window(il).is_none())
     }
 
     /// Which attention mechanism layer `layer_idx` (0-indexed, ferrox's
@@ -1226,18 +1341,26 @@ mod longrope_tests {
         let mut c = cfg_with_factors();
         c.apply_runtime_context(4096);
         assert_eq!(
-            c.rope_freqs.as_ref().unwrap()[1],
+            c.rope_freqs.as_ref().unwrap().full[1],
             1.0,
             "at the threshold, short"
         );
 
         let mut c = cfg_with_factors();
         c.apply_runtime_context(4097);
-        assert_eq!(c.rope_freqs.as_ref().unwrap()[1], 2.0, "above it, long");
+        assert_eq!(
+            c.rope_freqs.as_ref().unwrap().full[1],
+            2.0,
+            "above it, long"
+        );
 
         let mut c = cfg_with_factors();
         c.apply_runtime_context(1024);
-        assert_eq!(c.rope_freqs.as_ref().unwrap()[1], 1.0, "below it, short");
+        assert_eq!(
+            c.rope_freqs.as_ref().unwrap().full[1],
+            1.0,
+            "below it, short"
+        );
     }
 
     /// `rope_freqs.weight` (Llama 3) is not a LongRoPE set and outranks
@@ -1247,12 +1370,15 @@ mod longrope_tests {
     #[test]
     fn an_explicit_rope_freqs_tensor_is_never_overridden() {
         let mut c = test_dense_fixture();
-        c.rope_freqs = Some(vec![7.0; 48]);
+        c.rope_freqs = Some(RopeFreqs {
+            full: vec![7.0; 48],
+            swa: None,
+        });
         c.rope_orig_ctx = Some(4096);
         c.rope_freqs_long = None;
         c.rope_freqs_short = None;
         c.apply_runtime_context(131072);
-        assert_eq!(c.rope_freqs.as_ref().unwrap()[0], 7.0);
+        assert_eq!(c.rope_freqs.as_ref().unwrap().full[0], 7.0);
     }
 
     /// A checkpoint with neither set must come back untouched, so the

--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -898,10 +898,13 @@ impl Decoder {
         // the four host bodies and not by any of the seven fused
         // launches -- the same weights answering at two different
         // temperatures depending on which backend served the token.
-        // Inert today (`loader.rs` hardcodes `attention_scale = None`),
-        // which is exactly why it has to be written down as a fence
-        // instead of trusted: the day a loader sets it, this returns
-        // false and the layer takes the host path that does apply it.
+        //
+        // LIVE, not latent: `capability::attention_scale_override` sets
+        // it for Gemma-2-27B and Gemma-3-27B, so those two checkpoints
+        // take the host path here and are scaled exactly once. It was
+        // written down as a fence while `loader.rs` still hardcoded
+        // `None`, which is why the day the loader started setting it
+        // cost nothing.
         if self.config.attention_scale.is_some() {
             return false;
         }

--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -16,14 +16,13 @@ mod attn_block;
 mod ffn_act;
 mod lm_head;
 mod qk_norm;
+mod rope;
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) use attn_block::KvStep;
 use ferrox_core::attention::{
-    apply_rope, apply_rope_interleaved, apply_rope_interleaved_with_freq_factors,
-    apply_rope_with_freq_factors, causal_gqa_attention_prefill_shared_kv_windowed,
-    causal_gqa_attention_softcap,
+    causal_gqa_attention_prefill_shared_kv_windowed, causal_gqa_attention_softcap,
 };
 use ferrox_core::cache::{KvCache, PagedKvCache, PagedStoreExhausted, SharedPagedKv};
 use ferrox_core::matmul::rms_norm;
@@ -686,103 +685,6 @@ impl Decoder {
         }
     }
 
-    /// Applies RoPE to one head's Q or K slice. Dispatches on both
-    /// `rope_layout` (Norm = adjacent-pair / NeoX = split-half -- see
-    /// `RopeLayout`) and whether this checkpoint carries a real
-    /// `rope_freqs.weight` tensor (Llama 3/3.1/3.2's per-band frequency
-    /// correction). Getting the layout wrong for `llama` was the real
-    /// root cause of the Llama-3.1-8B early-stop bug: ferrox applied
-    /// NeoX pairing to an architecture that needs Norm.
-    fn apply_rope_head_theta(&self, slice: &mut [f32], pos: usize, theta: f32) {
-        use crate::config::RopeLayout;
-        // Partial rotary (llama.cpp `hparams.n_rot` < `n_embd_head_k`,
-        // GGUF `<arch>.rope.dimension_count`): Phi-3/Phi-4 rotate only the
-        // first 96 of each 128-wide head and pass the remaining 32
-        // through untouched. Rotating the whole head instead is not a
-        // subtle error — it moves dimensions the model never trained to
-        // be position-dependent.
-        let slice = match self.config.rope_dim {
-            Some(rot) if rot < slice.len() => &mut slice[..rot],
-            _ => slice,
-        };
-        match (self.config.rope_layout, &self.config.rope_freqs) {
-            (RopeLayout::Norm, Some(freq_factors)) => {
-                apply_rope_interleaved_with_freq_factors(slice, pos, theta, freq_factors)
-            }
-            (RopeLayout::Norm, None) => apply_rope_interleaved(slice, pos, theta),
-            (RopeLayout::Neox, Some(freq_factors)) => {
-                apply_rope_with_freq_factors(slice, pos, theta, freq_factors)
-            }
-            (RopeLayout::Neox, None) => apply_rope(slice, pos, theta),
-        }
-    }
-
-    fn apply_rope_head_layer(&self, slice: &mut [f32], pos: usize, layer_idx: usize) {
-        self.apply_rope_head_theta(slice, pos, self.config.layer_rope_theta(layer_idx))
-    }
-
-    /// llama.cpp's RoPE `mscale` (ggml `rope_yarn`), applied where the
-    /// QKV biases and QK-norms are: multiplying `cos`/`sin` by a constant
-    /// is the same as scaling the vector RoPE rotates, and rotation is
-    /// linear, so pre-scaling q and k here is exactly what the kernel
-    /// would do post-hoc — without a new uniform on five backends' RoPE
-    /// kernels.
-    ///
-    /// Both q and k are scaled, so attention logits carry `m²`, which is
-    /// the whole observable effect (V is untouched, and k enters the
-    /// cache scaled exactly as llama.cpp's does).
-    #[inline]
-    fn apply_rope_attn_factor(&self, q: &mut [f32], k: &mut [f32]) {
-        let m = self.config.rope_attn_factor;
-        if m == 1.0 {
-            return;
-        }
-        // ggml folds `attn_factor` into cos_theta/sin_theta inside
-        // `rope_yarn` (ops.cpp), so it reaches ONLY the rotated channels;
-        // `[n_rot, head_dim)` is then copied through untouched by the
-        // "fill the remain channels with data from src tensor" loop.
-        // Scaling the pass-through tail as well is a different graph, and
-        // `ferrox parity` caught it as the one DRIFT verdict in a
-        // 17-model sweep: Phi-4-mini rotates 96 of 128 dims with
-        // attn_factor 1.1902, so 32 dims per head were scaled that
-        // llama.cpp leaves alone.
-        let head_dim = self.config.head_dim;
-        let rot = self.config.rope_dim.unwrap_or(head_dim).min(head_dim);
-        for buf in [q, k] {
-            for head in buf.chunks_mut(head_dim) {
-                let n = rot.min(head.len());
-                for v in head[..n].iter_mut() {
-                    *v *= m;
-                }
-            }
-        }
-    }
-
-    /// An architecture's explicit attention score scale
-    /// (`ModelConfig::attention_scale`), applied to Q after RoPE.
-    ///
-    /// llama.cpp's Gemma graphs scale Q themselves and then call
-    /// `build_attn(..., 1.0f)`; ferrox's kernels always apply their own
-    /// `1/sqrt(head_dim)`, so the compensation has to be folded into Q
-    /// here for the NET score scale to equal `attention_scale`.
-    ///
-    /// One helper rather than one copy per host body, because that is
-    /// exactly how this feature came to be applied at two of four sites:
-    /// `forward_hidden_batch_inner` and `forward_multi_seq_kv` computed a
-    /// plausible distribution at the wrong temperature and nothing
-    /// failed. Elementwise, so a `[batch, n_heads*head_dim]` Q batch is
-    /// the same call as one row's.
-    #[inline]
-    fn apply_attention_scale(&self, q: &mut [f32]) {
-        let Some(scale) = self.config.attention_scale else {
-            return;
-        };
-        let compensate = scale * (self.config.head_dim as f32).sqrt();
-        for v in q.iter_mut() {
-            *v *= compensate;
-        }
-    }
-
     /// Builds a Metal [`MatvecLaunch`] for a quantized matrix, or `None`
     /// if the storage/kind cannot run on Metal.
     #[cfg(feature = "metal")]
@@ -939,6 +841,32 @@ impl Decoder {
             || self.config.layer_sliding_window(layer_idx).is_some()
             || !GluAct::from(self.config.ffn_activation).is_swiglu()
             || self.config.layer_rope_theta(layer_idx) != self.config.rope_theta
+    }
+
+    /// True when no fused Metal *stack* can serve this model, because
+    /// its sliding layers need different RoPE per-band divisors from its
+    /// full-attention ones.
+    ///
+    /// Per-LAYER Metal launches are fine: each takes its own
+    /// `freq_factors` slice and is handed
+    /// `ModelConfig::layer_rope_freqs(l)`. The two whole-stack launches
+    /// (`launch_prefill_dense_stack`, `launch_decode_dense_stack`) take
+    /// ONE slice for a whole run of layers -- `PrefillDenseLayerMetal`
+    /// and `DenseLayerMetal` carry a per-layer `rope_theta` and `window`
+    /// but no per-layer divisors -- so they would rope the sliding
+    /// layers with the full-attention set. That is precisely the bug
+    /// this refusal exists to stop, one layer of the stack down.
+    ///
+    /// The cost is Gemma-3 4B/12B/27B taking the per-layer Metal path
+    /// rather than the fused stacks. Correct and slower beats fast and
+    /// wrong; restoring the stacks needs a per-layer `freq_factors`
+    /// buffer in `ferrox-metal`.
+    ///
+    /// One predicate, two call sites, because four spellings of one
+    /// eligibility check is how the GPU-router gate drifted four ways.
+    #[cfg(feature = "metal")]
+    fn metal_stack_needs_per_layer_rope_freqs(&self) -> bool {
+        self.config.rope_freqs_vary_by_layer()
     }
 
     /// Optional QKV bias / QK-norm ops for the Metal attn paths.
@@ -1141,6 +1069,9 @@ impl Decoder {
         kv_caches: &mut [KvCache],
         host_kv_authoritative: bool,
     ) -> Option<Vec<f32>> {
+        if self.metal_stack_needs_per_layer_rope_freqs() {
+            return None;
+        }
         let gelu = !GluAct::from(self.config.ffn_activation).is_swiglu();
         let mut prefill_layers = Vec::with_capacity(run_len);
         let mut rope_thetas = Vec::with_capacity(run_len);
@@ -1180,7 +1111,11 @@ impl Decoder {
             batch_size,
             self.metal_rope(),
             &rope_thetas,
-            self.config.rope_freqs.as_deref(),
+            // One slice for the whole run. Sound only because
+            // `metal_stack_needs_per_layer_rope_freqs` refused above
+            // when the layers disagree, so every layer in the run --
+            // sliding or not -- resolves to this same set.
+            self.config.layer_rope_freqs(start),
             start_pos,
             self.config.rms_norm_eps,
             gelu,
@@ -2010,7 +1945,14 @@ impl Decoder {
                                     n_heads,
                                     self.metal_rope(),
                                     self.config.rope_theta,
-                                    self.config.rope_freqs.as_deref(),
+                                    // The stack-wide theta above is
+                                    // sound because no layer here
+                                    // `layer_needs_metal_stack`, which
+                                    // means none slides; the divisors
+                                    // are taken through the same
+                                    // accessor so the two stay one
+                                    // answer.
+                                    self.config.layer_rope_freqs(0),
                                     pos,
                                     self.config.rms_norm_eps,
                                     Some(&self.final_norm),
@@ -2064,6 +2006,7 @@ impl Decoder {
         #[cfg(feature = "metal")]
         if !metal_stack_done
             && use_metal_attn
+            && !self.metal_stack_needs_per_layer_rope_freqs()
             && self.layers.iter().all(Self::layer_supports_metal_dense_ffn)
         {
             if let Some(guard) = metal_kv_guard.as_mut() {
@@ -2161,7 +2104,14 @@ impl Decoder {
                                 n_heads,
                                 self.metal_rope(),
                                 self.config.rope_theta,
-                                self.config.rope_freqs.as_deref(),
+                                // `DenseLayerMetal` overrides the theta
+                                // per layer but has no per-layer
+                                // divisors, so this one slice must
+                                // serve them all --
+                                // `metal_stack_needs_per_layer_rope_freqs`
+                                // in the guard above is what makes that
+                                // true.
+                                self.config.layer_rope_freqs(0),
                                 pos,
                                 self.config.rms_norm_eps,
                                 final_norm_w,
@@ -2312,7 +2262,7 @@ impl Decoder {
                                             n_heads,
                                             self.metal_rope(),
                                             self.config.rope_theta,
-                                            self.config.rope_freqs.as_deref(),
+                                            self.config.layer_rope_freqs(l),
                                             pos,
                                             self.config.rms_norm_eps,
                                             &self.metal_attn_extras(layer),
@@ -2402,7 +2352,7 @@ impl Decoder {
                                                                 n_heads,
                                                                 self.metal_rope(),
                                                                 self.config.rope_theta,
-                                                                self.config.rope_freqs.as_deref(),
+                                                                self.config.layer_rope_freqs(l),
                                                                 pos,
                                                                 self.config.rms_norm_eps,
                                                                 &self.metal_attn_extras(layer),
@@ -2440,7 +2390,7 @@ impl Decoder {
                                                         n_heads,
                                                         self.metal_rope(),
                                                         self.config.rope_theta,
-                                                        self.config.rope_freqs.as_deref(),
+                                                        self.config.layer_rope_freqs(l),
                                                         pos,
                                                         self.config.rms_norm_eps,
                                                         &self.metal_attn_extras(layer),
@@ -2528,7 +2478,7 @@ impl Decoder {
                                             n_heads,
                                             self.metal_rope(),
                                             self.config.rope_theta,
-                                            self.config.rope_freqs.as_deref(),
+                                            self.config.layer_rope_freqs(l),
                                             pos,
                                             &self.metal_attn_extras(layer),
                                             self.config.rms_norm_eps,
@@ -3917,7 +3867,7 @@ impl Decoder {
                                         batch_size,
                                         self.metal_rope(),
                                         self.config.layer_rope_theta(l),
-                                        self.config.rope_freqs.as_deref(),
+                                        self.config.layer_rope_freqs(l),
                                         start_pos,
                                         self.config.rms_norm_eps,
                                         gelu,
@@ -4030,7 +3980,7 @@ impl Decoder {
                                     batch_size,
                                     self.metal_rope().attn_factor_applied_by_caller(),
                                     self.config.layer_rope_theta(l),
-                                    self.config.rope_freqs.as_deref(),
+                                    self.config.layer_rope_freqs(l),
                                     start_pos,
                                     self.config.attn_logit_softcap,
                                     false,
@@ -4715,143 +4665,6 @@ impl Decoder {
             .flatten()
             .collect();
         self.logits_from_flat_hidden(final_normed_batch, batch_size)
-    }
-}
-
-#[cfg(test)]
-mod partial_rotary_tests {
-    use super::*;
-
-    /// Phi-3/Phi-4 rotate `rope.dimension_count` of each head and pass
-    /// the rest through. The tail staying bit-identical is the whole
-    /// property: rotating it would make dimensions position-dependent
-    /// that the model never trained that way.
-    #[test]
-    fn partial_rotary_leaves_the_tail_untouched() {
-        let mut cfg = crate::config::test_dense_fixture();
-        cfg.head_dim = 8;
-        cfg.rope_layout = crate::config::RopeLayout::Neox;
-        cfg.rope_freqs = None;
-        cfg.rope_dim = Some(4);
-        let decoder = Decoder::new_random_small(cfg, 1, 32);
-
-        let mut head: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
-        let before = head.clone();
-        decoder.apply_rope_head_theta(&mut head, 3, 10000.0);
-
-        assert_eq!(
-            &head[4..],
-            &before[4..],
-            "dims at or past rope_dim must not rotate"
-        );
-        assert!(
-            head[..4] != before[..4],
-            "dims below rope_dim must rotate at a non-zero position"
-        );
-    }
-
-    /// `attn_factor` is a magnitude scale folded into cos/sin inside
-    /// ggml's `rope_yarn`, so it can only ever touch the rotated
-    /// channels. The pass-through tail must come out bit-identical —
-    /// scaling it is a different graph, and it was one, until
-    /// `ferrox parity` reported Phi-4-mini as the single DRIFT in a
-    /// 17-model sweep against llama.cpp.
-    #[test]
-    fn attn_factor_scales_only_the_rotated_channels() {
-        let mut cfg = crate::config::test_dense_fixture();
-        cfg.head_dim = 8;
-        cfg.n_heads = 2;
-        cfg.n_kv_heads = 2;
-        cfg.rope_dim = Some(4);
-        cfg.rope_attn_factor = 2.0;
-        let decoder = Decoder::new_random_small(cfg, 1, 32);
-
-        // Two heads, so a per-head slice bug cannot hide behind a single
-        // head that happens to span the whole buffer.
-        let mut q: Vec<f32> = (0..16).map(|i| 1.0 + i as f32).collect();
-        let mut k: Vec<f32> = (0..16).map(|i| 1.0 + i as f32).collect();
-        let before = q.clone();
-        decoder.apply_rope_attn_factor(&mut q, &mut k);
-
-        for h in 0..2 {
-            let base = h * 8;
-            for i in 0..4 {
-                assert_eq!(
-                    q[base + i],
-                    before[base + i] * 2.0,
-                    "rotated channel {i} of head {h} must be scaled"
-                );
-            }
-            for i in 4..8 {
-                assert_eq!(
-                    q[base + i],
-                    before[base + i],
-                    "pass-through channel {i} of head {h} must be untouched"
-                );
-            }
-        }
-        assert_eq!(q, k, "q and k take the same magnitude scale");
-    }
-
-    /// With no partial rotary the whole head is rotated, so the whole
-    /// head takes the scale — the narrow case must not become the rule.
-    #[test]
-    fn attn_factor_scales_the_whole_head_without_partial_rotary() {
-        let mut cfg = crate::config::test_dense_fixture();
-        cfg.head_dim = 8;
-        cfg.n_heads = 1;
-        cfg.n_kv_heads = 1;
-        cfg.rope_dim = None;
-        cfg.rope_attn_factor = 3.0;
-        let decoder = Decoder::new_random_small(cfg, 1, 32);
-
-        let mut q: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
-        let mut k = q.clone();
-        let before = q.clone();
-        decoder.apply_rope_attn_factor(&mut q, &mut k);
-        for i in 0..8 {
-            assert_eq!(q[i], before[i] * 3.0);
-        }
-    }
-
-    /// The same call with no `rope_dim` must rotate everything, so the
-    /// narrow case cannot silently become the default.
-    #[test]
-    fn full_rotary_still_rotates_the_whole_head() {
-        let mut cfg = crate::config::test_dense_fixture();
-        cfg.head_dim = 8;
-        cfg.rope_layout = crate::config::RopeLayout::Neox;
-        cfg.rope_freqs = None;
-        cfg.rope_dim = None;
-        let decoder = Decoder::new_random_small(cfg, 1, 32);
-
-        let mut head: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
-        let before = head.clone();
-        decoder.apply_rope_head_theta(&mut head, 3, 10000.0);
-        assert!(head[4..] != before[4..]);
-    }
-
-    /// `mscale` scales q and k and nothing else; `1.0` must be a literal
-    /// no-op so every other model pays nothing.
-    #[test]
-    fn rope_attn_factor_scales_q_and_k_only() {
-        let mut cfg = crate::config::test_dense_fixture();
-        cfg.rope_attn_factor = 2.0;
-        let decoder = Decoder::new_random_small(cfg, 1, 32);
-        let mut q = vec![1.0f32, -2.0, 3.0];
-        let mut k = vec![0.5f32, 4.0];
-        decoder.apply_rope_attn_factor(&mut q, &mut k);
-        assert_eq!(q, vec![2.0, -4.0, 6.0]);
-        assert_eq!(k, vec![1.0, 8.0]);
-
-        let mut cfg = crate::config::test_dense_fixture();
-        cfg.rope_attn_factor = 1.0;
-        let decoder = Decoder::new_random_small(cfg, 1, 32);
-        let mut q = vec![1.0f32, -2.0];
-        let mut k = vec![3.0f32];
-        decoder.apply_rope_attn_factor(&mut q, &mut k);
-        assert_eq!(q, vec![1.0, -2.0]);
-        assert_eq!(k, vec![3.0]);
     }
 }
 

--- a/crates/ferrox-models/src/decoder/rope.rs
+++ b/crates/ferrox-models/src/decoder/rope.rs
@@ -1,0 +1,392 @@
+//! RoPE as it reaches one head, and the two scalar corrections that
+//! ride beside it.
+//!
+//! Four per-architecture facts live here, and this repo has lost three
+//! of them at least once by leaving them inline in a decode body:
+//!
+//! * **Pairing.** `Norm` rotates adjacent pairs, `Neox` rotates split
+//!   halves. Applying NeoX to `llama` was the root cause of the
+//!   Llama-3.1-8B early-stop bug.
+//! * **Rotary width.** Phi-3/Phi-4 rotate `rope.dimension_count` of each
+//!   head and pass the tail through untouched.
+//! * **The per-LAYER pair.** The frequency base and the per-band
+//!   divisors are ONE answer, and llama.cpp varies both per layer
+//!   (`llama-model.cpp:2029-2035`, consumed at `gemma3.cpp:112-121`).
+//!   ferrox varied only the base, which rotated Gemma-3 4B/12B/27B's
+//!   sliding layers at scaled positions llama.cpp leaves unscaled -- see
+//!   [`crate::config::RopeFreqs`].
+//!   [`crate::config::ModelConfig::layer_rope`] now hands both out
+//!   together so they cannot drift apart again.
+//! * **`attn_factor` and `attention_scale`.** Two multipliers that are
+//!   not the same thing: the first is YaRN's `mscale` on the rotated
+//!   channels of q and k, the second is llama.cpp's `f_attention_scale`
+//!   pre-baked into Q. `attention_scale` reached two of four host sites
+//!   before it became one helper.
+
+use ferrox_core::attention::{
+    apply_rope, apply_rope_interleaved, apply_rope_interleaved_with_freq_factors,
+    apply_rope_with_freq_factors,
+};
+
+use super::Decoder;
+
+impl Decoder {
+    /// Applies RoPE to one head's Q or K slice. Dispatches on both
+    /// `rope_layout` (Norm = adjacent-pair / NeoX = split-half -- see
+    /// `RopeLayout`) and whether this checkpoint carries a real
+    /// `rope_freqs.weight` tensor (Llama 3/3.1/3.2's per-band frequency
+    /// correction). Getting the layout wrong for `llama` was the real
+    /// root cause of the Llama-3.1-8B early-stop bug: ferrox applied
+    /// NeoX pairing to an architecture that needs Norm.
+    ///
+    /// `theta` and `freq_factors` are ONE answer, taken together from
+    /// [`crate::config::ModelConfig::layer_rope`]. Passing them
+    /// separately is how the sliding-window RoPE bug happened: the base
+    /// varied per layer and the divisors did not.
+    pub(crate) fn apply_rope_head_theta(
+        &self,
+        slice: &mut [f32],
+        pos: usize,
+        theta: f32,
+        freq_factors: Option<&[f32]>,
+    ) {
+        use crate::config::RopeLayout;
+        // Partial rotary (llama.cpp `hparams.n_rot` < `n_embd_head_k`,
+        // GGUF `<arch>.rope.dimension_count`): Phi-3/Phi-4 rotate only the
+        // first 96 of each 128-wide head and pass the remaining 32
+        // through untouched. Rotating the whole head instead is not a
+        // subtle error — it moves dimensions the model never trained to
+        // be position-dependent.
+        let slice = match self.config.rope_dim {
+            Some(rot) if rot < slice.len() => &mut slice[..rot],
+            _ => slice,
+        };
+        match (self.config.rope_layout, freq_factors) {
+            (RopeLayout::Norm, Some(freq_factors)) => {
+                apply_rope_interleaved_with_freq_factors(slice, pos, theta, freq_factors)
+            }
+            (RopeLayout::Norm, None) => apply_rope_interleaved(slice, pos, theta),
+            (RopeLayout::Neox, Some(freq_factors)) => {
+                apply_rope_with_freq_factors(slice, pos, theta, freq_factors)
+            }
+            (RopeLayout::Neox, None) => apply_rope(slice, pos, theta),
+        }
+    }
+
+    pub(crate) fn apply_rope_head_layer(&self, slice: &mut [f32], pos: usize, layer_idx: usize) {
+        let (theta, freq_factors) = self.config.layer_rope(layer_idx);
+        self.apply_rope_head_theta(slice, pos, theta, freq_factors)
+    }
+
+    /// llama.cpp's RoPE `mscale` (ggml `rope_yarn`), applied where the
+    /// QKV biases and QK-norms are: multiplying `cos`/`sin` by a constant
+    /// is the same as scaling the vector RoPE rotates, and rotation is
+    /// linear, so pre-scaling q and k here is exactly what the kernel
+    /// would do post-hoc — without a new uniform on five backends' RoPE
+    /// kernels.
+    ///
+    /// Both q and k are scaled, so attention logits carry `m²`, which is
+    /// the whole observable effect (V is untouched, and k enters the
+    /// cache scaled exactly as llama.cpp's does).
+    #[inline]
+    pub(crate) fn apply_rope_attn_factor(&self, q: &mut [f32], k: &mut [f32]) {
+        let m = self.config.rope_attn_factor;
+        if m == 1.0 {
+            return;
+        }
+        // ggml folds `attn_factor` into cos_theta/sin_theta inside
+        // `rope_yarn` (ops.cpp), so it reaches ONLY the rotated channels;
+        // `[n_rot, head_dim)` is then copied through untouched by the
+        // "fill the remain channels with data from src tensor" loop.
+        // Scaling the pass-through tail as well is a different graph, and
+        // `ferrox parity` caught it as the one DRIFT verdict in a
+        // 17-model sweep: Phi-4-mini rotates 96 of 128 dims with
+        // attn_factor 1.1902, so 32 dims per head were scaled that
+        // llama.cpp leaves alone.
+        let head_dim = self.config.head_dim;
+        let rot = self.config.rope_dim.unwrap_or(head_dim).min(head_dim);
+        for buf in [q, k] {
+            for head in buf.chunks_mut(head_dim) {
+                let n = rot.min(head.len());
+                for v in head[..n].iter_mut() {
+                    *v *= m;
+                }
+            }
+        }
+    }
+
+    /// An architecture's explicit attention score scale
+    /// (`ModelConfig::attention_scale`), applied to Q after RoPE.
+    ///
+    /// llama.cpp's Gemma graphs scale Q themselves and then call
+    /// `build_attn(..., 1.0f)`; ferrox's kernels always apply their own
+    /// `1/sqrt(head_dim)`, so the compensation has to be folded into Q
+    /// here for the NET score scale to equal `attention_scale`.
+    ///
+    /// One helper rather than one copy per host body, because that is
+    /// exactly how this feature came to be applied at two of four sites:
+    /// `forward_hidden_batch_inner` and `forward_multi_seq_kv` computed a
+    /// plausible distribution at the wrong temperature and nothing
+    /// failed. Elementwise, so a `[batch, n_heads*head_dim]` Q batch is
+    /// the same call as one row's.
+    #[inline]
+    pub(crate) fn apply_attention_scale(&self, q: &mut [f32]) {
+        let Some(scale) = self.config.attention_scale else {
+            return;
+        };
+        let compensate = scale * (self.config.head_dim as f32).sqrt();
+        for v in q.iter_mut() {
+            *v *= compensate;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Phi-3/Phi-4 rotate `rope.dimension_count` of each head and pass
+    /// the rest through. The tail staying bit-identical is the whole
+    /// property: rotating it would make dimensions position-dependent
+    /// that the model never trained that way.
+    #[test]
+    fn partial_rotary_leaves_the_tail_untouched() {
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.head_dim = 8;
+        cfg.rope_layout = crate::config::RopeLayout::Neox;
+        cfg.rope_freqs = None;
+        cfg.rope_dim = Some(4);
+        let decoder = Decoder::new_random_small(cfg, 1, 32);
+
+        let mut head: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
+        let before = head.clone();
+        decoder.apply_rope_head_theta(&mut head, 3, 10000.0, None);
+
+        assert_eq!(
+            &head[4..],
+            &before[4..],
+            "dims at or past rope_dim must not rotate"
+        );
+        assert!(
+            head[..4] != before[..4],
+            "dims below rope_dim must rotate at a non-zero position"
+        );
+    }
+
+    /// `attn_factor` is a magnitude scale folded into cos/sin inside
+    /// ggml's `rope_yarn`, so it can only ever touch the rotated
+    /// channels. The pass-through tail must come out bit-identical —
+    /// scaling it is a different graph, and it was one, until
+    /// `ferrox parity` reported Phi-4-mini as the single DRIFT in a
+    /// 17-model sweep against llama.cpp.
+    #[test]
+    fn attn_factor_scales_only_the_rotated_channels() {
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.head_dim = 8;
+        cfg.n_heads = 2;
+        cfg.n_kv_heads = 2;
+        cfg.rope_dim = Some(4);
+        cfg.rope_attn_factor = 2.0;
+        let decoder = Decoder::new_random_small(cfg, 1, 32);
+
+        // Two heads, so a per-head slice bug cannot hide behind a single
+        // head that happens to span the whole buffer.
+        let mut q: Vec<f32> = (0..16).map(|i| 1.0 + i as f32).collect();
+        let mut k: Vec<f32> = (0..16).map(|i| 1.0 + i as f32).collect();
+        let before = q.clone();
+        decoder.apply_rope_attn_factor(&mut q, &mut k);
+
+        for h in 0..2 {
+            let base = h * 8;
+            for i in 0..4 {
+                assert_eq!(
+                    q[base + i],
+                    before[base + i] * 2.0,
+                    "rotated channel {i} of head {h} must be scaled"
+                );
+            }
+            for i in 4..8 {
+                assert_eq!(
+                    q[base + i],
+                    before[base + i],
+                    "pass-through channel {i} of head {h} must be untouched"
+                );
+            }
+        }
+        assert_eq!(q, k, "q and k take the same magnitude scale");
+    }
+
+    /// With no partial rotary the whole head is rotated, so the whole
+    /// head takes the scale — the narrow case must not become the rule.
+    #[test]
+    fn attn_factor_scales_the_whole_head_without_partial_rotary() {
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.head_dim = 8;
+        cfg.n_heads = 1;
+        cfg.n_kv_heads = 1;
+        cfg.rope_dim = None;
+        cfg.rope_attn_factor = 3.0;
+        let decoder = Decoder::new_random_small(cfg, 1, 32);
+
+        let mut q: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
+        let mut k = q.clone();
+        let before = q.clone();
+        decoder.apply_rope_attn_factor(&mut q, &mut k);
+        for i in 0..8 {
+            assert_eq!(q[i], before[i] * 3.0);
+        }
+    }
+
+    /// The same call with no `rope_dim` must rotate everything, so the
+    /// narrow case cannot silently become the default.
+    #[test]
+    fn full_rotary_still_rotates_the_whole_head() {
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.head_dim = 8;
+        cfg.rope_layout = crate::config::RopeLayout::Neox;
+        cfg.rope_freqs = None;
+        cfg.rope_dim = None;
+        let decoder = Decoder::new_random_small(cfg, 1, 32);
+
+        let mut head: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
+        let before = head.clone();
+        decoder.apply_rope_head_theta(&mut head, 3, 10000.0, None);
+        assert!(head[4..] != before[4..]);
+    }
+
+    /// `mscale` scales q and k and nothing else; `1.0` must be a literal
+    /// no-op so every other model pays nothing.
+    #[test]
+    fn rope_attn_factor_scales_q_and_k_only() {
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.rope_attn_factor = 2.0;
+        let decoder = Decoder::new_random_small(cfg, 1, 32);
+        let mut q = vec![1.0f32, -2.0, 3.0];
+        let mut k = vec![0.5f32, 4.0];
+        decoder.apply_rope_attn_factor(&mut q, &mut k);
+        assert_eq!(q, vec![2.0, -4.0, 6.0]);
+        assert_eq!(k, vec![1.0, 8.0]);
+
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.rope_attn_factor = 1.0;
+        let decoder = Decoder::new_random_small(cfg, 1, 32);
+        let mut q = vec![1.0f32, -2.0];
+        let mut k = vec![3.0f32];
+        decoder.apply_rope_attn_factor(&mut q, &mut k);
+        assert_eq!(q, vec![1.0, -2.0]);
+        assert_eq!(k, vec![3.0]);
+    }
+
+    /// A sliding layer and a full-attention layer of the same model get
+    /// DIFFERENT RoPE, in both halves: base and per-band divisors.
+    ///
+    /// llama.cpp splits both per layer (`llama-model.cpp:2029-2035`,
+    /// consumed at `gemma3.cpp:112-121`). ferrox split only the base:
+    /// `layer_rope_theta` varied per layer while `rope_freqs` was one
+    /// global vector applied everywhere. On Gemma-3 4B/12B/27B --
+    /// `rope_scaling: {linear, factor 8}`, `sliding_window_pattern = 6`
+    /// -- that rotated FIVE LAYERS IN SIX at position `p/8` where
+    /// llama.cpp rotates at `p`. Fluent output, worse the longer the
+    /// prompt, no error. Gemma-3-1B, the audited fixture, is the one
+    /// size with no `rope_scaling` at all, so it could not show this.
+    #[test]
+    fn a_sliding_layer_ropes_unscaled_where_a_full_attention_layer_ropes_scaled() {
+        use crate::config::{RopeFreqs, RopeLayout};
+
+        const FACTOR: f32 = 8.0;
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.head_dim = 8;
+        cfg.rope_layout = RopeLayout::Norm;
+        cfg.rope_theta = 1_000_000.0;
+        // Gemma-3's SWA base: `gemma3.cpp:11` reads only the BASE key and
+        // leaves `rope_freq_base_train_swa` at its 10000 default.
+        cfg.rope_theta_swa = Some(10_000.0);
+        cfg.sliding_window = Some(4);
+        // Period 2, last-dense: layer 0 slides, layer 1 does not.
+        cfg.swa_pattern = Some(2);
+        cfg.swa_dense_first = false;
+        cfg.rope_freqs = Some(RopeFreqs {
+            full: vec![FACTOR; 4],
+            swa: Some(vec![1.0; 4]),
+        });
+        assert_eq!(cfg.layer_sliding_window(0), Some(4), "layer 0 must slide");
+        assert_eq!(cfg.layer_sliding_window(1), None, "layer 1 must be dense");
+
+        let decoder = Decoder::new_random_small(cfg, 2, 32);
+        let source: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
+        let pos = 7;
+
+        // The sliding layer: llama.cpp's `freq_scale_l` is the 1.0
+        // default, so no divisor at all.
+        let mut sliding = source.clone();
+        decoder.apply_rope_head_layer(&mut sliding, pos, 0);
+        let mut want_sliding = source.clone();
+        apply_rope_interleaved(&mut want_sliding, pos, 10_000.0);
+        assert_eq!(
+            sliding, want_sliding,
+            "a Gemma-3 sliding layer rotates at the raw position, base 10000"
+        );
+
+        // The full-attention layer: the trained linear scale, folded
+        // into the per-band divisors.
+        let mut full = source.clone();
+        decoder.apply_rope_head_layer(&mut full, pos, 1);
+        let mut want_full = source.clone();
+        apply_rope_interleaved_with_freq_factors(&mut want_full, pos, 1_000_000.0, &[FACTOR; 4]);
+        assert_eq!(
+            full, want_full,
+            "a Gemma-3 full-attention layer rotates at p/8, base 1e6"
+        );
+
+        // Not vacuous: the two layers must actually disagree, which is
+        // the whole property. Before the fix both took `full`.
+        assert_ne!(
+            sliding, full,
+            "if these agree the test proves nothing about per-layer RoPE"
+        );
+
+        // And the sliding layer must NOT be the scaled rotation, which
+        // is precisely what it used to get.
+        let mut was_wrong = source.clone();
+        apply_rope_interleaved_with_freq_factors(&mut was_wrong, pos, 10_000.0, &[FACTOR; 4]);
+        assert_ne!(
+            sliding, was_wrong,
+            "the sliding layer must not carry the full-attention scale"
+        );
+    }
+
+    /// `swa: None` means "inherit", which is what llama.cpp does for
+    /// every architecture that assigns `rope_freq_scale_train_swa` from
+    /// `rope_freq_scale_train` (`gemma2.cpp:11` and the ten others in
+    /// `capability::swa_rope_scale_follows_model`). Gemma-2 must keep
+    /// its scaling on the sliding layers.
+    #[test]
+    fn an_inheriting_architecture_ropes_both_kinds_of_layer_with_one_set() {
+        use crate::config::{RopeFreqs, RopeLayout};
+
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.head_dim = 8;
+        cfg.rope_layout = RopeLayout::Norm;
+        cfg.sliding_window = Some(4);
+        cfg.swa_pattern = Some(2);
+        cfg.rope_freqs = Some(RopeFreqs {
+            full: vec![8.0; 4],
+            swa: None,
+        });
+        assert!(
+            !cfg.rope_freqs_vary_by_layer(),
+            "an inheriting model must stay eligible for the fused Metal stacks"
+        );
+
+        let decoder = Decoder::new_random_small(cfg, 2, 32);
+        let source: Vec<f32> = (0..8).map(|i| 1.0 + i as f32).collect();
+        let mut sliding = source.clone();
+        let mut full = source.clone();
+        decoder.apply_rope_head_layer(&mut sliding, 7, 0);
+        decoder.apply_rope_head_layer(&mut full, 7, 1);
+        assert_eq!(
+            sliding, full,
+            "both layers share one base and one divisor set here"
+        );
+    }
+}

--- a/crates/ferrox-models/src/loader.rs
+++ b/crates/ferrox-models/src/loader.rs
@@ -607,11 +607,21 @@ impl ModelConfig {
             None
         };
 
-        // Gemma's f_attention_scale equals 1/sqrt(n_embd_head_k) for non-27B,
-        // which is already what `causal_gqa_attention` applies. Do not also
-        // pre-scale Q (that double-scales scores vs llama.cpp's
-        // `build_attn(..., 1.0f)` after an explicit Q scale).
-        let attention_scale = None;
+        // llama.cpp's `f_attention_scale`, and ONLY where it differs from
+        // the `1/sqrt(head_dim)` ferrox's attention kernels already
+        // apply -- `Some` here means "pre-scale Q", so restating the
+        // kernels' own scale would double-scale every score.
+        //
+        // For Gemma-2 and Gemma-3 that difference is real at 27B and
+        // nowhere else (`capability::attention_scale_override` carries
+        // the llama.cpp lines). This used to be a hardcoded `None` under
+        // a comment that NAMED the 27B exception without implementing
+        // it, so Gemma-2-27B scored 1.061x and Gemma-3-27B 1.146x too
+        // large on every layer: a sharper softmax than the trained one,
+        // fluent and wrong, with no error.
+        let attention_scale = crate::capability::attention_scale_override(
+            &arch, n_layers, hidden_dim, n_heads, head_dim,
+        );
 
         // SWA-layer RoPE base. `llama_hparams` defaults it to 10000 and
         // the Gemma-3 lineage relies on that default; the architectures
@@ -4002,6 +4012,86 @@ mod tests {
         match ModelConfig::from_gguf(&seven_b) {
             Err(LoadError::MissingHparam(key)) => assert_eq!(key, "baichuan.embedding_length"),
             other => panic!("Baichuan-7B must pass the ALiBi gate, got {other:?}"),
+        }
+    }
+
+    /// The hyper-parameters a real Gemma-3 GGUF header carries for one
+    /// size. `block_count` is the field llama.cpp's `LLM_TYPE_27B`
+    /// switch reads (`gemma3.cpp:20-28`), so it is never a free
+    /// parameter here.
+    ///
+    /// `linear_factor` adds the pair `conversion/base.py:1222-1230`
+    /// writes from `rope_parameters["full_attention"]` -- and only from
+    /// there: its own comment is "TODO: Handle sliding_attention
+    /// similarly when models start implementing it", so the sliding
+    /// layers get no scaling key at all.
+    fn gemma3_config(
+        tag: &str,
+        n_layers: u32,
+        hidden_dim: u32,
+        n_heads: u32,
+        head_dim: u32,
+        linear_factor: Option<f32>,
+    ) -> ModelConfig {
+        let mut kvs: Vec<(&str, Kv)> = vec![
+            ("general.architecture", Kv::Str("gemma3")),
+            ("gemma3.block_count", Kv::U32(n_layers)),
+            ("gemma3.embedding_length", Kv::U32(hidden_dim)),
+            ("gemma3.attention.head_count", Kv::U32(n_heads)),
+            ("gemma3.attention.head_count_kv", Kv::U32(n_heads)),
+            ("gemma3.attention.key_length", Kv::U32(head_dim)),
+            ("gemma3.attention.value_length", Kv::U32(head_dim)),
+            // Global layers rotate at 1e6; the sliding ones fall back to
+            // llama.cpp's `rope_freq_base_train_swa` default of 10000,
+            // because `gemma3.cpp:11` reads only the BASE key.
+            ("gemma3.rope.freq_base", Kv::F32(1_000_000.0)),
+            ("gemma3.attention.sliding_window", Kv::U32(1024)),
+            ("gemma3.attention.sliding_window_pattern", Kv::U32(6)),
+        ];
+        if let Some(factor) = linear_factor {
+            kvs.push(("gemma3.rope.scaling.type", Kv::Str("linear")));
+            kvs.push(("gemma3.rope.scaling.factor", Kv::F32(factor)));
+        }
+        ModelConfig::from_gguf(&open_metadata_gguf(tag, &kvs)).expect("gemma3 fixture must load")
+    }
+
+    /// The 27B attention scale reaches `ModelConfig`, and no other
+    /// Gemma-3 size acquires one.
+    ///
+    /// `capability::attention_scale_override` is where the arithmetic is
+    /// checked; this pins that the LOADER calls it with this file's own
+    /// numbers. That step is the one that shipped broken: the function
+    /// did not exist and `attention_scale` was the literal `None`, under
+    /// a comment naming the exception. A helper nobody calls looks
+    /// exactly like a fix.
+    #[test]
+    fn a_gemma3_27b_header_sets_the_attention_scale_and_no_smaller_size_does() {
+        // Gemma-3-27B: 62 layers, n_embd 5376, 32 heads, head_dim 128.
+        let big = gemma3_config("g3_27b_scale", 62, 5376, 32, 128, Some(8.0));
+        let want = 1.0f32 / (5376.0f32 / 32.0).sqrt();
+        let got = big
+            .attention_scale
+            .expect("Gemma-3-27B is llama.cpp's LLM_TYPE_27B");
+        assert!(
+            (got - want).abs() < 1e-7,
+            "want 1/sqrt(168) = {want}, got {got}"
+        );
+        // The bug's magnitude: scores were sqrt(168/128) = 1.146x too
+        // large without this.
+        let kernel = 1.0f32 / 128.0f32.sqrt();
+        assert!((kernel / got - (168.0f32 / 128.0).sqrt()).abs() < 1e-5);
+
+        // Gemma-3-1B and -4B take llama.cpp's other branch, which is the
+        // scale the attention kernels already apply. A `Some` here would
+        // double-scale them.
+        for (tag, n_layers, hidden, heads) in
+            [("g3_1b_scale", 26, 1152, 4), ("g3_4b_scale", 34, 2560, 8)]
+        {
+            let cfg = gemma3_config(tag, n_layers, hidden, heads, 256, None);
+            assert_eq!(
+                cfg.attention_scale, None,
+                "{tag} must keep the kernels' own 1/sqrt(head_dim)"
+            );
         }
     }
 }

--- a/crates/ferrox-models/src/loader.rs
+++ b/crates/ferrox-models/src/loader.rs
@@ -752,6 +752,16 @@ impl ModelConfig {
         // llama.cpp divides them by 4. It answered as a different model
         // with no error. Affects the long-context community rescales
         // (`*-16k`, `*-32k` Llama-2 derivatives).
+
+        // The file's own per-band factors, BEFORE any position-scaling
+        // fold. That is what a sliding layer uses on an architecture
+        // whose SWA layers do not inherit the trained scale -- llama.cpp
+        // keeps the two apart as `freq_factors` (a tensor, the same for
+        // every layer) and `freq_scale` (per layer,
+        // `llama-model.cpp:2033`), while ferrox folds them into one
+        // vector. See `config::RopeFreqs`.
+        let rope_freqs_unscaled = rope_freqs.clone();
+
         let rope_freqs = match linear_scaling_from_gguf(file, &arch) {
             None => rope_freqs,
             Some(factor) => {
@@ -811,6 +821,29 @@ impl ModelConfig {
                 }
             }
         };
+
+        // The SWA half of the split. llama.cpp defaults
+        // `rope_freq_scale_train_swa` to `1.0f`
+        // (`src/llama-hparams.h:129`) and only the architectures in
+        // `swa_rope_scale_follows_model` assign it from
+        // `rope_freq_scale_train`; `get_rope_freq_scale`
+        // (`llama-model.cpp:2033-2035`) then picks between them per
+        // layer. `gemma3.cpp` is not on that list and its converter
+        // writes the FULL-ATTENTION factor
+        // (`conversion/base.py:1222-1230`), so a Gemma-3 4B/12B/27B was
+        // rotating five layers in six at `p/8` where llama.cpp rotates
+        // at `p`.
+        //
+        // "No scaling" is spelled as an all-ones divisor vector, which
+        // is what dividing by nothing is, so the sliding layers need no
+        // second code path anywhere downstream.
+        let rope_freqs = rope_freqs.map(|full| {
+            let swa = (sliding_window.is_some()
+                && !crate::capability::swa_rope_scale_follows_model(&arch))
+            .then(|| rope_freqs_unscaled.unwrap_or_else(|| vec![1.0; full.len()]))
+            .filter(|swa| *swa != full);
+            crate::config::RopeFreqs { full, swa }
+        });
 
         // RoPE layout comes from the capability registry above (fail-
         // closed). Getting this wrong for `llama` (needs Norm) was the
@@ -2921,7 +2954,8 @@ mod tests {
         );
         let factors = cfg
             .rope_freqs
-            .expect("a YaRN checkpoint must carry rewritten per-band frequencies");
+            .expect("a YaRN checkpoint must carry rewritten per-band frequencies")
+            .full;
         assert_eq!(factors.len(), 32, "one divisor per rotation band");
         assert!(
             (factors[0] - 1.0).abs() < 1e-6,
@@ -2960,10 +2994,11 @@ mod tests {
                 ("llama.rope.scaling.factor", Kv::F32(4.0)),
             ],
         );
-        let freqs = cfg
+        let freqs = &cfg
             .rope_freqs
             .as_ref()
-            .expect("linear scaling must produce frequency factors");
+            .expect("linear scaling must produce frequency factors")
+            .full;
         assert_eq!(freqs.len(), cfg.head_dim / 2, "one factor per rotated pair");
         assert!(
             freqs.iter().all(|f| (*f - 4.0).abs() < 1e-6),
@@ -4091,6 +4126,120 @@ mod tests {
             assert_eq!(
                 cfg.attention_scale, None,
                 "{tag} must keep the kernels' own 1/sqrt(head_dim)"
+            );
+        }
+    }
+
+    /// Gemma-3's declared linear scaling reaches the FULL-ATTENTION
+    /// layers only, and the sliding ones rope unscaled.
+    ///
+    /// `gemma3.cpp:11` reads `LLM_KV_ROPE_FREQ_BASE_SWA` and nothing
+    /// else, so `rope_freq_scale_train_swa` keeps its `1.0f` default
+    /// (`src/llama-hparams.h:129`) while `get_rope_freq_scale`
+    /// (`llama-model.cpp:2033-2035`) hands the trained scale to the full
+    /// layers. The converter agrees: `conversion/base.py:1222-1230`
+    /// takes the factor from `rope_parameters["full_attention"]` and
+    /// writes nothing for the sliding half.
+    ///
+    /// ferrox folded the factor into ONE global `rope_freqs` vector, so
+    /// Gemma-3-4B/12B/27B rotated five layers in six at `p/8`.
+    #[test]
+    fn gemma3_linear_scaling_reaches_the_full_layers_and_not_the_sliding_ones() {
+        // Gemma-3-4B: 34 layers, head_dim 256, `rope_scaling: linear 8`.
+        let cfg = gemma3_config("g3_4b_rope", 34, 2560, 8, 256, Some(8.0));
+        let freqs = cfg
+            .rope_freqs
+            .as_ref()
+            .expect("declared linear scaling must produce per-band divisors");
+        assert!(
+            freqs.full.iter().all(|f| (*f - 8.0).abs() < 1e-6),
+            "full-attention layers divide every band by the trained factor: {:?}",
+            freqs.full
+        );
+        let swa = freqs
+            .swa
+            .as_ref()
+            .expect("gemma3 does not assign rope_freq_scale_train_swa, so 1.0 applies");
+        assert!(
+            swa.iter().all(|f| (*f - 1.0).abs() < 1e-6),
+            "sliding layers rope at the raw position: {swa:?}"
+        );
+        assert_eq!(swa.len(), freqs.full.len(), "one divisor per rotated pair");
+
+        // Period 6, last-dense (`capability::default_swa_layout`), so
+        // layer 5 is the full-attention one and 0..=4 slide. The phase
+        // matters: getting it wrong swaps which five-sixths are wrong.
+        assert!(cfg.layer_sliding_window(0).is_some());
+        assert!(cfg.layer_sliding_window(5).is_none());
+        assert_eq!(cfg.layer_rope_freqs(0), Some(&[1.0f32; 128][..]));
+        assert_eq!(cfg.layer_rope_freqs(5), Some(&[8.0f32; 128][..]));
+        assert_eq!(cfg.layer_rope_theta(0), 10_000.0);
+        assert_eq!(cfg.layer_rope_theta(5), 1_000_000.0);
+        assert!(
+            cfg.rope_freqs_vary_by_layer(),
+            "the fused Metal stacks take one divisor slice for a whole run \
+             and so must refuse this model"
+        );
+
+        // Gemma-3-1B declares no scaling at all -- the audited fixture,
+        // and the reason this was invisible. Nothing to split, so no
+        // per-layer set and no Metal refusal.
+        let plain = gemma3_config("g3_1b_rope", 26, 1152, 4, 256, None);
+        assert!(plain.rope_freqs.is_none());
+        assert!(!plain.rope_freqs_vary_by_layer());
+    }
+
+    /// Gemma-2 is the counter-case, and it is why the SWA scale needs
+    /// its own table rather than reusing `swa_rope_base_follows_model`.
+    ///
+    /// `gemma2.cpp:10-11` assigns BOTH `rope_freq_base_train_swa` and
+    /// `rope_freq_scale_train_swa` from the model's trained values, so
+    /// its sliding layers keep the declared scaling. Splitting them here
+    /// would be the same bug pointed the other way.
+    #[test]
+    fn gemma2_sliding_layers_inherit_the_trained_rope_scale() {
+        let cfg = ModelConfig::from_gguf(&open_metadata_gguf(
+            "g2_rope",
+            &[
+                ("general.architecture", Kv::Str("gemma2")),
+                ("gemma2.block_count", Kv::U32(26)),
+                ("gemma2.embedding_length", Kv::U32(2304)),
+                ("gemma2.attention.head_count", Kv::U32(8)),
+                ("gemma2.attention.head_count_kv", Kv::U32(4)),
+                ("gemma2.attention.key_length", Kv::U32(256)),
+                ("gemma2.attention.value_length", Kv::U32(256)),
+                ("gemma2.rope.freq_base", Kv::F32(10_000.0)),
+                ("gemma2.attention.sliding_window", Kv::U32(4096)),
+                ("gemma2.rope.scaling.type", Kv::Str("linear")),
+                ("gemma2.rope.scaling.factor", Kv::F32(8.0)),
+            ],
+        ))
+        .expect("gemma2 fixture must load");
+
+        let freqs = cfg.rope_freqs.as_ref().expect("linear scaling declared");
+        assert_eq!(
+            freqs.swa, None,
+            "gemma2.cpp:11 assigns rope_freq_scale_train_swa from the trained scale"
+        );
+        assert!(!cfg.rope_freqs_vary_by_layer());
+        // Period 2, last-dense: layer 0 slides, layer 1 does not, and
+        // both get the same divisors.
+        assert!(cfg.layer_sliding_window(0).is_some());
+        assert!(cfg.layer_sliding_window(1).is_none());
+        assert_eq!(cfg.layer_rope_freqs(0), cfg.layer_rope_freqs(1));
+
+        // The two tables really are different: this is the pair that
+        // must not be collapsed into one.
+        assert!(crate::capability::swa_rope_scale_follows_model("gemma2"));
+        assert!(!crate::capability::swa_rope_scale_follows_model("gemma3"));
+        for arch in ["olmo2", "laguna"] {
+            assert!(
+                crate::capability::swa_rope_base_follows_model(arch),
+                "{arch} seeds the SWA base from the model"
+            );
+            assert!(
+                !crate::capability::swa_rope_scale_follows_model(arch),
+                "{arch} pins the SWA scale to 1.0 (olmo2.cpp:14, laguna.cpp:48)"
             );
         }
     }


### PR DESCRIPTION
Two numerical-correctness fixes on the Gemma family, both instances of the repo's dominant bug shape: a per-layer fact and a global one that must agree, with nothing enforcing it, and a comment that documented an exception the code did not implement.

Every claim below was verified against `.scratch/llama.cpp` before anything changed.

## #40 — Gemma-2-27B / Gemma-3-27B attention scale

`loader.rs` hardcoded `attention_scale = None` under a comment naming the 27B exception. llama.cpp:

```cpp
// src/models/gemma3.cpp:30-33   (src/models/gemma2.cpp:26-29, same shape)
hparams.f_attention_scale = type == LLM_TYPE_27B
    ? 1.0f / std::sqrt(float(hparams.n_embd / hparams.n_head(0)))
    : 1.0f / std::sqrt(float(hparams.n_embd_head_k()));
```

applied as an explicit `ggml_scale` on Q then `build_attn(..., 1.0f)` (`gemma3.cpp:154`, `gemma2.cpp:110`). So Gemma-3-27B scored `sqrt(168/128)` = 1.146x and Gemma-2-27B `sqrt(144/128)` = 1.061x too large on every layer: a sharper softmax than the trained one, fluent and silent.

`capability::attention_scale_override` now derives it, and the loader stores it.

**One correction to the issue's proposed fix.** #40 suggests deriving the override from `n_embd / n_head != head_dim`. That is wrong: **every** published Gemma size has `n_embd / n_head != head_dim` (3-1B is 288 vs 256, 3-4B 320 vs 256, 3-12B 240 vs 256, 2-2B 288 vs 256, 2-9B 224 vs 256), and seven of the eight take llama.cpp's `1/sqrt(n_embd_head_k)` branch. The selector upstream is the LAYER COUNT — `switch (hparams.n_layer())`, `gemma3.cpp:20-28` `case 62`, `gemma2.cpp:19-23` `case 46` — so that is what this implements, and the test walks all eight sizes to pin why.

The consumer needed no change: `apply_attention_scale` was already written and correct, and `layer_supports_metal_attn` already refused the fused Metal launches whenever `attention_scale.is_some()`. That fence was written down while it could not fire, which is why the day the loader started setting it cost nothing. Its comment, and the `unsupported_scaling_keys` exemption that claimed "Gemma implements its own attention scale", now describe behaviour instead of a gap.

## #39 — Gemma-3 sliding-window layers roped at scaled positions

llama.cpp splits both halves of RoPE per layer:

```cpp
// src/llama-model.cpp:2029-2035
float llama_model::get_rope_freq_base (const llama_cparams & cparams, int il) const {
    return hparams.is_swa(il) ? hparams.rope_freq_base_train_swa  : cparams.rope_freq_base;
}
float llama_model::get_rope_freq_scale(const llama_cparams & cparams, int il) const {
    return hparams.is_swa(il) ? hparams.rope_freq_scale_train_swa : cparams.rope_freq_scale;
}
```

consumed per layer at `gemma3.cpp:112-121`. `rope_freq_scale_train_swa` defaults to `1.0f` (`src/llama-hparams.h:129`), and `gemma3.cpp:11` reads only `LLM_KV_ROPE_FREQ_BASE_SWA` — it never assigns the scale, unlike `gemma2.cpp:11`, `openai-moe.cpp:14`, `cohere2.cpp:10` and eight others. The converter agrees: `conversion/base.py:1222-1230` takes the factor from `rope_parameters["full_attention"]` and writes nothing for the sliding half ("TODO: Handle sliding_attention similarly when models start implementing it"), which `conversion/gemma.py:134` inherits via `super().set_gguf_parameters()`.

ferrox varied the base per layer and kept the divisors global, so Gemma-3 4B/12B/27B rotated five layers in six at `p/8` where llama.cpp rotates at `p`.

The fix is the pairing, not the patch:

- `config::RopeFreqs { full, swa }` replaces the bare vector, so the sliding-layer question cannot be left unanswered.
- `ModelConfig::layer_rope(il)` returns base and divisors TOGETHER; every rotation site takes both from it, and `layer_rope_theta` is now a projection of it rather than a sibling.
- `capability::swa_rope_scale_follows_model` is **its own table**, deliberately not derived from `swa_rope_base_follows_model`: `olmo2.cpp:13-14` and `laguna.cpp:47-48` seed the base from the model and then pin the scale to `1.0`, so the lists genuinely differ and collapsing them would rope those two wrong.
- "No scaling" is an all-ones divisor vector, not a third state.

**Metal.** Per-layer launches now take `layer_rope_freqs(l)`. The two whole-stack launches take one `freq_factors` slice for a run of layers and have no per-layer field for it, so `metal_stack_needs_per_layer_rope_freqs` refuses them when the layers disagree — one predicate, both call sites. Gemma-3 4B/12B/27B therefore take the per-layer Metal path rather than the fused stacks: correct and slower beats fast and wrong. Restoring the fast path is #63.

## What would have to be true for this to be wrong

- #40: that `LLM_TYPE_27B` is selected by something other than `n_layer`, or that a real Gemma-2/3 27B ships a layer count other than 46/62.
- #39: that some Gemma-3 GGUF declares a sliding-window rope scaling key. No converter writes one today, and llama.cpp reads none.

## File sizes

`decoder.rs` went from 6886 to **6702** lines: the per-head RoPE helpers and their tests moved to the new `decoder/rope.rs` (392 lines), which is where the next per-architecture rotation fact belongs.

## Tests

Six new tests. Each was sabotaged once and confirmed red:

- `gemma_27b_is_the_only_size_that_overrides_the_kernel_scale` — walks the eight real Gemma sizes and asserts `n_embd / n_head != head_dim` for all of them, so the wrong derivation cannot pass.
- `a_gemma3_27b_header_sets_the_attention_scale_and_no_smaller_size_does` — pins that the LOADER calls the helper with the file's own numbers. A helper nobody calls looks exactly like a fix.
- `a_sliding_layer_ropes_unscaled_where_a_full_attention_layer_ropes_scaled` — a sliding layer and a full one get different base AND different divisors, checked against direct `ferrox_core` references, with an explicit "these must not be equal" so it cannot pass vacuously.
- `an_inheriting_architecture_ropes_both_kinds_of_layer_with_one_set`, `gemma3_linear_scaling_reaches_the_full_layers_and_not_the_sliding_ones`, `gemma2_sliding_layers_inherit_the_trained_rope_scale` — the other direction, driven through real GGUF headers, asserting the two capability tables disagree exactly where llama.cpp does.

Gates: `cargo build --workspace`, `cargo test --workspace` (2376 passed, 0 failed), `cargo clippy --workspace --all-targets -- -D warnings`, the same `--release`, `cargo fmt --all`, plus `cargo clippy --features metal` on the three crates that build with it.

## Not done

- No benchmark. An agent may not measure, and a loaded host reads 25-45% low. The Metal stack slowdown on Gemma-3 4B+ is unquantified and named in #63.
- No real-checkpoint parity run: no Gemma-3-4B/12B/27B or Gemma-2-27B GGUF is present locally. The evidence here is llama.cpp's source plus header-driven loader tests, not a logit comparison.
- `ferrox-metal` untouched: the fused stacks are refused rather than taught per-layer divisors.

## Doc delta

None applied (docs are owned elsewhere this round). Two things a docs pass should pick up:

- `docs/MODELS.md` — Gemma-3 4B/12B/27B and Gemma-2-27B were quietly wrong and are now right; on Metal, Gemma-3 4B+ no longer uses the fused dense stacks.
- `benchmarks/RESULTS.md` — any Gemma-3 4B+ Metal row predating this measures a different code path.

Closes #39
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
