### PR TITLE
fix(server): the prompt now reaches the sampling seam, so the HTTP API penalises what llama-server penalises

### DIFF
--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -1522,6 +1522,7 @@ pub fn generate(
     let (finish, generated_ids, final_logits) = sample_until_stop(
         logits,
         pos,
+        &tokens,
         stop_tokens,
         params,
         |ids| tokenizer.decode(ids),
@@ -1652,6 +1653,12 @@ pub fn generate(
 fn sample_until_stop(
     mut logits: Vec<f32>,
     mut pos: usize,
+    // The prompt this generation continues. Passed rather than derived
+    // because the penalties window is the tail of `prompt ++ generated`
+    // (llama-server seeds its sampler with the prompt before the first
+    // draw), and this seam previously had no way to see it, so the HTTP
+    // API and `ferrox run` disagreed about what one flag means (#73).
+    prompt_ids: &[usize],
     stop_tokens: &StopTokens,
     params: &GenerationParams,
     mut decode_one: impl FnMut(&[usize]) -> String,
@@ -1686,6 +1693,7 @@ fn sample_until_stop(
             &mut state,
             &logits,
             params,
+            prompt_ids,
             &generated_ids,
             stop_tokens,
             decode_token,
@@ -1799,6 +1807,7 @@ pub fn generate_engine<E: Engine, T: TextTokenizer>(
     let (finish, generated_ids, _final_logits) = sample_until_stop(
         logits,
         pos,
+        &tokens,
         stop_tokens,
         params,
         |ids| tokenizer.decode(ids),
@@ -2359,6 +2368,9 @@ mod tests {
         let (finish, ids, _) = sample_until_stop(
             first,
             0,
+            // A scripted-logits harness with no real prompt: the empty
+            // half is the truth here, not an omission.
+            &[],
             &stop_tokens,
             params,
             |ids| ids.iter().copied().map(&render).collect::<String>(),

--- a/crates/ferrox-server/src/sample_step.rs
+++ b/crates/ferrox-server/src/sample_step.rs
@@ -95,27 +95,19 @@ pub(crate) fn sample_next(
     state: &mut SampleState,
     logits: &[f32],
     params: &GenerationParams,
+    prompt: &[usize],
     history: &[usize],
     stop_tokens: &StopTokens,
     decode_token: &dyn Fn(usize) -> String,
 ) -> Result<Step, DecodeError> {
-    // The prompt half is EMPTY here, and that is a known divergence
-    // from llama.cpp, not a decision this function is making.
-    //
-    // llama.cpp seeds its penalties sampler with every prompt token
-    // before the first draw (`tools/server/server-context.cpp:386-390`),
-    // so `penalty_last_n` slides over `prompt ++ generated`. Both of
-    // this server's decode loops -- `generate::sample_until_stop` and
-    // `serving::batch::worker` -- hand this function the GENERATED ids
-    // alone, and neither has the prompt ids in scope to hand over:
-    // `sample_until_stop` takes `logits` and `pos`, never the ids.
-    // Closing it means threading the prompt through that signature,
-    // which is a `generate.rs` change and is tracked as issue #73.
-    //
-    // Spelled out as `&[]` at the ONE place the server builds a window,
-    // rather than left implicit in a slice argument, so the gap is a
-    // line someone deletes rather than a behaviour someone rediscovers.
-    let window = PenaltyWindow::new(&[], history);
+    // Both halves, so `penalty_last_n` slides over `prompt ++
+    // generated` exactly as llama-server's does: it seeds its sampler
+    // with every prompt token before the first draw
+    // (`tools/server/server-context.cpp:386-390`). The prompt used to
+    // be `&[]` here because the ids did not reach this seam, which made
+    // the HTTP API disagree with `ferrox run` about what the same flag
+    // means (#73).
+    let window = PenaltyWindow::new(prompt, history);
     if !params.needs_vocab_logits() {
         return Ok(Step::Token(state.sampler.sample(
             logits,
@@ -283,7 +275,9 @@ mod tests {
         stops: &StopTokens,
         decode: &dyn Fn(usize) -> String,
     ) -> Result<Step, DecodeError> {
-        sample_next(state, logits, params, history, stops, decode)
+        // These tests are about masking and stops, not penalties, so
+        // the prompt half is empty and says so.
+        sample_next(state, logits, params, &[], history, stops, decode)
     }
 
     /// The assertion neither decode path had. Token 0 wins the argmax by
@@ -608,5 +602,51 @@ mod tests {
         let chosen =
             token(step(&mut state, &logits, &params, &[], &letter_stops(), &letter).unwrap());
         assert_eq!(chosen, LETTER_EOG, "an optional trigger constrains nothing");
+    }
+
+    /// **The server must penalise the prompt, as llama-server does.**
+    ///
+    /// llama-server seeds its sampler with every prompt token before
+    /// the first draw (`tools/server/server-context.cpp:386-390`), so
+    /// `penalty_last_n` slides over `prompt ++ generated` there. This
+    /// seam passed `&[]` until #73, because the prompt ids did not
+    /// reach it, so the SAME request body produced different text from
+    /// llama-server, and from `ferrox run`, which was fixed first.
+    ///
+    /// Asserted on the sampled token. A test on the window's length
+    /// would pass with the window handed to the wrong distribution.
+    #[test]
+    fn a_prompt_token_is_penalised_by_the_server_before_it_is_generated() {
+        // Token 0 wins the argmax outright. A penalty heavy enough to
+        // dethrone it can only come from the PROMPT, since nothing has
+        // been generated yet.
+        let logits = vec![9.0, 8.0, 0.5];
+        let mut p = params(false, 0.0);
+        p.sampling.repetition_penalty = 50.0;
+        p.sampling.penalty_last_n = 64;
+
+        let mut state = SampleState::new(7);
+        let with_prompt = sample_next(&mut state, &logits, &p, &[0], &[], &letter_stops(), &|id| {
+            letter(id)
+        })
+        .expect("sampling succeeds");
+
+        let mut state = SampleState::new(7);
+        let without_prompt =
+            sample_next(&mut state, &logits, &p, &[], &[], &letter_stops(), &|id| {
+                letter(id)
+            })
+            .expect("sampling succeeds");
+
+        assert_eq!(
+            token(without_prompt),
+            0,
+            "with no prompt the argmax stands, which is what makes the other half meaningful"
+        );
+        assert_eq!(
+            token(with_prompt),
+            1,
+            "a token in the prompt must be penalised on its FIRST generated occurrence"
+        );
     }
 }

--- a/crates/ferrox-server/src/serving/batch/worker.rs
+++ b/crates/ferrox-server/src/serving/batch/worker.rs
@@ -341,6 +341,10 @@ pub(super) fn worker_loop(
                 &mut slot.sample,
                 &slot.logits,
                 &slot.params,
+                // The row already keeps its prompt, for the radix
+                // publish. The penalties window is the tail of
+                // `prompt ++ generated`, so it needs the same slice.
+                &slot.prompt_ids,
                 &slot.generated_ids,
                 &slot.stop_tokens,
                 &|id| decode(&[id]),


### PR DESCRIPTION
Closes #73, the half #55 could not reach.

#55 fixed `ferrox run`, `speculative`, `draft_model` and `kimi_generate`. It could not fix the server, because `sample_until_stop` took logits and a position and never the prompt ids.

**That left the fix worse than half done.** Before it, five call sites disagreed with llama.cpp *together*. After it, `ferrox run` matched llama.cpp and `ferrox serve` did not — so the two entry points of one binary answered the same request body differently. Replacing one disagreement with a newer one is not progress.

The batched path needed a slice it was already holding: rows keep `prompt_ids` for the radix publish.

Two call sites genuinely have no prompt and now say `&[]` **explicitly** — the scripted-logits harness and the masking/stop tests. That is what `PenaltyWindow` having no single-slice constructor buys: an empty half is a visible claim in the diff rather than an argument nobody passed.

The test asserts the sampled token: token 0 wins the argmax outright, so a penalty heavy enough to dethrone it can only come from the prompt. Restoring `PenaltyWindow::new(&[], history)` turns it red.

Gates: workspace build, 52 suites, clippy debug and release, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN