### PR TITLE
fix(server): a partial answer has no spelling that reaches the response cache

### DIFF
--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -987,7 +987,52 @@ impl FinishReason {
             _ => None,
         }
     }
+
+    /// Proof that this generation produced a WHOLE answer, or `None`
+    /// if it did not.
+    ///
+    /// The match is exhaustive with no `_` arm on purpose: it is the
+    /// one place in the server that decides what "the answer is
+    /// finished" means, and a variant added to this enum later must
+    /// stop this crate compiling here rather than defaulting to
+    /// whichever side of the question its author never considered.
+    ///
+    /// Anything that stores an answer for a LATER caller needs this,
+    /// because storing a partial answer republishes it as a finished
+    /// one. Today that is the whole-response cache; see
+    /// [`crate::response_cache::CachedCompletion::cacheable`], which is
+    /// the only holder of a [`Completed`] outside this module and
+    /// cannot mint one itself.
+    pub fn completed(&self) -> Option<Completed> {
+        match self {
+            // Every one of these is the generation reaching an end the
+            // request asked for: the model's own turn end, a stop
+            // string the caller supplied, or the caller's own token
+            // budget (`max_tokens` is part of the cache key, so
+            // replaying a `Length` answer replays it under the same
+            // budget that produced it).
+            FinishReason::Stop | FinishReason::StopSequence(_) | FinishReason::Length => {
+                Some(Completed(()))
+            }
+            // A canceller cut this short. The tokens that arrived are
+            // the honest answer to THIS request and a truncation of
+            // every other one.
+            FinishReason::Cancelled => None,
+        }
+    }
 }
+
+/// Evidence that a generation ran to an end of its own, produced only
+/// by [`FinishReason::completed`].
+///
+/// The unit field is private to this module, so no other module can
+/// build one, clone one out of thin air, or forget to obtain one: a
+/// function that requires a `Completed` is a function a partial answer
+/// cannot be passed to. That is the difference between this and a
+/// `bool` beside the data, which the next caller does not have to look
+/// at (#57).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Completed(());
 
 /// OpenAI-convention token accounting, reported in the response's
 /// `usage` field. Counted from the exact token ids the generation loop
