### PR TITLE
fix(rerank): /v1/rerank ranked the relevant document last, and could not load a reranker at all

### DIFF
--- a/crates/ferrox-models/src/bert_encoder.rs
+++ b/crates/ferrox-models/src/bert_encoder.rs
@@ -8,7 +8,7 @@
 //! # The graph, and the five places it is not a decoder
 //!
 //! ```text
-//! h[i] = tok_embd[t[i]] + type_embd[0] + pos_embd[i]      (1) (2)
+//! h[i] = tok_embd[t[i]] + type_embd[seg[i]] + pos_embd[i] (1) (2)
 //! h    = LayerNorm(h, token_embd_norm)                        (3)
 //! for each layer:
 //!     q,k,v = Wq h + bq,  Wk h + bk,  Wv h + bv
@@ -24,12 +24,20 @@
 //!    lookup. A learned table cannot be extrapolated, which is why
 //!    [`crate::encoder::EncodeError::TooLong`] is an error and not a
 //!    warning.
-//! 2. **A token-type embedding.** Upstream hardcodes row 0 ("Sentence
-//!    A") — `ggml_view_1d(ctx0, model.type_embd, n_embd, 0)` — because
-//!    the single-sequence embedding use never has a sentence B. Ferrox
-//!    does the same, and the loader refuses a checkpoint whose
-//!    `token_types` table is missing when the metadata says it should
-//!    have one.
+//! 2. **A token-type embedding, per position.** A single-sequence
+//!    embedding pass is all "Sentence A" and uses row 0, which is what
+//!    upstream hardcodes — `ggml_view_1d(ctx0, model.type_embd, n_embd,
+//!    0)`, with the comment that token types are hardcoded to zero
+//!    because `llama_batch` carries no segment ids. A cross-encoder
+//!    PAIR is not that case: HuggingFace's `tokenizer(query, document)`
+//!    emits `0…0 1…1` and `BertModel` adds row 1 to every position
+//!    after the first `[SEP]`. Ferrox adds the row the caller names,
+//!    which is row 0 for every embedding request and 0/1 for a rerank
+//!    pair. Matching upstream here instead was measured, on
+//!    `cross-encoder/ms-marco-MiniLM-L6-v2` against a NumPy transcription
+//!    of `BertForSequenceClassification`, to put the RELEVANT document
+//!    LAST in three of four rankings — see
+//!    `tests/rerank_cross_encoder_ordering.rs`.
 //! 3. **LayerNorm, not RMSNorm, at three sites per layer plus one on
 //!    the input.** Mean-subtracting, and every one of them carries a
 //!    `bias` tensor as well as a `weight`. Substituting RMSNorm here
@@ -55,7 +63,7 @@
 use ferrox_core::matmul::{gelu, layer_norm};
 use ferrox_core::weight_matrix::WeightMatrix;
 
-use crate::encoder::{EncodeError, TextEncoder};
+use crate::encoder::{EncodeError, PairSequence, TextEncoder};
 use crate::pooling::PoolingType;
 
 /// `bert.*` metadata, after the loader has checked it.
@@ -112,8 +120,13 @@ pub struct BertLayer {
 pub struct BertEncoder {
     pub hp: BertHparams,
     pub tok_embd: WeightMatrix,
-    /// Row 0 of `token_types.weight` — "Sentence A". See the module docs.
-    pub type_embd_row0: Option<Vec<f32>>,
+    /// `token_types.weight`, **every** row: `[n_token_types, n_embd]`.
+    /// Row 0 is "Sentence A" and row 1 "Sentence B". `None` when the
+    /// checkpoint carries no table at all, which upstream allows
+    /// (`TENSOR_NOT_REQUIRED`) and which means no segment embedding is
+    /// added anywhere. Loading only row 0 — what this held before — is
+    /// what made a rerank pair score both halves as Sentence A.
+    pub type_embd: Option<Vec<Vec<f32>>>,
     pub pos_embd: WeightMatrix,
     pub tok_norm_w: Vec<f32>,
     pub tok_norm_b: Vec<f32>,
@@ -229,33 +242,50 @@ impl TextEncoder for BertEncoder {
         out
     }
 
-    /// `[CLS] a [SEP] b [SEP]` — what HuggingFace's
-    /// `tokenizer(query, document)` builds for a BERT cross-encoder,
-    /// which is the input these checkpoints were trained on.
-    ///
-    /// The **segment ids** that pairing normally carries are not here,
-    /// and that is deliberate rather than forgotten: this graph adds
-    /// row 0 of `token_types.weight` to every position, because
-    /// llama.cpp does the same (`token types are hardcoded to zero`,
-    /// its `bert.cpp`; see [`BertEncoder::type_embd_row0`]). A reranker
-    /// scored here therefore differs from the HF reference by the
-    /// second segment's type embedding, on both engines equally. It is
-    /// recorded in the ferrox rerank docs and is the first thing to
-    /// check if an ordering disagrees with `transformers`.
-    fn wrap_special_pair(&self, a: &[u32], b: &[u32]) -> Option<Vec<u32>> {
-        let mut out = Vec::with_capacity(a.len() + b.len() + 3);
-        out.push(self.hp.cls_id);
-        out.extend_from_slice(a);
-        out.push(self.hp.sep_id);
-        out.extend_from_slice(b);
-        out.push(self.hp.sep_id);
-        Some(out)
+    /// The height of `token_types.weight`, or 1 when the checkpoint
+    /// carries no table (nothing is added at any position, which is
+    /// what a one-row table would do anyway).
+    fn n_segments(&self) -> usize {
+        self.type_embd.as_ref().map(Vec::len).unwrap_or(1)
     }
 
-    fn encode_tokens(&self, tokens: &[u32]) -> Result<Vec<f32>, EncodeError> {
+    /// `[CLS] a [SEP] b [SEP]` with segments `0…0 1…1` — what
+    /// HuggingFace's `tokenizer(query, document)` builds for a BERT
+    /// cross-encoder, which is the input these checkpoints were
+    /// trained on.
+    ///
+    /// The boundary is defined once, here, and both vectors are cut on
+    /// it: the first `[SEP]` closes segment 0 (HF counts it as part of
+    /// the first half) and everything after it is segment 1. Returning
+    /// the ids alone and letting the graph assume a segment is how the
+    /// document half came to be scored as "Sentence A".
+    fn wrap_special_pair(&self, a: &[u32], b: &[u32]) -> Option<PairSequence> {
+        let mut tokens = Vec::with_capacity(a.len() + b.len() + 3);
+        tokens.push(self.hp.cls_id);
+        tokens.extend_from_slice(a);
+        tokens.push(self.hp.sep_id);
+        let first_half = tokens.len();
+        tokens.extend_from_slice(b);
+        tokens.push(self.hp.sep_id);
+        let mut segments = vec![0u32; tokens.len()];
+        for s in segments[first_half..].iter_mut() {
+            *s = 1;
+        }
+        Some(PairSequence { tokens, segments })
+    }
+
+    fn encode(&self, tokens: &[u32], segments: Option<&[u32]>) -> Result<Vec<f32>, EncodeError> {
         let n = tokens.len();
         if n == 0 {
             return Err(EncodeError::EmptySequence);
+        }
+        if let Some(seg) = segments {
+            if seg.len() != n {
+                return Err(EncodeError::RaggedSegments {
+                    tokens: n,
+                    segments: seg.len(),
+                });
+            }
         }
         if n > self.hp.n_ctx_train {
             return Err(EncodeError::TooLong {
@@ -279,7 +309,15 @@ impl TextEncoder for BertEncoder {
             for (j, slot) in row.iter_mut().enumerate() {
                 *slot = tok[j] + pos[j];
             }
-            if let Some(ty) = &self.type_embd_row0 {
+            if let Some(table) = &self.type_embd {
+                let seg = segments.map(|s| s[i]).unwrap_or(0);
+                let ty = table
+                    .get(seg as usize)
+                    .ok_or(EncodeError::SegmentOutOfRange {
+                        id: seg,
+                        pos: i,
+                        n_segments: table.len(),
+                    })?;
                 for (slot, tv) in row.iter_mut().zip(ty.iter()) {
                     *slot += tv;
                 }
@@ -376,7 +414,8 @@ mod tests {
         let mut r = Lcg(0x5EED);
         let tok_embd = r.matrix(VOCAB, D);
         let pos_embd = r.matrix(CTX, D);
-        let type_embd_row0 = Some(r.vec(D));
+        // Two rows, like every real BERT: "Sentence A" and "Sentence B".
+        let type_embd = Some(vec![r.vec(D), r.vec(D)]);
         let tok_norm_w = r.vec(D);
         let tok_norm_b = r.vec(D);
         let layers = (0..n_layer)
@@ -415,7 +454,7 @@ mod tests {
                 sep_id: 2,
             },
             tok_embd,
-            type_embd_row0,
+            type_embd,
             pos_embd,
             tok_norm_w,
             tok_norm_b,
@@ -426,10 +465,10 @@ mod tests {
     /// An f64 transcription of the graph in the module docs, written
     /// the slowest possible way: no `apply_batch`, no shared buffers,
     /// one scalar loop per matrix element. It exists to disagree with
-    /// [`BertEncoder::encode_tokens`] if the fast path transposes a
-    /// matrix, drops a bias, norms the wrong residual, or reuses a
-    /// buffer it should not.
-    fn reference_forward(m: &BertEncoder, tokens: &[u32]) -> Vec<f64> {
+    /// [`BertEncoder::encode`] if the fast path transposes a matrix,
+    /// drops a bias, norms the wrong residual, reuses a buffer it
+    /// should not, or reads the wrong row of the token-type table.
+    fn reference_forward(m: &BertEncoder, tokens: &[u32], segments: &[u32]) -> Vec<f64> {
         let d = m.hp.n_embd;
         let n = tokens.len();
         let hd = m.hp.head_dim();
@@ -461,7 +500,11 @@ mod tests {
             .map(|(i, &t)| {
                 let tok = m.tok_embd.dequant_row(t as usize);
                 let pos = m.pos_embd.dequant_row(i);
-                let ty = m.type_embd_row0.clone().unwrap_or(vec![0.0; d]);
+                let ty = m
+                    .type_embd
+                    .as_ref()
+                    .map(|t| t[segments[i] as usize].clone())
+                    .unwrap_or_else(|| vec![0.0; d]);
                 let row: Vec<f64> = (0..d)
                     .map(|j| tok[j] as f64 + pos[j] as f64 + ty[j] as f64)
                     .collect();
@@ -554,7 +597,7 @@ mod tests {
         let m = fixture(3);
         let tokens = [1u32, 7, 13, 4, 9, 2];
         let got = m.encode_tokens(&tokens).unwrap();
-        let want = reference_forward(&m, &tokens);
+        let want = reference_forward(&m, &tokens, &[0; 6]);
         assert_eq!(got.len(), want.len());
         for (i, (g, w)) in got.iter().zip(&want).enumerate() {
             assert!(
@@ -562,6 +605,54 @@ mod tests {
                 "element {i}: {g} vs reference {w}"
             );
         }
+    }
+
+    /// The same transcription, driven with a real `0 0 0 1 1 1` split.
+    /// The point is not that segments *do something* — it is that the
+    /// fast path reads the SAME row the reference does at every
+    /// position, so an off-by-one on the boundary or a table indexed
+    /// with the token id would show up here.
+    #[test]
+    fn the_segment_id_selects_the_token_type_row_at_every_position() {
+        let m = fixture(3);
+        let tokens = [1u32, 7, 13, 4, 9, 2];
+        let segments = [0u32, 0, 0, 1, 1, 1];
+        let got = m.encode(&tokens, Some(&segments)).unwrap();
+        let want = reference_forward(&m, &tokens, &segments);
+        for (i, (g, w)) in got.iter().zip(&want).enumerate() {
+            assert!(
+                (*g as f64 - w).abs() < 2e-4,
+                "element {i}: {g} vs reference {w}"
+            );
+        }
+        // And it is genuinely a different graph from the all-zeros one,
+        // which is the whole of issue #44: scoring the second half as
+        // "Sentence A" is not a rounding difference.
+        let all_zero = m.encode_tokens(&tokens).unwrap();
+        let moved: f32 = all_zero
+            .iter()
+            .zip(&got)
+            .map(|(x, y)| (x - y).abs())
+            .sum::<f32>();
+        assert!(moved > 1e-3, "segment 1 changed nothing ({moved})");
+    }
+
+    /// A segment id with no row, and a segment list that is not one per
+    /// token, are refusals rather than a panic or a silently wrong row.
+    #[test]
+    fn a_segment_id_off_the_table_and_a_ragged_segment_list_are_refused() {
+        let m = fixture(1);
+        assert!(matches!(
+            m.encode(&[1, 7, 2], Some(&[0, 2, 0])),
+            Err(EncodeError::SegmentOutOfRange { id: 2, pos: 1, .. })
+        ));
+        assert!(matches!(
+            m.encode(&[1, 7, 2], Some(&[0, 0])),
+            Err(EncodeError::RaggedSegments {
+                tokens: 3,
+                segments: 2
+            })
+        ));
     }
 
     /// The property that makes this an encoder. Row 0's output must
@@ -640,27 +731,43 @@ mod tests {
         assert_eq!(m.wrap_special(&[]), vec![1, 2]);
     }
 
-    /// The cross-encoder input is `[CLS] a [SEP] b [SEP]` — the
-    /// boundary between the two halves is the whole reason a reranker
-    /// scores differently from an embedding model. Concatenating
-    /// without it, or dropping the trailing `[SEP]`, produces a
-    /// perfectly plausible ranking that is not the model's, so the
-    /// exact sequence is asserted rather than its length.
+    /// The cross-encoder input is `[CLS] a [SEP] b [SEP]` with segments
+    /// `0 0 0 0 1 1` — the boundary between the two halves is the whole
+    /// reason a reranker scores differently from an embedding model.
+    /// Concatenating without it, dropping the trailing `[SEP]`, or
+    /// leaving every segment at 0, produces a perfectly plausible
+    /// ranking that is not the model's, so both vectors are asserted
+    /// exactly rather than by length.
+    ///
+    /// The first `[SEP]` belongs to segment 0, which is what
+    /// HuggingFace's `tokenizer(query, document)` emits: an off-by-one
+    /// there is a one-position difference that no shape check catches.
     #[test]
-    fn the_pair_form_separates_the_two_halves_and_closes_the_second() {
+    fn the_pair_form_separates_the_two_halves_and_labels_each_one() {
         let m = fixture(1);
-        assert_eq!(
-            m.wrap_special_pair(&[7, 8], &[9]).unwrap(),
-            vec![1, 7, 8, 2, 9, 2]
-        );
+        let pair = m.wrap_special_pair(&[7, 8], &[9]).unwrap();
+        assert_eq!(pair.tokens, vec![1, 7, 8, 2, 9, 2]);
+        assert_eq!(pair.segments, vec![0, 0, 0, 0, 1, 1]);
         // An empty half is still a half: the boundary stays.
-        assert_eq!(m.wrap_special_pair(&[], &[]).unwrap(), vec![1, 2, 2]);
+        let empty = m.wrap_special_pair(&[], &[]).unwrap();
+        assert_eq!(empty.tokens, vec![1, 2, 2]);
+        assert_eq!(empty.segments, vec![0, 0, 1]);
         // And it is NOT the single-sequence form of the two texts run
         // together, which is what a defaulted implementation would give.
-        assert_ne!(
-            m.wrap_special_pair(&[7, 8], &[9]).unwrap(),
-            m.wrap_special(&[7, 8, 9])
-        );
+        assert_ne!(pair.tokens, m.wrap_special(&[7, 8, 9]));
+    }
+
+    /// A checkpoint with no "Sentence B" row cannot express a pair, and
+    /// [`crate::EmbeddingModel`] refuses one at load. This is the value
+    /// that refusal reads.
+    #[test]
+    fn n_segments_is_the_height_of_the_token_type_table() {
+        let mut m = fixture(1);
+        assert_eq!(m.n_segments(), 2);
+        m.type_embd = Some(vec![vec![0.0; D]]);
+        assert_eq!(m.n_segments(), 1);
+        m.type_embd = None;
+        assert_eq!(m.n_segments(), 1);
     }
 
     /// `embed_tokens` must return the CLS row of the hidden states this

--- a/crates/ferrox-models/src/bert_gguf_loader.rs
+++ b/crates/ferrox-models/src/bert_gguf_loader.rs
@@ -188,12 +188,17 @@ pub fn load_bert_encoder(file: &ShardedGguf) -> Result<BertEncoder, LoadError> {
         )));
     }
 
-    // Row 0 only: upstream views `type_embd` at offset 0 and adds it,
-    // because a single-sequence embedding pass is always "Sentence A".
-    // The tensor is `TENSOR_NOT_REQUIRED` there, so its absence is not
-    // an error — but the whole table is then unused, and
-    // `assert_every_tensor_consumed` would flag any other row anyway.
-    let type_embd_row0 = match file.find_tensor("token_types.weight") {
+    // The WHOLE table, not row 0. Upstream views `type_embd` at offset
+    // 0 and adds it everywhere, because `llama_batch` carries no
+    // segment ids; ferrox's encoder takes them as a parameter, so a
+    // cross-encoder pair can put its document half on row 1 the way the
+    // checkpoint was trained. Loading row 0 alone is what made
+    // `/v1/rerank` rank the relevant document last (see
+    // `bert_encoder`'s module docs). The tensor is
+    // `TENSOR_NOT_REQUIRED` upstream, so its absence is not an error —
+    // it means no segment embedding is added at all, and a reranker
+    // checkpoint in that state is refused by `EmbeddingModel`.
+    let type_embd = match file.find_tensor("token_types.weight") {
         Some(_) => {
             let table = load_weight_matrix(file, "token_types.weight")?;
             if table.rows() != hp.n_token_types || table.cols() != hp.n_embd {
@@ -205,7 +210,7 @@ pub fn load_bert_encoder(file: &ShardedGguf) -> Result<BertEncoder, LoadError> {
                     hp.n_embd
                 )));
             }
-            Some(table.dequant_row(0))
+            Some((0..table.rows()).map(|r| table.dequant_row(r)).collect())
         }
         None => None,
     };
@@ -291,7 +296,7 @@ pub fn load_bert_encoder(file: &ShardedGguf) -> Result<BertEncoder, LoadError> {
     Ok(BertEncoder {
         hp,
         tok_embd,
-        type_embd_row0,
+        type_embd,
         pos_embd,
         tok_norm_w,
         tok_norm_b,

--- a/crates/ferrox-models/src/embedding_model.rs
+++ b/crates/ferrox-models/src/embedding_model.rs
@@ -14,7 +14,7 @@
 use thiserror::Error;
 
 use crate::bert_gguf_loader::{load_bert_encoder, read_bert_hparams, BERT_ARCH};
-use crate::encoder::{EncodeError, TextEncoder};
+use crate::encoder::{EncodeError, PairSequence, TextEncoder};
 use crate::loader::LoadError;
 use crate::pooling::{l2_normalize, pool, PoolingType};
 use crate::rank_head::{load_rank_head, RankHead};
@@ -103,6 +103,48 @@ pub enum EmbedError {
          wrongly, so this refuses instead"
     )]
     NoPairInput { arch: String },
+    #[error(
+        "the reranker checkpoint {name:?} ({arch}) carries a classification head but only \
+         {rows} token-type row(s): there is no \"Sentence B\" embedding to put the document \
+         half of a pair on. Scoring both halves as Sentence A is what this cross-encoder was \
+         NOT trained on, and it reorders the results rather than merely shifting them, so \
+         this refuses at load instead of serving a plausible wrong ranking"
+    )]
+    NoSegmentB {
+        name: String,
+        arch: String,
+        rows: usize,
+    },
+}
+
+/// The one condition under which a checkpoint that HAS a classification
+/// head still cannot serve `/v1/rerank`: its token-type table has no
+/// "Sentence B" row, so a pair would put both halves on segment 0.
+///
+/// A function rather than an `if` inside the loader so the arm is
+/// testable without a GGUF carrying that shape. A refusal whose
+/// condition cannot be shown to fire reads as coverage and is not: this
+/// repo has shipped one keyed on a GGUF spelling nothing writes.
+///
+/// It is checked at LOAD, and only here, because this is the only place
+/// the head and the encoder are both in hand — the BERT loader does not
+/// know whether a head was found, and asking once per request would put
+/// the answer in two places. A checkpoint in this state cannot answer
+/// the one route it exists for, so it does not load.
+fn refuse_unpairable_reranker(
+    has_rank_head: bool,
+    n_segments: usize,
+    name: &str,
+    arch: &str,
+) -> Option<EmbedError> {
+    if has_rank_head && n_segments < 2 {
+        return Some(EmbedError::NoSegmentB {
+            name: name.to_string(),
+            arch: arch.to_string(),
+            rows: n_segments,
+        });
+    }
+    None
 }
 
 /// A loaded embedding model: tokenizer + encoder + the checkpoint's own
@@ -157,6 +199,12 @@ impl EmbeddingModel {
         let hp = read_bert_hparams(&file)?;
         let rank_head = load_rank_head(&file, &hp.arch, hp.n_embd, hp.layer_norm_eps)?;
         let encoder = load_bert_encoder(&file)?;
+
+        if let Some(refusal) =
+            refuse_unpairable_reranker(rank_head.is_some(), encoder.n_segments(), &name, &arch)
+        {
+            return Err(refusal);
+        }
 
         Ok(Self {
             encoder: Box::new(encoder),
@@ -239,14 +287,15 @@ impl EmbeddingModel {
         self.rank_head.as_ref()
     }
 
-    /// The exact ids [`Self::rerank_score`] will see for one
-    /// `(query, document)` pair: `[CLS] query [SEP] document [SEP]`.
+    /// The exact input [`Self::rerank_score`] will see for one
+    /// `(query, document)` pair: `[CLS] query [SEP] document [SEP]`,
+    /// **with** the segment id of every position.
     ///
     /// Separate from the scoring call for the same reason
     /// [`Self::token_ids`] is separate from [`Self::embed`] — a route
-    /// has to report `usage.prompt_tokens`, and that number is this
-    /// length.
-    pub fn rerank_token_ids(&self, query: &str, document: &str) -> Result<Vec<u32>, EmbedError> {
+    /// has to report `usage.prompt_tokens`, and that number is
+    /// `tokens.len()`.
+    pub fn rerank_input(&self, query: &str, document: &str) -> Result<PairSequence, EmbedError> {
         self.encoder
             .wrap_special_pair(
                 &self.tokenizer.encode(query),
@@ -258,7 +307,7 @@ impl EmbeddingModel {
     }
 
     /// The head's relevance score for a pair sequence built by
-    /// [`Self::rerank_token_ids`].
+    /// [`Self::rerank_input`].
     ///
     /// This is upstream's RANK path in full: encode, take the **CLS**
     /// row, run the classification head, report output 0
@@ -272,7 +321,7 @@ impl EmbeddingModel {
     /// No L2 normalization and no sigmoid: upstream reports the raw
     /// logit, so a score is comparable only against other scores from
     /// the same head, and this must not quietly squash it into `0..1`.
-    pub fn rerank_score(&self, pair_ids: &[u32]) -> Result<f32, EmbedError> {
+    pub fn rerank_score(&self, pair: &PairSequence) -> Result<f32, EmbedError> {
         let head = self
             .rank_head
             .as_ref()
@@ -280,10 +329,31 @@ impl EmbeddingModel {
                 name: self.name.clone(),
                 arch: self.arch.clone(),
             })?;
-        let hidden = self.encoder.encode_tokens(pair_ids)?;
+        let hidden = self.pair_hidden_states(pair)?;
         let cls = pool(&hidden, self.encoder.n_embd(), PoolingType::Cls)
             .map_err(|e| EmbedError::Encode(EncodeError::Pooling(e)))?;
         Ok(head.score(&cls))
+    }
+
+    /// Un-pooled `n_tokens × n_embd` hidden states for a pair built by
+    /// [`Self::rerank_input`] — [`Self::hidden_states`]'s counterpart
+    /// for the cross-encoder input, and the one graph call
+    /// [`Self::rerank_score`] itself makes.
+    ///
+    /// Public for the same reason [`Self::hidden_states`] is: when a
+    /// relevance score is surprising, the first questions are what
+    /// tokens the model saw and what came out before the head, and
+    /// without this the only way to ask was to load the checkpoint a
+    /// second time — which for a reranker does not even work, because
+    /// [`crate::load_bert_encoder_from_path`] alone leaves `cls.*`
+    /// unconsumed and refuses.
+    ///
+    /// The pair's own `segments` are honoured, so passing a
+    /// [`PairSequence`] whose segments are all zero reproduces the
+    /// segment-blind graph exactly, without a second copy of it to
+    /// drift.
+    pub fn pair_hidden_states(&self, pair: &PairSequence) -> Result<Vec<f32>, EmbedError> {
+        Ok(self.encoder.encode(&pair.tokens, Some(&pair.segments))?)
     }
 }
 
@@ -359,5 +429,29 @@ mod tests {
         for arch in ["llama", "qwen3", "gemma3", "deepseek2"] {
             assert!(!is_embedding_arch(arch), "{arch} was routed to this path");
         }
+    }
+
+    /// A reranker that cannot express "Sentence B" is refused at load,
+    /// and a plain embedding model in the same state is NOT — an
+    /// embedding pass is all segment 0 and has nothing to say about a
+    /// second row.
+    ///
+    /// The point of the test is that the refusing arm is REACHABLE.
+    /// Written as a condition inside the loader it could only be
+    /// exercised by a checkpoint nobody publishes, which is how a gate
+    /// comes to read as coverage while never firing.
+    #[test]
+    fn only_a_reranker_needs_a_second_token_type_row_and_it_is_refused_without_one() {
+        assert!(refuse_unpairable_reranker(true, 2, "r", "bert").is_none());
+        assert!(refuse_unpairable_reranker(false, 1, "e", "bert").is_none());
+        assert!(refuse_unpairable_reranker(false, 0, "e", "bert").is_none());
+
+        let err = refuse_unpairable_reranker(true, 1, "some-reranker", "bert")
+            .expect("a head with one segment row must refuse");
+        let msg = err.to_string();
+        for fact in ["some-reranker", "bert", "1 token-type row"] {
+            assert!(msg.contains(fact), "{msg} does not carry {fact}");
+        }
+        assert!(matches!(err, EmbedError::NoSegmentB { rows: 1, .. }));
     }
 }

--- a/crates/ferrox-models/src/encoder.rs
+++ b/crates/ferrox-models/src/encoder.rs
@@ -53,8 +53,43 @@ pub enum EncodeError {
     },
     #[error("token id {id} is outside this checkpoint's {vocab_size}-entry vocabulary")]
     TokenOutOfRange { id: u32, vocab_size: usize },
+    #[error(
+        "segment id {id} at position {pos} is outside this checkpoint's {n_segments}-row \
+         token-type table"
+    )]
+    SegmentOutOfRange {
+        id: u32,
+        pos: usize,
+        n_segments: usize,
+    },
+    #[error(
+        "{tokens} token(s) were given {segments} segment id(s); every position needs exactly \
+         one, or the graph would add a segment embedding to the wrong row"
+    )]
+    RaggedSegments { tokens: usize, segments: usize },
     #[error(transparent)]
     Pooling(#[from] PoolingError),
+}
+
+/// One two-segment encoder input: the token ids and, for each of them,
+/// which half of the pair it belongs to.
+///
+/// The two vectors are built together and travel together on purpose.
+/// They are the repo's dominant bug shape waiting to happen — two
+/// structures that must agree, here about a length and about where the
+/// boundary is — and the single place that can get them right is
+/// [`TextEncoder::wrap_special_pair`], which inserts the `[SEP]` that
+/// the boundary is defined by. Handing a caller the ids alone (what
+/// this seam used to do) meant the segment ids did not exist at all
+/// and every position was scored as "Sentence A".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairSequence {
+    /// `[CLS] a [SEP] b [SEP]` for BERT.
+    pub tokens: Vec<u32>,
+    /// `0` for the `[CLS] a [SEP]` half, `1` for the `b [SEP]` half —
+    /// HuggingFace's `token_type_ids`. Always the same length as
+    /// [`Self::tokens`].
+    pub segments: Vec<u32>,
 }
 
 /// A model that turns a whole token sequence into hidden states in one
@@ -84,9 +119,25 @@ pub trait TextEncoder {
         pieces.to_vec()
     }
 
+    /// How many rows the checkpoint's token-type ("segment") table
+    /// carries, i.e. the number of distinct segment ids
+    /// [`Self::encode`] will accept.
+    ///
+    /// `1` — the default — means the encoder can only represent
+    /// "Sentence A", which is enough for an embedding pass and is not
+    /// enough for a cross-encoder pair. Read at load time by
+    /// [`crate::EmbeddingModel`], which refuses a reranker checkpoint
+    /// that cannot express segment 1 rather than silently scoring the
+    /// document half as segment 0.
+    fn n_segments(&self) -> usize {
+        1
+    }
+
     /// The two-segment input a **cross-encoder** scores: one sequence
     /// holding a query and a document with the model's own boundary
-    /// between them. For BERT that is `[CLS] a [SEP] b [SEP]`.
+    /// between them, and the segment id of every position. For BERT
+    /// that is `[CLS] a [SEP] b [SEP]` with segments `0…0 1…1`, which is
+    /// exactly what HuggingFace's `tokenizer(query, document)` emits.
     ///
     /// `None` — the default — means this encoder has no two-segment
     /// form, and a caller that needs one must refuse. Deliberately NOT
@@ -95,12 +146,26 @@ pub trait TextEncoder {
     /// still returns a plausible float. That is the "computes something
     /// else" failure, and it is invisible — a rerank with no boundary
     /// produces an ordering, just not the model's.
-    fn wrap_special_pair(&self, _a: &[u32], _b: &[u32]) -> Option<Vec<u32>> {
+    fn wrap_special_pair(&self, _a: &[u32], _b: &[u32]) -> Option<PairSequence> {
         None
     }
 
     /// `n_tokens × n_embd` hidden states, in row order.
-    fn encode_tokens(&self, tokens: &[u32]) -> Result<Vec<f32>, EncodeError>;
+    ///
+    /// `segments` is the per-position segment id, or `None` for "all
+    /// zeros" — the single-sequence case. There is deliberately ONE
+    /// graph with a parameter rather than a segment-aware copy of a
+    /// segment-blind one: this repo has lost a model feature to every
+    /// copied forward pass it has ever had, and the pair path is
+    /// exercised far less often than the embedding path, so a copy is
+    /// exactly where a fix would fail to land.
+    fn encode(&self, tokens: &[u32], segments: Option<&[u32]>) -> Result<Vec<f32>, EncodeError>;
+
+    /// [`Self::encode`] for a single sequence: every position is
+    /// segment 0.
+    fn encode_tokens(&self, tokens: &[u32]) -> Result<Vec<f32>, EncodeError> {
+        self.encode(tokens, None)
+    }
 
     /// [`Self::encode_tokens`] followed by the checkpoint's own pooling.
     /// Not L2-normalized — see [`crate::pooling::pool`].

--- a/crates/ferrox-models/src/lib.rs
+++ b/crates/ferrox-models/src/lib.rs
@@ -80,7 +80,7 @@ pub use decoder::{Decoder, MultiSeqKv};
 pub use device_budget::{BudgetBackend, DeviceBudget};
 pub use draft_model::{DraftModelSpeculator, VocabMismatch};
 pub use embedding_model::{is_embedding_arch, EmbedError, EmbeddingModel};
-pub use encoder::{EncodeError, TextEncoder};
+pub use encoder::{EncodeError, PairSequence, TextEncoder};
 pub use engine::{
     DeepseekV4Engine, Engine, Glm52Engine, KimiEngine, MlaDenseFfn, MlaEngine, MlaLayerFfn,
     MlaLayerWeights, MlaMoeFfn, MlaMoeRuntime, TextTokenizer,

--- a/crates/ferrox-models/src/loader.rs
+++ b/crates/ferrox-models/src/loader.rs
@@ -1461,8 +1461,20 @@ pub(crate) fn load_weight_matrix(
     // as a real transposition bug affecting every externally-produced
     // GGUF file, caught by serving a real downloaded checkpoint.
     let shape: Vec<usize> = info.shape.iter().rev().map(|&d| d as usize).collect();
+    // A ggml tensor's `ne[]` is always four long and trailing 1s are
+    // implicit, so a GGUF writer is free to store a `[in, 1]` matrix
+    // with `n_dims = 1`. llama.cpp reads it back as a matrix anyway --
+    // `check_tensor_dims` compares each requested dimension against
+    // `cur->ne[i]` and requires 1 for the dimensions the file does not
+    // carry -- so a single-output projection is a 2-D weight there and
+    // must be one here. Refusing it instead made a real checkpoint
+    // unloadable: `cross-encoder/ms-marco-MiniLM-L6-v2` writes
+    // `cls.output.weight` as `[384]`, i.e. the 1x384 relevance head
+    // that `/v1/rerank` exists to run, and the whole route died at load
+    // with "expected 2D".
     let (rows, cols) = match shape.as_slice() {
         [r, c] => (*r, *c),
+        [c] => (1, *c),
         other => {
             return Err(LoadError::UnsupportedDtype(
                 format!("{name} (expected 2D, got shape {other:?})"),
@@ -1470,6 +1482,10 @@ pub(crate) fn load_weight_matrix(
             ))
         }
     };
+    // `shape` is what the file said; `[rows, cols]` is what the matrix
+    // is. They differ exactly in the 1-D case above, and the `Tensor`
+    // must carry the matrix shape or `apply` reads it as a vector.
+    let shape = vec![rows, cols];
 
     match info.dtype {
         // BF16 has no block/scale structure to keep quantized-in-place

--- a/crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs
+++ b/crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs
@@ -1,0 +1,304 @@
+//! `/v1/rerank`'s model half, on a real cross-encoder checkpoint, with
+//! the ORDER checked against an independent implementation.
+//!
+//! # Why this file exists
+//!
+//! The rerank route (PR #42) shipped assembled from pieces that were
+//! each unit-tested and never once run together, because there was no
+//! reranker checkpoint on the development machine (issue #43). "It
+//! returns 200" is not evidence for a route whose entire contract is
+//! that the ordering is right, and a wrong ordering is invisible: it
+//! produces a ranking, just not the model's.
+//!
+//! Running it end to end found two defects that green CI could not:
+//!
+//! 1. **The checkpoint would not load at all.** `cls.output.weight` is
+//!    a `1 x 384` projection, and GGUF stores it with `n_dims = 1`
+//!    because ggml's trailing dimensions are implicitly 1. ferrox's
+//!    `load_weight_matrix` demanded two, so every reranker died with
+//!    `UnsupportedDtype("cls.output.weight (expected 2D, got shape
+//!    [384])")`.
+//! 2. **The ordering was wrong** — see
+//!    [`scoring_both_halves_as_segment_zero_ranks_the_relevant_document_last`],
+//!    which is the old behaviour, preserved as a test so the fix cannot
+//!    silently revert. That is issue #44: the document half of the pair
+//!    was embedded as "Sentence A".
+//!
+//! # Getting the checkpoint
+//!
+//! ```text
+//! ferrox download sinjab/ms-marco-MiniLM-L6-v2-Q8_0-GGUF --local-dir models
+//! cargo test -p ferrox-models --test rerank_cross_encoder_ordering -- --ignored --nocapture
+//! ```
+//!
+//! 24 MB, `bert` / WordPiece, six layers, `n_embd = 384`, one output
+//! labelled `LABEL_0`. `bge-reranker-*` cannot stand in for it: those
+//! are XLM-R with a SentencePiece vocabulary and refuse at
+//! `EmbedError::UnsupportedTokenizer`.
+//!
+//! **These tests FAIL rather than skip when the file is absent.** The
+//! repo's other checkpoint tests print `SKIP` and return, which passes
+//! in 0.00 s — and a `--ignored` run that silently passes is exactly
+//! how a route ships unverified twice. `#[ignore]` already means "only
+//! when asked"; asking and getting nothing is a failure.
+//!
+//! # Where the expected numbers come from
+//!
+//! `scripts/rerank_reference_ms_marco.py` — a NumPy transcription of
+//! HuggingFace `BertForSequenceClassification` read straight from the
+//! checkpoint's safetensors, with no `transformers` model classes and
+//! no torch, so it is a genuinely second implementation rather than a
+//! recording of ferrox's own output.
+//!
+//! # The one place ferrox does NOT match HuggingFace, deliberately
+//!
+//! llama.cpp's converter drops `bert.pooler.dense` ("we are only using
+//! BERT for embeddings so we don't need the pooling layer",
+//! `conversion/bert.py`), so the GGUF does not contain it and the head
+//! runs as `classifier(cls_hidden)` instead of
+//! `classifier(tanh(pooler(cls_hidden)))`. No engine can apply a tensor
+//! that is not in the file. The measured effect is on the score SCALE
+//! (about +-0.2 rather than about +-11), not on which document wins;
+//! the reference script prints both columns so the difference stays
+//! visible. The assertions below are against the column ferrox can
+//! actually reach, plus the *ordering* of the full HuggingFace
+//! reference.
+
+use std::path::{Path, PathBuf};
+
+use ferrox_models::{pool, EmbeddingModel, PoolingType};
+
+/// The Q8_0 conversion of `cross-encoder/ms-marco-MiniLM-L6-v2`.
+///
+/// Absence is a failure, not a skip: see the module docs.
+fn checkpoint() -> PathBuf {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../models/ms-marco-MiniLM-L6-v2-Q8_0.gguf");
+    assert!(
+        path.exists(),
+        "{} is missing. These tests are `#[ignore]`d precisely so that running them means \
+         you want them to run, so this fails instead of passing in 0.00s.\n    \
+         ferrox download sinjab/ms-marco-MiniLM-L6-v2-Q8_0-GGUF --local-dir models\n\
+         (a git worktree has no models/ of its own — symlink the one in the main checkout)",
+        path.display()
+    );
+    path
+}
+
+/// The query, and documents in an order that is NOT the answer.
+///
+/// Document 1 answers the question and documents 2 and 3 are about
+/// something else entirely, so "the relevant one ranks first" is a
+/// property of the model and not of the fixture. Document 4 is loosely
+/// on-topic and document 0 is about the right city and the wrong thing,
+/// which is what distinguishes a reranker from a keyword match.
+const QUERY: &str = "How many people live in Berlin?";
+const DOCUMENTS: [&str; 5] = [
+    "Berlin is well known for its museums.",
+    "Berlin had a population of 3,520,031 registered inhabitants in an area of 891.82 square kilometers.",
+    "The capital of France is Paris.",
+    "Elephants are the largest land animals.",
+    "Berlin is the capital and largest city of Germany by both area and population.",
+];
+
+/// `scripts/rerank_reference_ms_marco.py`, `ferrox` row: the NumPy
+/// reference restricted to what the GGUF carries (no pooler, real
+/// segment ids).
+const REFERENCE_SCORES: [f32; 5] = [-0.027210, 0.073057, -0.172285, -0.245995, 0.010248];
+
+/// `scripts/rerank_reference_ms_marco.py`, `hf` row: the ordering the
+/// checkpoint's full HuggingFace head produces. ferrox must reproduce
+/// this ORDER even though it cannot reproduce those scores.
+const REFERENCE_ORDER: [usize; 5] = [1, 4, 0, 2, 3];
+
+/// Q8_0 weights against an f64 reference. The largest deviation
+/// measured across all four query sets in the script is 1.7e-3.
+const TOLERANCE: f32 = 4e-3;
+
+fn ranking(scores: &[f32]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..scores.len()).collect();
+    order.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]));
+    order
+}
+
+/// The load itself, which is where this route died before anything
+/// could be said about its ordering.
+///
+/// Three claims in one, because each was broken or untested:
+///
+/// * a `1 x n_embd` `cls.output.weight` stored with `n_dims = 1` loads;
+/// * `load_rank_head` runs before `load_bert_encoder`, so
+///   `assert_every_tensor_consumed` does not reject `cls.*` — the
+///   ordering carried a load-bearing comment and no test;
+/// * the head is the checkpoint's own, with its declared label.
+#[test]
+#[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+fn a_real_reranker_checkpoint_loads_with_its_classification_head() {
+    let model = EmbeddingModel::from_gguf_path(checkpoint()).expect("load the reranker");
+    assert_eq!(model.architecture(), "bert");
+    assert_eq!(model.n_embd(), 384);
+    let head = model
+        .rank_head()
+        .expect("a reranker checkpoint with no head is not a reranker");
+    assert_eq!(head.n_cls_out(), 1);
+    assert_eq!(head.labels(), ["LABEL_0"]);
+}
+
+/// The input the head was trained on: `[CLS] query [SEP] document
+/// [SEP]`, with the query half segment 0 and the document half segment
+/// 1 — `tokenizer(query, document)`'s `token_type_ids`.
+///
+/// Checked against ids this checkpoint's own vocabulary produces, so a
+/// tokenizer change that silently drops the boundary shows up here and
+/// not as a slightly worse ranking.
+#[test]
+#[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+fn the_pair_is_cls_query_sep_document_sep_with_the_document_on_segment_one() {
+    let model = EmbeddingModel::from_gguf_path(checkpoint()).expect("load the reranker");
+    let pair = model.rerank_input(QUERY, DOCUMENTS[0]).expect("pair input");
+
+    // [CLS] how many people live in berlin ? [SEP] berlin is well known
+    // for its museums . [SEP]
+    assert_eq!(
+        pair.tokens,
+        vec![
+            101, 2129, 2116, 2111, 2444, 1999, 4068, 1029, 102, 4068, 2003, 2092, 2124, 2005, 2049,
+            9941, 1012, 102
+        ]
+    );
+    assert_eq!(
+        pair.segments,
+        vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    );
+    assert_eq!(pair.tokens.len(), pair.segments.len());
+    // The boundary is the first [SEP] and it belongs to the query half.
+    assert_eq!(pair.tokens[8], 102);
+    assert_eq!(pair.segments[8], 0);
+    assert_eq!(pair.segments[9], 1);
+}
+
+/// **The point of the whole file.** The document that answers the
+/// question must rank FIRST, and the assertion is on the INDEX, not on
+/// a score threshold: a score says nothing without the others to
+/// compare it against, and it is the index a client joins its own array
+/// back onto.
+///
+/// Also asserts the scores themselves against the NumPy reference. That
+/// is what rules out "it ranks plausibly for the wrong reason": a
+/// cosine similarity, or a head that ran on the wrong row, would still
+/// put document 1 near the top on a fixture this easy.
+#[test]
+#[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+fn the_relevant_document_ranks_first_and_the_scores_match_the_numpy_reference() {
+    let model = EmbeddingModel::from_gguf_path(checkpoint()).expect("load the reranker");
+    let scores: Vec<f32> = DOCUMENTS
+        .iter()
+        .map(|d| {
+            let pair = model.rerank_input(QUERY, d).expect("pair input");
+            model.rerank_score(&pair).expect("score")
+        })
+        .collect();
+
+    let order = ranking(&scores);
+    assert_eq!(
+        order[0],
+        1,
+        "the document that answers the query ranked {} of {}: {scores:?}",
+        order.iter().position(|&i| i == 1).unwrap() + 1,
+        DOCUMENTS.len()
+    );
+    assert_eq!(
+        order,
+        REFERENCE_ORDER.to_vec(),
+        "ferrox ordered {order:?}, HuggingFace {REFERENCE_ORDER:?}, from {scores:?}"
+    );
+
+    for (i, (got, want)) in scores.iter().zip(REFERENCE_SCORES).enumerate() {
+        assert!(
+            (got - want).abs() < TOLERANCE,
+            "document {i}: ferrox {got}, NumPy reference {want}"
+        );
+    }
+    // A relevance logit, not a similarity: it is signed and it is not
+    // confined to -1..1, so nothing here could be a cosine standing in
+    // for the head.
+    assert!(scores.iter().any(|s| *s < 0.0) && scores.iter().any(|s| *s > 0.0));
+}
+
+/// The number `/v1/rerank` reports is the classification head's output
+/// applied to the CLS row, and this rebuilds that composition from its
+/// parts to prove it.
+///
+/// `rerank_score` is one call; this is `encode`, then CLS pooling, then
+/// [`ferrox_models::RankHead::score`], assembled here. If they disagree,
+/// the route is reporting something other than the head — which is the
+/// failure the whole route was written to avoid, and the reason
+/// `/v1/embeddings` refuses a RANK checkpoint rather than serving a
+/// cosine.
+#[test]
+#[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+fn the_reported_score_is_the_head_run_on_the_cls_row() {
+    let model = EmbeddingModel::from_gguf_path(checkpoint()).expect("load the reranker");
+    let head = model.rank_head().expect("head is present");
+
+    let pair = model.rerank_input(QUERY, DOCUMENTS[1]).expect("pair input");
+    let hidden = model.pair_hidden_states(&pair).expect("hidden states");
+    assert_eq!(hidden.len(), pair.tokens.len() * model.n_embd());
+    let cls = pool(&hidden, model.n_embd(), PoolingType::Cls).expect("cls row");
+    let by_hand = head.score(&cls);
+
+    let by_route = model.rerank_score(&pair).expect("score");
+    assert_eq!(
+        by_hand, by_route,
+        "the score the model reports is not the head applied to the CLS row"
+    );
+    // The head is doing real work: 384 floats in, one out, and it is
+    // not the CLS row's own first element passed through.
+    assert_eq!(cls.len(), 384);
+    assert_ne!(by_route, cls[0]);
+}
+
+/// **The old behaviour, kept as a test so the fix cannot revert.**
+///
+/// Before issue #44 was fixed, `encode` added row 0 of
+/// `token_types.weight` at every position, matching llama.cpp — whose
+/// `llama_batch` carries no segment ids, so its `bert.cpp` views
+/// `type_embd` at offset 0 and says token types are hardcoded to zero.
+/// #44 recorded that as a defensible shared deviation and asked for it
+/// to be MEASURED before being changed. Measured, on this checkpoint,
+/// it puts the document that answers the question DEAD LAST out of
+/// five, and it does the same in two of the other three query sets in
+/// `scripts/rerank_reference_ms_marco.py`.
+///
+/// So the deviation is not a scale difference, it is a different
+/// ranking, and this asserts the size of what was fixed rather than
+/// leaving "it changes the order" as a claim in a commit message.
+#[test]
+#[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+fn scoring_both_halves_as_segment_zero_ranks_the_relevant_document_last() {
+    let model = EmbeddingModel::from_gguf_path(checkpoint()).expect("load the reranker");
+    let head = model.rank_head().expect("head is present");
+
+    let segment_blind: Vec<f32> = DOCUMENTS
+        .iter()
+        .map(|d| {
+            let mut pair = model.rerank_input(QUERY, d).expect("pair input");
+            // The old graph, expressed as data rather than as a second
+            // copy of the forward pass: every position on "Sentence A".
+            pair.segments.fill(0);
+            let hidden = model.pair_hidden_states(&pair).expect("hidden states");
+            let cls = pool(&hidden, model.n_embd(), PoolingType::Cls).expect("cls row");
+            head.score(&cls)
+        })
+        .collect();
+
+    let order = ranking(&segment_blind);
+    assert_eq!(
+        *order.last().unwrap(),
+        1,
+        "the segment-blind graph no longer ranks the relevant document last ({order:?} from \
+         {segment_blind:?}); if the reference changed, re-run \
+         scripts/rerank_reference_ms_marco.py before relaxing this"
+    );
+    assert_ne!(order, REFERENCE_ORDER.to_vec());
+}

--- a/crates/ferrox-server/src/rerank.rs
+++ b/crates/ferrox-server/src/rerank.rs
@@ -245,9 +245,9 @@ fn validate(query: &str, documents: &[String]) -> Result<(), ApiError> {
 /// is the caller's 400, named with the document it came from.
 fn embed_error(index: usize, e: EmbedError) -> ApiError {
     match e {
-        EmbedError::NoRankHead { .. } | EmbedError::NoPairInput { .. } => {
-            unsupported_feature(&e.to_string())
-        }
+        EmbedError::NoRankHead { .. }
+        | EmbedError::NoPairInput { .. }
+        | EmbedError::NoSegmentB { .. } => unsupported_feature(&e.to_string()),
         other => bad_request(format!("document {index}: {other}")),
     }
 }
@@ -266,11 +266,11 @@ async fn score_documents(
         let mut scores = Vec::with_capacity(documents.len());
         let mut prompt_tokens = 0usize;
         for (i, doc) in documents.iter().enumerate() {
-            let ids = encoder
-                .rerank_token_ids(&query, doc)
+            let pair = encoder
+                .rerank_input(&query, doc)
                 .map_err(|e| embed_error(i, e))?;
-            prompt_tokens += ids.len();
-            let score = encoder.rerank_score(&ids).map_err(|e| embed_error(i, e))?;
+            prompt_tokens += pair.tokens.len();
+            let score = encoder.rerank_score(&pair).map_err(|e| embed_error(i, e))?;
             scores.push(finite_score(score, i)?);
         }
         Ok::<_, ApiError>((scores, prompt_tokens))
@@ -529,5 +529,171 @@ mod tests {
 
         let bare = results_json(&order, &scores, &docs(3), false);
         assert!(bare[0].get("document").is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // The composition, on a real cross-encoder.
+    //
+    // Everything above this line is the route's arithmetic with
+    // hand-written scores, which is what shipped in PR #42 and is
+    // exactly the coverage issue #43 said was not enough: a wrong
+    // ordering does not come from `ranking`, it comes from what
+    // `score_documents` puts into it. These run the encoder.
+    //
+    //     ferrox download sinjab/ms-marco-MiniLM-L6-v2-Q8_0-GGUF \
+    //         --local-dir models
+    //     cargo test -p ferrox-server rerank -- --ignored --nocapture
+    //
+    // The model half's own evidence -- the ordering against a NumPy
+    // transcription of HuggingFace `BertForSequenceClassification` --
+    // is `ferrox-models/tests/rerank_cross_encoder_ordering.rs`. What
+    // is added here is the part that lives in this file: that the
+    // route's `index` addresses the CALLER's array when the scores are
+    // real and the input is not already sorted.
+    // ---------------------------------------------------------------
+
+    /// Fails rather than skips when the checkpoint is absent -- see the
+    /// same rule in `rerank_cross_encoder_ordering.rs`. A `--ignored`
+    /// run that passes in 0.00s is how this route shipped unverified.
+    fn reranker() -> Arc<EmbeddingModel> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../models/ms-marco-MiniLM-L6-v2-Q8_0.gguf");
+        assert!(
+            path.exists(),
+            "{} is missing; these tests are #[ignore]d so that running them means you want \
+             them to run.\n    ferrox download sinjab/ms-marco-MiniLM-L6-v2-Q8_0-GGUF \
+             --local-dir models",
+            path.display()
+        );
+        Arc::new(EmbeddingModel::from_gguf_path(&path).expect("load the reranker"))
+    }
+
+    const QUERY: &str = "How many people live in Berlin?";
+
+    /// Deliberately NOT in score order, and the answer is not first,
+    /// not last, and not at any index a fencepost error would land on.
+    fn berlin_documents() -> Vec<String> {
+        [
+            "Berlin is well known for its museums.",
+            "The capital of France is Paris.",
+            "Berlin had a population of 3,520,031 registered inhabitants in an area of \
+             891.82 square kilometers.",
+            "Elephants are the largest land animals.",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    /// **The whole route, on a real checkpoint.** The document that
+    /// answers the query is at index 2 of what the caller sent, so the
+    /// first result row must carry `index: 2` — the position in the
+    /// REQUEST. Reporting the position in the sorted output would give
+    /// `index: 0` here and would have been indistinguishable from
+    /// correct in every test that existed before this one, because
+    /// those supplied their own scores.
+    #[tokio::test]
+    #[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+    async fn the_relevant_document_wins_and_its_index_is_the_one_the_caller_sent() {
+        let documents = Arc::new(berlin_documents());
+        let (scores, prompt_tokens) =
+            score_documents(reranker(), QUERY.to_string(), Arc::clone(&documents))
+                .await
+                .expect("scoring");
+        assert_eq!(scores.len(), 4);
+
+        let order = ranking(&scores, None);
+        assert_eq!(order[0], 2, "ranked {order:?} from {scores:?}");
+        let rows = results_json(&order, &scores, &documents, true);
+        assert_eq!(rows[0]["index"], 2);
+        assert!(rows[0]["document"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("3,520,031"));
+        // The score travelled with its document, not with its rank.
+        assert_eq!(rows[0]["relevance_score"], scores[2]);
+        // Every caller index appears exactly once.
+        let mut seen: Vec<u64> = rows.iter().map(|r| r["index"].as_u64().unwrap()).collect();
+        seen.sort_unstable();
+        assert_eq!(seen, vec![0, 1, 2, 3]);
+        // `usage.prompt_tokens` counts the pair sequences the encoder
+        // actually saw, specials included -- four pairs of a nine-token
+        // query plus a document, so comfortably over four.
+        assert!(prompt_tokens > 4 * 9, "{prompt_tokens}");
+    }
+
+    /// `top_n` truncates the ANSWER, and the indices in what survives
+    /// are still the caller's. Also the three boundaries, against real
+    /// scores rather than a fixture: 0, past the end, and absent.
+    #[tokio::test]
+    #[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+    async fn top_n_truncates_the_answer_without_renumbering_it() {
+        let documents = Arc::new(berlin_documents());
+        let (scores, _) = score_documents(reranker(), QUERY.to_string(), Arc::clone(&documents))
+            .await
+            .expect("scoring");
+
+        let top1 = ranking(&scores, Some(1));
+        assert_eq!(top1, vec![2]);
+        assert_eq!(
+            results_json(&top1, &scores, &documents, false)[0]["index"],
+            2
+        );
+
+        assert!(ranking(&scores, Some(0)).is_empty());
+        assert_eq!(ranking(&scores, Some(99)), ranking(&scores, None));
+        assert_eq!(ranking(&scores, Some(4)), ranking(&scores, None));
+    }
+
+    /// Duplicate documents are a real tie, not a contrived one: the
+    /// encoder is deterministic, so the same text against the same
+    /// query is the same float. The tie must keep the caller's order,
+    /// which is what makes the same request answer the same way twice.
+    #[tokio::test]
+    #[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+    async fn identical_documents_tie_exactly_and_keep_the_caller_s_order() {
+        let relevant = "Berlin had a population of 3,520,031 registered inhabitants.";
+        let documents = Arc::new(vec![
+            "The capital of France is Paris.".to_string(),
+            relevant.to_string(),
+            "Elephants are the largest land animals.".to_string(),
+            relevant.to_string(),
+        ]);
+        let (scores, _) = score_documents(reranker(), QUERY.to_string(), Arc::clone(&documents))
+            .await
+            .expect("scoring");
+        assert_eq!(scores[1], scores[3], "the encoder is not deterministic");
+        assert_eq!(scores[0], scores[0]);
+
+        let order = ranking(&scores, None);
+        assert_eq!(
+            order[0], 1,
+            "the earlier of the two tied winners must come first: {order:?}"
+        );
+        assert_eq!(order[1], 3);
+    }
+
+    /// The refusals in front of the encoder, with a real one loaded:
+    /// `require_reranker` accepts it (so the 501 path cannot be masking
+    /// a checkpoint that would have worked), and `validate` still turns
+    /// the two empty inputs away before a single encoder pass is paid
+    /// for.
+    #[tokio::test]
+    #[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+    async fn a_real_reranker_answers_this_route_and_only_this_route() {
+        let encoder = reranker();
+        assert!(encoder.rank_head().is_some());
+        assert_eq!(
+            encoder_endpoints(&encoder),
+            vec![
+                ferrox_api::routes::V1_EMBEDDINGS,
+                ferrox_api::routes::V1_RERANK
+            ],
+            "this checkpoint carries no {{arch}}.pooling_type, so it is a RANK head on an \
+             encoder whose pooling is NONE -- both routes are honestly listed"
+        );
+        assert!(validate(QUERY, &berlin_documents()).is_ok());
+        assert!(validate(QUERY, &[]).is_err());
+        assert!(validate("", &berlin_documents()).is_err());
     }
 }

--- a/scripts/rerank_reference_ms_marco.py
+++ b/scripts/rerank_reference_ms_marco.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""An independent NumPy reference for a BERT cross-encoder reranker.
+
+Prints the relevance scores that `cross-encoder/ms-marco-MiniLM-L6-v2`
+gives for the query/document pairs in
+`crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs`, so the
+golden values that test asserts against are reproducible rather than
+recorded from ferrox itself (which would only prove ferrox agrees with
+ferrox).
+
+It is a transcription of HuggingFace `BertForSequenceClassification`
+straight from the safetensors -- no `transformers` model classes, no
+torch -- because the whole point is to be a *second* implementation.
+Only `numpy`, `safetensors` and `huggingface_hub` are needed.
+
+    python3 scripts/rerank_reference_ms_marco.py
+
+# The three variants it prints, and why they differ
+
+    hf      pooler + segment ids 0/1        the reference the checkpoint
+                                            was trained to produce
+    ferrox  no pooler + segment ids 0/1     what ferrox computes today
+    seg0    no pooler + all segments 0      what ferrox and llama.cpp
+                                            both computed before #44
+
+`ferrox` is missing the pooler because llama.cpp's converter DROPS
+`bert.pooler.dense` -- `conversion/bert.py`, "we are only using BERT for
+embeddings so we don't need the pooling layer" -- so the GGUF simply
+does not carry it, and no engine can apply a tensor that is not in the
+file. That flattens the score range (about +-0.2 instead of about +-11)
+and it is why the test asserts on the ORDER and on the `ferrox` column,
+not on the `hf` column.
+
+`seg0` is the one that was wrong: it puts the RELEVANT document LAST in
+three of these four rankings.
+"""
+
+import json
+import math
+import sys
+import unicodedata
+
+import numpy as np
+from huggingface_hub import snapshot_download
+from safetensors import safe_open
+
+REPO = "cross-encoder/ms-marco-MiniLM-L6-v2"
+
+CASES = [
+    (
+        "How many people live in Berlin?",
+        [
+            "Berlin is well known for its museums.",
+            "Berlin had a population of 3,520,031 registered inhabitants in an "
+            "area of 891.82 square kilometers.",
+            "The capital of France is Paris.",
+            "Elephants are the largest land animals.",
+            "Berlin is the capital and largest city of Germany by both area and "
+            "population.",
+        ],
+    ),
+    (
+        "What is the boiling point of water?",
+        [
+            "Water freezes at 0 degrees Celsius at sea level.",
+            "At standard atmospheric pressure water boils at 100 degrees Celsius.",
+            "The Pacific Ocean is the largest ocean on Earth.",
+            "Coffee is usually brewed just below boiling.",
+        ],
+    ),
+    (
+        "Who wrote Romeo and Juliet?",
+        [
+            "Romeo and Juliet is a tragedy written by William Shakespeare early "
+            "in his career.",
+            "The play is set in Verona, Italy.",
+            "Python is a programming language created by Guido van Rossum.",
+            "Juliet is fourteen years old in the play.",
+        ],
+    ),
+    (
+        "How do I install Rust on macOS?",
+        [
+            "Run the rustup installer script from rustup.rs to install the Rust "
+            "toolchain.",
+            "Rust is a systems programming language focused on safety.",
+            "macOS Ventura was released in 2022.",
+            "Cargo is the Rust package manager.",
+        ],
+    ),
+]
+
+
+def load(repo):
+    d = snapshot_download(repo_id=repo, allow_patterns=["*.json", "*.txt", "*.safetensors"])
+    w = {}
+    with safe_open(d + "/model.safetensors", framework="numpy") as f:
+        for k in f.keys():
+            w[k] = f.get_tensor(k).astype(np.float64)
+    cfg = json.load(open(d + "/config.json"))
+    vocab = [line.rstrip("\n") for line in open(d + "/vocab.txt", encoding="utf-8")]
+    return w, cfg, {t: i for i, t in enumerate(vocab)}
+
+
+W, CFG, TOK = load(REPO)
+NL, NH, D = CFG["num_hidden_layers"], CFG["num_attention_heads"], CFG["hidden_size"]
+EPS = CFG["layer_norm_eps"]
+HD = D // NH
+
+
+def wordpiece(text):
+    """`BertTokenizer(do_lower_case=True)`: strip accents, split on
+    punctuation and whitespace, then greedy longest-match wordpiece."""
+    text = unicodedata.normalize("NFD", text.lower())
+    text = "".join(c for c in text if unicodedata.category(c) != "Mn")
+    words, cur = [], ""
+    for ch in text:
+        if ch.isspace():
+            if cur:
+                words.append(cur)
+            cur = ""
+        elif not ch.isalnum() and ch != "_":
+            if cur:
+                words.append(cur)
+            cur = ""
+            words.append(ch)
+        else:
+            cur += ch
+    if cur:
+        words.append(cur)
+
+    ids = []
+    for word in words:
+        start, pieces, ok = 0, [], True
+        while start < len(word):
+            end, hit = len(word), None
+            while start < end:
+                sub = word[start:end]
+                if start > 0:
+                    sub = "##" + sub
+                if sub in TOK:
+                    hit = sub
+                    break
+                end -= 1
+            if hit is None:
+                ok = False
+                break
+            pieces.append(hit)
+            start = end
+        ids.extend(TOK[p] for p in pieces) if ok else ids.append(TOK["[UNK]"])
+    return ids
+
+
+def layer_norm(x, weight, bias):
+    mean = x.mean(-1, keepdims=True)
+    var = x.var(-1, keepdims=True)
+    return (x - mean) / np.sqrt(var + EPS) * weight + bias
+
+
+def gelu(x):
+    return 0.5 * x * (1.0 + np.vectorize(math.erf)(x / math.sqrt(2.0)))
+
+
+def encoder(ids, seg):
+    h = (
+        W["bert.embeddings.word_embeddings.weight"][ids]
+        + W["bert.embeddings.token_type_embeddings.weight"][seg]
+        + W["bert.embeddings.position_embeddings.weight"][: len(ids)]
+    )
+    h = layer_norm(h, W["bert.embeddings.LayerNorm.weight"], W["bert.embeddings.LayerNorm.bias"])
+    n = len(ids)
+    for i in range(NL):
+        p = f"bert.encoder.layer.{i}."
+        q = h @ W[p + "attention.self.query.weight"].T + W[p + "attention.self.query.bias"]
+        k = h @ W[p + "attention.self.key.weight"].T + W[p + "attention.self.key.bias"]
+        v = h @ W[p + "attention.self.value.weight"].T + W[p + "attention.self.value.bias"]
+        q, k, v = (t.reshape(n, NH, HD).transpose(1, 0, 2) for t in (q, k, v))
+        s = q @ k.transpose(0, 2, 1) / np.sqrt(HD)
+        e = np.exp(s - s.max(-1, keepdims=True))
+        ctx = ((e / e.sum(-1, keepdims=True)) @ v).transpose(1, 0, 2).reshape(n, D)
+        x = ctx @ W[p + "attention.output.dense.weight"].T + W[p + "attention.output.dense.bias"]
+        x = layer_norm(
+            x + h,
+            W[p + "attention.output.LayerNorm.weight"],
+            W[p + "attention.output.LayerNorm.bias"],
+        )
+        u = gelu(x @ W[p + "intermediate.dense.weight"].T + W[p + "intermediate.dense.bias"])
+        d = u @ W[p + "output.dense.weight"].T + W[p + "output.dense.bias"]
+        h = layer_norm(d + x, W[p + "output.LayerNorm.weight"], W[p + "output.LayerNorm.bias"])
+    return h
+
+
+def score(query, document, pooler, segment_ids):
+    a, b = wordpiece(query), wordpiece(document)
+    ids = [TOK["[CLS]"]] + a + [TOK["[SEP]"]] + b + [TOK["[SEP]"]]
+    seg = [0] * (len(a) + 2) + [1] * (len(b) + 1) if segment_ids else [0] * len(ids)
+    cls = encoder(ids, seg)[0]
+    if pooler:
+        cls = np.tanh(cls @ W["bert.pooler.dense.weight"].T + W["bert.pooler.dense.bias"])
+    return float(cls @ W["classifier.weight"][0] + W["classifier.bias"][0])
+
+
+VARIANTS = [
+    ("hf    ", dict(pooler=True, segment_ids=True)),
+    ("ferrox", dict(pooler=False, segment_ids=True)),
+    ("seg0  ", dict(pooler=False, segment_ids=False)),
+]
+
+
+def main():
+    for query, documents in CASES:
+        print(f"\nQ: {query}")
+        for label, kwargs in VARIANTS:
+            scores = [score(query, d, **kwargs) for d in documents]
+            order = sorted(range(len(scores)), key=lambda i: -scores[i])
+            print(f"  {label}  order={order}  scores={[round(s, 6) for s in scores]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`/v1/rerank` had never run end to end. Running it found two defects, and
the second is that the route **ranked the relevant document last**.

## What was wrong

**1. No reranker checkpoint could load.** `cls.output.weight` is a
`1 x n_embd` projection and GGUF stores it with `n_dims = 1`, because a
ggml tensor's trailing dimensions are implicitly 1.
`loader::load_weight_matrix` demanded two, so
`cross-encoder/ms-marco-MiniLM-L6-v2` died with
`UnsupportedDtype("cls.output.weight (expected 2D, got shape [384])")`.
llama.cpp reads the same file as a matrix (`check_tensor_dims` requires
1 for each dimension the file does not carry), and now so does ferrox.

**2. The ordering was wrong.** `token_types.weight` row 0 was added at
every position, so the document half of `[CLS] query [SEP] document
[SEP]` was embedded as "Sentence A". That is #44, which said the
deviation was defensible because llama.cpp shares it and asked for it to
be MEASURED before being changed. Measured, on
`cross-encoder/ms-marco-MiniLM-L6-v2`:

| variant | order | |
|---|---|---|
| HuggingFace reference | `[1, 4, 0, 2, 3]` | the answer first |
| ferrox / llama.cpp, before | `[4, 2, 0, 3, 1]` | **the answer LAST** |
| ferrox, after | `[1, 4, 0, 2, 3]` | matches |

Query `"How many people live in Berlin?"`; document 1 is the population
figure. Three of the four query sets in the reference script were wrong
the same way. It is not a shifted score, it is a different ranking.

## What changed

- `TextEncoder::encode(tokens, segments)` is the one graph, with the
  segments as a **parameter**; `encode_tokens(tokens)` is a thin default
  meaning "all zeros". Not a segment-aware copy of a segment-blind
  forward pass — the pair path runs far less often than the embedding
  path, so a copy is exactly where the next fix would fail to land.
- `load_bert_encoder` loads the whole `token_types.weight` table
  (`type_embd_row0: Option<Vec<f32>>` -> `type_embd:
  Option<Vec<Vec<f32>>>`).
- `wrap_special_pair` returns `PairSequence { tokens, segments }`, cut
  on one boundary in one place, because otherwise they are two
  structures that must agree with nothing enforcing it. The first
  `[SEP]` is segment 0, as HuggingFace counts it.
- A head plus fewer than two token-type rows is refused at LOAD
  (`EmbedError::NoSegmentB`), through `refuse_unpairable_reranker` — a
  function rather than an `if`, so the arm can be shown to fire without
  a GGUF nobody publishes.
- `EmbeddingModel::rerank_token_ids` -> `rerank_input` returning the
  pair; `rerank_score` takes it; `pair_hidden_states` is public for the
  same reason `hidden_states` is.

## Evidence

Not "it returned 200".

- `crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs` — five
  `#[ignore]`d tests on the real checkpoint. The relevant document ranks
  first and **the assertion is on the index**; the scores match an
  independent NumPy transcription of HuggingFace
  `BertForSequenceClassification` to 4e-3; the reported score is shown
  to be the head applied to the CLS row (so it is not a cosine standing
  in for it); and the OLD graph is kept as a test asserting it ranks the
  answer last, so the fix cannot revert quietly.
- Sabotaged once: making `wrap_special_pair` emit all-zero segments
  turns the ordering test red with "the document that answers the query
  ranked 5 of 5".
- `crates/ferrox-server/src/rerank.rs` gains the route composition on
  the same checkpoint — `score_documents` -> `ranking` ->
  `results_json`, with a deliberately unsorted request so `index`
  addressing the caller's array is exercised by real scores rather than
  hand-written floats; plus `top_n` 0 / past the end / absent, and a
  real tie from duplicate documents.
- `scripts/rerank_reference_ms_marco.py` — where the golden numbers come
  from. safetensors + numpy, no `transformers` model classes and no
  torch, so it is a second implementation and not a recording of
  ferrox's own output.
- The live server, by hand:

      FERROX_MODEL_PATH=models/ms-marco-MiniLM-L6-v2-Q8_0.gguf ferrox-server
      POST /v1/rerank {"query": "How many people live in Berlin?", ...}
      -> index 2 (the population figure) first, score 0.0731; the
         caller's indices, `top_n: 0` empty, `top_n: 99` clamped,
         `documents: []` a 400. `/v1/models` lists both endpoints.

Both new test files **fail rather than print SKIP** when the checkpoint
is absent. The repo's other checkpoint tests return early and pass in
0.00s, and a `--ignored` run that silently passes is how this route came
to ship unverified.

Get the checkpoint with:

    ferrox download sinjab/ms-marco-MiniLM-L6-v2-Q8_0-GGUF --local-dir models

24 MB, sha256 `abd9981017b2…`, the Q8_0 conversion of
`cross-encoder/ms-marco-MiniLM-L6-v2`. `bge-reranker-*` cannot stand in:
XLM-R / SentencePiece, refused at `EmbedError::UnsupportedTokenizer`.

## What would have to be true for this to be wrong

The NumPy reference would have to be a wrong transcription of
`BertForSequenceClassification` in the same way ferrox is — it is not,
since it reproduces the checkpoint's documented ±11 logit range with the
pooler and ferrox's ±0.2 without it, from the same code path. And the
`[SEP]`-belongs-to-segment-0 convention would have to be the other way
round; it is asserted position by position against HuggingFace's own
`token_type_ids` shape.

## Deviation that remains, filed separately

llama.cpp's converter deletes `bert.pooler.dense` ("we are only using
BERT for embeddings so we don't need the pooling layer"), so no
`BertForSequenceClassification` GGUF carries it and the head runs as
`classifier(cls)` rather than `classifier(tanh(pooler(cls)))`. No engine
can apply a tensor that is not in the file. Measured effect is on the
score SCALE (about ±0.2 instead of ±11), not on which document wins.
Filed as #82 with the numbers.

## Doc delta (this branch touches no docs — another agent owns them)

- `docs/API.md` "Reranking": drop the closing **"End-to-end ordering is
  unverified"** paragraph and the #43 link. Rewrite the segment
  paragraph: both halves no longer carry segment 0 — the document half
  is segment 1, matching HuggingFace and deliberately NOT matching
  llama.cpp, because matching it ranked the relevant document last. Add
  one line for #82: scores are the head without its pooler, so the range
  is roughly ±0.2 and is not comparable to a `transformers` score.
- `docs/FEATURES.md` reranking bullet: "End-to-end ordering against a
  real reranker is UNVERIFIED, see issue #43" is no longer true; replace
  with the checkpoint it is verified on and the test file.

## Files touched outside the assignment

`crates/ferrox-models/src/loader.rs` (+16, the 1-D `ne` rule) and
`crates/ferrox-models/src/bert_gguf_loader.rs` (+21/-16, the whole
token-type table). Both were unavoidable: the first is the single place
GGUF's `ne[]` becomes `(rows, cols)`, and putting a second matrix loader
in `rank_head.rs` would have been the copy this repo keeps paying for.

## Known rough edge, not fixed here

`load_bert_encoder_from_path` alone still refuses a reranker
checkpoint with `UnconsumedTensors("cls.output.bias, cls.output.weight")`
— only `EmbeddingModel::from_gguf_path` loads the head first. Worth an
issue if anyone wants the standalone loader to work; the supported path
is unaffected.

Closes #43
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
