### PR TITLE
docs: the Gemma sizes that were quietly wrong, and tokenize answering for an encoder

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -505,10 +505,15 @@ model rather than blaming a tensor:
 }}
 ```
 
-`/v1/tokenize` and `/v1/detokenize` refuse the same way. They report the
-prompt the *generation* path would build, and an encoder has no
-generation path; `usage.prompt_tokens` on an embeddings response already
-counts the `[CLS]`/`[SEP]` the model actually saw.
+`/v1/tokenize` and `/v1/detokenize` are the exception: they ANSWER for
+an encoder, because an encoder has a real tokenizer and asking what
+tokens it saw is not asking it to generate. They used to refuse with the
+rest, which left no way to check a surprising embedding without loading
+the checkpoint in a second tool. `add_special` is a no-op there, since
+an encoder wraps its own `[CLS]`/`[SEP]` already, and those are the same
+tokens `usage.prompt_tokens` counts on an embeddings response.
+
+Every route that needs a decode still refuses.
 
 Only `bert` loads. The other encoder rows upstream builds from
 `bert.cpp`: `nomic-bert`, `jina-bert-v2/v3`, `neo-bert`,

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -149,6 +149,29 @@ The error always names the reason. Six things cause it:
    An architecture reaches it only if there is a benchmark row, a pinned
    logit comparison against real `libllama`, or a fixture; 11 do today
    (`llama`, `qwen2`, `qwen2moe`, `qwen3`, `qwen3moe`, `olmoe`,
+**Gemma-2-27B, Gemma-3-4B/12B/27B: corrected 2026-09-02.** Those four
+sizes were quietly wrong until then, in two ways that both produce
+fluent text. The 27B checkpoints took `1/sqrt(head_dim)` as their
+attention scale where llama.cpp takes `1/sqrt(n_embd/n_head)` for that
+size alone, selected by layer count; and Gemma-3 4B and up applied
+linear RoPE scaling to the sliding-window layers llama.cpp ropes
+unscaled, because `rope_theta` is per layer while `rope_freqs` was
+global. Gemma-3-1B is the one size with no `rope_scaling`, and it was
+the audited fixture, which is why neither was visible.
+
+The evidence is llama.cpp's source and header-driven loader tests, NOT a
+logit comparison: no checkpoint of those sizes exists on the development
+host. A `ferrox parity` run against one is what would settle it.
+
+A cost came with it. Gemma-3 4B and up no longer use the fused Metal
+dense stacks, because those take one `freq_factors` slice for a whole
+run of layers and these models need one per layer. They take the
+per-layer path instead: correct, and slower. No published number
+changes: [`benchmarks/RESULTS.md`](../benchmarks/RESULTS.md) carries
+Gemma-3-1B only, and 1B is neither 27B nor rope-scaled, so it is
+untouched by both corrections. Tracked as
+[#63](https://github.com/antonellof/ferrox/issues/63).
+
    `gemma2`, `gemma3`, `phi3`, `gpt-oss`, `dots1`). The other **46**
    stop with `UnauditedArchitecture`. `FERROX_ALLOW_UNAUDITED_ARCH=1`
    runs one anyway; compare the output against llama.cpp yourself

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -168,7 +168,7 @@ Beyond closing the measured gaps.
 - Docker images (CPU, Metal and CUDA variants)
 - Throughput measurement for concurrent continuous-batching requests
   (Metal parallel fix shipped 0.15.2; CB garbled-output fix and Host B
-  serving receipts in 0.15.3 — see
+  serving receipts in 0.15.3, see
   [`plans/metal-parallel-concurrency.md`](plans/metal-parallel-concurrency.md)
   and [`benchmarks/receipts/serving/`](../benchmarks/receipts/serving/))
 - Full KV layer offload, multi-GPU, tensor parallel, PD disaggregation


### PR DESCRIPTION
Doc deltas for #65 and #64.

`docs/MODELS.md` records that Gemma-2-27B and Gemma-3-4B/12B/27B were wrong until today in two ways that both produce fluent text, and why neither was visible: Gemma-3-1B is the one size with no `rope_scaling` and it was the audited fixture. Evidence stated honestly as llama.cpp source plus loader tests, not a logit comparison, since no checkpoint of those sizes is on this host.

It also records the cost: Gemma-3 4B+ no longer uses the fused Metal dense stacks (one `freq_factors` slice per run of layers vs one per layer). Correct, slower, tracked as #63.

**No published number changes.** I checked rather than writing the usual "any row before this date is suspect" hedge: `benchmarks/RESULTS.md` carries Gemma-3-1B only, which is neither 27B nor rope-scaled.

`docs/API.md` stops saying the tokenize routes refuse for an encoder, and says why that is not a hole: every route needing a *decode* still refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN