### PR TITLE
docs: forced tool_choice reaches eight formats, and Gemma-3 4B+ is back on the fused Metal path

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -64,7 +64,7 @@ conversation or a large `/v1/embeddings` batch past that comes back
 | `presence_penalty`, `frequency_penalty` | Supported |
 | `stream` | Supported (overlapped SSE when tools off and CB off) |
 | `tools` / `tool_choice: none\|auto` | Supported (prompt-engineered, parsed in eleven wire formats) |
-| `tool_choice: required` / named function | Supported on the three JSON-object wire formats (Hermes/Qwen2.5, Llama 3, Mistral), by a lazy grammar. **501 naming the format** on the other eight |
+| `tool_choice: required` / named function | Supported on **eight of the eleven** wire formats, by a lazy grammar built from the same marker description the parser reads with. **501 naming the format** on the remaining three (`gemma4`, `minimax_m3`, `muse_glimmer`), each for a reason the refusal states |
 | `logprobs` / `top_logprobs` / `n` (>1) | **Reject** |
 | `response_format: json_object` | Supported (best-effort character mask + validate) |
 | `grammar` | Supported. llama.cpp's own field: a GBNF string, enforced per token by a real parser |
@@ -1190,11 +1190,28 @@ The cost, stated: a model that never opens a call runs to `max_tokens`
 and finishes `"length"`, a visible failure rather than prose served as
 the call that was asked for.
 
-Only the three wire formats whose call is a JSON object behind a marker
-are supported: Hermes/Qwen2.5, Llama 3 and Mistral. The other eight
-return **501 naming the format**, because a Hermes-shaped grammar on a
-GLM checkpoint would force output that ferrox's own streaming parser
-cannot read back.
+**Eight of the eleven** wire formats are supported: the three whose call
+is a JSON object behind a marker (Hermes/Qwen2.5, Llama 3, Mistral),
+plus `qwen3_coder`, `glm47`, `minimax`, `deepseekv32` and `gpt_oss`.
+
+The grammar's literals are built from the SAME marker description the
+streaming parser reads with, which is the only reason this is safe to
+widen. Two hand-kept tables, one for writing a call and one for reading
+it, would drift, and the symptom would be output the engine forced and
+then could not parse back.
+
+Three still return **501 naming the format**, each for a reason the
+refusal states:
+
+- `gemma4`: arguments are a comma-separated list in gemma's own quoting
+  rather than a JSON object, so required-versus-optional cannot be said
+  by the object rule every other format shares. llama.cpp does not
+  schema-constrain gemma4 either.
+- `minimax_m3`: an argument is named by an element, and a repeated
+  element means an array, so what a name means depends on siblings that
+  have not been written yet.
+- `muse_glimmer`: the call boundary is not syntactic. The same ATEM
+  block is a call in a tool channel and prose in a user-facing one.
 
 ## Not yet
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -163,14 +163,28 @@ The evidence is llama.cpp's source and header-driven loader tests, NOT a
 logit comparison: no checkpoint of those sizes exists on the development
 host. A `ferrox parity` run against one is what would settle it.
 
-A cost came with it. Gemma-3 4B and up no longer use the fused Metal
-dense stacks, because those take one `freq_factors` slice for a whole
-run of layers and these models need one per layer. They take the
-per-layer path instead: correct, and slower. No published number
-changes: [`benchmarks/RESULTS.md`](../benchmarks/RESULTS.md) carries
-Gemma-3-1B only, and 1B is neither 27B nor rope-scaled, so it is
-untouched by both corrections. Tracked as
-[#63](https://github.com/antonellof/ferrox/issues/63).
+A cost came with it and has since been paid back. Gemma-3 4B and up
+briefly left the fused Metal dense stacks, because those took one
+`freq_factors` slice for a whole run of layers while these models need
+one per layer: correct, and slower. The stacks now carry a per-layer
+`LayerRope` holding the base and its divisors together, so supplying one
+without the other does not compile, and Gemma-3 4B+ is back on the fused
+path (#63).
+
+**That last part is proven on synthetic layers, not on a checkpoint.**
+No Gemma-3 4B/12B/27B GGUF exists on the development host, and
+Gemma-3-1B would prove nothing because it declares no rope scaling. The
+Metal tests build a two-layer stack carrying Gemma-3's two answers
+(base 1e6 divided by 8, and base 1e4 divided by 1) and assert the fused
+and per-layer launches agree bit for bit, then re-run the old bug on
+purpose so neither can pass vacuously. `ferrox layer-divergence` on a
+real gemma-3-4b, plus `ferrox parity` at Q8_0, is what would settle it.
+
+No published number changes:
+[`benchmarks/RESULTS.md`](../benchmarks/RESULTS.md) carries Gemma-3-1B
+only, and 1B is neither 27B nor rope-scaled, so it is untouched by all
+of this. The speed recovery from returning to the fused path is
+unmeasured, because measuring it needs a quiet host.
 
    `gemma2`, `gemma3`, `phi3`, `gpt-oss`, `dots1`). The other **41**
    stop with `UnauditedArchitecture`. `FERROX_ALLOW_UNAUDITED_ARCH=1`


### PR DESCRIPTION
Doc deltas for #77 and #75.

`docs/API.md` said three of eleven and used GLM as the refusal example. GLM is served now. The paragraph also records *why* widening was safe, which is the part that matters: the grammar's literals come from the same marker description the parser reads with, so there aren't two hand-kept tables of eleven framings to drift. Two would, and the symptom would be output the engine forced and then could not parse back.

The three that still refuse are listed with reasons rather than as a count, because each is a different kind of "cannot".

`docs/MODELS.md` said Gemma-3 4B+ was off the fused Metal stacks and "correct, and slower". It is back on them. The limit is now written where a reader hits it: that fix is proven on **synthetic layers, not a checkpoint**, and the speed recovery is **unmeasured** because measuring needs a quiet host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN