### PR TITLE
feat(metal): the fused dense stacks take a RoPE pair per layer, not one for the run

### DIFF
--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -138,6 +138,32 @@ impl MetalRope {
     }
 }
 
+/// The half of a RoPE call that varies from LAYER to layer: the
+/// frequency base and the per-band divisors. [`MetalRope`] carries the
+/// half that does not (pairing, rotary width, magnitude scale), so a
+/// fused stack takes one `MetalRope` and one of these per layer.
+///
+/// Both halves live in one struct because they vary TOGETHER and
+/// llama.cpp varies them together (`llama-model.cpp:2029-2035`,
+/// mirrored by `ferrox_models::config::ModelConfig::layer_rope`).
+/// Splitting them is what this type exists to prevent: the fused stacks
+/// used to take a per-layer `rope_theta` beside ONE `freq_factors`
+/// slice for the whole run, so a model whose sliding layers scale
+/// differently from its full-attention ones (Gemma-3 4B/12B/27B:
+/// `rope_scaling {linear, factor 8}` on the full layers, unscaled on
+/// the sliding ones) could not ride them at all. Answering the base
+/// question without answering the divisor question no longer compiles.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayerRope<'a> {
+    /// This layer's RoPE frequency base (`rope_theta`, or
+    /// `rope_theta_swa` on a sliding layer).
+    pub theta: f32,
+    /// This layer's per-band divisors (`rope_freqs.weight`, folded with
+    /// any linear `freq_scale`), `n_rot/2` long. `None` = divide by
+    /// nothing.
+    pub freq_factors: Option<&'a [f32]>,
+}
+
 /// Whether the fused Metal attention block should run (in addition to
 /// dense Metal matvecs). Default off until measured; `1|true|on` enables.
 pub fn metal_attn_enabled() -> bool {
@@ -5726,9 +5752,11 @@ pub struct DenseLayerMetal<'a> {
     pub up: MatvecLaunch<'a>,
     pub down: MatvecLaunch<'a>,
     pub extras: AttnExtras<'a>,
-    /// Per-layer RoPE base override (Gemma-3 SWA layers use
-    /// `rope_theta_swa`); `None` = the stack-wide theta.
-    pub rope_theta: Option<f32>,
+    /// This layer's RoPE base AND divisors. Both halves, always: a
+    /// Gemma-3 SWA layer differs from its full-attention neighbours in
+    /// both (`rope_theta_swa`, and no linear scale folded into the
+    /// divisors). See [`LayerRope`].
+    pub rope: LayerRope<'a>,
     /// Sliding-window size for this layer (`None` = full causal).
     pub window: Option<usize>,
     /// Gemma post-attention / post-FFN sandwich norms, applied to the
@@ -5765,8 +5793,6 @@ pub fn launch_decode_dense_stack(
     kvs: &mut [MetalKvBuffers],
     n_heads: usize,
     rope_layout: MetalRope,
-    rope_theta: f32,
-    freq_factors: Option<&[f32]>,
     pos: usize,
     rms_eps: f32,
     final_norm_w: Option<&[f32]>,
@@ -5792,7 +5818,9 @@ pub fn launch_decode_dense_stack(
             return Err(MetalError::CommandFailed);
         }
     }
-    assert_freq_factors_len(freq_factors, rope_layout, head_dim);
+    for layer in layers.iter() {
+        assert_freq_factors_len(layer.rope.freq_factors, rope_layout, head_dim);
+    }
 
     let max_q = layers.iter().map(|l| l.q.rows).max().unwrap();
     let max_kv = layers.iter().map(|l| l.k.rows).max().unwrap();
@@ -5840,11 +5868,19 @@ pub fn launch_decode_dense_stack(
     let logits_buf = scratch.logits.as_ref();
     let argmax_idx_buf = &scratch.argmax_idx;
 
-    let ff_resident = match freq_factors {
-        Some(ff) => Some(resident_f32_buffer(device, ff)?),
-        None => None,
-    };
-    let ff_buf = ff_resident.as_ref().map(|b| b.buffer.as_ref());
+    // One resident buffer PER LAYER. `resident_f32_buffer` keys its
+    // cache on (pointer, len), so the at-most-two distinct divisor sets
+    // an alternating-SWA model has are uploaded once each and every
+    // layer past the first two is a cache hit -- no per-layer upload,
+    // and no table of "which set does layer i use" for a call site to
+    // get out of step with.
+    let ff_resident = layers
+        .iter()
+        .map(|l| match l.rope.freq_factors {
+            Some(ff) => resident_f32_buffer(device, ff).map(Some),
+            None => Ok(None),
+        })
+        .collect::<Result<Vec<_>, MetalError>>()?;
 
     let cmd_buf = queue.commandBuffer().ok_or(MetalError::CommandFailed)?;
     // Sandwich (Gemma post-norms): use the default serial encoder. Concurrent
@@ -5973,7 +6009,8 @@ pub fn launch_decode_dense_stack(
         )?;
         mrs.end_op(&[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
 
-        let layer_theta = layer.rope_theta.unwrap_or(rope_theta);
+        let layer_theta = layer.rope.theta;
+        let ff_buf = ff_resident[layer_idx].as_ref().map(|b| b.buffer.as_ref());
         mrs.begin_op(&encoder, &[q_buf, k_buf], &[q_buf, k_buf]);
         encode_rope(
             &encoder,
@@ -6256,6 +6293,8 @@ pub struct PrefillDenseLayerMetal<'a> {
     /// QKV bias / QK-norm (Qwen2.5, Qwen3, Gemma-3). Applied after GEMM,
     /// before RoPE — same order as the CPU / decode paths.
     pub extras: AttnExtras<'a>,
+    /// This layer's RoPE base AND divisors; see [`LayerRope`].
+    pub rope: LayerRope<'a>,
     /// Layer index for [`PrefillCbCache`] keying only.
     pub layer_idx: u32,
 }
@@ -6728,8 +6767,6 @@ pub fn launch_prefill_dense_stack(
     n_heads: usize,
     batch: usize,
     rope_layout: MetalRope,
-    rope_thetas: &[f32],
-    freq_factors: Option<&[f32]>,
     start_pos: usize,
     rms_eps: f32,
     gelu_ffn: bool,
@@ -6739,7 +6776,6 @@ pub fn launch_prefill_dense_stack(
         return Err(MetalError::CommandFailed);
     }
     assert_eq!(layers.len(), kvs.len());
-    assert_eq!(layers.len(), rope_thetas.len());
     assert!(!layers.is_empty());
 
     let hidden_dim = layers[0].attn_norm_w.len();
@@ -6768,8 +6804,8 @@ pub fn launch_prefill_dense_stack(
         }
         assert_eq!(kv.head_dim, head_dim);
         assert_eq!(kv.n_kv_heads, n_kv_heads);
+        assert_freq_factors_len(layer.rope.freq_factors, rope_layout, head_dim);
     }
-    assert_freq_factors_len(freq_factors, rope_layout, head_dim);
 
     let max_q = layers.iter().map(|l| l.q.rows).max().unwrap();
     let max_kv = layers.iter().map(|l| l.k.rows.max(l.v.rows)).max().unwrap();
@@ -6810,11 +6846,15 @@ pub fn launch_prefill_dense_stack(
         half_act: &scratch.half_act,
     };
 
-    let ff_resident = match freq_factors {
-        Some(ff) => Some(resident_f32_buffer(device, ff)?),
-        None => None,
-    };
-    let ff_buf = ff_resident.as_ref().map(|b| b.buffer.as_ref());
+    // Per layer, cached on (pointer, len) -- see the same comment in
+    // `launch_decode_dense_stack`.
+    let ff_resident = layers
+        .iter()
+        .map(|l| match l.rope.freq_factors {
+            Some(ff) => resident_f32_buffer(device, ff).map(Some),
+            None => Ok(None),
+        })
+        .collect::<Result<Vec<_>, MetalError>>()?;
 
     {
         let mut graph = metal_graph();
@@ -6868,8 +6908,8 @@ pub fn launch_prefill_dense_stack(
             batch,
             hidden_dim,
             rope_layout,
-            rope_thetas[layer_idx],
-            ff_buf,
+            layer.rope.theta,
+            ff_resident[layer_idx].as_ref().map(|b| b.buffer.as_ref()),
             start_pos,
             rms_eps,
             gelu_ffn,
@@ -6920,8 +6960,6 @@ pub fn launch_prefill_dense_layer(
     n_heads: usize,
     batch: usize,
     rope_layout: MetalRope,
-    rope_theta: f32,
-    freq_factors: Option<&[f32]>,
     start_pos: usize,
     rms_eps: f32,
     gelu_ffn: bool,
@@ -6934,8 +6972,6 @@ pub fn launch_prefill_dense_layer(
         n_heads,
         batch,
         rope_layout,
-        std::slice::from_ref(&rope_theta),
-        freq_factors,
         start_pos,
         rms_eps,
         gelu_ffn,
@@ -8856,5 +8892,440 @@ mod tests {
         }
         let (k_dl, _) = kv_q8.tokens_host(0, n_q);
         assert_eq!(k_dl.len(), n_q * n_kv_heads * head_dim);
+    }
+
+    /// Deterministic weights for one dense decode layer, owned so the
+    /// `MatvecLaunch` byte views below can borrow them.
+    struct DenseLayerBytes {
+        attn_norm: Vec<f32>,
+        ffn_norm: Vec<f32>,
+        q: Vec<u8>,
+        k: Vec<u8>,
+        v: Vec<u8>,
+        o: Vec<u8>,
+        gate: Vec<u8>,
+        up: Vec<u8>,
+        down: Vec<u8>,
+    }
+
+    fn f32_weight_bytes(rows: usize, cols: usize, seed: f32) -> Vec<u8> {
+        (0..rows * cols)
+            .flat_map(|i| (((i as f32 + seed) * 0.017).sin() * 0.25).to_le_bytes())
+            .collect()
+    }
+
+    impl DenseLayerBytes {
+        fn new(hidden: usize, n_q: usize, n_kv: usize, ffn: usize, seed: f32) -> Self {
+            Self {
+                attn_norm: (0..hidden)
+                    .map(|i| 1.0 + (i as f32 * 0.01 + seed).sin() * 0.1)
+                    .collect(),
+                ffn_norm: (0..hidden)
+                    .map(|i| 1.0 + (i as f32 * 0.02 + seed).cos() * 0.1)
+                    .collect(),
+                q: f32_weight_bytes(n_q, hidden, seed + 1.0),
+                k: f32_weight_bytes(n_kv, hidden, seed + 2.0),
+                v: f32_weight_bytes(n_kv, hidden, seed + 3.0),
+                o: f32_weight_bytes(hidden, n_q, seed + 4.0),
+                gate: f32_weight_bytes(ffn, hidden, seed + 5.0),
+                up: f32_weight_bytes(ffn, hidden, seed + 6.0),
+                down: f32_weight_bytes(hidden, ffn, seed + 7.0),
+            }
+        }
+    }
+
+    fn f32_matvec(bytes: &[u8], rows: usize, cols: usize) -> MatvecLaunch<'_> {
+        let (kernel_src, fn_name, block_bytes, block_elems, rows_per_tg) =
+            crate::gpu::matvec_launch_meta("F32").expect("F32 matvec kernel");
+        MatvecLaunch {
+            kernel_src,
+            fn_name,
+            block_bytes,
+            block_elems,
+            weights: bytes,
+            rows,
+            row_bytes: cols * 4,
+            rows_per_tg,
+        }
+    }
+
+    fn dense_layer_metal<'a>(
+        w: &'a DenseLayerBytes,
+        rope: LayerRope<'a>,
+        hidden: usize,
+        n_q: usize,
+        n_kv: usize,
+        ffn: usize,
+    ) -> DenseLayerMetal<'a> {
+        DenseLayerMetal {
+            attn_norm_w: &w.attn_norm,
+            ffn_norm_w: &w.ffn_norm,
+            q: f32_matvec(&w.q, n_q, hidden),
+            k: f32_matvec(&w.k, n_kv, hidden),
+            v: f32_matvec(&w.v, n_kv, hidden),
+            o: f32_matvec(&w.o, hidden, n_q),
+            gate: f32_matvec(&w.gate, ffn, hidden),
+            up: f32_matvec(&w.up, ffn, hidden),
+            down: f32_matvec(&w.down, hidden, ffn),
+            extras: AttnExtras::default(),
+            rope,
+            window: None,
+            post_attn_norm: None,
+            post_ffn_norm: None,
+        }
+    }
+
+    /// The fused decode stack must rope EVERY layer with that layer's
+    /// own per-band divisors, not with the first layer's.
+    ///
+    /// Gemma-3 4B/12B/27B are the model that needs this: `rope_scaling
+    /// {linear, factor 8}` folded into the full-attention layers'
+    /// divisors, nothing on the sliding ones (`gemma3.cpp` never assigns
+    /// `rope_freq_scale_train_swa`), five layers in six sliding. The
+    /// stack used to take ONE `freq_factors` slice for a whole run, so
+    /// `Decoder::metal_stack_needs_per_layer_rope_freqs` refused those
+    /// checkpoints off the fused path rather than rotate them wrongly
+    /// (issue #63). This test is what makes deleting that refusal safe.
+    ///
+    /// The oracle is the per-layer launch, which has always taken its
+    /// own `freq_factors` per call. The last assertion is what stops the
+    /// test being vacuous: feed the stack ONE set for both layers --
+    /// exactly the old bug -- and it must answer differently.
+    #[test]
+    #[ignore = "needs a real Metal GPU"]
+    fn a_decode_stack_ropes_each_layer_with_its_own_freq_factors() {
+        let (hidden, n_heads, n_kv_heads, head_dim, ffn) =
+            (32usize, 2usize, 1usize, 16usize, 32usize);
+        let n_q = n_heads * head_dim;
+        let n_kv = n_kv_heads * head_dim;
+        let rope = MetalRope::new(MetalRopeLayout::Norm);
+        let eps = 1e-5f32;
+        // Gemma-3's two sets: the full-attention layers divide every
+        // band by the trained linear factor, the sliding ones do not.
+        let full_ff = vec![8.0f32; head_dim / 2];
+        let swa_ff = vec![1.0f32; head_dim / 2];
+        // ... and its two bases, so the layers differ in BOTH halves of
+        // `LayerRope` at once, as a real checkpoint does.
+        let full_rope = LayerRope {
+            theta: 1_000_000.0,
+            freq_factors: Some(&full_ff),
+        };
+        let swa_rope = LayerRope {
+            theta: 10_000.0,
+            freq_factors: Some(&swa_ff),
+        };
+
+        let w: Vec<DenseLayerBytes> = (0..2)
+            .map(|i| DenseLayerBytes::new(hidden, n_q, n_kv, ffn, i as f32 * 11.0))
+            .collect();
+        // Layer 0 slides, layer 1 attends in full: the alternating
+        // pattern, in the smallest stack that can show it.
+        let ropes = [swa_rope, full_rope];
+
+        let steps = 6usize;
+        let hidden0: Vec<f32> = (0..hidden).map(|i| (i as f32 * 0.13).sin()).collect();
+
+        let mut kv_stack: Vec<MetalKvBuffers> = (0..2)
+            .map(|_| MetalKvBuffers::with_capacity(n_kv_heads, head_dim, 32).expect("kv"))
+            .collect();
+        let mut kv_ref: Vec<MetalKvBuffers> = (0..2)
+            .map(|_| MetalKvBuffers::with_capacity(n_kv_heads, head_dim, 32).expect("kv"))
+            .collect();
+        let mut kv_one: Vec<MetalKvBuffers> = (0..2)
+            .map(|_| MetalKvBuffers::with_capacity(n_kv_heads, head_dim, 32).expect("kv"))
+            .collect();
+
+        let mut h_stack = hidden0.clone();
+        let mut h_ref = hidden0.clone();
+        let mut h_one = hidden0.clone();
+
+        for pos in 0..steps {
+            let layers: Vec<DenseLayerMetal<'_>> = (0..2)
+                .map(|i| dense_layer_metal(&w[i], ropes[i], hidden, n_q, n_kv, ffn))
+                .collect();
+            h_stack = launch_decode_dense_stack(
+                &h_stack,
+                &layers,
+                &mut kv_stack,
+                n_heads,
+                rope,
+                pos,
+                eps,
+                None,
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("decode stack");
+
+            // Oracle: the same two layers, one command buffer each.
+            for i in 0..2 {
+                h_ref = launch_decode_dense_layer(
+                    &h_ref,
+                    &w[i].attn_norm,
+                    &f32_matvec(&w[i].q, n_q, hidden),
+                    &f32_matvec(&w[i].k, n_kv, hidden),
+                    &f32_matvec(&w[i].v, n_kv, hidden),
+                    &f32_matvec(&w[i].o, hidden, n_q),
+                    &mut kv_ref[i],
+                    &w[i].ffn_norm,
+                    &f32_matvec(&w[i].gate, ffn, hidden),
+                    &f32_matvec(&w[i].up, ffn, hidden),
+                    &f32_matvec(&w[i].down, hidden, ffn),
+                    n_heads,
+                    rope,
+                    ropes[i].theta,
+                    ropes[i].freq_factors,
+                    pos,
+                    eps,
+                    &AttnExtras::default(),
+                )
+                .expect("decode layer");
+            }
+
+            // The bug, run deliberately: layer 0's rope for both layers.
+            let one_set: Vec<DenseLayerMetal<'_>> = (0..2)
+                .map(|i| dense_layer_metal(&w[i], ropes[0], hidden, n_q, n_kv, ffn))
+                .collect();
+            h_one = launch_decode_dense_stack(
+                &h_one,
+                &one_set,
+                &mut kv_one,
+                n_heads,
+                rope,
+                pos,
+                eps,
+                None,
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("decode stack, one set");
+        }
+
+        assert_eq!(h_stack.len(), h_ref.len());
+        for (i, (a, b)) in h_ref.iter().zip(h_stack.iter()).enumerate() {
+            // Same kernels and the same f16 KV; the stack only
+            // reassociates the residual add into the next layer's norm,
+            // and on this device that is bit-identical. The tolerance is
+            // room for a future reassociation, not for a rope that
+            // rotated at the wrong scale: sharing one set instead of two
+            // moves the answer ~300x further than this (asserted below).
+            let tol = 1e-6 * a.abs().max(1.0);
+            assert!(
+                (a - b).abs() <= tol,
+                "elem {i}: per-layer={a} stack={b} tol={tol}"
+            );
+        }
+        let drift = h_stack
+            .iter()
+            .zip(h_one.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            drift > 1e-3,
+            "one shared rope for both layers answered the same as two: \
+             this test proves nothing (max drift {drift})"
+        );
+    }
+
+    /// Q8_0 weights for one dense PREFILL layer, owned like
+    /// [`DenseLayerBytes`] so the `MulMmSgLaunch` views can borrow them.
+    struct PrefillLayerBytes {
+        attn_norm: Vec<f32>,
+        ffn_norm: Vec<f32>,
+        q: Vec<u8>,
+        k: Vec<u8>,
+        v: Vec<u8>,
+        o: Vec<u8>,
+        gate: Vec<u8>,
+        up: Vec<u8>,
+        down: Vec<u8>,
+    }
+
+    fn q8_0_weight_bytes(rows: usize, cols: usize, seed: f32) -> Vec<u8> {
+        let mut out = Vec::new();
+        for r in 0..rows {
+            let row: Vec<f32> = (0..cols)
+                .map(|c| (((r * cols + c) as f32 + seed) * 0.017).sin() * 0.25)
+                .collect();
+            out.extend(ferrox_quant::quantize_q8_0(&row));
+        }
+        out
+    }
+
+    impl PrefillLayerBytes {
+        fn new(hidden: usize, n_q: usize, n_kv: usize, ffn: usize, seed: f32) -> Self {
+            Self {
+                attn_norm: (0..hidden)
+                    .map(|i| 1.0 + (i as f32 * 0.01 + seed).sin() * 0.1)
+                    .collect(),
+                ffn_norm: (0..hidden)
+                    .map(|i| 1.0 + (i as f32 * 0.02 + seed).cos() * 0.1)
+                    .collect(),
+                q: q8_0_weight_bytes(n_q, hidden, seed + 1.0),
+                k: q8_0_weight_bytes(n_kv, hidden, seed + 2.0),
+                v: q8_0_weight_bytes(n_kv, hidden, seed + 3.0),
+                o: q8_0_weight_bytes(hidden, n_q, seed + 4.0),
+                gate: q8_0_weight_bytes(ffn, hidden, seed + 5.0),
+                up: q8_0_weight_bytes(ffn, hidden, seed + 6.0),
+                down: q8_0_weight_bytes(hidden, ffn, seed + 7.0),
+            }
+        }
+    }
+
+    fn q8_0_mul_mm_sg(bytes: &[u8], rows: usize, cols: usize) -> MulMmSgLaunch<'_> {
+        let (fn_name, block_bytes, block_elems) =
+            crate::gpu::mul_mm_sg_meta("Q8_0").expect("Q8_0 mul_mm_sg kernel");
+        assert!(cols.is_multiple_of(block_elems));
+        MulMmSgLaunch {
+            weights: bytes,
+            rows,
+            row_bytes: (cols / block_elems) * block_bytes,
+            fn_name,
+            block_bytes,
+            block_elems,
+        }
+    }
+
+    fn prefill_layer_metal<'a>(
+        w: &'a PrefillLayerBytes,
+        rope: LayerRope<'a>,
+        layer_idx: u32,
+        hidden: usize,
+        n_q: usize,
+        n_kv: usize,
+        ffn: usize,
+    ) -> PrefillDenseLayerMetal<'a> {
+        PrefillDenseLayerMetal {
+            attn_norm_w: &w.attn_norm,
+            ffn_norm_w: &w.ffn_norm,
+            q: q8_0_mul_mm_sg(&w.q, n_q, hidden),
+            k: q8_0_mul_mm_sg(&w.k, n_kv, hidden),
+            v: q8_0_mul_mm_sg(&w.v, n_kv, hidden),
+            o: q8_0_mul_mm_sg(&w.o, hidden, n_q),
+            ffn: PrefillFfnMetal::Dense {
+                gate: q8_0_mul_mm_sg(&w.gate, ffn, hidden),
+                up: q8_0_mul_mm_sg(&w.up, ffn, hidden),
+                down: q8_0_mul_mm_sg(&w.down, hidden, ffn),
+            },
+            post_attn_norm: None,
+            post_ffn_norm: None,
+            extras: AttnExtras::default(),
+            rope,
+            layer_idx,
+        }
+    }
+
+    /// The prefill twin of
+    /// `a_decode_stack_ropes_each_layer_with_its_own_freq_factors`, and
+    /// it matters as much: prefill is where a long Gemma-3 prompt spends
+    /// its time, and the wrong divisors get worse the longer the prompt.
+    ///
+    /// Oracle and non-vacuity check are the same shape as the decode
+    /// test. The one-layer launch is the oracle because a run of one
+    /// cannot index the wrong layer's divisors.
+    #[test]
+    #[ignore = "needs a real Metal GPU"]
+    fn a_prefill_stack_ropes_each_layer_with_its_own_freq_factors() {
+        let (hidden, n_heads, n_kv_heads, head_dim, ffn) =
+            (32usize, 2usize, 2usize, 16usize, 64usize);
+        let n_q = n_heads * head_dim;
+        let n_kv = n_kv_heads * head_dim;
+        let batch = 8usize;
+        let rope = MetalRope::new(MetalRopeLayout::Norm);
+        let eps = 1e-5f32;
+        let full_ff = vec![8.0f32; head_dim / 2];
+        let swa_ff = vec![1.0f32; head_dim / 2];
+        let ropes = [
+            LayerRope {
+                theta: 10_000.0,
+                freq_factors: Some(&swa_ff),
+            },
+            LayerRope {
+                theta: 1_000_000.0,
+                freq_factors: Some(&full_ff),
+            },
+        ];
+
+        let w: Vec<PrefillLayerBytes> = (0..2)
+            .map(|i| PrefillLayerBytes::new(hidden, n_q, n_kv, ffn, i as f32 * 11.0))
+            .collect();
+        let hidden0: Vec<f32> = (0..batch * hidden)
+            .map(|i| (i as f32 * 0.031).sin())
+            .collect();
+
+        let mut kv_stack: Vec<MetalKvBuffers> = (0..2)
+            .map(|_| MetalKvBuffers::with_capacity(n_kv_heads, head_dim, 32).expect("kv"))
+            .collect();
+        let layers: Vec<PrefillDenseLayerMetal<'_>> = (0..2)
+            .map(|i| prefill_layer_metal(&w[i], ropes[i], i as u32, hidden, n_q, n_kv, ffn))
+            .collect();
+        let h_stack = launch_prefill_dense_stack(
+            &hidden0,
+            &layers,
+            &mut kv_stack,
+            n_heads,
+            batch,
+            rope,
+            0,
+            eps,
+            false,
+            None,
+        )
+        .expect("prefill stack");
+
+        let mut h_ref = hidden0.clone();
+        for i in 0..2 {
+            let mut kv = MetalKvBuffers::with_capacity(n_kv_heads, head_dim, 32).expect("kv");
+            let layer = prefill_layer_metal(&w[i], ropes[i], i as u32, hidden, n_q, n_kv, ffn);
+            let input = std::mem::take(&mut h_ref);
+            h_ref = launch_prefill_dense_layer(
+                &input, &layer, &mut kv, n_heads, batch, rope, 0, eps, false, None,
+            )
+            .expect("prefill layer");
+        }
+
+        // The bug: layer 0's rope for the whole run.
+        let mut kv_one: Vec<MetalKvBuffers> = (0..2)
+            .map(|_| MetalKvBuffers::with_capacity(n_kv_heads, head_dim, 32).expect("kv"))
+            .collect();
+        let one_set: Vec<PrefillDenseLayerMetal<'_>> = (0..2)
+            .map(|i| prefill_layer_metal(&w[i], ropes[0], i as u32, hidden, n_q, n_kv, ffn))
+            .collect();
+        let h_one = launch_prefill_dense_stack(
+            &hidden0,
+            &one_set,
+            &mut kv_one,
+            n_heads,
+            batch,
+            rope,
+            0,
+            eps,
+            false,
+            None,
+        )
+        .expect("prefill stack, one set");
+
+        assert_eq!(h_stack.len(), h_ref.len());
+        for (i, (a, b)) in h_ref.iter().zip(h_stack.iter()).enumerate() {
+            let tol = 1e-6 * a.abs().max(1.0);
+            assert!(
+                (a - b).abs() <= tol,
+                "elem {i}: per-layer={a} stack={b} tol={tol}"
+            );
+        }
+        let drift = h_stack
+            .iter()
+            .zip(h_one.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            drift > 1e-3,
+            "one shared rope for both layers answered the same as two: \
+             this test proves nothing (max drift {drift})"
+        );
     }
 }

--- a/crates/ferrox-models/src/config.rs
+++ b/crates/ferrox-models/src/config.rs
@@ -539,9 +539,16 @@ impl ModelConfig {
     }
 
     /// True when the sliding layers need different per-band divisors
-    /// from the full-attention ones, so a fused launch taking ONE
-    /// `freq_factors` buffer for a whole run of layers cannot serve this
-    /// model.
+    /// from the full-attention ones, i.e. when one `freq_factors` slice
+    /// cannot describe every layer of this model. Gemma-3 4B/12B/27B
+    /// are the shape that answers yes.
+    ///
+    /// It is NOT an eligibility check any more. It was one: the fused
+    /// Metal stacks took a single slice for a whole run of layers and
+    /// refused a model that answered yes here. They now take a
+    /// `ferrox_metal::attn::LayerRope` per layer, so this is a statement
+    /// about the checkpoint and nothing else -- which is all the loader
+    /// tests ever wanted from it.
     pub fn rope_freqs_vary_by_layer(&self) -> bool {
         self.rope_freqs
             .as_ref()

--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -843,30 +843,24 @@ impl Decoder {
             || self.config.layer_rope_theta(layer_idx) != self.config.rope_theta
     }
 
-    /// True when no fused Metal *stack* can serve this model, because
-    /// its sliding layers need different RoPE per-band divisors from its
-    /// full-attention ones.
+    /// BOTH halves of layer `il`'s RoPE, in the shape the Metal
+    /// launches take.
     ///
-    /// Per-LAYER Metal launches are fine: each takes its own
-    /// `freq_factors` slice and is handed
-    /// `ModelConfig::layer_rope_freqs(l)`. The two whole-stack launches
-    /// (`launch_prefill_dense_stack`, `launch_decode_dense_stack`) take
-    /// ONE slice for a whole run of layers -- `PrefillDenseLayerMetal`
-    /// and `DenseLayerMetal` carry a per-layer `rope_theta` and `window`
-    /// but no per-layer divisors -- so they would rope the sliding
-    /// layers with the full-attention set. That is precisely the bug
-    /// this refusal exists to stop, one layer of the stack down.
-    ///
-    /// The cost is Gemma-3 4B/12B/27B taking the per-layer Metal path
-    /// rather than the fused stacks. Correct and slower beats fast and
-    /// wrong; restoring the stacks needs a per-layer `freq_factors`
-    /// buffer in `ferrox-metal`.
-    ///
-    /// One predicate, two call sites, because four spellings of one
-    /// eligibility check is how the GPU-router gate drifted four ways.
+    /// One conversion, every Metal call site, because
+    /// `ModelConfig::layer_rope` returning a pair and the launches
+    /// taking a pair is only worth anything while nothing in between
+    /// gets to take one half and default the other. That is exactly
+    /// what the fused stacks used to do: a per-layer `rope_theta` beside
+    /// ONE `freq_factors` slice for the whole run, which refused
+    /// Gemma-3 4B/12B/27B off the fused path entirely rather than rope
+    /// five layers in six at the wrong scale.
     #[cfg(feature = "metal")]
-    fn metal_stack_needs_per_layer_rope_freqs(&self) -> bool {
-        self.config.rope_freqs_vary_by_layer()
+    fn metal_layer_rope(&self, layer_idx: usize) -> ferrox_metal::attn::LayerRope<'_> {
+        let (theta, freq_factors) = self.config.layer_rope(layer_idx);
+        ferrox_metal::attn::LayerRope {
+            theta,
+            freq_factors,
+        }
     }
 
     /// Optional QKV bias / QK-norm ops for the Metal attn paths.
@@ -1069,12 +1063,8 @@ impl Decoder {
         kv_caches: &mut [KvCache],
         host_kv_authoritative: bool,
     ) -> Option<Vec<f32>> {
-        if self.metal_stack_needs_per_layer_rope_freqs() {
-            return None;
-        }
         let gelu = !GluAct::from(self.config.ffn_activation).is_swiglu();
         let mut prefill_layers = Vec::with_capacity(run_len);
-        let mut rope_thetas = Vec::with_capacity(run_len);
         for li in start..start + run_len {
             let layer = &self.layers[li];
             let ffn = Self::metal_prefill_ffn(layer, &self.config)?;
@@ -1098,9 +1088,9 @@ impl Decoder {
                 post_attn_norm: layer.attn.post_attn_norm.as_deref(),
                 post_ffn_norm: layer.attn.post_ffn_norm.as_deref(),
                 extras: self.metal_attn_extras(layer),
+                rope: self.metal_layer_rope(li),
                 layer_idx: li as u32,
             });
-            rope_thetas.push(self.config.layer_rope_theta(li));
         }
         let kvs = &mut metal_kvs[start..start + run_len];
         let h_out = ferrox_metal::attn::launch_prefill_dense_stack(
@@ -1110,12 +1100,6 @@ impl Decoder {
             n_heads,
             batch_size,
             self.metal_rope(),
-            &rope_thetas,
-            // One slice for the whole run. Sound only because
-            // `metal_stack_needs_per_layer_rope_freqs` refused above
-            // when the layers disagree, so every layer in the run --
-            // sliding or not -- resolves to this same set.
-            self.config.layer_rope_freqs(start),
             start_pos,
             self.config.rms_norm_eps,
             gelu,
@@ -2006,7 +1990,6 @@ impl Decoder {
         #[cfg(feature = "metal")]
         if !metal_stack_done
             && use_metal_attn
-            && !self.metal_stack_needs_per_layer_rope_freqs()
             && self.layers.iter().all(Self::layer_supports_metal_dense_ffn)
         {
             if let Some(guard) = metal_kv_guard.as_mut() {
@@ -2046,10 +2029,7 @@ impl Decoder {
                                 up: u,
                                 down: d,
                                 extras: self.metal_attn_extras(layer),
-                                rope_theta: {
-                                    let t = self.config.layer_rope_theta(li);
-                                    (t != self.config.rope_theta).then_some(t)
-                                },
+                                rope: self.metal_layer_rope(li),
                                 window: self.config.layer_sliding_window(li),
                                 post_attn_norm: layer.attn.post_attn_norm.as_deref(),
                                 post_ffn_norm: layer.attn.post_ffn_norm.as_deref(),
@@ -2103,15 +2083,6 @@ impl Decoder {
                                 metal_kvs,
                                 n_heads,
                                 self.metal_rope(),
-                                self.config.rope_theta,
-                                // `DenseLayerMetal` overrides the theta
-                                // per layer but has no per-layer
-                                // divisors, so this one slice must
-                                // serve them all --
-                                // `metal_stack_needs_per_layer_rope_freqs`
-                                // in the guard above is what makes that
-                                // true.
-                                self.config.layer_rope_freqs(0),
                                 pos,
                                 self.config.rms_norm_eps,
                                 final_norm_w,
@@ -3857,6 +3828,7 @@ impl Decoder {
                                             post_attn_norm: layer.attn.post_attn_norm.as_deref(),
                                             post_ffn_norm: layer.attn.post_ffn_norm.as_deref(),
                                             extras: self.metal_attn_extras(layer),
+                                            rope: self.metal_layer_rope(l),
                                             layer_idx: l as u32,
                                         };
                                     ferrox_metal::attn::launch_prefill_dense_layer(
@@ -3866,8 +3838,6 @@ impl Decoder {
                                         n_heads,
                                         batch_size,
                                         self.metal_rope(),
-                                        self.config.layer_rope_theta(l),
-                                        self.config.layer_rope_freqs(l),
                                         start_pos,
                                         self.config.rms_norm_eps,
                                         gelu,
@@ -6698,5 +6668,66 @@ mod metal_rope_tests {
         let mut odd = phi_like_config();
         odd.rope_dim = Some(95);
         assert!(!supported(odd), "odd n_rot must keep the model off Metal");
+    }
+
+    /// A Gemma-3-4B-shaped config: `rope_scaling {linear, factor 8}`
+    /// folded into the full-attention layers' divisors, nothing on the
+    /// sliding ones, `sliding_window_pattern = 6` last-dense.
+    fn gemma3_4b_shaped_config() -> ModelConfig {
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.head_dim = 8;
+        cfg.rope_layout = crate::config::RopeLayout::Norm;
+        cfg.rope_theta = 1_000_000.0;
+        cfg.rope_theta_swa = Some(10_000.0);
+        cfg.sliding_window = Some(4);
+        cfg.swa_pattern = Some(6);
+        cfg.rope_freqs = Some(crate::config::RopeFreqs {
+            full: vec![8.0; 4],
+            swa: Some(vec![1.0; 4]),
+        });
+        // One full period, so the run holds five sliding layers and one
+        // full-attention layer -- Gemma-3's ratio, and the smallest one
+        // that makes `rope_freqs_vary_by_layer` true.
+        cfg.n_layers = 6;
+        cfg
+    }
+
+    /// What the fused Metal stacks are handed per layer must be BOTH
+    /// halves of `ModelConfig::layer_rope`, layer by layer.
+    ///
+    /// `Decoder::metal_stack_needs_per_layer_rope_freqs` used to refuse
+    /// exactly this config off the fused prefill/decode stacks, because
+    /// those took one `freq_factors` slice for a whole run beside a
+    /// per-layer theta -- half the answer varying and half not, which is
+    /// this repo's dominant bug shape. `LayerRope` carries the pair, and
+    /// this pins that the decoder fills it from the pair rather than
+    /// re-deriving either half on its own.
+    #[test]
+    fn the_metal_stacks_are_handed_each_layer_s_own_rope_pair() {
+        let cfg = gemma3_4b_shaped_config();
+        assert!(
+            cfg.rope_freqs_vary_by_layer(),
+            "fixture must be the shape that used to be refused"
+        );
+        let decoder = Decoder::new_random_small(cfg, 6, 32);
+
+        for il in 0..decoder.layers.len() {
+            let (theta, ff) = decoder.config.layer_rope(il);
+            let sent = decoder.metal_layer_rope(il);
+            assert_eq!(sent.theta, theta, "layer {il} base");
+            assert_eq!(sent.freq_factors, ff, "layer {il} divisors");
+        }
+
+        // Not vacuous: with `swa_pattern = 6` last-dense, layers 0..=4
+        // slide and layer 5 does not, so the run really does hold two
+        // different answers.
+        let sliding = decoder.metal_layer_rope(0);
+        let full = decoder.metal_layer_rope(5);
+        assert_eq!(sliding.freq_factors, Some(&[1.0f32; 4][..]));
+        assert_eq!(full.freq_factors, Some(&[8.0f32; 4][..]));
+        assert_ne!(
+            sliding, full,
+            "a run of layers that all rope alike proves nothing here"
+        );
     }
 }

--- a/crates/ferrox-models/src/decoder/rope.rs
+++ b/crates/ferrox-models/src/decoder/rope.rs
@@ -375,7 +375,7 @@ mod tests {
         });
         assert!(
             !cfg.rope_freqs_vary_by_layer(),
-            "an inheriting model must stay eligible for the fused Metal stacks"
+            "an inheriting model resolves to ONE divisor set for every layer"
         );
 
         let decoder = Decoder::new_random_small(cfg, 2, 32);


### PR DESCRIPTION
Closes #63.

## What changed

The two fused Metal dense stacks took ONE `freq_factors` slice for a
whole run of layers, beside a *per-layer* `rope_theta`. Half of one
answer varied per layer and half did not — the repo's dominant bug
shape, in a function signature. #39 took the safe half and REFUSED any
model with per-layer divisors off the fused path
(`Decoder::metal_stack_needs_per_layer_rope_freqs`), which is why
Gemma-3 4B/12B/27B are correct and slower on `--ngl 99` today.

Both halves now travel as one value:

- `ferrox_metal::attn::LayerRope { theta, freq_factors }`, on
  `DenseLayerMetal` and `PrefillDenseLayerMetal`.
- The stack-wide `rope_theta` / `rope_thetas` / `freq_factors`
  parameters are gone from `launch_decode_dense_stack`,
  `launch_prefill_dense_stack` and `launch_prefill_dense_layer`. Giving
  a base without giving the divisors it goes with no longer compiles.
- `Decoder::metal_layer_rope(il)` is the single conversion from
  `ModelConfig::layer_rope`, shared by all four construction sites.
- The refusal is deleted.

Per-layer resident buffers are free: `resident_f32_buffer` keys its
cache on `(pointer, len)`, and an alternating-SWA model has at most two
distinct sets — two uploads, `N-2` cache hits, and no separate
"which set does layer *i* use" table for a call site to drift from.

## Why it should be believed

On this machine's Metal GPU:

- **`a_decode_stack_ropes_each_layer_with_its_own_freq_factors`** and
  **`a_prefill_stack_ropes_each_layer_with_its_own_freq_factors`**
  (`ferrox-metal`, `#[ignore]`d): a two-layer stack whose layers carry
  Gemma-3's two answers (base `1e6` ÷ 8, base `1e4` ÷ 1) against the
  per-layer launches. Bit-identical today; asserted at `1e-6` relative.
  Each then runs the old bug deliberately — one layer's rope for both
  layers — and asserts the answer MOVES, so neither can pass vacuously.
- **Sabotaged, each goes red**: `ff_resident[0]` instead of
  `ff_resident[layer_idx]` in either launch; and dropping the divisors
  past layer 0 in `metal_layer_rope` reddens
  `the_metal_stacks_are_handed_each_layer_s_own_rope_pair`.
- **`ferrox layer-divergence --backend metal`** stays under tolerance on
  gemma-2-2b (SWA + sandwich norms, so it actually rides the fused
  stacks), Llama-3.2-1B (carries `rope_freqs.weight`) and Qwen2.5-1.5B.
  The Gemma-2 Metal quality gate and `paged_metal_parity` still pass;
  greedy Metal completions on gemma-2-2b and Llama-3.2-1B are sane.

## What would have to be true for this to be wrong

**No Gemma-3 4B/12B/27B checkpoint exists on this host**, and Gemma-3-1B
declares no rope scaling, so it cannot exercise the per-layer path — a
pass on 1B would prove nothing. Gemma-4-E2B has the two-set shape but
runs on the dedicated `gemma4` engine, not these stacks. So the property
is proven on **synthetic layers shaped like Gemma-3 4B**, not on the
checkpoint itself. What would settle it: `ferrox layer-divergence
--backend metal` on `gemma-3-4b-it-Q4_K_M.gguf`, plus `ferrox parity` at
Q8_0.

**No benchmark was run** — an agent may not, and a loaded host reads
25-45% low. The whole point of the issue is a speed recovery, so the
number is the maintainer's to take on a quiet host: `ferrox bench -m
gemma-3-4b... --backend metal --compare`, before and after.

## Not done, on purpose

- `launch_moe_decode_stack` still takes one `(theta, freq_factors)` pair
  for its whole run. It is sound — its gate requires
  `!layer_needs_metal_stack` for every layer, so no layer of an admitted
  model slides, and `rope_freqs_vary_by_layer` cannot be true — and the
  existing comment says so. Converting it to `LayerRope` is consistency
  work with no checkpoint behind it; not in this PR.
- `ModelConfig::rope_freqs_vary_by_layer` is kept: the loader tests use
  it as a statement about a checkpoint. Its doc no longer claims to be
  an eligibility check (a one-line doc edit in `config.rs`, the only
  file touched outside the stated scope).

## Doc delta for the maintainer

`docs/MODELS.md` records Gemma-3 4B+ on Metal as correct-but-slower with
the fused stacks refused. That is no longer the state: the stacks now
serve them. This PR does not touch `docs/` (another agent owns it), so
that line still needs updating — ideally alongside the tok/s number from
the bench above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
