### PR TITLE
chore: 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-api"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cli"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-core"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cuda"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "cudarc",
  "ferrox-quant",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-gguf"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-inference"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "ferrox-api",
  "ferrox-core",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-metal"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "ferrox-quant",
  "half",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-models"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-moe"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "ferrox-core",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-quant"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "half",
  "thiserror",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-safetensors"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "byteorder",
  "memmap2",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-server"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-vulkan"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "ash",
  "ferrox-quant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.3"
+version = "0.16.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/antonellof/ferrox"
@@ -57,19 +57,19 @@ minijinja = { version = "2.21", features = ["loop_controls", "json"] }
 libc = "0.2"
 
 # Internal crates — path for local builds, version for crates.io.
-ferrox-api = { version = "0.15.3", path = "crates/ferrox-api" }
-ferrox-gguf = { version = "0.15.3", path = "crates/ferrox-gguf" }
-ferrox-quant = { version = "0.15.3", path = "crates/ferrox-quant" }
-ferrox-safetensors = { version = "0.15.3", path = "crates/ferrox-safetensors" }
-ferrox-cuda = { version = "0.15.3", path = "crates/ferrox-cuda" }
-ferrox-metal = { version = "0.15.3", path = "crates/ferrox-metal" }
-ferrox-vulkan = { version = "0.15.3", path = "crates/ferrox-vulkan" }
-ferrox-core = { version = "0.15.3", path = "crates/ferrox-core" }
-ferrox-moe = { version = "0.15.3", path = "crates/ferrox-moe" }
-ferrox-models = { version = "0.15.3", path = "crates/ferrox-models" }
-ferrox-inference = { version = "0.15.3", path = "crates/ferrox-inference" }
+ferrox-api = { version = "0.16.0", path = "crates/ferrox-api" }
+ferrox-gguf = { version = "0.16.0", path = "crates/ferrox-gguf" }
+ferrox-quant = { version = "0.16.0", path = "crates/ferrox-quant" }
+ferrox-safetensors = { version = "0.16.0", path = "crates/ferrox-safetensors" }
+ferrox-cuda = { version = "0.16.0", path = "crates/ferrox-cuda" }
+ferrox-metal = { version = "0.16.0", path = "crates/ferrox-metal" }
+ferrox-vulkan = { version = "0.16.0", path = "crates/ferrox-vulkan" }
+ferrox-core = { version = "0.16.0", path = "crates/ferrox-core" }
+ferrox-moe = { version = "0.16.0", path = "crates/ferrox-moe" }
+ferrox-models = { version = "0.16.0", path = "crates/ferrox-models" }
+ferrox-inference = { version = "0.16.0", path = "crates/ferrox-inference" }
 # Only ferrox-cli depends on this, and only behind its optional `serve`
 # feature. The server's dependency set is a strict superset of the CLI's
 # (+98 crates, +6 MB), so an unconditional dependency would make
 # `cargo install ferrox-cli` compile an HTTP and TLS stack it never runs.
-ferrox-server = { version = "0.15.3", path = "crates/ferrox-server" }
+ferrox-server = { version = "0.16.0", path = "crates/ferrox-server" }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ curl -fsSL https://raw.githubusercontent.com/antonellof/ferrox/main/scripts/inst
 ```
 
 Installs `ferrox` and `ferrox-server` into `~/.local/bin` (override with
-`FERROX_INSTALL_DIR`, pin with `FERROX_VERSION=v0.15.3`). The downloaded
+`FERROX_INSTALL_DIR`, pin with `FERROX_VERSION=v0.16.0`). The downloaded
 `ferrox` is built with `serve`, so one binary runs completions and
 serves the API. `ferrox-server` ships alongside it so an existing one on
 your PATH keeps working. Prebuilts are macOS arm64 with Metal and Linux
@@ -142,7 +142,7 @@ belongs to an unrelated crate.
 
 ```toml
 [dependencies]
-ferrox-inference = "0.15"
+ferrox-inference = "0.16"
 ```
 
 ```rust

--- a/crates/ferrox-inference/tests/publishable.rs
+++ b/crates/ferrox-inference/tests/publishable.rs
@@ -111,3 +111,20 @@ fn ferrox_vulkan_stays_publishable_because_core_depends_on_it() {
          optional or not. Either publish it, or remove the dependency from ferrox-core."
     );
 }
+
+// A test asserting that the internal `version = "x"` pins match
+// `[workspace.package] version` was written here and DELETED, because
+// it could not fail. Cargo resolves a path dependency's version
+// requirement against the crate at that path, so a stale pin does not
+// build at all:
+//
+//     error: failed to select a version for the requirement
+//     `ferrox-api = "^0.15.3"`
+//     candidate versions found which didn't match: 0.16.0
+//
+// Recorded rather than silently dropped, because "the version is
+// written in eleven places" looks exactly like this repo's dominant bug
+// shape and the next person will reach for the same test. It is not an
+// instance of it: the build system is the thing enforcing agreement.
+// What DID cost a release was a `publish = false` crate, which the
+// tests above cover, and that failure is invisible until publish time.


### PR DESCRIPTION
A **minor** bump rather than a patch, because generated text changes.

Penalties now see the prompt, as llama.cpp's do (#55, #73), so a token occurring in the prompt is penalised on its first generated occurrence instead of its second — on every run at the default `--repeat-penalty 1.1`. `--repeat-penalty 1.0` or `--repeat-last-n 0` reproduces the old output exactly. `docs/ROADMAP.md` leads with it.

## Also since 0.15.3

`ferrox quantize` (Q8_0, byte-identical to `llama_model_quantize()` on 272/272 tensors, every other target refused by name) · `/v1/rerank` verified end to end and **fixed twice** — it could not load a reranker at all, and ranked the answering document last · forced `tool_choice` at eight of eleven wire formats · `FERROX_CPU_POOL=spin` persistent decode pool, opt-in and token-identical · Gemma-3 4B+ back on the fused Metal stacks · llama.cpp's `-hf` and the server flags a copied `llama-server` command carries.

## One deliberate divergence from llama.cpp, newly added

Reranking puts the document in segment 1 where llama.cpp hardcodes token types to zero. That is backed by measurement rather than preference: segment ids **reorder** results, and with all-zero segments the answering document ranks fifth instead of first.

## Removed a test that could not fail

A version-pin consistency test was written and deleted in this branch: Cargo already refuses to build with a stale internal pin, so it asserted what the build system guarantees. The reason is recorded in `publishable.rs` so the next person does not re-add it.

Gates: 54 suites, clippy debug and release, fmt, cross-target including real Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN