### PR TITLE
fix(sampling): the penalty window sees the prompt, and one type decides it

### DIFF
--- a/crates/ferrox-cli/src/run.rs
+++ b/crates/ferrox-cli/src/run.rs
@@ -12,7 +12,7 @@ use ferrox_gguf::ShardedGguf;
 use ferrox_models::{
     ensure_generic_decoder, load_gemma4_engine_from_path, load_glm52_engine_from_path,
     load_mla_engine_from_path, select_engine_kind, Decoder, Engine, GgufBpeTokenizer,
-    GgufSpmTokenizer, GgufUnigramTokenizer, ModelConfig, Sampler, SamplingParams,
+    GgufSpmTokenizer, GgufUnigramTokenizer, ModelConfig, PenaltyWindow, Sampler, SamplingParams,
     SelectedEngineKind, ServedEngine,
 };
 
@@ -332,14 +332,20 @@ impl TokenStep {
     /// `Ok(None)` means the grammar is SATISFIED and has no legal
     /// continuation -- a finished answer, not a failure. An unsatisfied
     /// dead end is the `Err`.
+    ///
+    /// `history` is a [`PenaltyWindow`], not the generated tokens: the
+    /// penalties look back over the PROMPT as well, which is what
+    /// llama.cpp does (see `ferrox_models::penalty_window`). Passing a
+    /// slice here is what let these four loops disagree with
+    /// `speculative` about the same flags.
     pub fn next(
         &mut self,
         logits: &[f32],
         sampling: &ferrox_models::sampling::SamplingParams,
-        generated: &[usize],
+        history: PenaltyWindow<'_>,
     ) -> anyhow::Result<Option<usize>> {
         let Some(grammar) = self.grammar.as_mut() else {
-            return Ok(Some(self.sampler.sample(logits, sampling, generated)));
+            return Ok(Some(self.sampler.sample(logits, sampling, history)));
         };
         let mut refusal = None;
         let mut outcome = ferrox_models::grammar_sampler::MaskOutcome::Allowed;
@@ -350,7 +356,7 @@ impl TokenStep {
                 Err(e) => refusal = Some(e),
             };
             self.sampler
-                .sample_with_mask(logits, sampling, generated, Some(&mut mask))
+                .sample_with_mask(logits, sampling, history, Some(&mut mask))
         };
         if let Some(e) = refusal {
             anyhow::bail!("grammar refused every continuation: {e}");
@@ -1305,7 +1311,8 @@ pub fn run_infer(args: InferArgs) -> anyhow::Result<()> {
     let mut stdout = io::stdout().lock();
     let decode_t = Instant::now();
     for _ in 0..max_new {
-        let Some(next) = step.next(&logits, &sampling, &generated)? else {
+        let Some(next) = step.next(&logits, &sampling, PenaltyWindow::new(&tokens, &generated))?
+        else {
             // The grammar is satisfied and permits nothing further: a
             // finished answer, not a failure.
             break;
@@ -1435,7 +1442,8 @@ fn run_mla_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow::Re
     let mut stdout = io::stdout().lock();
     let decode_t = Instant::now();
     for _ in 0..max_new {
-        let Some(next) = step.next(&logits, &sampling, &generated)? else {
+        let Some(next) = step.next(&logits, &sampling, PenaltyWindow::new(&tokens, &generated))?
+        else {
             // The grammar is satisfied and permits nothing further: a
             // finished answer, not a failure.
             break;
@@ -1565,7 +1573,8 @@ fn run_gemma4_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow:
     let mut stdout = io::stdout().lock();
     let decode_t = Instant::now();
     for _ in 0..max_new {
-        let Some(next) = step.next(&logits, &sampling, &generated)? else {
+        let Some(next) = step.next(&logits, &sampling, PenaltyWindow::new(&tokens, &generated))?
+        else {
             // The grammar is satisfied and permits nothing further: a
             // finished answer, not a failure.
             break;
@@ -1694,7 +1703,8 @@ fn run_glm52_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow::
     let mut stdout = io::stdout().lock();
     let decode_t = Instant::now();
     for _ in 0..max_new {
-        let Some(next) = step.next(&logits, &sampling, &generated)? else {
+        let Some(next) = step.next(&logits, &sampling, PenaltyWindow::new(&tokens, &generated))?
+        else {
             // The grammar is satisfied and permits nothing further: a
             // finished answer, not a failure.
             break;
@@ -1841,12 +1851,6 @@ fn run_infer_speculative(
             start_pos: 0,
             sampling: sampling.clone(),
             seed,
-            // Match the ordinary decode loop, which penalises over the
-            // generated tokens only. A draft model must not change the
-            // output, and at the default --repeat-penalty 1.1 a
-            // different penalty window changes it on the first repeated
-            // token: verified by running the same prompt both ways.
-            penalty_history_start: tokens.len(),
         },
     );
     if let Some(e) = write_err {

--- a/crates/ferrox-models/src/draft_model.rs
+++ b/crates/ferrox-models/src/draft_model.rs
@@ -50,6 +50,7 @@
 
 use crate::config::ModelConfig;
 use crate::decoder::Decoder;
+use crate::penalty_window::PenaltyWindow;
 use crate::sampling::{sampling_distribution, Sampler, SamplingParams};
 use crate::speculative::{DraftBlock, DraftDist, Drafter};
 use ferrox_core::cache::KvCache;
@@ -232,12 +233,19 @@ impl Drafter for DraftModelSpeculator {
 
         let mut tokens = Vec::with_capacity(budget);
         let mut dists = Vec::with_capacity(budget);
-        // The drafter's own view of the sequence, so its penalties see
-        // the tokens it has already proposed in this block.
-        let mut local: Vec<usize> = history.to_vec();
 
         for _ in 0..budget {
-            let probs = sampling_distribution(&logits, &self.sampling, &local);
+            // `history` is everything the target has committed --
+            // prompt included -- and `tokens` is what this block has
+            // proposed on top of it, so the drafter's penalties see the
+            // same sequence the target's would. The block used to clone
+            // `history` per call to concatenate the two; the window
+            // borrows both halves instead.
+            let probs = sampling_distribution(
+                &logits,
+                &self.sampling,
+                PenaltyWindow::new(history, &tokens),
+            );
             let token = self.rng.sample_from(&probs);
 
             // `q` MUST be the distribution this token was actually
@@ -254,7 +262,6 @@ impl Drafter for DraftModelSpeculator {
 
             tokens.push(token);
             dists.push(dist);
-            local.push(token);
 
             let pos = self.synced;
             logits = self.decoder.forward_token(token, pos, &mut self.kv_caches);

--- a/crates/ferrox-models/src/kimi_generate.rs
+++ b/crates/ferrox-models/src/kimi_generate.rs
@@ -13,6 +13,7 @@ use crate::kimi_decoder::{
     kimi_forward_token, KimiDecodeState, KimiDecoderConfig, KimiDecoderWeights,
 };
 use crate::kimi_tokenizer::KimiTokenizer;
+use crate::penalty_window::PenaltyWindow;
 use crate::sampling::{Sampler, SamplingParams};
 
 /// Encodes `prompt`, runs it through the decoder to prime `KimiDecodeState`,
@@ -39,22 +40,30 @@ pub fn kimi_generate(
     let prompt_ids = tokenizer.encode(prompt);
     let mut state = KimiDecodeState::new(weights, kda_cfg);
     let mut sampler = Sampler::new(seed);
-    let mut history: Vec<usize> = Vec::with_capacity(prompt_ids.len() + max_new_tokens);
+    // The two halves of the penalty window, kept apart because that is
+    // what `PenaltyWindow` is built from. The prompt half is what
+    // llama.cpp seeds its sampler with before the first draw.
+    let mut prompt_history: Vec<usize> = Vec::with_capacity(prompt_ids.len());
+    let mut generated_history: Vec<usize> = Vec::with_capacity(max_new_tokens);
 
     let mut logits = vec![0.0f32; weights.output_head.rows()];
     for &tok in &prompt_ids {
         logits = kimi_forward_token(weights, cfg, mla_cfg, kda_cfg, tok as usize, &mut state);
-        history.push(tok as usize);
+        prompt_history.push(tok as usize);
     }
 
     let mut generated_ids = Vec::with_capacity(max_new_tokens);
     for _ in 0..max_new_tokens {
-        let next = sampler.sample(&logits, sampling, &history) as u32;
+        let next = sampler.sample(
+            &logits,
+            sampling,
+            PenaltyWindow::new(&prompt_history, &generated_history),
+        ) as u32;
         if Some(next) == eos_id {
             break;
         }
         generated_ids.push(next);
-        history.push(next as usize);
+        generated_history.push(next as usize);
         logits = kimi_forward_token(weights, cfg, mla_cfg, kda_cfg, next as usize, &mut state);
     }
 

--- a/crates/ferrox-models/src/lib.rs
+++ b/crates/ferrox-models/src/lib.rs
@@ -54,6 +54,7 @@ pub mod mla;
 pub mod mla_gguf_loader;
 pub mod mmproj;
 pub mod output_projection;
+pub mod penalty_window;
 pub mod pooling;
 pub mod prefix_cache;
 pub mod rank_head;
@@ -97,6 +98,7 @@ pub use kv_budget::{
 };
 pub use loader::LoadError;
 pub use output_projection::grouped_output_projection;
+pub use penalty_window::PenaltyWindow;
 pub use pooling::{l2_normalize, pool, PoolingError, PoolingType};
 pub use prefix_cache::{PrefixCache, PrefixCacheStats, PrefixMatch};
 pub use rank_head::{load_rank_head, RankHead};

--- a/crates/ferrox-models/src/penalty_window.rs
+++ b/crates/ferrox-models/src/penalty_window.rs
@@ -38,7 +38,8 @@
 //!
 //! Because it was a slice, and five call sites each chose their own.
 //! `ferrox run`'s decode loops passed the generated tokens; the server's
-//! two decode loops passed the generated tokens; `speculative` passed
+//! two decode loops passed the generated tokens (still do -- issue #73,
+//! the prompt ids do not reach that seam); `speculative` passed
 //! the prompt as well and then grew a `penalty_history_start` knob to
 //! paper over the disagreement; `draft_model` cloned the whole history
 //! per block; `kimi_generate` passed prompt and generated and was the

--- a/crates/ferrox-models/src/penalty_window.rs
+++ b/crates/ferrox-models/src/penalty_window.rs
@@ -1,0 +1,158 @@
+//! The one place that decides which tokens the repetition, presence
+//! and frequency penalties look back over.
+//!
+//! # What llama.cpp does, and where
+//!
+//! llama.cpp's penalties sampler is stateful: it keeps a ring buffer of
+//! the last `penalty_last_n` tokens it has ACCEPTED, plus a count map
+//! over that buffer, and `apply` walks the candidate list looking each
+//! candidate up in the map (`src/llama-sampler.cpp:2698-2759`). Nothing
+//! about that buffer knows whether a token was generated or read out of
+//! the prompt -- only that the sampler was told about it.
+//!
+//! Both front ends tell it about the prompt.
+//!
+//! - `llama-server` seeds the sampler with every prompt token before
+//!   the first token is drawn
+//!   (`tools/server/server-context.cpp:375-397`, the loop at 386-390:
+//!   `for (int i = 0; i < prompt.tokens.size(); i++) { ...
+//!   common_sampler_accept(smpl.get(), id, false); }`).
+//! - `llama-cli` does the same as it consumes the prompt, with the
+//!   reason written on the line above
+//!   (`tools/completion/completion.cpp:730-736`: *"push the prompt in
+//!   the sampling context in order to apply repetition penalties
+//!   later"*, `common_sampler_accept(smpl, embd_inp[n_consumed],
+//!   /* accept_grammar= */ false)`).
+//!
+//! `common_sampler_accept` pushes into the chain unconditionally
+//! (`common/sampling.cpp:472-504`), so a prompt token lands in the
+//! penalties ring buffer exactly like a generated one.
+//!
+//! So llama.cpp's window is the last `penalty_last_n` tokens of
+//! `prompt ++ generated`, and ferrox matches that. **This changes
+//! output** relative to ferrox before this module existed, on every run
+//! at the default `--repeat-penalty 1.1`: a token that occurs in the
+//! prompt is now penalised on its first generated occurrence.
+//!
+//! # Why it is a type and not a slice
+//!
+//! Because it was a slice, and five call sites each chose their own.
+//! `ferrox run`'s decode loops passed the generated tokens; the server's
+//! two decode loops passed the generated tokens; `speculative` passed
+//! the prompt as well and then grew a `penalty_history_start` knob to
+//! paper over the disagreement; `draft_model` cloned the whole history
+//! per block; `kimi_generate` passed prompt and generated and was the
+//! only one that matched llama.cpp. Five sites, four answers, nothing
+//! enforcing agreement -- this repo's dominant bug shape.
+//!
+//! A [`PenaltyWindow`] is built from BOTH halves and there is no
+//! constructor that takes one slice, so a caller cannot produce a window
+//! without saying what its prompt is. A caller that genuinely has none
+//! writes `&[]` and that is visible in the diff.
+
+/// The tokens the penalties may see: a prompt and the tokens generated
+/// after it, in that order.
+///
+/// Borrowed rather than owned because this is built once per sampled
+/// token on every decode loop in the workspace; an owning window would
+/// clone the whole sequence per token.
+///
+/// The two halves are kept separate rather than concatenated because a
+/// decode loop already holds them separately, and concatenating would
+/// mean an allocation per token for a value only ever read back as "the
+/// last N of the two".
+#[derive(Debug, Clone, Copy)]
+pub struct PenaltyWindow<'a> {
+    prompt: &'a [usize],
+    generated: &'a [usize],
+}
+
+impl<'a> PenaltyWindow<'a> {
+    /// The window over `prompt` followed by `generated`.
+    ///
+    /// `prompt` is the tokens the model was fed before generation
+    /// started, and it belongs in the window: see the module docs for
+    /// the llama.cpp lines that put it there.
+    pub fn new(prompt: &'a [usize], generated: &'a [usize]) -> Self {
+        PenaltyWindow { prompt, generated }
+    }
+
+    /// Total tokens in the sequence, before `penalty_last_n` truncates
+    /// it.
+    pub fn len(&self) -> usize {
+        self.prompt.len() + self.generated.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The most recent `last_n` tokens of `prompt ++ generated`, oldest
+    /// first.
+    ///
+    /// This is llama.cpp's ring buffer expressed as a view: the buffer
+    /// holds at most `penalty_last_n` entries and the oldest is dropped
+    /// on every accept (`src/llama-sampler.cpp:2707-2716`), so its
+    /// contents are exactly the tail of the accepted sequence.
+    ///
+    /// Order does not matter to any caller -- only the multiset does --
+    /// but it is the natural one anyway, and a test reads it.
+    pub fn recent(&self, last_n: usize) -> impl Iterator<Item = usize> + '_ {
+        let start = self.len().saturating_sub(last_n);
+        // Split the single cut point across the two halves. `start` is
+        // at most `len()`, so both indices are in range and neither
+        // subtraction can wrap.
+        let from_prompt = start.min(self.prompt.len());
+        let from_generated = start.saturating_sub(self.prompt.len());
+        self.prompt[from_prompt..]
+            .iter()
+            .chain(self.generated[from_generated..].iter())
+            .copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The window is the tail of `prompt ++ generated`, so it slides
+    /// across the seam between them rather than restarting at it.
+    ///
+    /// A window implemented as "the last N of `generated`, plus all of
+    /// `prompt`" would keep token 0 here, and a window implemented as
+    /// "the last N of `generated`" would keep neither prompt token.
+    /// llama.cpp's ring buffer keeps exactly the last N accepted tokens
+    /// whichever half they came from.
+    #[test]
+    fn the_window_is_the_tail_of_the_prompt_and_the_generation_together() {
+        let window = PenaltyWindow::new(&[0, 1, 2], &[3, 4]);
+        assert_eq!(window.len(), 5);
+        assert_eq!(window.recent(3).collect::<Vec<_>>(), vec![2, 3, 4]);
+        // The cut can land inside the prompt, inside the generation, or
+        // exactly on the seam.
+        assert_eq!(window.recent(4).collect::<Vec<_>>(), vec![1, 2, 3, 4]);
+        assert_eq!(window.recent(2).collect::<Vec<_>>(), vec![3, 4]);
+        // Wider than the sequence is the whole sequence, not a panic.
+        assert_eq!(window.recent(1000).collect::<Vec<_>>(), vec![0, 1, 2, 3, 4]);
+        assert_eq!(window.recent(0).count(), 0);
+    }
+
+    /// Nothing generated yet is still a non-empty window, which is the
+    /// whole point: the first sampled token is already penalised
+    /// against the prompt.
+    #[test]
+    fn a_prompt_alone_is_a_window() {
+        let window = PenaltyWindow::new(&[7, 7, 8], &[]);
+        assert!(!window.is_empty());
+        assert_eq!(window.recent(64).collect::<Vec<_>>(), vec![7, 7, 8]);
+        assert_eq!(window.recent(2).collect::<Vec<_>>(), vec![7, 8]);
+    }
+
+    /// And an empty prompt is not a special case.
+    #[test]
+    fn an_empty_prompt_leaves_the_generated_tail() {
+        let window = PenaltyWindow::new(&[], &[1, 2, 3]);
+        assert_eq!(window.recent(2).collect::<Vec<_>>(), vec![2, 3]);
+        assert!(PenaltyWindow::new(&[], &[]).is_empty());
+    }
+}

--- a/crates/ferrox-models/src/sampling.rs
+++ b/crates/ferrox-models/src/sampling.rs
@@ -14,6 +14,7 @@
 //! dependency tree the same minimal, pure-Rust shape as the rest of
 //! this crate.
 
+use crate::penalty_window::PenaltyWindow;
 use crate::sampler_chain::Candidates;
 
 /// Sampling parameters for one generation request. `temperature <= 0.0`
@@ -42,7 +43,8 @@ pub struct SamplingParams {
     /// Keep only the `top_k` highest-probability tokens before
     /// sampling. 0 disables top-k filtering.
     pub top_k: usize,
-    /// > 1.0 discourages repeating a token already in `history`; 1.0
+    /// > 1.0 discourages repeating a token already in the
+    /// > [`PenaltyWindow`] -- prompt included; 1.0
     /// > disables repetition penalty. Uses the standard convention
     /// > (divide positive logits, multiply negative ones) so the penalty
     /// > always pushes toward *less* likely, regardless of logit sign.
@@ -57,10 +59,12 @@ pub struct SamplingParams {
     /// which is exactly when a repetition penalty matters most.
     pub penalty_last_n: usize,
     /// OpenAI-style presence penalty: subtract from logits of tokens
-    /// that already appeared in `history` (once per distinct token).
+    /// that already appeared in the [`PenaltyWindow`] (once per
+    /// distinct token).
     pub presence_penalty: f32,
     /// OpenAI-style frequency penalty: subtract `frequency_penalty *
-    /// count` from logits for each token id seen in `history`.
+    /// count` from logits for each token id seen in the
+    /// [`PenaltyWindow`].
     pub frequency_penalty: f32,
 }
 
@@ -278,13 +282,22 @@ impl Sampler {
     }
 
     /// Samples one token id from `logits`, given `params` and the
-    /// already-generated `history` (for repetition penalty). Falls back
-    /// to plain greedy argmax when `params.temperature <= 0.0`.
+    /// [`PenaltyWindow`] the penalties look back over. Falls back to
+    /// plain greedy argmax when `params.temperature <= 0.0`.
+    ///
+    /// `history` is a window and not a slice on purpose: it carries the
+    /// PROMPT as well as the generated tokens, which is what llama.cpp
+    /// penalises over. See [`crate::penalty_window`].
     ///
     /// A length-1 `logits` vector is treated as a precomputed greedy token
     /// id (`logits[0] as usize`) — used by the Metal dense-stack path that
     /// returns GPU argmax instead of downloading the full vocab.
-    pub fn sample(&mut self, logits: &[f32], params: &SamplingParams, history: &[usize]) -> usize {
+    pub fn sample(
+        &mut self,
+        logits: &[f32],
+        params: &SamplingParams,
+        history: PenaltyWindow<'_>,
+    ) -> usize {
         self.sample_with_mask(logits, params, history, None)
     }
 
@@ -294,7 +307,7 @@ impl Sampler {
         &mut self,
         logits: &[f32],
         params: &SamplingParams,
-        history: &[usize],
+        history: PenaltyWindow<'_>,
         mut mask: Option<LogitMask<'_>>,
     ) -> usize {
         if params.temperature <= 0.0 && mask.is_none() {
@@ -390,7 +403,7 @@ impl Sampler {
 pub fn sampling_distribution(
     logits: &[f32],
     params: &SamplingParams,
-    history: &[usize],
+    history: PenaltyWindow<'_>,
 ) -> Vec<f32> {
     let mut scores = logits.to_vec();
     apply_history_penalties(&mut scores, params, history);
@@ -448,6 +461,12 @@ fn filtered_distribution(scores: Vec<f32>, params: &SamplingParams) -> Vec<f32> 
 
 /// Penalise tokens that already appear in `history`, once each.
 ///
+/// `history` is a [`PenaltyWindow`], so "already appear" includes the
+/// PROMPT. That is llama.cpp's rule and the module docs of
+/// [`crate::penalty_window`] carry the upstream lines; before it, every
+/// caller in this workspace picked its own slice and four of the five
+/// picked differently.
+///
 /// ONCE EACH is the whole subtlety, and ferrox used to get it wrong.
 /// llama.cpp walks the CANDIDATE list and looks each candidate up in a
 /// count map (`llama-sampler.cpp:2735-2756`), so a token repeated `n`
@@ -462,7 +481,11 @@ fn filtered_distribution(scores: Vec<f32>, params: &SamplingParams) -> Vec<f32> 
 /// The sign convention is llama.cpp's and its comment explains it:
 /// dividing alone would make tokens with NEGATIVE logits more likely,
 /// so negatives are multiplied instead.
-fn apply_history_penalties(scores: &mut [f32], params: &SamplingParams, history: &[usize]) {
+fn apply_history_penalties(
+    scores: &mut [f32],
+    params: &SamplingParams,
+    history: PenaltyWindow<'_>,
+) {
     if params.repetition_penalty == 1.0
         && params.presence_penalty == 0.0
         && params.frequency_penalty == 0.0
@@ -473,9 +496,8 @@ fn apply_history_penalties(scores: &mut [f32], params: &SamplingParams, history:
     if params.penalty_last_n == 0 {
         return;
     }
-    let window = history.len().saturating_sub(params.penalty_last_n);
     let mut counts = std::collections::HashMap::<usize, usize>::new();
-    for &tok in &history[window..] {
+    for tok in history.recent(params.penalty_last_n) {
         *counts.entry(tok).or_insert(0) += 1;
     }
     for (tok, count) in counts {
@@ -507,6 +529,86 @@ fn argmax(logits: &[f32]) -> usize {
 mod tests {
     use super::*;
 
+    /// A token that has only ever appeared in the PROMPT is penalised
+    /// on the very first generated position, and that changes which
+    /// token is sampled.
+    ///
+    /// This is the divergence issue #55 reported. llama.cpp seeds its
+    /// penalties sampler with every prompt token before drawing
+    /// anything (`tools/server/server-context.cpp:386-390`,
+    /// `tools/completion/completion.cpp:730-736`); ferrox's decode
+    /// loops handed the sampler the generated tokens alone, so the same
+    /// checkpoint, flags and prompt could produce different text at the
+    /// default `--repeat-penalty 1.1`.
+    ///
+    /// Asserted on the SAMPLED TOKEN rather than on the window's
+    /// contents: a test that only checked the slice could not tell the
+    /// window being applied to the wrong distribution from the window
+    /// being wrong. Drop `prompt` from `PenaltyWindow::recent` and this
+    /// goes red -- the second assertion returns 0.
+    #[test]
+    fn a_prompt_token_is_penalised_before_it_is_ever_generated() {
+        let params = SamplingParams {
+            // Greedy, so the assertion is on the chosen id and not on a
+            // draw. Everything below is arithmetic, not sampling.
+            temperature: 0.0,
+            repetition_penalty: 1.1,
+            ..SamplingParams::default()
+        };
+        // Token 0 leads token 1 by less than the 1.1 penalty: 4.0 / 1.1
+        // = 3.636, which is below 3.9.
+        let logits = vec![4.0f32, 3.9];
+        let mut sampler = Sampler::new(1);
+
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            0,
+            "with nothing behind it the argmax wins"
+        );
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[0], &[])),
+            1,
+            "token 0 is in the prompt, so llama.cpp penalises it here"
+        );
+        // And a window that reaches back past the prompt is the same
+        // answer, which is what makes the two halves one sequence.
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[9, 0], &[8])),
+            1
+        );
+    }
+
+    /// `penalty_last_n` counts across the prompt/generated seam, so a
+    /// prompt token falls OUT of the window once enough tokens have
+    /// been generated after it -- and the sampled token moves back.
+    ///
+    /// A window that added the whole prompt to the last N generated
+    /// tokens would keep penalising token 0 forever and this would stay
+    /// at 1.
+    #[test]
+    fn a_prompt_token_leaves_the_window_once_the_generation_outgrows_it() {
+        let params = SamplingParams {
+            temperature: 0.0,
+            repetition_penalty: 1.1,
+            penalty_last_n: 2,
+            ..SamplingParams::default()
+        };
+        let logits = vec![4.0f32, 3.9];
+        let mut sampler = Sampler::new(1);
+
+        // Prompt token 0, one token generated: the window is [0, 5] and
+        // token 0 is still penalised.
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[0], &[5])),
+            1
+        );
+        // Two generated: the window is [5, 6] and token 0 is clear.
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[0], &[5, 6])),
+            0
+        );
+    }
+
     /// The repetition penalty is applied ONCE per token, however many
     /// times that token appears in the history.
     ///
@@ -534,7 +636,11 @@ mod tests {
         // Token 0 appears five times. Penalised once, its score is 2.0;
         // compounded it would be 4 / 2^5 = 0.125.
         let mut scores = logits.clone();
-        apply_history_penalties(&mut scores, &params, &[0, 0, 0, 0, 0]);
+        apply_history_penalties(
+            &mut scores,
+            &params,
+            PenaltyWindow::new(&[], &[0, 0, 0, 0, 0]),
+        );
         assert!(
             (scores[0] - 2.0).abs() < 1e-6,
             "expected one division (2.0), got {} -- {} would be 2^5",
@@ -545,13 +651,13 @@ mod tests {
         // And once really is once: one occurrence and five occurrences
         // must land on the same score, or the count still leaks in.
         let mut once = logits.clone();
-        apply_history_penalties(&mut once, &params, &[0]);
+        apply_history_penalties(&mut once, &params, PenaltyWindow::new(&[], &[0]));
         assert_eq!(once[0].to_bits(), scores[0].to_bits());
 
         // A NEGATIVE logit is multiplied rather than divided, or the
         // penalty would make it more likely -- llama.cpp's own comment.
         let mut negative = vec![-4.0f32];
-        apply_history_penalties(&mut negative, &params, &[0, 0, 0]);
+        apply_history_penalties(&mut negative, &params, PenaltyWindow::new(&[], &[0, 0, 0]));
         assert!((negative[0] + 8.0).abs() < 1e-6, "got {}", negative[0]);
     }
 
@@ -573,7 +679,7 @@ mod tests {
         };
         let mut scores = vec![8.0f32, 8.0, 8.0];
         // Token 0 fell out of the window; tokens 1 and 2 are in it.
-        apply_history_penalties(&mut scores, &params, &[0, 1, 2]);
+        apply_history_penalties(&mut scores, &params, PenaltyWindow::new(&[], &[0, 1, 2]));
         assert_eq!(
             scores[0].to_bits(),
             8.0f32.to_bits(),
@@ -588,7 +694,7 @@ mod tests {
             ..params
         };
         let mut untouched = vec![8.0f32; 3];
-        apply_history_penalties(&mut untouched, &off, &[0, 1, 2]);
+        apply_history_penalties(&mut untouched, &off, PenaltyWindow::new(&[], &[0, 1, 2]));
         assert_eq!(untouched, vec![8.0f32; 3]);
 
         // A window longer than the history is not an overflow.
@@ -597,7 +703,7 @@ mod tests {
             ..params
         };
         let mut short = vec![8.0f32];
-        apply_history_penalties(&mut short, &wide, &[0]);
+        apply_history_penalties(&mut short, &wide, PenaltyWindow::new(&[], &[0]));
         assert!((short[0] - 4.0).abs() < 1e-6);
     }
 
@@ -614,7 +720,7 @@ mod tests {
             ..SamplingParams::default()
         };
         let mut scores = vec![10.0f32];
-        apply_history_penalties(&mut scores, &params, &[0, 0, 0, 0]);
+        apply_history_penalties(&mut scores, &params, PenaltyWindow::new(&[], &[0, 0, 0, 0]));
         // 10 - 0.5*4 - 0.25 = 7.75
         assert!((scores[0] - 7.75).abs() < 1e-6, "got {}", scores[0]);
     }
@@ -638,7 +744,7 @@ mod tests {
                 top_k: 0,
                 ..SamplingParams::default()
             };
-            sampling_distribution(&logits, &params, &[])
+            sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]))
                 .iter()
                 .map(|&p| p > 0.0)
                 .collect()
@@ -678,7 +784,7 @@ mod tests {
             min_p: 0.2,
             ..SamplingParams::default()
         };
-        let probs = sampling_distribution(&logits, &params, &[]);
+        let probs = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]));
         assert!(probs[0] > 0.0 && probs[1] > 0.0);
         assert_eq!(probs[2], 0.0, "2.0 is below 4 + ln(0.2) = 2.3905");
         assert_eq!(probs[3], 0.0);
@@ -694,7 +800,7 @@ mod tests {
             min_p: 0.0,
             ..params.clone()
         };
-        let unfiltered = sampling_distribution(&logits, &off, &[]);
+        let unfiltered = sampling_distribution(&logits, &off, PenaltyWindow::new(&[], &[]));
         assert!(unfiltered.iter().all(|&p| p > 0.0));
     }
 
@@ -720,7 +826,7 @@ mod tests {
                 min_p: 0.2,
                 ..SamplingParams::default()
             };
-            sampling_distribution(&logits, &params, &[])
+            sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]))
                 .iter()
                 .map(|&p| p > 0.0)
                 .collect()
@@ -753,7 +859,7 @@ mod tests {
             min_p: 0.2,
             ..SamplingParams::default()
         };
-        let probs = sampling_distribution(&logits, &params, &[]);
+        let probs = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]));
         assert_eq!(
             probs.iter().map(|&p| p > 0.0).collect::<Vec<_>>(),
             vec![true, true, false, false]
@@ -768,7 +874,7 @@ mod tests {
             ..params.clone()
         };
         assert_eq!(
-            sampling_distribution(&logits, &top_p_only, &[])
+            sampling_distribution(&logits, &top_p_only, PenaltyWindow::new(&[], &[]))
                 .iter()
                 .filter(|&&p| p > 0.0)
                 .count(),
@@ -780,14 +886,20 @@ mod tests {
     fn temperature_zero_accepts_precomputed_argmax_singleton() {
         let mut sampler = Sampler::new(1);
         let params = SamplingParams::default();
-        assert_eq!(sampler.sample(&[42.0], &params, &[]), 42);
+        assert_eq!(
+            sampler.sample(&[42.0], &params, PenaltyWindow::new(&[], &[])),
+            42
+        );
         // Non-greedy must not treat a singleton as a token id.
         let sampled = SamplingParams {
             temperature: 0.8,
             ..SamplingParams::default()
         };
         // Softmax of a single logit → only token 0 is eligible.
-        assert_eq!(sampler.sample(&[42.0], &sampled, &[]), 0);
+        assert_eq!(
+            sampler.sample(&[42.0], &sampled, PenaltyWindow::new(&[], &[])),
+            0
+        );
     }
 
     #[test]
@@ -795,9 +907,15 @@ mod tests {
         let logits = vec![0.1, 0.9, 0.3, -0.2];
         let params = SamplingParams::default();
         let mut sampler = Sampler::new(42);
-        assert_eq!(sampler.sample(&logits, &params, &[]), 1);
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            1
+        );
         // Must be deterministic regardless of RNG state advancing.
-        assert_eq!(sampler.sample(&logits, &params, &[]), 1);
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            1
+        );
     }
 
     #[test]
@@ -810,7 +928,7 @@ mod tests {
         let mut sampler = Sampler::new(7);
         let mut seen = std::collections::HashSet::new();
         for _ in 0..200 {
-            seen.insert(sampler.sample(&logits, &params, &[]));
+            seen.insert(sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])));
         }
         assert!(
             seen.len() > 1,
@@ -828,7 +946,10 @@ mod tests {
         };
         let mut sampler = Sampler::new(123);
         for _ in 0..20 {
-            assert_eq!(sampler.sample(&logits, &params, &[]), 1);
+            assert_eq!(
+                sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+                1
+            );
         }
     }
 
@@ -842,7 +963,10 @@ mod tests {
         };
         let mut sampler = Sampler::new(9);
         for _ in 0..20 {
-            assert_eq!(sampler.sample(&logits, &params, &[]), 1);
+            assert_eq!(
+                sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+                1
+            );
         }
     }
 
@@ -858,7 +982,7 @@ mod tests {
         let mut sampler = Sampler::new(1);
         let mut counts = [0usize; 3];
         for _ in 0..500 {
-            counts[sampler.sample(&logits, &params, &[1])] += 1;
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1]))] += 1;
         }
         assert!(
             counts[1] < 250,
@@ -874,7 +998,7 @@ mod tests {
         let mut sampler = Sampler::new(2);
         counts = [0; 3];
         for _ in 0..500 {
-            counts[sampler.sample(&logits, &params, &[1, 1, 1])] += 1;
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1, 1, 1]))] += 1;
         }
         assert!(
             counts[1] < 250,
@@ -893,7 +1017,7 @@ mod tests {
         let mut sampler = Sampler::new(3);
         let mut counts = [0usize; 3];
         for _ in 0..500 {
-            counts[sampler.sample(&logits, &params, &[1])] += 1;
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1]))] += 1;
         }
         assert!(
             counts[1] < 250,
@@ -919,7 +1043,7 @@ mod tests {
         let seeds = 4_000u64;
         let mut counts = vec![0usize; vocab];
         for seed in 1..=seeds {
-            counts[Sampler::new(seed).sample(&logits, &params, &[])] += 1;
+            counts[Sampler::new(seed).sample(&logits, &params, PenaltyWindow::new(&[], &[]))] += 1;
         }
         let expected = seeds as f64 / vocab as f64;
         for (token, &c) in counts.iter().enumerate() {
@@ -948,14 +1072,14 @@ mod tests {
             ..SamplingParams::default()
         };
         let history = [1usize, 4];
-        let claimed = sampling_distribution(&logits, &params, &history);
+        let claimed = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &history));
         assert!((claimed.iter().sum::<f32>() - 1.0).abs() < 1e-5);
 
         let draws = 100_000;
         let mut counts = vec![0usize; logits.len()];
         let mut sampler = Sampler::new(0xC0FFEE);
         for _ in 0..draws {
-            counts[sampler.sample(&logits, &params, &history)] += 1;
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &history))] += 1;
         }
         for (i, &c) in counts.iter().enumerate() {
             let empirical = c as f64 / draws as f64;
@@ -971,7 +1095,11 @@ mod tests {
     #[test]
     fn greedy_is_published_as_a_point_mass_not_a_special_case() {
         let logits = vec![0.1, 0.9, 0.3, -0.2];
-        let probs = sampling_distribution(&logits, &SamplingParams::default(), &[]);
+        let probs = sampling_distribution(
+            &logits,
+            &SamplingParams::default(),
+            PenaltyWindow::new(&[], &[]),
+        );
         assert_eq!(probs, vec![0.0, 1.0, 0.0, 0.0]);
         // Penalties still apply at temperature 0, so the point mass
         // moves with them.
@@ -981,7 +1109,7 @@ mod tests {
                 repetition_penalty: 100.0,
                 ..SamplingParams::default()
             },
-            &[1],
+            PenaltyWindow::new(&[], &[1]),
         );
         assert_eq!(penalized[1], 0.0);
         assert_eq!(penalized.iter().sum::<f32>(), 1.0);
@@ -1000,7 +1128,10 @@ mod tests {
             ..SamplingParams::default()
         };
         let mut sampler = Sampler::new(1);
-        assert_eq!(sampler.sample(&logits, &params, &[]), 1);
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            1
+        );
     }
 
     /// Only the keys the file actually carries become a recommendation.

--- a/crates/ferrox-models/src/speculative.rs
+++ b/crates/ferrox-models/src/speculative.rs
@@ -51,6 +51,7 @@
 //! temperature 0.
 
 use crate::decoder::Decoder;
+use crate::penalty_window::PenaltyWindow;
 use crate::sampling::{sampling_distribution, Sampler, SamplingParams};
 use ferrox_core::cache::KvCache;
 
@@ -346,23 +347,6 @@ pub struct SpeculativeOptions {
     /// exactly these parameters (see [`accept_or_resample`]).
     pub sampling: SamplingParams,
     pub seed: u64,
-    /// Index into the history at which the repetition / presence /
-    /// frequency penalty window starts.
-    ///
-    /// `0` penalises over the prompt as well, which is what
-    /// llama-server does (it seeds the sampler with the prompt tokens).
-    /// `prompt_tokens.len()` penalises over the generated tokens only,
-    /// which is what `ferrox run`'s ordinary decode loop does.
-    ///
-    /// This is a knob because the two ferrox paths currently disagree,
-    /// and a caller must be able to make speculation match whichever
-    /// path it is standing in for. Speculation that changes the output
-    /// at default settings is not speculation, it is a different
-    /// decoder: the whole promise is that the text is what the target
-    /// would have written alone. The underlying divergence from
-    /// llama.cpp is tracked separately and is not this option's job to
-    /// decide.
-    pub penalty_history_start: usize,
 }
 
 /// Result of a speculative decode run, with the counters that make its
@@ -471,16 +455,6 @@ impl SpeculativeDecodeResult {
             self.accepted_tokens += 1;
         }
     }
-}
-
-/// The slice of history the penalties see, per
-/// [`SpeculativeOptions::penalty_history_start`].
-///
-/// Clamped rather than indexed directly: a caller that passes a start
-/// past the current history (a warm cache resumed oddly, say) should
-/// get an empty window, not a panic mid-generation.
-fn penalty_window<'a>(history: &'a [usize], options: &SpeculativeOptions) -> &'a [usize] {
-    &history[options.penalty_history_start.min(history.len())..]
 }
 
 /// Greedy speculative decode over a **fresh** KV cache, with
@@ -602,8 +576,16 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
     // fed as the anchor of the next batch, which is what lets one
     // forward call both commit it and verify a block after it.
     let mut pending = {
-        let probs =
-            sampling_distribution(last, &options.sampling, penalty_window(&history, options));
+        // Split ONE structure rather than pairing `history` with the
+        // separate `generated` vector: the two would then have to agree
+        // about every push, which is exactly the shape this fix exists
+        // to remove.
+        let (seen_prompt, seen_generated) = history.split_at(prompt_tokens.len());
+        let probs = sampling_distribution(
+            last,
+            &options.sampling,
+            PenaltyWindow::new(seen_prompt, seen_generated),
+        );
         rng.sample_from(&probs)
     };
     let mut pos = options.start_pos + prompt_tokens.len();
@@ -653,10 +635,11 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
         let mut accepted = 0usize;
         let mut replacement: Option<usize> = None;
         for (i, (&token, dist)) in draft.tokens().iter().zip(draft.dists()).enumerate() {
+            let (seen_prompt, seen_generated) = history.split_at(prompt_tokens.len());
             let target = sampling_distribution(
                 &batch_logits[i],
                 &options.sampling,
-                penalty_window(&history, options),
+                PenaltyWindow::new(seen_prompt, seen_generated),
             );
             match accept_or_resample(&target, dist, token, &mut rng) {
                 None => {
@@ -701,10 +684,11 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
             // batch predicts a genuinely new position -- the free bonus
             // token that makes a fully-accepted block worth `k + 1`.
             None => {
+                let (seen_prompt, seen_generated) = history.split_at(prompt_tokens.len());
                 let probs = sampling_distribution(
                     &batch_logits[accepted],
                     &options.sampling,
-                    penalty_window(&history, options),
+                    PenaltyWindow::new(seen_prompt, seen_generated),
                 );
                 rng.sample_from(&probs)
             }
@@ -995,7 +979,10 @@ mod tests {
             params: &SamplingParams,
             marginals: &mut [Vec<f64>],
         ) {
-            let probs = sampling_distribution(logits, params, history);
+            // `history` is already prompt-then-generated, and the
+            // window only ever reads the tail of the two halves
+            // together, so the whole sequence goes in the first one.
+            let probs = sampling_distribution(logits, params, PenaltyWindow::new(history, &[]));
             for (token, &p) in probs.iter().enumerate() {
                 if p <= 0.0 {
                     continue;
@@ -1040,6 +1027,100 @@ mod tests {
             &mut marginals,
         );
         marginals
+    }
+
+    /// Speculation and plain token-at-a-time decoding must agree about
+    /// WHICH tokens the penalties look back over, including the prompt.
+    ///
+    /// This is issue #55's other half. `SpeculativeOptions` used to
+    /// carry a `penalty_history_start` knob whose only job was to let a
+    /// caller line the two paths up by hand, which meant nothing failed
+    /// when they drifted -- and `--model-draft` shipped setting it to
+    /// `prompt.len()` because the plain loop penalised the generated
+    /// tokens alone. Both now go through `PenaltyWindow`, and this test
+    /// is what notices if one of them stops.
+    ///
+    /// Greedy on purpose: the assertion is token-for-token equality, so
+    /// a one-token disagreement in the window is a hard failure rather
+    /// than a shift in a sampled distribution. The prompt repeats
+    /// tokens 1 and 2, so the penalty has something to bite on from the
+    /// very first generated position.
+    #[test]
+    fn speculation_and_plain_decoding_penalise_the_same_window() {
+        let cfg = tiny_test_config();
+        let vocab = 6;
+        let prompt = vec![0usize, 1, 2, 3, 1];
+        let max_new = 6;
+        let params = SamplingParams {
+            temperature: 0.0,
+            repetition_penalty: 3.0,
+            penalty_last_n: 8,
+            ..SamplingParams::default()
+        };
+
+        let decoder = Decoder::new_random_small(cfg, 2, vocab);
+
+        // Plain token-at-a-time decoding, penalising over the same
+        // window `Sampler::sample` would use on any decode loop.
+        let mut kv = caches(&decoder);
+        let mut pos = 0usize;
+        let mut logits = Vec::new();
+        for &tok in &prompt {
+            logits = decoder.forward_token(tok, pos, &mut kv);
+            pos += 1;
+        }
+        let mut sampler = Sampler::new(7);
+        let mut plain: Vec<usize> = Vec::new();
+        for _ in 0..max_new {
+            let next = sampler.sample(&logits, &params, PenaltyWindow::new(&prompt, &plain));
+            plain.push(next);
+            logits = decoder.forward_token(next, pos, &mut kv);
+            pos += 1;
+        }
+
+        let mut speculator = PromptLookupSpeculator::new(2, 3);
+        let mut spec_kv = caches(&decoder);
+        let out = speculative_decode_with(
+            &decoder,
+            &prompt,
+            &mut spec_kv,
+            &mut speculator,
+            &SpeculativeOptions {
+                max_new_tokens: max_new,
+                sampling: params.clone(),
+                seed: 7,
+                ..SpeculativeOptions::default()
+            },
+        );
+        assert_eq!(
+            out.generated_tokens, plain,
+            "speculation changed the text at --repeat-penalty {}",
+            params.repetition_penalty
+        );
+
+        // And the penalty is doing something here, or the equality
+        // above is satisfied by a window nobody reads.
+        let mut off = params.clone();
+        off.repetition_penalty = 1.0;
+        let mut kv = caches(&decoder);
+        let mut pos = 0usize;
+        let mut logits = Vec::new();
+        for &tok in &prompt {
+            logits = decoder.forward_token(tok, pos, &mut kv);
+            pos += 1;
+        }
+        let mut sampler = Sampler::new(7);
+        let mut unpenalised: Vec<usize> = Vec::new();
+        for _ in 0..max_new {
+            let next = sampler.sample(&logits, &off, PenaltyWindow::new(&prompt, &unpenalised));
+            unpenalised.push(next);
+            logits = decoder.forward_token(next, pos, &mut kv);
+            pos += 1;
+        }
+        assert_ne!(
+            unpenalised, plain,
+            "the penalty must change this generation, or the agreement above proves nothing"
+        );
     }
 
     #[test]
@@ -1483,7 +1564,6 @@ mod tests {
                 start_pos: 0,
                 sampling: SamplingParams::default(),
                 seed: 0,
-                penalty_history_start: 0,
             },
         );
         assert_eq!(
@@ -1510,7 +1590,6 @@ mod tests {
                 start_pos: 0,
                 sampling: SamplingParams::default(),
                 seed: 0,
-                penalty_history_start: 0,
             },
         );
         assert_eq!(

--- a/crates/ferrox-server/src/sample_step.rs
+++ b/crates/ferrox-server/src/sample_step.rs
@@ -26,6 +26,7 @@
 //! shorter call for it to reach for.
 
 use ferrox_models::grammar_sampler::{ConstraintError, GrammarSampler, MaskOutcome};
+use ferrox_models::penalty_window::PenaltyWindow;
 use ferrox_models::sampling::Sampler;
 use ferrox_models::tokenizer::StopTokens;
 
@@ -98,11 +99,28 @@ pub(crate) fn sample_next(
     stop_tokens: &StopTokens,
     decode_token: &dyn Fn(usize) -> String,
 ) -> Result<Step, DecodeError> {
+    // The prompt half is EMPTY here, and that is a known divergence
+    // from llama.cpp, not a decision this function is making.
+    //
+    // llama.cpp seeds its penalties sampler with every prompt token
+    // before the first draw (`tools/server/server-context.cpp:386-390`),
+    // so `penalty_last_n` slides over `prompt ++ generated`. Both of
+    // this server's decode loops -- `generate::sample_until_stop` and
+    // `serving::batch::worker` -- hand this function the GENERATED ids
+    // alone, and neither has the prompt ids in scope to hand over:
+    // `sample_until_stop` takes `logits` and `pos`, never the ids.
+    // Closing it means threading the prompt through that signature,
+    // which is a `generate.rs` change and is tracked as its own issue.
+    //
+    // Spelled out as `&[]` at the ONE place the server builds a window,
+    // rather than left implicit in a slice argument, so the gap is a
+    // line someone deletes rather than a behaviour someone rediscovers.
+    let window = PenaltyWindow::new(&[], history);
     if !params.needs_vocab_logits() {
         return Ok(Step::Token(state.sampler.sample(
             logits,
             &params.sampling,
-            history,
+            window,
         )));
     }
     // A backend that folded lm_head+argmax onto the device returns one
@@ -157,7 +175,7 @@ pub(crate) fn sample_next(
                 }
             }
         };
-        sampler.sample_with_mask(logits, &params.sampling, history, Some(&mut mask))
+        sampler.sample_with_mask(logits, &params.sampling, window, Some(&mut mask))
     };
     if let Some(e) = refusal {
         return Err(DecodeError::GrammarConstraint {

--- a/crates/ferrox-server/src/sample_step.rs
+++ b/crates/ferrox-server/src/sample_step.rs
@@ -110,7 +110,7 @@ pub(crate) fn sample_next(
     // alone, and neither has the prompt ids in scope to hand over:
     // `sample_until_stop` takes `logits` and `pos`, never the ids.
     // Closing it means threading the prompt through that signature,
-    // which is a `generate.rs` change and is tracked as its own issue.
+    // which is a `generate.rs` change and is tracked as issue #73.
     //
     // Spelled out as `&[]` at the ONE place the server builds a window,
     // rather than left implicit in a slice argument, so the gap is a

--- a/crates/ferrox-server/src/serving/batch/tests/mod.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/mod.rs
@@ -92,7 +92,15 @@ fn sequential_ids(decoder: &Decoder, prompt: &[usize], params: &GenerationParams
     let mut sampler = Sampler::new(params.seed);
     let mut generated = Vec::new();
     for _ in 0..params.max_tokens {
-        let next = sampler.sample(&logits, &params.sampling, &generated);
+        // The empty prompt half mirrors `sample_step::sample_next`,
+        // which is what the batcher goes through: this reference decode
+        // has to make the SAME penalty-window choice the server makes,
+        // or it stops being a reference. See the note there.
+        let next = sampler.sample(
+            &logits,
+            &params.sampling,
+            ferrox_models::PenaltyWindow::new(&[], &generated),
+        );
         generated.push(next);
         logits = decoder.forward_token(next, pos, &mut caches);
         pos += 1;


### PR DESCRIPTION
Closes #55

## What changed

ferrox's penalties now look back over `prompt ++ generated`, which is
what llama.cpp does, and one type decides that for every call site in
the workspace.

## The evidence

llama.cpp's penalties sampler is stateful: a ring buffer of the last
`penalty_last_n` tokens it has ACCEPTED, plus a count map, and `apply`
walks the candidate list looking each candidate up in the map
(`src/llama-sampler.cpp:2698-2759`). Nothing in that buffer knows
whether a token was generated or read out of the prompt.

Both front ends put the prompt in it:

- **llama-server** — `tools/server/server-context.cpp:375-397`,
  `init_sampler()`. The loop at **386-390**:
  ```cpp
  for (int i = 0; i < (int) prompt.tokens.size(); i++) {
      const llama_token id = prompt.tokens[i];
      if (id != LLAMA_TOKEN_NULL) {
          common_sampler_accept(smpl.get(), id, false);
  ```
- **llama-cli** — `tools/completion/completion.cpp:730-736`, with the
  reason on the line above:
  ```cpp
  // push the prompt in the sampling context in order to apply repetition penalties later
  // for the prompt, we don't apply grammar rules
  common_sampler_accept(smpl, embd_inp[n_consumed], /* accept_grammar= */ false);
  ```
- `common_sampler_accept` pushes into the chain unconditionally
  (`common/sampling.cpp:472-504`), so a prompt token lands in the
  penalties ring buffer exactly like a generated one.

Verified against `.scratch/llama.cpp` at the checkout in this tree, not
from memory.

## Which behaviour, and why

**Match llama.cpp.** The north star is "same models, same command
shapes, same output"; the repo already carries one deliberate deviation
(`--repeat-penalty` defaults to 1.1 here, 1.0 upstream) and that one is
a *default*, visible on a flag the user typed. This was not a default,
it was a different definition of the same flag, invisible from the
command line. `ferrox parity` cannot see it either, since it compares
logits and tokenizers, not sampled text.

## This changes output

**For every existing user at the default `--repeat-penalty 1.1`.** A
token that occurs in the prompt is now penalised on its first generated
occurrence instead of its second. Same checkpoint, same flags, same
prompt, different text from the previous release. **This belongs in the
release notes**, not in a quiet patch. `--repeat-penalty 1.0` (or
`--repeat-last-n 0`) restores the old text exactly, since both disable
the penalties entirely.

## The durable half

The window was a `&[usize]` and FIVE call sites each chose their own:

| Site | Window it passed |
|---|---|
| `ferrox-cli/src/run.rs`, four decode loops | generated only |
| `ferrox-server` (`generate`, `serving::batch::worker`) | generated only |
| `ferrox-models/src/speculative.rs` | prompt + generated, behind a `penalty_history_start` knob added so `--model-draft` would not change the output |
| `ferrox-models/src/draft_model.rs` | prompt + generated + the block's own drafts (via a `history.to_vec()` per block) |
| `ferrox-models/src/kimi_generate.rs` | prompt + generated — the only one that matched llama.cpp, and nothing said so |

Five sites, four answers, nothing enforcing agreement. The repo's
dominant bug shape.

`ferrox_models::penalty_window::PenaltyWindow` is now the one place that
decides. It is constructed from BOTH halves and there is **no
constructor that takes a single slice**, so a caller cannot produce a
window without saying what its prompt is; a caller that genuinely has
none writes `&[]` and that shows up in the diff rather than in the
output.

`SpeculativeOptions::penalty_history_start` is **deleted**, not
defaulted. Speculation and the plain loop now share the definition
instead of being lined up by hand.

`speculative` derives both halves by splitting its single `history`
vector at `prompt_tokens.len()` rather than pairing it with the separate
`generated` vector, so there is no second structure to drift.
`draft_model` loses a per-block `history.to_vec()` as a side effect.

## Tests

Every one sabotaged once and confirmed red:

- `a_prompt_token_is_penalised_before_it_is_ever_generated` — asserts
  the **sampled token**, not the slice. A test on the slice cannot tell
  a correct window applied to the wrong distribution from a wrong
  window.
- `a_prompt_token_leaves_the_window_once_the_generation_outgrows_it` —
  catches the plausible wrong answer, "all of the prompt plus the last N
  generated", which the first test alone passes.
- `the_window_is_the_tail_of_the_prompt_and_the_generation_together` —
  the cut landing inside either half or exactly on the seam.
- `speculation_and_plain_decoding_penalise_the_same_window` — decodes
  the same prompt both ways at `--repeat-penalty 3.0` and demands
  token-for-token equality, then proves the penalty bit at all by
  showing `1.0` gives different text. Re-arming the old speculative
  behaviour turns it red (`[4,5,0,2,0,1]` vs `[4,5,0,0,0,0]`).

Sabotages run: dropping the prompt half from `recent()` (4 tests red);
returning "whole prompt + last N generated" (3 red); forcing
`speculative`'s prompt half empty (the cross-path test red).

## What would have to be true for this to be wrong

That llama.cpp does *not* seed the sampler with the prompt on some path
ferrox is standing in for. The two front ends are cited above; if a
third disagrees, the fix is one constructor argument, not a new knob.

## Not done here

**The server still passes an empty prompt half**, at exactly one line
(`ferrox-server/src/sample_step.rs`, `sample_next`), documented there
and filed as **#73**. Neither server decode loop has the prompt ids in
scope — `generate::sample_until_stop` takes `logits` and `pos`, never
the ids — so closing it means threading the prompt through that
signature, i.e. a `generate.rs` change, which this branch does not own.
Both server loops must move together or they disagree with each other,
which is the defect `sample_step` exists to prevent. The batcher's
reference decode in `serving/batch/tests/mod.rs` deliberately mirrors
the current server choice so the reference stays a reference.

## Doc delta (not applied — `docs/` is owned elsewhere)

`docs/CLI.md`, the sampling table around lines 70 and 74:

- `--repeat-penalty` (line 70) — the note explains the *default* differs
  from llama.cpp. It should now also say the window matches: penalties
  see the prompt as well as the generation, as llama.cpp's do.
- `--repeat-last-n` (line 74) — "How many recent tokens the ... penalties
  consider" should read "recent tokens **of the prompt and the
  generation together**".
- A release note: output changes at the default `--repeat-penalty 1.1`;
  `1.0` or `--repeat-last-n 0` reproduces the old text.

## Gates

`cargo build --workspace`, `cargo test --workspace` (2409 passing, 0
failing), `cargo clippy --workspace --all-targets -- -D warnings`, the
same `--release`, `cargo fmt --all`. No benchmarks were run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