@@ -1804,8 +1849,38 @@ pub(crate) fn floor_char_boundary(s: &str, idx: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use ferrox_models::config::test_dense_fixture;
+
+    /// Which endings may be replayed to a LATER caller, enumerated so
+    /// the answer is on the record rather than inferred from whichever
+    /// handler happens to hold a cancel token (#57).
+    ///
+    /// `Length` is on the completed side deliberately: `max_tokens` is
+    /// part of the response cache's key, so an answer truncated at the
+    /// budget is only ever replayed under the same budget that produced
+    /// it. `Cancelled` is the whole of the other side -- it kept the
+    /// tokens that had arrived, which answers the cancelled request and
+    /// truncates every other one.
+    #[test]
+    fn only_a_generation_that_reached_an_end_of_its_own_counts_as_completed() {
+        for reason in [
+            FinishReason::Stop,
+            FinishReason::StopSequence("<END>".to_string()),
+            FinishReason::Length,
+        ] {
+            assert!(
+                reason.completed().is_some(),
+                "{reason:?} produced the whole answer the request asked for"
+            );
+        }
+        assert!(
+            FinishReason::Cancelled.completed().is_none(),
+            "a cancelled generation is a partial answer and may not be stored \
+             for anybody else"
+        );
+    }
 
     fn small_decoder() -> Decoder {
         Decoder::new_random_small(test_dense_fixture(), 2, 256)

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -2053,9 +2053,12 @@ struct ChatCompletionResponse {
     /// contract, but additive and harmless to OpenAI-compatible
     /// clients that ignore unknown fields): "hit" if this exact
     /// cacheable request was already computed, "miss" if this request
-    /// just computed and cached a fresh completion, or "skip" if the
-    /// request wasn't cacheable at all (sampling without a seed --
-    /// see `ChatCompletionRequest::is_cacheable`).
+    /// just computed and cached a fresh completion, or "skip" if
+    /// nothing was stored -- either the request wasn't cacheable at all
+    /// (sampling without a seed -- see
+    /// `ChatCompletionRequest::is_cacheable`) or the answer was not a
+    /// complete one and may not be replayed to anybody (a cancelled
+    /// generation -- see `response_cache::CachedCompletion::cacheable`).
     ferrox_cache: &'static str,
 }
 
@@ -3174,12 +3177,24 @@ async fn chat_completions_full(
             finish,
             usage,
         };
-        let cache_status = if let Some(key) = key {
-            tracing::debug!("cache miss for key {}", key.digest());
-            lock_cache(&state.response_cache).put(key, completion.clone());
-            "miss"
-        } else {
-            "skip"
+        // A cacheable KEY is not on its own permission to store an
+        // answer: `cacheable` refuses a generation that did not run to
+        // its own end, and is the only way to build the value `put`
+        // takes, so a cancelled partial cannot become the cached answer
+        // for the next caller (#57).
+        let cache_status = match key {
+            // Nothing is cloned unless there is a key to store it
+            // under: the common path here is a sampled request, which
+            // has none.
+            Some(key) => match completion.clone().cacheable() {
+                Some(cacheable) => {
+                    tracing::debug!("cache miss for key {}", key.digest());
+                    lock_cache(&state.response_cache).put(key, cacheable);
+                    "miss"
+                }
+                None => "skip",
+            },
+            None => "skip",
         };
         (completion, cache_status)
     };

--- a/crates/ferrox-server/src/response_cache.rs
+++ b/crates/ferrox-server/src/response_cache.rs
@@ -14,7 +14,7 @@
 //! KV-prefix cache (reusing the shared prefix of two *different*
 //! prompts) is a separate, larger piece of work, tracked separately.
 
-use crate::generate::{FinishReason, GenerationParams, Usage};
+use crate::generate::{Completed, FinishReason, GenerationParams, Usage};
 use ferrox_models::grammar::Grammar;
 use ferrox_models::sampling::SamplingParams;
 use std::collections::{HashMap, VecDeque};
@@ -136,12 +136,13 @@ pub fn generation_key(params: &GenerationParams) -> GenerationKey {
         // unique key and switch the cache off.
         //
         // Cancellation does change what comes back -- a `Cancelled`
-        // partial -- but it is `None` on the only path that reaches
-        // this key: `chat_completions_full` registers no token (the
-        // STREAMING handler is the one that does, and it does not
-        // cache). If that ever changes, the guard belongs on the PUT,
-        // as "do not cache a partial answer", and not on this key.
-        // Tracked in #57.
+        // partial -- but that is not a question for the key. A partial
+        // answer must not be stored under ANY key, so the guard is on
+        // the PUT: [`CachedCompletion::cacheable`] is the only way to
+        // build the value [`ResponseCache::put`] accepts, and a
+        // cancelled generation cannot produce one (#57). Which handler
+        // happens to register a cancel token no longer decides whether
+        // this cache is correct.
         cancel: _,
         ignore_eos,
     } = params;
@@ -243,6 +244,45 @@ pub struct CachedCompletion {
     pub usage: Usage,
 }
 
+impl CachedCompletion {
+    /// This completion in the form [`ResponseCache::put`] accepts, or
+    /// `None` when it is a PARTIAL answer and may not be stored at all.
+    ///
+    /// The whole guard against #57 is that this is the only
+    /// constructor of [`CacheableCompletion`]: a cancelled generation
+    /// keeps the tokens it managed to decode, which is the right
+    /// response to the request that was cancelled and a truncation of
+    /// every later request that would be served it. The completeness
+    /// question is [`FinishReason::completed`]'s, asked once, next to
+    /// the enum that answers it.
+    pub fn cacheable(self) -> Option<CacheableCompletion> {
+        // Obtaining the proof IS the check, and it is then dropped:
+        // what a `Completed` certifies is that the value below may
+        // exist at all, so from here on the value's own existence
+        // carries it.
+        let _proof: Completed = self.finish.completed()?;
+        Some(CacheableCompletion { completion: self })
+    }
+}
+
+/// A completion that has been shown to be COMPLETE, and is therefore
+/// allowed into the cache.
+///
+/// Both fields are private and there is no public constructor, so this
+/// type cannot be built outside this module and
+/// [`CachedCompletion::cacheable`] is the only thing inside it that
+/// builds one. A caller holding a `Cancelled` partial has nothing it
+/// can pass to [`ResponseCache::put`]; it cannot forget the check,
+/// because there is no argument it could pass instead.
+///
+/// The [`Completed`] is minted from THIS completion's own finish
+/// reason, not handed in beside it, so the proof cannot be borrowed
+/// from some other generation that happened to end well.
+#[derive(Debug)]
+pub struct CacheableCompletion {
+    completion: CachedCompletion,
+}
+
 struct Entry {
     completion: CachedCompletion,
     inserted_at: Instant,
@@ -325,7 +365,12 @@ impl ResponseCache {
     /// Inserts or replaces the cached response for `key`, evicting the
     /// least-recently-used entry first if the cache is already at
     /// `max_entries` and `key` isn't already present.
-    pub fn put(&mut self, key: CacheKey, completion: CachedCompletion) {
+    ///
+    /// Takes a [`CacheableCompletion`] rather than a
+    /// [`CachedCompletion`] so that a partial answer has no spelling
+    /// that reaches this function (#57).
+    pub fn put(&mut self, key: CacheKey, completion: CacheableCompletion) {
+        let CacheableCompletion { completion } = completion;
         if !self.entries.contains_key(&key) && self.entries.len() >= self.max_entries {
             if let Some(oldest) = self.order.pop_front() {
                 self.entries.remove(&oldest);
@@ -410,11 +455,109 @@ mod tests {
         }
     }
 
+    /// The same thing in the form `put` accepts. It exists because
+    /// `put` takes proof of completeness and [`cc`] builds a `Stop`,
+    /// which has it. There is no expression that would put a
+    /// `Cancelled` partial in here.
+    fn cacheable(text: &str) -> CacheableCompletion {
+        cc(text)
+            .cacheable()
+            .expect("a completion that stopped on its own is cacheable")
+    }
+
+    /// The miss branch of `chat_completions_full`, in miniature: look
+    /// the request up, and on a miss offer what was generated to the
+    /// cache before answering with it.
+    ///
+    /// The two tests below assert on what this RETURNS, which is what a
+    /// later identical request is actually served. Asserting on
+    /// `stats()` instead would pass happily while a caller was being
+    /// handed somebody else's truncated answer.
+    fn serve(
+        cache: &mut ResponseCache,
+        key: &CacheKey,
+        generated: CachedCompletion,
+    ) -> CachedCompletion {
+        if let Some(hit) = cache.get(key) {
+            return hit;
+        }
+        // The handler's shape, and the whole guard: what is offered to
+        // the cache is whatever `cacheable` accepts, and there is no
+        // branch here that inspects a finish reason.
+        if let Some(cacheable) = generated.clone().cacheable() {
+            cache.put(key.clone(), cacheable);
+        }
+        generated
+    }
+
+    /// #57's two clients. Client A cancels after a few tokens; client B
+    /// sends the identical body and never cancels. B would have been
+    /// served A's fragment, carrying A's `finish_reason: "cancelled"`
+    /// for a request nobody cancelled.
+    ///
+    /// `cacheable` refuses the partial, so `serve` has nothing to hand
+    /// `put` -- and note there is no `if cancelled` in `serve` that
+    /// could have been forgotten. That is the fix: the check is not one
+    /// a caller can omit, because the caller cannot express the
+    /// alternative.
+    #[test]
+    fn a_cancelled_partial_is_not_served_to_a_later_identical_request() {
+        let mut cache = ResponseCache::new(10, Duration::from_secs(60));
+        let k = key("What is the capital of France?");
+
+        let partial = CachedCompletion {
+            content: "The capital of".to_string(),
+            finish: FinishReason::Cancelled,
+            usage: Usage::new(7, 3),
+        };
+        let client_a = serve(&mut cache, &k, partial.clone());
+        assert_eq!(
+            client_a, partial,
+            "the client that cancelled still gets the tokens it paid for"
+        );
+
+        let whole = CachedCompletion {
+            content: "The capital of France is Paris.".to_string(),
+            finish: FinishReason::Stop,
+            usage: Usage::new(7, 9),
+        };
+        let client_b = serve(&mut cache, &k, whole.clone());
+        assert_eq!(
+            client_b, whole,
+            "a request nobody cancelled must be answered by its own \
+             generation, never replayed from a cancelled one"
+        );
+        assert_eq!(
+            cache.stats().hits,
+            0,
+            "there was nothing to hit: the partial never became an entry"
+        );
+    }
+
+    /// The other half, because a guard that refuses everything reads as
+    /// coverage while quietly switching the cache off. The second
+    /// generation here produces DIFFERENT text, so if the first answer
+    /// was not stored and replayed, the difference reaches the caller.
+    #[test]
+    fn a_completed_answer_is_still_served_to_a_later_identical_request() {
+        let mut cache = ResponseCache::new(10, Duration::from_secs(60));
+        let k = key("What is the capital of France?");
+
+        let whole = cc("The capital of France is Paris.");
+        assert_eq!(serve(&mut cache, &k, whole.clone()), whole);
+        assert_eq!(
+            serve(&mut cache, &k, cc("something else entirely")),
+            whole,
+            "a completed answer must still be cached and replayed"
+        );
+        assert_eq!(cache.stats().hits, 1);
+    }
+
     #[test]
     fn miss_then_hit_for_the_same_key() {
         let mut cache = ResponseCache::new(10, Duration::from_secs(60));
         assert_eq!(cache.get(&key("hello")), None);
-        cache.put(key("hello"), cc("world"));
+        cache.put(key("hello"), cacheable("world"));
         assert_eq!(cache.get(&key("hello")), Some(cc("world")));
 
         let stats = cache.stats();
@@ -426,8 +569,8 @@ mod tests {
     #[test]
     fn different_keys_do_not_collide() {
         let mut cache = ResponseCache::new(10, Duration::from_secs(60));
-        cache.put(key("prompt a"), cc("response a"));
-        cache.put(key("prompt b"), cc("response b"));
+        cache.put(key("prompt a"), cacheable("response a"));
+        cache.put(key("prompt b"), cacheable("response b"));
         assert_eq!(cache.get(&key("prompt a")), Some(cc("response a")));
         assert_eq!(cache.get(&key("prompt b")), Some(cc("response b")));
     }
@@ -438,7 +581,7 @@ mod tests {
         let k1 = key_under("same prompt", |p| p.max_tokens = 16);
         let k2 = key_under("same prompt", |p| p.max_tokens = 32);
 
-        cache.put(k1.clone(), cc("short response"));
+        cache.put(k1.clone(), cacheable("short response"));
         assert_eq!(
             cache.get(&k2),
             None,
@@ -461,7 +604,7 @@ mod tests {
         let mut cache = ResponseCache::new(10, Duration::from_secs(60));
 
         let plain = key("same prompt");
-        cache.put(plain.clone(), cc("Sure! Here are a few options..."));
+        cache.put(plain.clone(), cacheable("Sure! Here are a few options..."));
 
         let constrained = key_under("same prompt", |p| {
             p.grammar = Some(grammar("root ::= \"yes\" | \"no\""))
@@ -493,7 +636,7 @@ mod tests {
 
         let yes_no = keyed("root ::= \"yes\" | \"no\"");
         let digits = keyed("root ::= [0-9]+");
-        cache.put(yes_no.clone(), cc("yes"));
+        cache.put(yes_no.clone(), cacheable("yes"));
 
         assert_eq!(
             cache.get(&digits),
@@ -514,7 +657,7 @@ mod tests {
         let mut cache = ResponseCache::new(10, Duration::from_secs(60));
 
         let plain = key("same prompt");
-        cache.put(plain.clone(), cc("Sure! Here are a few options..."));
+        cache.put(plain.clone(), cacheable("Sure! Here are a few options..."));
 
         let json = key_under("same prompt", |p| p.json_object = true);
 
@@ -540,7 +683,7 @@ mod tests {
         let mut cache = ResponseCache::new(10, Duration::from_secs(60));
 
         let stops_at_eos = key("same prompt");
-        cache.put(stops_at_eos.clone(), cc("short"));
+        cache.put(stops_at_eos.clone(), cacheable("short"));
 
         let runs_on = key_under("same prompt", |p| p.ignore_eos = true);
 
@@ -556,7 +699,7 @@ mod tests {
     #[test]
     fn expired_entry_is_a_miss_and_is_evicted() {
         let mut cache = ResponseCache::new(10, Duration::from_millis(10));
-        cache.put(key("hello"), cc("world"));
+        cache.put(key("hello"), cacheable("world"));
         std::thread::sleep(Duration::from_millis(30));
         assert_eq!(
             cache.get(&key("hello")),
@@ -573,11 +716,11 @@ mod tests {
     #[test]
     fn evicts_least_recently_used_entry_when_full() {
         let mut cache = ResponseCache::new(2, Duration::from_secs(60));
-        cache.put(key("a"), cc("1"));
-        cache.put(key("b"), cc("2"));
+        cache.put(key("a"), cacheable("1"));
+        cache.put(key("b"), cacheable("2"));
         // touch "a" so "b" becomes the least-recently-used entry
         assert_eq!(cache.get(&key("a")), Some(cc("1")));
-        cache.put(key("c"), cc("3"));
+        cache.put(key("c"), cacheable("3"));
 
         assert_eq!(
             cache.get(&key("b")),
@@ -599,9 +742,9 @@ mod tests {
     #[test]
     fn putting_an_existing_key_again_does_not_grow_past_capacity() {
         let mut cache = ResponseCache::new(2, Duration::from_secs(60));
-        cache.put(key("a"), cc("1"));
-        cache.put(key("b"), cc("2"));
-        cache.put(key("a"), cc("1-updated")); // re-insert, should replace, not evict
+        cache.put(key("a"), cacheable("1"));
+        cache.put(key("b"), cacheable("2"));
+        cache.put(key("a"), cacheable("1-updated")); // re-insert, should replace, not evict
         assert_eq!(cache.stats().entries, 2);
         assert_eq!(cache.get(&key("a")), Some(cc("1-updated")));
         assert_eq!(


### PR DESCRIPTION
Closes #57

## What was wrong

`chat_completions_full` cached whatever `decode_task::buffered` returned,
including a `FinishReason::Cancelled` partial. Client A cancels a greedy
request after five tokens; client B sends the identical body, never
cancels, and is served A's five tokens with `ferrox_cache: "hit"` and
`finish_reason: "cancelled"`.

It was unreachable, and only by an accident nothing stated:
`chat_completions_full` is the only handler that touches the cache and it
happens not to register a cancel token, while the handlers that do
register one (`chat_completions_stream`, `completion/mod.rs`,
`responses.rs`, `anthropic.rs`) happen not to cache. The correctness of
the cache rested on a fact about a different function. Two structures
that must agree about one thing, with nothing enforcing it.

## What changed

Not `if cancelled { return }` at the call site -- the next caller does
not have that. The call site can no longer express the alternative:

- **`FinishReason::completed() -> Option<Completed>`** (`generate.rs`).
  `Completed` is a unit struct whose field is private to the `generate`
  module, so no other module can build one. The match is exhaustive with
  no `_` arm: a variant added to `FinishReason` later stops the crate
  compiling *there*, next to the enum, rather than defaulting to
  whichever side of the question its author never considered.
- **`ResponseCache::put` takes `CacheableCompletion`**
  (`response_cache.rs`), whose field is private to that module and whose
  only constructor is `CachedCompletion::cacheable`, which obtains a
  `Completed` from *this* completion's own finish reason or returns
  `None`.

`Length` is on the completed side deliberately: `max_tokens` is part of
the cache key, so an answer truncated at the budget is only ever replayed
under the budget that produced it. `Cancelled` is the whole of the other
side.

## What now fails to compile

Verified by temporarily adding each to `lib.rs`:

```
cache.put(key, partial);
// error[E0308]: expected `CacheableCompletion`, found `CachedCompletion`

cache.put(key, response_cache::CacheableCompletion { completion: partial });
// error[E0451]: field `completion` of struct
//               `response_cache::CacheableCompletion` is private
```

There is no boolean beside the data that a caller can forget to read,
and no argument a caller can pass instead. A future handler that wires
cancellation into the buffered chat route inherits the guard without
knowing it exists.

## Evidence

Every new test sabotaged once and confirmed red.

- `a_cancelled_partial_is_not_served_to_a_later_identical_request` drives
  #57's two clients through a miniature of the handler's miss branch and
  asserts on **the answer client B is served**, not on `stats()`. Under
  `Cancelled => Some(Completed(()))` it fails showing B handed
  `"The capital of"` with `finish: Cancelled` -- the bug, verbatim.
- `a_completed_answer_is_still_served_to_a_later_identical_request` is
  the other half, because a guard that refuses everything reads as
  coverage while quietly switching the cache off. Under every variant
  returning `None` it fails.
- `only_a_generation_that_reached_an_end_of_its_own_counts_as_completed`
  puts the per-variant verdict on the record beside the enum.

Gates: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy
--workspace --all-targets -- -D warnings`, the same `--release`, and
`cargo fmt --all` all pass.

## The lib.rs delta

The minimum the change forces, two hunks:

1. The `put` call site: `if let Some(key)` becomes a nested match so a
   cacheable key with an incomplete answer stores nothing. Nothing is
   cloned unless there is a key to store under, as before.
2. The `ferrox_cache` doc comment: `"skip"` now also covers "the answer
   was not complete", not only "the request was not cacheable".

## What would have to be true for this to be wrong

That `FinishReason::Length` is not a complete answer -- it is, because
`max_tokens` is in the cache key -- or that a cancelled generation's
tokens are a legitimate answer to some *other* request, which is the
thing the issue exists to deny.

## Not done

`chat_completions_full` still registers no cancel token; wiring
cancellation into the buffered chat route is a separate feature. This
change is what makes it safe to add. No docs were touched (another agent
owns `docs/`); nothing in `policy/`, `tool_grammar.rs`,
`sampling_knobs.rs`, `ferrox-cli` or `ferrox-metal` was touched. No
benchmarks were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
