### PR TITLE
docs: rerank is verified and deliberately unlike llama.cpp, and ferrox can write a GGUF

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -551,19 +551,31 @@ Request `{"model"?, "query", "documents": [...], "top_n"?,
 `pooling_type` is RANK, which is a classification head and not a pooling
 rule, and that refusal is what sends a caller here.
 
-The pair is encoded as `[CLS] query [SEP] document [SEP]`. Both halves
-carry segment id 0, because llama.cpp hardcodes token types to zero;
-HuggingFace gives the second half segment 1, so a ferrox score can
-differ from a `transformers` reference by the second segment's type
-embedding. Tracked as
-[#44](https://github.com/antonellof/ferrox/issues/44).
+The pair is encoded as `[CLS] query [SEP] document [SEP]`, with the
+query in segment 0 and the document in segment 1.
 
-**End-to-end ordering is unverified.** The route has never run against a
-real reranker checkpoint, because there is none on the development host.
-Its parts are tested and CI is green; neither is evidence that it ranks
-correctly.
-[#43](https://github.com/antonellof/ferrox/issues/43) names the
-checkpoint that would settle it.
+**This deliberately differs from llama.cpp**, which hardcodes token
+types to zero, and it is one of the few places ferrox does. The reason
+is measured rather than preferred: segment ids do not merely shift the
+scores, THEY REORDER THE RESULTS. On "How many people live in Berlin?"
+against five documents, the one carrying the population figure ranks
+first with segments 0/1 and FIFTH with segments all zero. Matching
+HuggingFace is what makes the ranking right, so a reranker checkpoint
+whose token-type table has fewer than two rows is refused at load.
+
+Verified end to end against `ms-marco-MiniLM-L6-v2`, with scores
+matching an independent NumPy transcription of
+`BertForSequenceClassification` to 4e-3 and the order matching the
+HuggingFace reference on four query sets.
+
+One known difference remains, and it is not ferrox's to fix in the
+reader: llama.cpp's converter deletes `bert.pooler.dense`, so no
+`BertForSequenceClassification` GGUF carries it and the head runs as
+`classifier(cls)` rather than `classifier(tanh(pooler(cls)))`. That
+changes the score SCALE, roughly plus or minus 0.2 where the reference
+spans plus or minus 11, and not which document wins. A client
+thresholding on an absolute score gets a range that never fires. See
+[#82](https://github.com/antonellof/ferrox/issues/82).
 
 ## Errors that retrying will not fix
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -465,6 +465,39 @@ and would hand a swapped-in tensor another tensor's repacked bytes.
 Cost is one forward pass per tensor: about two minutes for a 1B model's
 112 tensors at 16 prompt tokens. `--layers 0:4` restricts the sweep.
 
+## Quantize (`ferrox quantize`)
+
+Writes a `Q8_0` GGUF from an F32/F16/BF16 one, and **refuses every other
+target by name**.
+
+```bash
+ferrox quantize model-f16.gguf model-q8_0.gguf --type q8_0
+```
+
+That refusal is the point rather than a limitation to apologise for.
+ferrox READS every quant kind it runs and until now could write only
+one, so evaluating it against llama.cpp side by side meant installing
+llama.cpp to produce the file ferrox then reads. A `quantize` whose name
+implied llama.cpp's whole range while emitting Q8_0 for everything would
+be worse than the gap: a K-quant encoder that takes min and max over a
+block, where llama.cpp does an iterative scale and min fit, produces a
+file that loads and generates measurably worse text.
+
+The output is **byte-identical to `llama_model_quantize()`**: 272 of 272
+tensors on `SmolLM2-135M-Instruct-f16`, same metadata, same size. Which
+tensors are quantized is transcribed from llama.cpp's
+`tensor_allows_quantization` rather than reinvented: everything 2-D
+ending in `weight`, except norms, router gates, position and token-type
+embeddings, SSM and shortconv kernels, RWKV time-mix, T5 position bias,
+multimodal patch tables and audio codebooks. `token_embd.weight` and
+`output.weight` ARE quantized here, because the arm that lifts the
+output head to Q6_K in other mixes is gated on the target not being
+Q8_0.
+
+K-quants, the IQ tiers, MXFP4 and imatrix are not implemented, and each
+is refused by name rather than approximated. Tracked as
+[#70](https://github.com/antonellof/ferrox/issues/70).
+
 ## Hugging Face Hub (`download`, `pull`)
 
 Fetches a GGUF over HTTPS directly. No Python and no

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -174,8 +174,10 @@ OpenAI-compatible HTTP API:
   `POST /v1/rerank`, scoring `[CLS] query [SEP] document [SEP]` through
   the head itself rather than through the cosine of two embeddings. Such
   a checkpoint could not load at all before: `assert_every_tensor_
-  consumed` rejected the `cls.*` tensors nobody read. End-to-end
-  ordering against a real reranker is UNVERIFIED, see issue #43
+  consumed` rejected the `cls.*` tensors nobody read. Verified end to
+  end against `ms-marco-MiniLM-L6-v2`: the order matches a HuggingFace
+  reference, which needed the document to be segment 1 rather than
+  llama.cpp's all-zero token types
 - Anthropic Messages: `POST /v1/messages` streaming and buffered
   (thinking and tool blocks, protocol-native `ping` keepalive) plus
   `POST /v1/messages/count_tokens`

--- a/docs/plans/llama-cpp-parity-review-2026-09-02.md
+++ b/docs/plans/llama-cpp-parity-review-2026-09-02.md
@@ -18,7 +18,7 @@ now carries what is true rather than what was true at breakfast.
 | CLI flag semantics | `-ngl` still refuses a partial count deliberately; `-e` and `--repeat-last-n` already match | P2, documented rather than divergent |
 | Server flags | **DONE**: `-c`, `--api-key`, `--api-key-file`, `--alias`, `--ctk`, `-hf`, `--hf-file`, `-cb`, `-np` | closed |
 | Sampling / grammar | **Mostly done**: GBNF, JSON Schema, forced `tool_choice`, `--presence-penalty` / `--frequency-penalty` | P2, `--samplers` ordering left |
-| Tools (quantize, perplexity) | No in-tree quantize or corpus eval | P1, and quantize is a CAPABILITY gap, not a CLI one |
+| Tools (quantize, perplexity) | `ferrox quantize` writes Q8_0 byte-identically to llama.cpp and refuses the rest by name; no corpus eval | P1, K-quant encoders are the remaining work (#70) |
 | Serving / batching | CB auto-on Metal; incremental CB streaming | P1, slot save/load |
 | Metal concurrency | Phase 1 shipped (#46 closed); per-request Metal KV is follow-up | P2 |
 


### PR DESCRIPTION
Doc deltas for #84 and #83.

**`docs/API.md`** loses "End-to-end ordering is unverified" — which was true when written, and is the reason the defects were found at all. The route could not load a reranker, and once loaded it ranked the answering document *last* on three of four query sets.

The segment paragraph is rewritten in the **other direction**. It said both halves carry segment 0 "because llama.cpp hardcodes token types to zero", filed as a scores-not-order difference. Segment ids are the dominant factor and they **reorder**. So ferrox now deliberately differs from llama.cpp, and the doc records why — a deviation without its measurement reads as an accident to the next person.

The remaining difference (#82) is stated with its consequence: the head runs unpooled, which changes score *scale*, not which document wins, so a client thresholding on an absolute score gets a range that never fires.

**`docs/CLI.md`** gains `ferrox quantize`, written around the refusal rather than the feature: Q8_0 out, everything else refused by name, and why — a min/max K-quant encoder where llama.cpp does an iterative fit produces a file that loads and generates measurably worse text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN