### PR TITLE
feat(cli): the llama.cpp server flags a copied command actually carries

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ in the CLI or the server.
 ## Quick start
 
 ```bash
+# 0. Or skip step 1 entirely: -hf is llama.cpp's, and fetches on first use.
+ferrox serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M
+
 # 1. Get a model. No Python, no huggingface_hub: same syntax as `hf download`.
+#    The `:QUANT` tag works here too and picks the file for you.
 ferrox download bartowski/Llama-3.2-3B-Instruct-GGUF \
   Llama-3.2-3B-Instruct-Q4_K_M.gguf --local-dir models
 
@@ -114,7 +118,7 @@ ferrox -m models/Llama-3.2-3B-Instruct-Q4_K_M.gguf \
   -p "Explain quantization in two sentences" -n 128 -dev metal -ngl all
 
 # 3. Or serve it on 127.0.0.1:8383 and point any OpenAI client at /v1.
-#    On Metal, continuous batching is on by default — several clients can
+#    On Metal, continuous batching is on by default, so several clients can
 #    stream in parallel. `ferrox-server` is the same server standalone.
 ferrox serve -m models/Llama-3.2-3B-Instruct-Q4_K_M.gguf -dev metal -ngl all &
 curl -s -X POST http://127.0.0.1:8383/v1/chat/completions \

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ in the CLI or the server.
 
 ```bash
 # 0. Or skip step 1 entirely: -hf is llama.cpp's, and fetches on first use.
-ferrox serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M
+#    Most llama-server flags work as spelled: -c, --api-key, --alias, --jinja.
+ferrox serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M -c 8192 --alias local
 
 # 1. Get a model. No Python, no huggingface_hub: same syntax as `hf download`.
 #    The `:QUANT` tag works here too and picks the file for you.

--- a/crates/ferrox-cli/src/download.rs
+++ b/crates/ferrox-cli/src/download.rs
@@ -16,7 +16,14 @@ use std::path::PathBuf;
 
 #[derive(clap::Args, Debug)]
 pub struct DownloadArgs {
-    /// Hugging Face repo id, for example `bartowski/Llama-3.2-3B-Instruct-GGUF`.
+    /// Hugging Face repo id, for example
+    /// `bartowski/Llama-3.2-3B-Instruct-GGUF`.
+    ///
+    /// Also accepts llama.cpp's `-hf` shape, `repo:QUANT`, so
+    /// `TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF:Q4_K_M` works. Before
+    /// that, the whole string was sent to the Hub as a repo id and came
+    /// back a bare `401`, which reads like an auth problem and is not
+    /// one.
     pub repo: String,
 
     /// File to fetch, or a glob. Defaults to the repo's single GGUF,
@@ -51,13 +58,22 @@ pub fn run(args: DownloadArgs) -> anyhow::Result<()> {
         let _ = std::io::stdout().flush();
     };
 
-    let path = ferrox_models::hub::fetch_to_dir_with_progress(
-        &args.repo,
-        &args.file,
-        &args.local_dir,
-        &mut draw,
-    )
-    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // `repo:QUANT` is resolved here rather than passed through, so the
+    // quant tag matches case-insensitively the way llama.cpp's does.
+    // An explicit `file` argument still wins: it is what the user typed.
+    let hf = ferrox_models::hub::HfRef::parse(&args.repo);
+    let (repo, file) = match (&hf.quant, args.file.as_str()) {
+        (Some(_), "*.gguf") => {
+            let resolved = hf.resolve().map_err(|e| anyhow::anyhow!("{e}"))?;
+            println!("resolved {} to {resolved}", args.repo);
+            (hf.repo.clone(), resolved)
+        }
+        _ => (hf.repo.clone(), args.file.clone()),
+    };
+
+    let path =
+        ferrox_models::hub::fetch_to_dir_with_progress(&repo, &file, &args.local_dir, &mut draw)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     println!();
     let gb = std::fs::metadata(&path)

--- a/crates/ferrox-cli/src/hf.rs
+++ b/crates/ferrox-cli/src/hf.rs
@@ -10,8 +10,11 @@
 ///
 /// Progress goes to stderr so a caller redirecting stdout gets the
 /// model's output and not a progress bar.
-pub fn resolve(spec: &str) -> anyhow::Result<String> {
-    let hf = ferrox_models::hub::HfRef::parse(spec);
+pub fn resolve(spec: &str, file: Option<&str>) -> anyhow::Result<String> {
+    let mut hf = ferrox_models::hub::HfRef::parse(spec);
+    if let Some(f) = file {
+        hf.file = Some(f.to_string());
+    }
     eprintln!(
         "ferrox: resolving {} on the Hub{}",
         hf.repo,

--- a/crates/ferrox-cli/src/hf.rs
+++ b/crates/ferrox-cli/src/hf.rs
@@ -1,0 +1,50 @@
+//! `-hf user/repo[:QUANT]`, llama.cpp's one-command model fetch.
+//!
+//! The parsing and the cache live in [`ferrox_models::hub`], which the
+//! server uses too; this is the CLI's progress reporting around them.
+//! Kept as one function rather than two so `ferrox run` and
+//! `ferrox serve` cannot drift about where a model lands or what they
+//! print when it is already there.
+
+/// Resolves a `-hf` reference to a local path, downloading it once.
+///
+/// Progress goes to stderr so a caller redirecting stdout gets the
+/// model's output and not a progress bar.
+pub fn resolve(spec: &str) -> anyhow::Result<String> {
+    let hf = ferrox_models::hub::HfRef::parse(spec);
+    eprintln!(
+        "ferrox: resolving {} on the Hub{}",
+        hf.repo,
+        hf.quant
+            .as_deref()
+            .map(|q| format!(" ({q})"))
+            .unwrap_or_default()
+    );
+
+    let mut last = std::time::Instant::now();
+    let mut draw = move |done: u64, total: Option<u64>| {
+        if last.elapsed() < std::time::Duration::from_millis(200) {
+            return;
+        }
+        last = std::time::Instant::now();
+        let mib = done as f64 / 1024.0 / 1024.0;
+        match total {
+            Some(t) if t > 0 => eprint!(
+                "\r  {mib:>9.1} MiB  {:5.1}%",
+                (done as f64 / t as f64) * 100.0
+            ),
+            _ => eprint!("\r  {mib:>9.1} MiB"),
+        }
+    };
+
+    let (path, downloaded) = hf
+        .ensure_local(&mut draw)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if downloaded {
+        eprintln!();
+        eprintln!("ferrox: downloaded {}", path.display());
+    } else {
+        eprintln!("ferrox: using cached {}", path.display());
+    }
+    Ok(path.to_string_lossy().into_owned())
+}

--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -8,6 +8,7 @@ mod bench_model;
 mod bench_suite;
 mod chat;
 mod download;
+mod hf;
 mod host_state;
 mod http;
 mod layer_divergence;
@@ -518,6 +519,12 @@ fn rewrite_llama_style_argv(args: Vec<String>) -> Vec<String> {
         .map(|arg| match arg.as_str() {
             "-ngl" => "--n-gpu-layers".into(),
             "-dev" => "--device".into(),
+            // llama.cpp's parser is hand-written, so `-hf` is ONE
+            // token. clap reads it as `-h` plus `f` and prints help,
+            // which is what `ferrox serve -hf repo:Q4_K_M` did: it
+            // looked like the flag did not exist.
+            "-hf" => "--hf-repo".into(),
+            "-hff" => "--hf-file".into(),
             _ => arg,
         })
         .collect();

--- a/crates/ferrox-cli/src/run.rs
+++ b/crates/ferrox-cli/src/run.rs
@@ -42,6 +42,24 @@ pub struct InferArgs {
     )]
     pub hf_repo: Option<String>,
 
+    /// Exact filename inside `--hf-repo`, llama.cpp's `-hff`.
+    #[arg(long = "hf-file", value_name = "FILE", requires = "hf_repo")]
+    pub hf_file: Option<String>,
+
+    /// Penalise a token for having appeared at all, llama.cpp's
+    /// `--presence-penalty`. `0.0` = off, which is llama.cpp's default.
+    ///
+    /// The engine and `/v1/chat/completions` have always supported
+    /// this; the CLI hardcoded it to zero, so the two disagreed about
+    /// what `ferrox` could do.
+    #[arg(long = "presence-penalty", value_name = "P", default_value_t = 0.0)]
+    pub presence_penalty: f32,
+
+    /// Penalise a token in proportion to how often it has appeared,
+    /// llama.cpp's `--frequency-penalty`. `0.0` = off.
+    #[arg(long = "frequency-penalty", value_name = "P", default_value_t = 0.0)]
+    pub frequency_penalty: f32,
+
     /// Prompt string. Alias of llama.cpp `-p`.
     #[arg(short = 'p', long = "prompt", default_value = "")]
     pub prompt: String,
@@ -51,7 +69,12 @@ pub struct InferArgs {
     pub file: Option<String>,
 
     /// Number of tokens to predict (`-1` = fill remaining context).
-    #[arg(short = 'n', long = "n-predict", default_value_t = 128)]
+    #[arg(
+        short = 'n',
+        long = "n-predict",
+        visible_alias = "predict",
+        default_value_t = 128
+    )]
     pub n_predict: i64,
 
     /// Context size: `auto` = largest that fits the device memory
@@ -229,7 +252,12 @@ pub struct InferArgs {
     /// KV cache dtype (llama.cpp `-ctk` analogue). Sets `FERROX_CTK`.
     /// Values: `f16` (default), `q8_0`, `fp8`, `turbo8`, `turbo4`, `turbo3`.
     /// Non-f16 paths warn and fall back to f16 until Metal kernels land.
-    #[arg(long = "ctk", value_name = "TYPE", default_value = "f16")]
+    #[arg(
+        long = "ctk",
+        visible_alias = "cache-type-k",
+        value_name = "TYPE",
+        default_value = "f16"
+    )]
     pub ctk: String,
 }
 
@@ -392,8 +420,8 @@ impl InferArgs {
             top_k: self.top_k,
             repetition_penalty: self.repeat_penalty,
             penalty_last_n: self.repeat_last_n,
-            presence_penalty: 0.0,
-            frequency_penalty: 0.0,
+            presence_penalty: self.presence_penalty,
+            frequency_penalty: self.frequency_penalty,
         }
     }
 }
@@ -1064,7 +1092,7 @@ pub fn run_infer(args: InferArgs) -> anyhow::Result<()> {
     // `--model`, so the rest of this function sees one kind of input.
     let mut args = args;
     if let Some(spec) = args.hf_repo.clone() {
-        args.model = Some(crate::hf::resolve(&spec)?);
+        args.model = Some(crate::hf::resolve(&spec, args.hf_file.as_deref())?);
     }
     if args.mtp {
         anyhow::bail!(

--- a/crates/ferrox-cli/src/run.rs
+++ b/crates/ferrox-cli/src/run.rs
@@ -24,9 +24,23 @@ pub struct InferArgs {
         short = 'm',
         long = "model",
         value_name = "FILE",
-        required_unless_present = "list_devices"
+        required_unless_present_any = ["list_devices", "hf_repo"]
     )]
     pub model: Option<String>,
+
+    /// Hugging Face repo to run, `user/repo[:QUANT]`, llama.cpp's
+    /// `-hf`.
+    ///
+    /// Fetched into the ferrox cache on first use and reused after. The
+    /// tag after the colon is a QUANT LABEL, not a git revision, and it
+    /// matches without regard to case.
+    #[arg(
+        long = "hf-repo",
+        visible_alias = "hf",
+        value_name = "REPO[:QUANT]",
+        conflicts_with = "model"
+    )]
+    pub hf_repo: Option<String>,
 
     /// Prompt string. Alias of llama.cpp `-p`.
     #[arg(short = 'p', long = "prompt", default_value = "")]
@@ -1045,6 +1059,12 @@ pub fn run_infer(args: InferArgs) -> anyhow::Result<()> {
     if args.list_devices {
         print_available_devices();
         return Ok(());
+    }
+    // `-hf` resolves to a local path before anything else looks at
+    // `--model`, so the rest of this function sees one kind of input.
+    let mut args = args;
+    if let Some(spec) = args.hf_repo.clone() {
+        args.model = Some(crate::hf::resolve(&spec)?);
     }
     if args.mtp {
         anyhow::bail!(

--- a/crates/ferrox-models/src/hub.rs
+++ b/crates/ferrox-models/src/hub.rs
@@ -133,6 +133,10 @@ pub fn cache_dir() -> std::path::PathBuf {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HfRef {
     pub repo: String,
+    /// An exact filename, llama.cpp's `-hff`. When set it wins over
+    /// `quant`: the user named the file, so there is nothing left to
+    /// resolve and nothing to guess.
+    pub file: Option<String>,
     /// The quant label, upper-cased for reporting. Matching is
     /// case-insensitive: repos spell it `Q4_K_M` and `q4_k_m` about
     /// equally often, and a case-sensitive match would 404 on half of
@@ -147,6 +151,7 @@ impl HfRef {
         match spec.rsplit_once(':') {
             Some((repo, quant)) if !repo.is_empty() && !quant.is_empty() => HfRef {
                 repo: repo.to_string(),
+                file: None,
                 quant: Some(quant.to_ascii_uppercase()),
             },
             // A TRAILING colon is a typo, not a tag, and the colon is
@@ -155,10 +160,12 @@ impl HfRef {
             // repo the user can see exists.
             Some((repo, _)) if !repo.is_empty() => HfRef {
                 repo: repo.to_string(),
+                file: None,
                 quant: None,
             },
             _ => HfRef {
                 repo: spec.to_string(),
+                file: None,
                 quant: None,
             },
         }
@@ -173,8 +180,15 @@ impl HfRef {
     }
 
     /// Resolves to one filename in the repo.
+    ///
+    /// An explicit `file` short-circuits the Hub listing entirely: the
+    /// user named it, so asking the API which files exist would only
+    /// add a way to fail.
     pub fn resolve(&self) -> Result<String, String> {
-        resolve_glob_ci(&self.repo, &self.pattern())
+        match &self.file {
+            Some(f) => Ok(f.clone()),
+            None => resolve_glob_ci(&self.repo, &self.pattern()),
+        }
     }
 }
 
@@ -571,5 +585,15 @@ mod hf_ref_tests {
             !dir.as_os_str().is_empty(),
             "a cache dir must always resolve, even with no HOME"
         );
+    }
+
+    /// An explicit `--hf-file` wins over the quant tag and skips the
+    /// Hub listing entirely: the user named the file, so asking the API
+    /// which files exist only adds a way to fail.
+    #[test]
+    fn an_explicit_file_short_circuits_resolution() {
+        let mut r = HfRef::parse("owner/repo:Q4_K_M");
+        r.file = Some("exact-name.gguf".into());
+        assert_eq!(r.resolve().unwrap(), "exact-name.gguf");
     }
 }

--- a/crates/ferrox-models/src/hub.rs
+++ b/crates/ferrox-models/src/hub.rs
@@ -97,6 +97,172 @@ fn with_auth(req: ureq::Request) -> ureq::Request {
 /// same repo rather than depending on the order the API happens to
 /// return. A repo with several matching quantizations is ambiguous by
 /// construction; the caller can name one exactly to be sure.
+/// Where a `-hf` download lands, and where a second run finds it
+/// already there.
+///
+/// `FERROX_CACHE`, else `$XDG_CACHE_HOME/ferrox`, else `~/.cache/ferrox`.
+/// llama.cpp does the same thing with `LLAMA_CACHE`, and for the same
+/// reason: a model fetched by `-hf` is not part of the project you are
+/// standing in, so it does not belong in `./models`.
+pub fn cache_dir() -> std::path::PathBuf {
+    if let Some(dir) = std::env::var_os("FERROX_CACHE") {
+        return std::path::PathBuf::from(dir);
+    }
+    if let Some(dir) = std::env::var_os("XDG_CACHE_HOME") {
+        return std::path::PathBuf::from(dir).join("ferrox");
+    }
+    match std::env::var_os("HOME") {
+        Some(home) => std::path::PathBuf::from(home).join(".cache").join("ferrox"),
+        // No HOME is a real case in a container. A relative path is a
+        // worse cache than an absolute one and a better failure than a
+        // panic.
+        None => std::path::PathBuf::from(".ferrox-cache"),
+    }
+}
+
+/// A `-hf` argument: `user/repo`, optionally `:QUANT`.
+///
+/// llama.cpp's spelling, so a command copied off a model card runs
+/// unchanged: `-hf TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF:Q4_K_M`.
+/// The tag after the colon is a QUANT LABEL, not a git revision, which
+/// is worth saying because the same `repo:thing` shape means a revision
+/// almost everywhere else.
+///
+/// Without a tag the pattern is every GGUF in the repo, which resolves
+/// only when there is exactly one and otherwise refuses by name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HfRef {
+    pub repo: String,
+    /// The quant label, upper-cased for reporting. Matching is
+    /// case-insensitive: repos spell it `Q4_K_M` and `q4_k_m` about
+    /// equally often, and a case-sensitive match would 404 on half of
+    /// them for a reason the user cannot see.
+    pub quant: Option<String>,
+}
+
+impl HfRef {
+    /// Splits on the LAST colon, so a repo id containing one is still
+    /// parsed the way the user meant.
+    pub fn parse(spec: &str) -> Self {
+        match spec.rsplit_once(':') {
+            Some((repo, quant)) if !repo.is_empty() && !quant.is_empty() => HfRef {
+                repo: repo.to_string(),
+                quant: Some(quant.to_ascii_uppercase()),
+            },
+            // A TRAILING colon is a typo, not a tag, and the colon is
+            // dropped rather than carried into the repo id. Keeping it
+            // sent `owner/repo:` to the Hub and came back a 404 about a
+            // repo the user can see exists.
+            Some((repo, _)) if !repo.is_empty() => HfRef {
+                repo: repo.to_string(),
+                quant: None,
+            },
+            _ => HfRef {
+                repo: spec.to_string(),
+                quant: None,
+            },
+        }
+    }
+
+    /// The filename glob this reference resolves through.
+    pub fn pattern(&self) -> String {
+        match &self.quant {
+            Some(q) => format!("*{q}*.gguf"),
+            None => "*.gguf".to_string(),
+        }
+    }
+
+    /// Resolves to one filename in the repo.
+    pub fn resolve(&self) -> Result<String, String> {
+        resolve_glob_ci(&self.repo, &self.pattern())
+    }
+}
+
+impl HfRef {
+    /// The local path this reference resolves to, downloading it into
+    /// [`cache_dir`] only when it is not already there.
+    ///
+    /// Returns `(path, downloaded)` so a caller can say "using cached"
+    /// rather than printing a progress bar that never moves.
+    pub fn ensure_local(
+        &self,
+        on_progress: &mut dyn FnMut(u64, Option<u64>),
+    ) -> Result<(std::path::PathBuf, bool), String> {
+        let filename = self.resolve()?;
+        // Under `hub/` rather than directly in the cache root, which
+        // already holds `instances/` (the running-instance registry). A
+        // repo named `instances` would otherwise land on top of it.
+        let dir = cache_dir().join("hub").join(self.repo.replace('/', "__"));
+        let path = dir.join(&filename);
+        if path.is_file() {
+            return Ok((path, false));
+        }
+        let path = fetch_to_dir_with_progress(&self.repo, &filename, &dir, on_progress)?;
+        Ok((path, true))
+    }
+}
+
+/// [`resolve_glob`], matching without regard to case.
+///
+/// Separate from `resolve_glob` rather than replacing it: the exact
+/// pattern a caller passes to `ferrox download` should mean what it
+/// says, and only the `-hf` quant tag is case-insensitive.
+pub fn resolve_glob_ci(repo: &str, pattern: &str) -> Result<String, String> {
+    let names = list_files(repo)?;
+    let lowered = pattern.to_ascii_lowercase();
+    names
+        .iter()
+        .find(|n| glob_matches(&lowered, &n.to_ascii_lowercase()))
+        .cloned()
+        .ok_or_else(|| {
+            let ggufs: Vec<&str> = names
+                .iter()
+                .filter(|n| n.to_ascii_lowercase().ends_with(".gguf"))
+                .map(String::as_str)
+                .collect();
+            if ggufs.is_empty() {
+                format!("no file in {repo} matches '{pattern}', and the repo holds no GGUF at all")
+            } else {
+                // Listing what IS there turns "no match" into an
+                // answerable question: the usual cause is a quant this
+                // repo does not publish, and the user cannot see the
+                // repo's file list from a command line.
+                format!(
+                    "no file in {repo} matches '{pattern}'. That repo publishes: {}",
+                    ggufs.join(", ")
+                )
+            }
+        })
+}
+
+/// Every root-level filename in `repo`.
+fn list_files(repo: &str) -> Result<Vec<String>, String> {
+    let url = format!("{}/api/models/{repo}", endpoint());
+    let response = with_auth(agent().get(&url))
+        .call()
+        .map_err(|e| format!("listing {repo} on the Hub failed: {e}"))?;
+    let body = response
+        .into_string()
+        .map_err(|e| format!("reading the file list for {repo}: {e}"))?;
+    let value: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("the Hub's file list for {repo} was not JSON: {e}"))?;
+    let mut names: Vec<String> = value
+        .get("siblings")
+        .and_then(|s| s.as_array())
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|e| e.get("rfilename")?.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    names.sort();
+    // A repo may hold shards in subdirectories; a target this server
+    // can safely write is a bare name in the repo root.
+    names.retain(|n| !n.contains('/'));
+    Ok(names)
+}
+
 pub fn resolve_glob(repo: &str, pattern: &str) -> Result<String, String> {
     let url = format!("{}/api/models/{repo}", endpoint());
     let response = with_auth(agent().get(&url))
@@ -333,5 +499,77 @@ mod tests {
     fn the_endpoint_has_no_trailing_slash_to_double_up() {
         // Default, and any override, must join cleanly with "/api/...".
         assert!(!endpoint().ends_with('/'));
+    }
+}
+
+#[cfg(test)]
+mod hf_ref_tests {
+    use super::*;
+
+    /// llama.cpp's `-hf user/repo:QUANT`. The tag is a quant label, not
+    /// a git revision, which is the opposite of what `repo:thing` means
+    /// nearly everywhere else.
+    #[test]
+    fn a_quant_tag_is_split_off_and_becomes_a_glob() {
+        let r = HfRef::parse("TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF:Q4_K_M");
+        assert_eq!(r.repo, "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF");
+        assert_eq!(r.quant.as_deref(), Some("Q4_K_M"));
+        assert_eq!(r.pattern(), "*Q4_K_M*.gguf");
+    }
+
+    /// Without a tag the whole string is the repo. Sending
+    /// `repo:Q4_K_M` to the Hub as a repo id is what produced a bare
+    /// `401`, which reads like an auth failure and is not one.
+    #[test]
+    fn a_bare_repo_keeps_its_whole_name_and_matches_every_gguf() {
+        let r = HfRef::parse("bartowski/Llama-3.2-3B-Instruct-GGUF");
+        assert_eq!(r.repo, "bartowski/Llama-3.2-3B-Instruct-GGUF");
+        assert_eq!(r.quant, None);
+        assert_eq!(r.pattern(), "*.gguf");
+    }
+
+    /// A trailing or leading colon is not a tag. Treating `repo:` as
+    /// "quant is empty string" would build the pattern `**.gguf` and
+    /// match a file the user did not ask for.
+    #[test]
+    fn a_degenerate_colon_is_not_a_tag() {
+        assert_eq!(HfRef::parse("owner/repo:").quant, None);
+        assert_eq!(HfRef::parse("owner/repo:").repo, "owner/repo");
+        assert_eq!(HfRef::parse(":Q4_K_M").quant, None);
+    }
+
+    /// Case-insensitive on purpose: repos spell the quant `Q4_K_M` and
+    /// `q4_k_m` about equally often, and a case-sensitive match would
+    /// fail on half of them for a reason invisible from a command line.
+    #[test]
+    fn a_lowercase_tag_matches_an_uppercase_filename() {
+        let r = HfRef::parse("owner/repo:q4_k_m");
+        assert_eq!(r.quant.as_deref(), Some("Q4_K_M"));
+        assert!(glob_matches(
+            &r.pattern().to_ascii_lowercase(),
+            &"SmolLM2-135M-Instruct-Q4_K_M.gguf".to_ascii_lowercase()
+        ));
+    }
+
+    /// A quant label is a substring of a longer one, so the glob must
+    /// not let `Q4_K_M` answer a request for `Q4_K`.
+    #[test]
+    fn a_tag_does_not_match_a_longer_quant_by_accident() {
+        let asked = HfRef::parse("owner/repo:Q4_K_M");
+        assert!(!glob_matches(
+            &asked.pattern().to_ascii_lowercase(),
+            &"model-Q4_K_S.gguf".to_ascii_lowercase()
+        ));
+    }
+
+    /// The cache is per repo, and under `hub/` rather than the cache
+    /// root, which already holds `instances/`.
+    #[test]
+    fn the_cache_path_is_namespaced_under_hub() {
+        let dir = cache_dir();
+        assert!(
+            !dir.as_os_str().is_empty(),
+            "a cache dir must always resolve, even with no HOME"
+        );
     }
 }

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -124,6 +124,21 @@ pub struct ServerArgs {
     #[arg(short = 'm', long = "model", value_name = "FILE")]
     model: Option<String>,
 
+    /// Hugging Face repo to serve, `user/repo[:QUANT]`, llama.cpp's
+    /// `-hf`.
+    ///
+    /// Downloads into the ferrox cache on first use and reuses it
+    /// after, so `-hf TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF:Q4_K_M`
+    /// is the whole command. The tag after the colon is a QUANT LABEL,
+    /// not a git revision, and it matches without regard to case.
+    #[arg(
+        long = "hf-repo",
+        visible_alias = "hf",
+        value_name = "REPO[:QUANT]",
+        conflicts_with = "model"
+    )]
+    hf_repo: Option<String>,
+
     /// IP address to listen on.
     #[arg(long, value_name = "HOST")]
     host: Option<IpAddr>,
@@ -292,6 +307,12 @@ fn rewrite_llama_style_argv(args: Vec<String>) -> Vec<String> {
             "-dev" => "--device".into(),
             "-cb" => "--cont-batching".into(),
             "-np" => "--parallel".into(),
+            // One token in llama.cpp's hand-written parser. clap sees
+            // `-h` followed by `f` and prints help, which is what
+            // `ferrox serve -hf repo:Q4_K_M` did: the flag looked
+            // absent rather than mis-spelled.
+            "-hf" => "--hf-repo".into(),
+            "-hff" => "--hf-file".into(),
             _ => arg,
         })
         .collect()
@@ -333,10 +354,61 @@ fn cli_bind_addr(args: &ServerArgs, env_addr: Option<&str>) -> Option<String> {
     Some(SocketAddr::new(host, port).to_string())
 }
 
+/// Resolves a `-hf` reference to a local path, downloading it once.
+///
+/// Progress goes to STDERR, not stdout: stdout carries the
+/// `ferrox.server.ready` line a supervising process parses, and a
+/// progress bar in the middle of it would break that contract.
+fn resolve_hf_repo(spec: &str) -> anyhow::Result<String> {
+    let hf = ferrox_models::hub::HfRef::parse(spec);
+    eprintln!(
+        "ferrox: resolving {} on the Hub{}",
+        hf.repo,
+        hf.quant
+            .as_deref()
+            .map(|q| format!(" ({q})"))
+            .unwrap_or_default()
+    );
+
+    let mut last = std::time::Instant::now();
+    let mut draw = move |done: u64, total: Option<u64>| {
+        if last.elapsed() < std::time::Duration::from_millis(200) {
+            return;
+        }
+        last = std::time::Instant::now();
+        let mib = done as f64 / 1024.0 / 1024.0;
+        match total {
+            Some(t) if t > 0 => {
+                eprint!(
+                    "\r  {mib:>9.1} MiB  {:5.1}%",
+                    (done as f64 / t as f64) * 100.0
+                )
+            }
+            _ => eprint!("\r  {mib:>9.1} MiB"),
+        }
+    };
+
+    let (path, downloaded) = hf
+        .ensure_local(&mut draw)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if downloaded {
+        eprintln!();
+        eprintln!("ferrox: downloaded {}", path.display());
+    } else {
+        eprintln!("ferrox: using cached {}", path.display());
+    }
+    Ok(path.to_string_lossy().into_owned())
+}
+
 fn apply_cli_overrides(args: &ServerArgs) -> anyhow::Result<()> {
     if let Some(model) = &args.model {
         // SAFETY: called before the runtime starts worker threads.
         unsafe { std::env::set_var("FERROX_MODEL_PATH", model) };
+    }
+    if let Some(spec) = &args.hf_repo {
+        let path = resolve_hf_repo(spec)?;
+        // SAFETY: called before the runtime starts worker threads.
+        unsafe { std::env::set_var("FERROX_MODEL_PATH", &path) };
     }
 
     if let Some(addr) = cli_bind_addr(args, std::env::var("FERROX_ADDR").ok().as_deref()) {

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -139,6 +139,66 @@ pub struct ServerArgs {
     )]
     hf_repo: Option<String>,
 
+    /// Exact filename inside `--hf-repo`, llama.cpp's `-hff`.
+    ///
+    /// For a repo whose quant labels do not disambiguate, or a file
+    /// whose name carries no quant at all.
+    #[arg(long = "hf-file", value_name = "FILE", requires = "hf_repo")]
+    hf_file: Option<String>,
+
+    /// Context size, llama.cpp's `-c`. Sets `FERROX_CB_MAX_CONTEXT`.
+    ///
+    /// Unset means the ceiling is derived at load from the weights and
+    /// the per-token KV against the device budget, capped at the
+    /// model's trained context, which is usually what you want.
+    #[arg(short = 'c', long = "ctx-size", value_name = "N")]
+    ctx_size: Option<usize>,
+
+    /// Require `Authorization: Bearer <key>`, llama.cpp's `--api-key`.
+    /// Sets `FERROX_API_KEY`, which also gates `/admin`.
+    #[arg(long = "api-key", value_name = "KEY")]
+    api_key: Option<String>,
+
+    /// Read the API key from a file, llama.cpp's `--api-key-file`.
+    ///
+    /// Preferred over `--api-key` on a shared host: an argument is
+    /// visible in `ps` to every user on the machine.
+    #[arg(long = "api-key-file", value_name = "PATH", conflicts_with = "api_key")]
+    api_key_file: Option<std::path::PathBuf>,
+
+    /// Name this model answers to in `/v1/models` and in responses,
+    /// llama.cpp's `--alias`. Sets `FERROX_MODEL_NAME`.
+    #[arg(long = "alias", visible_alias = "model-alias", value_name = "NAME")]
+    alias: Option<String>,
+
+    /// KV cache dtype, llama.cpp's `--cache-type-k`. Metal only; the
+    /// CPU and CUDA KV cache is the host `Vec<f32>`.
+    #[arg(long = "ctk", visible_alias = "cache-type-k", value_name = "TYPE")]
+    ctk: Option<String>,
+
+    /// Accepted and already the default: ferrox always compiles and
+    /// evaluates the GGUF's own `tokenizer.chat_template`. llama.cpp
+    /// needs `--jinja` to do that, so a command copied from there
+    /// carries it, and dying on an unknown flag would be a worse answer
+    /// than saying "yes, always".
+    #[arg(long = "jinja", default_value_t = false)]
+    jinja: bool,
+
+    /// Refused rather than ignored: ferrox has no
+    /// template-free/sniffing mode to fall back to. See `--jinja`.
+    #[arg(long = "no-jinja", default_value_t = false)]
+    no_jinja: bool,
+
+    /// Accepted; ferrox does no warm-up pass, so there is none to skip.
+    #[arg(long = "no-warmup", default_value_t = false)]
+    no_warmup: bool,
+
+    /// Accepted. Fused attention is a backend decision here, not a
+    /// request-time one: it is on wherever the Metal kernels support
+    /// the shape (`FERROX_METAL_ATTN`).
+    #[arg(long = "flash-attn", visible_alias = "fa", value_name = "MODE", num_args = 0..=1, default_missing_value = "auto")]
+    flash_attn: Option<String>,
+
     /// IP address to listen on.
     #[arg(long, value_name = "HOST")]
     host: Option<IpAddr>,
@@ -359,8 +419,11 @@ fn cli_bind_addr(args: &ServerArgs, env_addr: Option<&str>) -> Option<String> {
 /// Progress goes to STDERR, not stdout: stdout carries the
 /// `ferrox.server.ready` line a supervising process parses, and a
 /// progress bar in the middle of it would break that contract.
-fn resolve_hf_repo(spec: &str) -> anyhow::Result<String> {
-    let hf = ferrox_models::hub::HfRef::parse(spec);
+fn resolve_hf_repo(spec: &str, file: Option<&str>) -> anyhow::Result<String> {
+    let mut hf = ferrox_models::hub::HfRef::parse(spec);
+    if let Some(f) = file {
+        hf.file = Some(f.to_string());
+    }
     eprintln!(
         "ferrox: resolving {} on the Hub{}",
         hf.repo,
@@ -406,9 +469,63 @@ fn apply_cli_overrides(args: &ServerArgs) -> anyhow::Result<()> {
         unsafe { std::env::set_var("FERROX_MODEL_PATH", model) };
     }
     if let Some(spec) = &args.hf_repo {
-        let path = resolve_hf_repo(spec)?;
+        let path = resolve_hf_repo(spec, args.hf_file.as_deref())?;
         // SAFETY: called before the runtime starts worker threads.
         unsafe { std::env::set_var("FERROX_MODEL_PATH", &path) };
+    }
+    if let Some(n) = args.ctx_size {
+        if n == 0 {
+            anyhow::bail!("--ctx-size must be greater than zero");
+        }
+        // SAFETY: called before the runtime starts worker threads.
+        unsafe { std::env::set_var("FERROX_CB_MAX_CONTEXT", n.to_string()) };
+    }
+    if let Some(key) = &args.api_key {
+        // SAFETY: called before the runtime starts worker threads.
+        unsafe { std::env::set_var("FERROX_API_KEY", key) };
+    }
+    if let Some(path) = &args.api_key_file {
+        let key = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("reading --api-key-file {}: {e}", path.display()))?;
+        let key = key.trim();
+        if key.is_empty() {
+            anyhow::bail!(
+                "--api-key-file {} is empty: an empty key would leave every route open, \
+                 which is the opposite of what passing the flag asked for",
+                path.display()
+            );
+        }
+        // SAFETY: called before the runtime starts worker threads.
+        unsafe { std::env::set_var("FERROX_API_KEY", key) };
+    }
+    if let Some(alias) = &args.alias {
+        // SAFETY: called before the runtime starts worker threads.
+        unsafe { std::env::set_var("FERROX_MODEL_NAME", alias) };
+    }
+    if let Some(ctk) = &args.ctk {
+        // SAFETY: called before the runtime starts worker threads.
+        unsafe { std::env::set_var("FERROX_CTK", ctk.trim()) };
+    }
+    // Refused by NAME rather than ignored. A prompt framed by a
+    // hand-written guess instead of the checkpoint's own template is
+    // the kind of wrong answer that reads as a model quality problem,
+    // so "ferrox cannot do that" is the honest reply.
+    if args.no_jinja {
+        anyhow::bail!(
+            "--no-jinja: ferrox has no template-free mode. It compiles and evaluates the GGUF's \
+             own tokenizer.chat_template, which is what llama.cpp's --jinja turns on, and there \
+             is no sniffing fallback to switch to. Use --no-cnv on `ferrox run` for a raw \
+             completion"
+        );
+    }
+    if let Some(mode) = &args.flash_attn {
+        let mode = mode.trim().to_ascii_lowercase();
+        if mode == "off" || mode == "disabled" || mode == "0" {
+            anyhow::bail!(
+                "--flash-attn off: fused attention is a backend property here, not a per-run \
+                 switch. Set FERROX_METAL_ATTN=0 to take the unfused Metal path, or --device cpu"
+            );
+        }
     }
 
     if let Some(addr) = cli_bind_addr(args, std::env::var("FERROX_ADDR").ok().as_deref()) {

--- a/crates/ferrox-server/src/loaded.rs
+++ b/crates/ferrox-server/src/loaded.rs
@@ -82,6 +82,23 @@ pub(crate) struct ActiveModel {
     pub(crate) ceiling: Option<Arc<budget::ContextCeiling>>,
 }
 
+/// `FERROX_MODEL_NAME`, cached because `name()` returns a `&str` and is
+/// called per request.
+///
+/// Read once: the server sets it before any worker thread starts, and a
+/// name that changed under a running server would make two responses
+/// disagree about which model answered them.
+fn served_name_override() -> Option<&'static str> {
+    static NAME: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    NAME.get_or_init(|| {
+        std::env::var("FERROX_MODEL_NAME")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    })
+    .as_deref()
+}
+
 impl ActiveModel {
     /// The model to decode with, or a refusal naming the encoder that
     /// is loaded instead.
@@ -150,7 +167,18 @@ impl ActiveModel {
 
     /// What `/v1/models` and `/health` call this checkpoint. Both kinds
     /// have a real name.
+    ///
+    /// `FERROX_MODEL_NAME` (llama.cpp's `--alias`) wins when set. It is
+    /// read HERE rather than at load because three loader paths derive
+    /// a name from `general.name` independently, and threading an
+    /// override through all three would be three places that have to
+    /// agree about one string. This is the single place the served name
+    /// is decided, so the override cannot apply to some models and not
+    /// others.
     pub(crate) fn name(&self) -> &str {
+        if let Some(alias) = served_name_override() {
+            return alias;
+        }
         match &self.loaded {
             Loaded::Generative(m) => m.name(),
             Loaded::Encoder(e) => e.name(),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -56,6 +56,7 @@ Same via explicit subcommand: `ferrox run -m …`.
 | Flag | Notes |
 |---|---|
 | `-m` / `--model` | GGUF path |
+| `-hf` / `--hf-repo` | Hugging Face repo, `user/repo[:QUANT]`. Fetched to the cache on first use. Mutually exclusive with `-m`, see below |
 | `-p` / `--prompt` | Prompt string |
 | `-f` / `--file` | Prompt from file |
 | `-n` / `--n-predict` | `-1` = fill remaining context |
@@ -468,8 +469,42 @@ Fetches a GGUF over HTTPS directly. No Python and no
 Rust engine could not fetch its own weights without a Python
 toolchain.
 
-`download` takes the same arguments as `hf download`, so a command
-copied off a model card runs unchanged:
+### `-hf`, llama.cpp's one-command form
+
+`-hf user/repo[:QUANT]` fetches on first use and serves or runs
+straight away, so nothing has to be downloaded by hand first:
+
+```bash
+ferrox serve -hf bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M
+ferrox -hf bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M -p "Hi" -n 64
+```
+
+The tag after the colon is a **quant label, not a git revision**, which
+is worth saying because `repo:thing` means a revision nearly everywhere
+else. It matches without regard to case, because repos spell it
+`Q4_K_M` and `q4_k_m` about equally often. A tag the repo does not
+publish is refused with the list of quants it does publish, since you
+cannot see a repo's file list from a command line.
+
+`-hf` is one token in llama.cpp's hand-written parser, and clap reads
+`-hf` as `-h` followed by `f`. Both ferrox binaries rewrite `-hf` and
+`-hff` before parsing, so the llama.cpp spelling works; `--hf-repo` is
+the same flag.
+
+Downloads land in the ferrox cache, not in `./models`: a model fetched
+by `-hf` is not part of the project directory you happen to be standing
+in. `FERROX_CACHE`, else `$XDG_CACHE_HOME/ferrox`, else
+`~/.cache/ferrox`, under `hub/<owner>__<repo>/`. A second run says
+`using cached` instead of fetching again, and an interrupted download
+resumes by byte range rather than starting over.
+
+`ferrox download` takes the same `repo:QUANT` shape and puts the file
+where you ask instead of in the cache. Before that it sent the whole
+string to the Hub as a repo id and returned a bare `401`, which reads
+like an auth problem and is not one.
+
+`download` otherwise takes the same arguments as `hf download`, so a
+command copied off a model card runs unchanged:
 
 ```bash
 ferrox download bartowski/Llama-3.2-3B-Instruct-GGUF \

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -68,6 +68,9 @@ Same via explicit subcommand: `ferrox run -m …`.
 | `--top-p` | Nucleus sampling. Default `0.95`, llama.cpp's |
 | `--min-p` | Drop every candidate less than this fraction as likely as the most likely one. `0.0` = off. Default `0.05`, llama.cpp's (`common/common.h:231`) |
 | `--repeat-penalty` | `1.0` = off. Default `1.1`; llama.cpp defaults this one to `1.0` |
+| `--presence-penalty` | Penalise a token for having appeared at all. `0.0` = off, llama.cpp's default. The engine and the HTTP API always supported this; the CLI used to hardcode it to zero |
+| `--frequency-penalty` | Penalise a token in proportion to how often it has appeared. `0.0` = off |
+| `--hf-file` | Exact filename inside `--hf-repo`, llama.cpp's `-hff`. Skips quant resolution entirely |
 | `--repeat-last-n` | How many recent tokens the repetition / presence / frequency penalties consider. `0` = penalties off. Default `64`, llama.cpp's (`common/common.h:238`) |
 | `-s` / `--seed` | `-1` = time-based |
 | `--grammar` | Constrain generation to a GBNF grammar, llama.cpp's `--grammar` |
@@ -560,6 +563,33 @@ Two ways to start the same server. `ferrox serve` is a subcommand of the
 main binary and needs the optional `serve` feature at build time.
 `ferrox-server` is that same server as its own executable, and both
 parse identical arguments through the same code.
+
+### Server flags, and llama.cpp's spellings
+
+`llama-server` commands mostly run unchanged:
+
+| Flag | Notes |
+|---|---|
+| `-m` / `--model` | GGUF path or Kimi directory |
+| `-hf` / `--hf-repo`, `--hf-file` | Fetch from the Hub, see above |
+| `-c` / `--ctx-size` | Positions any one request may ask for. Sets `FERROX_CB_MAX_CONTEXT`. Unset means the ceiling is derived at load from weights and per-token KV against the device budget, capped at the model's trained context |
+| `--api-key`, `--api-key-file` | Require `Authorization: Bearer`. Also gates `/admin`. Prefer the file form on a shared host: an argument is visible in `ps` to every user on the machine. An empty key file is refused rather than leaving every route open |
+| `--alias` | What the model is called in `/v1/models` and in every response's `model` field |
+| `--ctk` / `--cache-type-k` | KV dtype. **Metal only**, the CPU and CUDA cache is the host `Vec<f32>` |
+| `--host`, `--port` | `--port 0` asks the kernel for a free one and announces it on stdout |
+| `-t`, `-ngl`, `-dev` | Threads, GPU layers, device |
+| `-cb` / `--cont-batching`, `-np` / `--parallel` | Continuous batching and its sequence cap |
+| `--jinja` | Accepted, and already the default: ferrox always compiles and evaluates the GGUF's own `tokenizer.chat_template` |
+| `--no-warmup` | Accepted; there is no warm-up pass to skip |
+| `--flash-attn` / `-fa` | Accepted. Fused attention is a backend property here, not a per-run switch |
+
+Two are **refused by name** rather than ignored, because ignoring them
+would change the answer without saying so:
+
+- `--no-jinja`. There is no template-free mode to fall back to, and a
+  prompt framed by a guess instead of the checkpoint's own template
+  reads as a model-quality problem rather than a flag that was dropped.
+- `--flash-attn off`. Set `FERROX_METAL_ATTN=0` or `--device cpu`.
 
 `serve` is on by default, so a stock `cargo install ferrox-cli` has it:
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -47,6 +47,7 @@ library or overriding the CLI.
 | `FERROX_CUDA` | `1` / `0` / `auto` (build with `--features cuda`) |
 | `FERROX_VULKAN` | `1` / `0` / `auto` (build with `--features vulkan`). `Q8_0` matvec only and no GEMM, so a prefill stays on the host |
 | `FERROX_VULKAN_LOADER` | Path to a `libvulkan` the loader should use. Only needed when the platform default is not found; the error names this variable |
+| `FERROX_MODEL_NAME` | What the served model is called in `/v1/models` and every response's `model` field. Same as `--alias`. Read in one place, so it cannot apply to some routes and not others |
 | `FERROX_CACHE` | Where `-hf` puts downloaded checkpoints. Default `$XDG_CACHE_HOME/ferrox`, else `~/.cache/ferrox`; models go under `hub/<owner>__<repo>/`. llama.cpp spells this `LLAMA_CACHE` |
 | `FERROX_CPU_THREADS` | Worker threads; same as `-t`. Default: **performance cores** (`hw.perflevel0.physicalcpu` on macOS), matching llama.cpp, not logical cores |
 | `FERROX_CPU_INT_DOT` | int8×int8 matvec + repacked GEMV. **On by default** in `ferrox` / `ferrox-server`; `0` opts out. Off in the library so golden cross-validation stays reference-exact |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -47,6 +47,7 @@ library or overriding the CLI.
 | `FERROX_CUDA` | `1` / `0` / `auto` (build with `--features cuda`) |
 | `FERROX_VULKAN` | `1` / `0` / `auto` (build with `--features vulkan`). `Q8_0` matvec only and no GEMM, so a prefill stays on the host |
 | `FERROX_VULKAN_LOADER` | Path to a `libvulkan` the loader should use. Only needed when the platform default is not found; the error names this variable |
+| `FERROX_CACHE` | Where `-hf` puts downloaded checkpoints. Default `$XDG_CACHE_HOME/ferrox`, else `~/.cache/ferrox`; models go under `hub/<owner>__<repo>/`. llama.cpp spells this `LLAMA_CACHE` |
 | `FERROX_CPU_THREADS` | Worker threads; same as `-t`. Default: **performance cores** (`hw.perflevel0.physicalcpu` on macOS), matching llama.cpp, not logical cores |
 | `FERROX_CPU_INT_DOT` | int8×int8 matvec + repacked GEMV. **On by default** in `ferrox` / `ferrox-server`; `0` opts out. Off in the library so golden cross-validation stays reference-exact |
 | `FERROX_METAL_FA_VEC` | `0`, disable llama-style FA-vec for decode **and** prefill and fall back to the legacy online-softmax GQA. Default **on** for `head_dim` in {64, 96, 128, 256}; other widths take the legacy kernel either way. Prefill at 64 / 128 / 256 with at least 8 new tokens goes further and takes the simdgroup-MMA `flash_attn_ext` kernel, which is not separately switchable |


### PR DESCRIPTION
Audited `common/arg.cpp`: llama.cpp accepts **426** long options, ferrox **42**. Most of the gap is work ferrox does not do (training, diffusion, perplexity, RPC, vision, LoRA) and a flag for absent behaviour is worse than no flag. This is the subset that makes a copied command fail on something ferrox *can* do.

**Fixes a hole I opened last PR:** the argv rewriter mapped `-hff` to `--hf-file`, which did not exist.

**`serve` gains** `-c/--ctx-size`, `--api-key`, `--api-key-file`, `--alias`, `--ctk/--cache-type-k`, `--hf-file`.

**`run` gains** `--presence-penalty` and `--frequency-penalty` — the engine and HTTP API always supported these while the CLI hardcoded both to `0.0`, so two of llama.cpp's sampler knobs were unreachable from the command line while the docs said the chain matched.

## The one worth reviewing

`--alias`. Three loader paths derive a served name from `general.name` independently, so threading an override through them would have been three places that must agree about one string. It is read once in `ActiveModel::name()` — the single place the served name is decided — so it cannot apply to `/v1/models` and not to a response body. Verified both.

## Accepted vs refused

Accepted, because ferrox already does them: `--jinja` (always evaluates the GGUF's own template), `--no-warmup`, `--flash-attn`.

**Refused by name**, because ignoring them changes the answer silently: `--no-jinja` (no template-free mode to fall back to) and `--flash-attn off` (names the env var that does it).

An empty `--api-key-file` is refused rather than accepted — accepting it leaves every route open, the opposite of what passing the flag asked for.

## Evidence

A llama.cpp-shaped command against the real Hub with SmolLM2-135M: starts, 401s an unkeyed request, answers a keyed one, reports the alias. Gates: 52 suites, clippy debug and release, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN