### PR TITLE
refactor(core): KvCache::seq_len meant two things, so it is now positions and rows

### DIFF
--- a/crates/ferrox-cli/src/bench_model.rs
+++ b/crates/ferrox-cli/src/bench_model.rs
@@ -371,7 +371,9 @@ fn probe(caches: &[KvCache]) -> Vec<CacheProbe> {
     caches
         .iter()
         .map(|c| CacheProbe {
-            seq_len: c.seq_len,
+            // ROWS: this probe reports buffer state, beside the two
+            // lengths it is derived from.
+            seq_len: c.rows(),
             k_len: c.k.len(),
             v_len: c.v.len(),
         })
@@ -386,7 +388,9 @@ fn probe_gemma4(state: &ferrox_models::gemma4_engine::Gemma4DecodeState) -> Vec<
         .iter()
         .flatten()
         .map(|c| CacheProbe {
-            seq_len: c.seq_len,
+            // ROWS: this probe reports buffer state, beside the two
+            // lengths it is derived from.
+            seq_len: c.rows(),
             k_len: c.k.len(),
             v_len: c.v.len(),
         })

--- a/crates/ferrox-cli/src/layer_divergence.rs
+++ b/crates/ferrox-cli/src/layer_divergence.rs
@@ -488,7 +488,8 @@ fn emit(model: &str, prompt: &str, prompt_tokens: Option<usize>) -> anyhow::Resu
             };
             let heads = cache.n_kv_heads;
             let dim = cache.head_dim;
-            let seq = cache.seq_len;
+            // ROWS: `last` indexes the final resident row of k/v below.
+            let seq = cache.rows();
             let last = seq.saturating_sub(1);
             LayerProbe {
                 seq,

--- a/crates/ferrox-core/src/cache.rs
+++ b/crates/ferrox-core/src/cache.rs
@@ -124,9 +124,28 @@ struct PooledState {
 pub struct KvCache {
     pub n_kv_heads: usize,
     pub head_dim: usize,
-    pub k: Vec<f32>, // [seq_len, n_kv_heads, head_dim], flattened
+    pub k: Vec<f32>, // [rows, n_kv_heads, head_dim], flattened
     pub v: Vec<f32>,
-    pub seq_len: usize,
+    /// Positions this sequence has consumed.
+    ///
+    /// **Not the same thing as the number of rows in `k`/`v`**, and the
+    /// distinction is the whole reason this field is private. They are
+    /// equal today because nothing evicts, and they stop being equal
+    /// the moment a windowed layer drops a position behind its window
+    /// (#61): `positions` keeps counting, `rows` does not.
+    ///
+    /// Every reader has to say which one it meant, so there is no
+    /// `seq_len` any more. [`Self::positions`] is what RoPE, a resume
+    /// point and a truncate target mean; [`Self::rows`] is what
+    /// attention iterates and what the bytes cost.
+    ///
+    /// Two bugs have already been caused by the two being one field.
+    /// `PrefillState` read the KV's length as the position to resume at
+    /// (#37), and `DraftModelSpeculator::sync` trusted a counter beside
+    /// a cache that a device-resident backend leaves empty. Both were
+    /// right to read the store rather than keep a copy; both would be
+    /// wrong the day the store evicts.
+    positions: usize,
     /// The capacity (in positions) this cache was pre-allocated for,
     /// if any. `None` for caches built with `new` or `with_pool`.
     planned_capacity: Option<usize>,
@@ -149,7 +168,7 @@ impl Clone for KvCache {
             head_dim: self.head_dim,
             k: self.k.clone(),
             v: self.v.clone(),
-            seq_len: self.seq_len,
+            positions: self.positions,
             planned_capacity: self.planned_capacity,
             pool_state: None,
         }
@@ -167,13 +186,69 @@ impl Drop for KvCache {
 }
 
 impl KvCache {
+    /// Positions this sequence has consumed: what RoPE means, what a
+    /// resume point means, and what a truncate target is measured in.
+    ///
+    /// Monotonic except through [`Self::truncate`] and [`Self::clear`].
+    /// Equal to [`Self::rows`] today, and deliberately a different
+    /// method so it stops being equal safely (#61).
+    #[inline]
+    pub fn positions(&self) -> usize {
+        self.positions
+    }
+
+    /// Sets the position counter directly, for a constructor that
+    /// filled `k`/`v` by hand rather than through `push`.
+    ///
+    /// Deliberately narrow and deliberately not `pub`: the only honest
+    /// caller is one that has just written exactly this many rows, and
+    /// a public setter on a counter the buffer should imply is how the
+    /// two drift apart again.
+    pub(crate) fn set_positions(&mut self, positions: usize) {
+        debug_assert_eq!(
+            positions,
+            self.rows(),
+            "set_positions must agree with the rows just written"
+        );
+        self.positions = positions;
+    }
+
+    /// Test-only: sets the position counter WITHOUT the agreement check
+    /// [`Self::set_positions`] makes.
+    ///
+    /// Exists for one caller: `kv_signature`'s test that a serialized
+    /// payload whose declared count contradicts its buffers is
+    /// rejected. That contradiction is the thing under test, so it has
+    /// to be constructible, and it must not be constructible anywhere
+    /// else.
+    #[cfg(test)]
+    pub(crate) fn force_positions_for_test(&mut self, positions: usize) {
+        self.positions = positions;
+    }
+
+    /// Rows of K/V actually resident: what attention iterates over and
+    /// what the memory costs.
+    ///
+    /// Derived from the buffer rather than counted alongside it, so it
+    /// cannot drift from what is really there. That is the same rule
+    /// the batched prefill learned in #37: read the cursor, do not keep
+    /// a copy of it.
+    #[inline]
+    pub fn rows(&self) -> usize {
+        let elems_per_position = self.n_kv_heads * self.head_dim;
+        if elems_per_position == 0 {
+            return 0;
+        }
+        self.k.len() / elems_per_position
+    }
+
     pub fn new(n_kv_heads: usize, head_dim: usize) -> Self {
         KvCache {
             n_kv_heads,
             head_dim,
             k: Vec::new(),
             v: Vec::new(),
-            seq_len: 0,
+            positions: 0,
             planned_capacity: None,
             pool_state: None,
         }
@@ -189,7 +264,7 @@ impl KvCache {
             head_dim,
             k: Vec::with_capacity(max_seq_len * elems_per_position),
             v: Vec::with_capacity(max_seq_len * elems_per_position),
-            seq_len: 0,
+            positions: 0,
             planned_capacity: Some(max_seq_len),
             pool_state: None,
         }
@@ -230,7 +305,7 @@ impl KvCache {
             head_dim,
             k: Vec::with_capacity(blocks_needed * block_size * elems_per_position),
             v: Vec::with_capacity(blocks_needed * block_size * elems_per_position),
-            seq_len: 0,
+            positions: 0,
             planned_capacity: None,
             pool_state: Some(PooledState {
                 pool,
@@ -253,7 +328,7 @@ impl KvCache {
         let elems_per_position = self.n_kv_heads * self.head_dim;
         if let Some(state) = &mut self.pool_state {
             let capacity_positions = self.k.capacity() / elems_per_position;
-            if self.seq_len == capacity_positions {
+            if self.positions == capacity_positions {
                 if !state.pool.lock().unwrap().try_acquire(1) {
                     return Err(KvPoolExhausted);
                 }
@@ -265,7 +340,7 @@ impl KvCache {
 
         self.k.extend_from_slice(k_step);
         self.v.extend_from_slice(v_step);
-        self.seq_len += 1;
+        self.positions += 1;
         Ok(())
     }
 
@@ -299,7 +374,7 @@ impl KvCache {
     pub fn clear(&mut self) {
         self.k.clear();
         self.v.clear();
-        self.seq_len = 0;
+        self.positions = 0;
     }
 
     /// Rolls the cache back to exactly `new_seq_len` positions,
@@ -310,14 +385,14 @@ impl KvCache {
     /// last *accepted* position, not the last *attempted* one.
     pub fn truncate(&mut self, new_seq_len: usize) {
         assert!(
-            new_seq_len <= self.seq_len,
+            new_seq_len <= self.positions,
             "truncate target {new_seq_len} must not exceed current seq_len {}",
-            self.seq_len
+            self.positions
         );
         let elems_per_position = self.n_kv_heads * self.head_dim;
         self.k.truncate(new_seq_len * elems_per_position);
         self.v.truncate(new_seq_len * elems_per_position);
-        self.seq_len = new_seq_len;
+        self.positions = new_seq_len;
     }
 
     /// Bytes currently resident for this cache's K and V buffers
@@ -335,8 +410,8 @@ impl KvCache {
     pub fn is_within_planned_capacity(&self) -> bool {
         match self.planned_capacity {
             Some(cap) => {
-                self.seq_len <= cap
-                    && self.k.capacity() >= self.seq_len * self.n_kv_heads * self.head_dim
+                self.positions <= cap
+                    && self.k.capacity() >= self.positions * self.n_kv_heads * self.head_dim
             }
             None => false,
         }
@@ -662,7 +737,9 @@ impl PagedKvCache {
             cache.k.extend_from_slice(store.k_row(block_id, offset));
             cache.v.extend_from_slice(store.v_row(block_id, offset));
         }
-        cache.seq_len = self.seq_len;
+        // The paged store does not evict either, so its positions and
+        // its rows agree and this one assignment is both.
+        cache.set_positions(self.seq_len);
         cache
     }
 
@@ -1283,7 +1360,7 @@ mod tests {
         }
 
         let flat = cache.to_contiguous(&store);
-        assert_eq!(flat.seq_len, 5);
+        assert_eq!(flat.positions(), 5);
         assert_eq!(flat.k.len(), 5 * 4);
         for (i, r) in rows.iter().enumerate() {
             assert_eq!(&flat.k[i * 4..(i + 1) * 4], r, "position {i} k");
@@ -1300,7 +1377,7 @@ mod tests {
         let again = rebuilt.to_contiguous(&store2);
         assert_eq!(again.k, flat.k);
         assert_eq!(again.v, flat.v);
-        assert_eq!(again.seq_len, flat.seq_len);
+        assert_eq!(again.positions(), flat.positions());
     }
 
     #[test]
@@ -1309,11 +1386,11 @@ mod tests {
         cache
             .push(&[1.0, 2.0, 3.0, 4.0], &[5.0, 6.0, 7.0, 8.0])
             .unwrap();
-        assert_eq!(cache.seq_len, 1);
+        assert_eq!(cache.positions(), 1);
         cache
             .push(&[9.0, 10.0, 11.0, 12.0], &[13.0, 14.0, 15.0, 16.0])
             .unwrap();
-        assert_eq!(cache.seq_len, 2);
+        assert_eq!(cache.positions(), 2);
         assert_eq!(cache.k.len(), 2 * 2 * 2);
         assert_eq!(cache.k[4], 9.0);
     }
@@ -1330,7 +1407,7 @@ mod tests {
         let mut cache = KvCache::new(1, 1);
         cache.push(&[1.0], &[2.0]).unwrap();
         cache.clear();
-        assert_eq!(cache.seq_len, 0);
+        assert_eq!(cache.positions(), 0);
         assert!(cache.k.is_empty());
     }
 
@@ -1346,10 +1423,10 @@ mod tests {
         cache
             .push(&[9.0, 9.0, 9.0, 9.0], &[90.0, 90.0, 90.0, 90.0])
             .unwrap();
-        assert_eq!(cache.seq_len, 3);
+        assert_eq!(cache.positions(), 3);
 
         cache.truncate(1);
-        assert_eq!(cache.seq_len, 1);
+        assert_eq!(cache.positions(), 1);
         assert_eq!(cache.k, vec![1.0, 2.0, 3.0, 4.0]);
         assert_eq!(cache.v, vec![10.0, 20.0, 30.0, 40.0]);
     }
@@ -1359,7 +1436,7 @@ mod tests {
         let mut cache = KvCache::new(1, 2);
         cache.push(&[1.0, 2.0], &[3.0, 4.0]).unwrap();
         cache.truncate(1);
-        assert_eq!(cache.seq_len, 1);
+        assert_eq!(cache.positions(), 1);
         assert_eq!(cache.k, vec![1.0, 2.0]);
     }
 
@@ -1368,7 +1445,7 @@ mod tests {
         let mut cache = KvCache::new(1, 2);
         cache.push(&[1.0, 2.0], &[3.0, 4.0]).unwrap();
         cache.truncate(0);
-        assert_eq!(cache.seq_len, 0);
+        assert_eq!(cache.positions(), 0);
         assert!(cache.k.is_empty());
         assert!(cache.v.is_empty());
     }
@@ -1389,7 +1466,7 @@ mod tests {
         cache.push(&[3.0], &[30.0]).unwrap(); // this one will be "rejected"
         cache.truncate(2);
         cache.push(&[99.0], &[990.0]).unwrap(); // real continuation after rejection
-        assert_eq!(cache.seq_len, 3);
+        assert_eq!(cache.positions(), 3);
         assert_eq!(cache.k, vec![1.0, 2.0, 99.0]);
         assert_eq!(cache.v, vec![10.0, 20.0, 990.0]);
     }
@@ -1429,7 +1506,7 @@ mod tests {
             cache.allocated_bytes()
         );
         // Nothing has been pushed yet, but the memory is already reserved.
-        assert_eq!(cache.seq_len, 0);
+        assert_eq!(cache.positions(), 0);
     }
 
     #[test]
@@ -1449,7 +1526,7 @@ mod tests {
         let pool = Arc::new(Mutex::new(KvBlockPool::new(4, 10)));
         let cache = KvCache::with_pool(2, 2, pool.clone(), 0).unwrap();
         assert_eq!(pool.lock().unwrap().free_blocks(), 9);
-        assert_eq!(cache.seq_len, 0);
+        assert_eq!(cache.positions(), 0);
     }
 
     #[test]
@@ -1480,7 +1557,7 @@ mod tests {
         // The third position crosses into a second block.
         cache.push(&[3.0], &[3.0]).unwrap();
         assert_eq!(pool.lock().unwrap().free_blocks(), 8);
-        assert_eq!(cache.seq_len, 3);
+        assert_eq!(cache.positions(), 3);
         assert_eq!(cache.k, vec![1.0, 2.0, 3.0]);
     }
 
@@ -1496,7 +1573,11 @@ mod tests {
         let before_k = cache.k.clone();
         let result = cache.push(&[2.0], &[2.0]);
         assert_eq!(result, Err(KvPoolExhausted));
-        assert_eq!(cache.seq_len, 1, "a failed push must not change seq_len");
+        assert_eq!(
+            cache.positions(),
+            1,
+            "a failed push must not change seq_len"
+        );
         assert_eq!(cache.k, before_k, "a failed push must not append data");
     }
 
@@ -1623,5 +1704,51 @@ mod tests {
         assert_eq!(p.free_blocks(), 32 - in_use);
         drop(p);
         drop(held);
+    }
+
+    /// Positions and rows agree for every store that does not evict,
+    /// and this pins that they are DERIVED separately rather than one
+    /// being an alias for the other.
+    ///
+    /// The point of the split is #61: a windowed layer will drop rows
+    /// behind its window while its position count keeps climbing. Until
+    /// then the two are equal, so this test cannot prove much about
+    /// eviction. What it CAN prove, and what matters, is that `rows`
+    /// reads the buffer rather than the counter: set the counter to a
+    /// lie and `rows` still reports the truth.
+    #[test]
+    fn rows_is_read_from_the_buffer_and_positions_from_the_counter() {
+        let mut cache = KvCache::new(2, 4);
+        for i in 0..5 {
+            let step = vec![i as f32; 8];
+            cache.push(&step, &step).expect("unbounded growth");
+        }
+        assert_eq!(cache.positions(), 5);
+        assert_eq!(cache.rows(), 5, "nothing evicts, so they agree");
+
+        // The counter lies; the buffer does not.
+        cache.force_positions_for_test(99);
+        assert_eq!(cache.positions(), 99);
+        assert_eq!(
+            cache.rows(),
+            5,
+            "rows must come from k/v, or it is just a second name for the counter"
+        );
+    }
+
+    /// `truncate` is measured in POSITIONS, and it moves both, because
+    /// nothing evicts yet. Written down because it is the first thing
+    /// eviction changes: a truncate target will stop being a row index.
+    #[test]
+    fn truncate_moves_positions_and_rows_together_while_nothing_evicts() {
+        let mut cache = KvCache::new(1, 2);
+        for i in 0..4 {
+            let step = vec![i as f32; 2];
+            cache.push(&step, &step).expect("unbounded growth");
+        }
+        cache.truncate(2);
+        assert_eq!(cache.positions(), 2);
+        assert_eq!(cache.rows(), 2);
+        assert_eq!(cache.k.len(), 4, "two positions of two elements each");
     }
 }

--- a/crates/ferrox-core/src/kv_disk.rs
+++ b/crates/ferrox-core/src/kv_disk.rs
@@ -400,7 +400,9 @@ pub fn decode_block(bytes: &[u8]) -> Result<DecodedBlock, BlockFormatError> {
         let mut cache = KvCache::new(n_kv_heads, head_dim);
         cache.k = k;
         cache.v = v;
-        cache.seq_len = tokens;
+        // The rows were just written by hand, so this is the one place
+        // a position count is set rather than counted by `push`.
+        cache.set_positions(tokens);
         layers.push(cache);
     }
 
@@ -2267,7 +2269,7 @@ mod tests {
         for (a, b) in read.layers().iter().zip(copy.layers()) {
             assert_eq!(a.k, b.k);
             assert_eq!(a.v, b.v);
-            assert_eq!(a.seq_len, b.seq_len);
+            assert_eq!(a.positions(), b.positions());
         }
         let stats = store.stats();
         assert_eq!(stats.hits, 1);

--- a/crates/ferrox-core/src/kv_signature.rs
+++ b/crates/ferrox-core/src/kv_signature.rs
@@ -305,12 +305,19 @@ fn measure_layer(index: usize, layer: &KvCache, per_token: usize) -> Result<usiz
         });
     }
     let tokens = layer.k.len() / per_token;
-    if layer.seq_len != tokens {
+    // Positions against rows. They are equal for anything this codec
+    // can currently produce, and a payload where they disagree is
+    // ragged rather than windowed. When a store learns to evict (#61)
+    // a restored windowed layer will legitimately carry more positions
+    // than rows, and THIS CHECK IS WHERE THAT HAS TO BE TAUGHT: the
+    // codec will need to serialize the position count separately
+    // instead of deriving it from the byte length.
+    if layer.positions() != tokens {
         return Err(SignatureError::RaggedPayload {
             layer: index,
-            field: "seq_len",
+            field: "positions",
             expected: tokens.to_string(),
-            found: layer.seq_len.to_string(),
+            found: layer.positions().to_string(),
         });
     }
     Ok(tokens)
@@ -690,14 +697,15 @@ mod tests {
     #[test]
     fn a_layer_whose_seq_len_contradicts_its_buffers_is_rejected() {
         let mut layers = payload(2, 2, 8, 4);
-        layers[1].seq_len = 7;
+        // The contradiction is the thing under test.
+        layers[1].force_positions_for_test(7);
         let err = CacheSignature::from_payload("model-a", flat(4), &layers)
             .expect_err("seq_len must be verified, not believed");
         assert_eq!(
             err,
             SignatureError::RaggedPayload {
                 layer: 1,
-                field: "seq_len",
+                field: "positions",
                 expected: "4".into(),
                 found: "7".into(),
             }

--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -1030,7 +1030,9 @@ impl Decoder {
             if !self.metal_prefill_dense_swa_fits(li, start_pos, batch_size) {
                 break;
             }
-            if metal_kvs[li].seq_len != cache.seq_len || start_pos != cache.seq_len {
+            // POSITIONS: compared against `start_pos`, and against
+            // Metal's own count of the same sequence.
+            if metal_kvs[li].seq_len != cache.positions() || start_pos != cache.positions() {
                 break;
             }
             let ok = layer.attn.q_proj.mul_mm_sg_launch().is_some()
@@ -1539,7 +1541,7 @@ impl Decoder {
     ) {
         if host_kv_authoritative {
             Self::catch_up_host_kv_from_metal(mkv, cache);
-            debug_assert_eq!(cache.seq_len, mkv.seq_len);
+            debug_assert_eq!(cache.positions(), mkv.seq_len);
         } else {
             cache
                 .advance_len(batch_size)
@@ -1551,10 +1553,14 @@ impl Decoder {
     /// skipped (dense-stack fast path). No-op when `cache.seq_len` is caught up.
     #[cfg(feature = "metal")]
     fn catch_up_host_kv_from_metal(mkv: &ferrox_metal::attn::MetalKvBuffers, cache: &mut KvCache) {
-        if cache.seq_len >= mkv.seq_len {
+        // ROWS on both sides: this fills the host buffer with rows
+        // Metal already holds, and `push` below advances positions with
+        // them. Neither store evicts, so the two agree; when one learns
+        // to (#61) this is a place that has to say which it meant.
+        if cache.rows() >= mkv.seq_len {
             return;
         }
-        let start = cache.seq_len;
+        let start = cache.rows();
         let n = mkv.seq_len - start;
         let (k, v) = mkv.tokens_host(start, n);
         let per = cache.n_kv_heads * cache.head_dim;
@@ -1748,7 +1754,8 @@ impl Decoder {
             let need = self.layers.len();
             let cap = kv_caches
                 .iter()
-                .map(|c| c.seq_len.max(pos + 1).saturating_add(256))
+                // POSITIONS: sized against `pos`, which is a position.
+                .map(|c| c.positions().max(pos + 1).saturating_add(256))
                 .max()
                 .unwrap_or(512)
                 .max(512)
@@ -1791,7 +1798,9 @@ impl Decoder {
                     // Sync from host after CPU prefill / prefix restore / capacity grow.
                     let mut ok = true;
                     for (m, c) in bufs.iter_mut().zip(kv_caches.iter()) {
-                        if c.seq_len > 0 && m.upload_from_host(&c.k, &c.v, c.seq_len).is_err() {
+                        // ROWS: this uploads `c.k` / `c.v` themselves, so the
+                        // count must describe those buffers.
+                        if c.rows() > 0 && m.upload_from_host(&c.k, &c.v, c.rows()).is_err() {
                             ok = false;
                             break;
                         }
@@ -2259,7 +2268,7 @@ impl Decoder {
                                         if dense_ok {
                                             did_metal_dense = true;
                                             did_metal_attn = true;
-                                        } else if metal_kvs[l].seq_len != cache.seq_len {
+                                        } else if metal_kvs[l].seq_len != cache.rows() {
                                             // Dense path may have advanced Metal KV before failing.
                                             Self::catch_up_host_kv_from_metal(&metal_kvs[l], cache);
                                             clear_metal_kv = true;
@@ -2423,7 +2432,7 @@ impl Decoder {
                                                             hidden = h;
                                                         }
                                                             metal_moe_resident = false;
-                                                            if metal_kvs[l].seq_len != cache.seq_len
+                                                            if metal_kvs[l].seq_len != cache.rows()
                                                             {
                                                                 Self::catch_up_host_kv_from_metal(
                                                                     &metal_kvs[l],
@@ -2478,7 +2487,7 @@ impl Decoder {
                                         }
                                     }
                                 }
-                            } else if metal_kvs[l].seq_len > cache.seq_len {
+                            } else if metal_kvs[l].seq_len > cache.rows() {
                                 // Leaving Metal path: host must see full KV for CPU attn.
                                 Self::catch_up_host_kv_from_metal(&metal_kvs[l], cache);
                             }
@@ -3709,7 +3718,9 @@ impl Decoder {
                         || v.iter().any(|m| m.capacity() < need_cap)
                         || v.iter()
                             .zip(kv_caches.iter())
-                            .any(|(m, c)| m.seq_len != c.seq_len)
+                            // ROWS: Metal holds rows, and this asks whether the
+                            // host buffer matches them.
+                            .any(|(m, c)| m.seq_len != c.rows())
                 }
             };
             if reset {
@@ -3728,7 +3739,7 @@ impl Decoder {
                 if bufs.len() == need {
                     let mut ok = true;
                     for (m, c) in bufs.iter_mut().zip(kv_caches.iter()) {
-                        if c.seq_len > 0 && m.upload_from_host(&c.k, &c.v, c.seq_len).is_err() {
+                        if c.rows() > 0 && m.upload_from_host(&c.k, &c.v, c.rows()).is_err() {
                             ok = false;
                             break;
                         }
@@ -3794,7 +3805,10 @@ impl Decoder {
                 if swa_fits {
                     if let Some(guard) = metal_kv_guard.as_mut() {
                         if let Some(metal_kvs) = guard.as_mut() {
-                            if metal_kvs[l].seq_len == cache.seq_len && start_pos == cache.seq_len {
+                            // POSITIONS: compared against `start_pos`.
+                            if metal_kvs[l].seq_len == cache.positions()
+                                && start_pos == cache.positions()
+                            {
                                 layer.moe.record_activations(&[0]);
                                 let fused = layer.moe.with_expert(0, |ex| {
                                     let (q, k, v, o) = (
@@ -3930,8 +3944,9 @@ impl Decoder {
                 // Metal prefill applies attn softcap in FA-vec / legacy GQA.
                 if let Some(guard) = metal_kv_guard.as_mut() {
                     if let Some(metal_kvs) = guard.as_mut() {
-                        if metal_kvs[l].seq_len == cache.seq_len
-                            && start_pos == cache.seq_len
+                        // POSITIONS: compared against `start_pos`.
+                        if metal_kvs[l].seq_len == cache.positions()
+                            && start_pos == cache.positions()
                             && swa_fits
                         {
                             let prefill_res = {
@@ -4134,7 +4149,10 @@ impl Decoder {
             // `attention_scale` is set is in `layer_supports_metal_attn`.
             self.apply_attention_scale(&mut q_batch);
 
-            let base_seq_len = cache.seq_len;
+            // ROWS, not positions: it is added to `b + 1` below to give
+            // each query in the batch the length of the KV it attends
+            // over, which is a count of resident rows.
+            let base_seq_len = cache.rows();
             for b in 0..batch_size {
                 cache
                     .push(
@@ -4884,7 +4902,7 @@ mod tests {
         decoder.forward_token(2, 2, &mut caches);
 
         for cache in &caches {
-            assert_eq!(cache.seq_len, 3);
+            assert_eq!(cache.positions(), 3);
         }
     }
 
@@ -6410,7 +6428,7 @@ mod tests {
         decoder_b.forward_batch(&tokens, 0, &mut caches_b);
 
         for (ca, cb) in caches_a.iter().zip(caches_b.iter()) {
-            assert_eq!(ca.seq_len, cb.seq_len);
+            assert_eq!(ca.positions(), cb.positions());
             assert_eq!(ca.k.len(), cb.k.len());
             for (a, b) in ca.k.iter().zip(cb.k.iter()) {
                 assert!((a - b).abs() < 1e-4);

--- a/crates/ferrox-models/src/decoder/attn_block.rs
+++ b/crates/ferrox-models/src/decoder/attn_block.rs
@@ -193,7 +193,7 @@ impl Decoder {
                         n_heads,
                         n_kv_heads,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                         window,
                         &oai.attn_sinks,
                     );
@@ -206,7 +206,7 @@ impl Decoder {
                         n_heads,
                         n_kv_heads,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                         window,
                         self.config.attn_logit_softcap,
                     ),
@@ -218,7 +218,7 @@ impl Decoder {
                         n_heads,
                         n_kv_heads,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                     ),
                     (None, None) => causal_gqa_attention_softcap(
                         q,
@@ -227,7 +227,7 @@ impl Decoder {
                         n_heads,
                         n_kv_heads,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                         self.config.attn_logit_softcap,
                     ),
                 }

--- a/crates/ferrox-models/src/draft_model.rs
+++ b/crates/ferrox-models/src/draft_model.rs
@@ -121,7 +121,9 @@ impl DraftModelSpeculator {
     /// this after one warm-up rather than discovering it as a wrong
     /// accept rate.
     pub fn keeps_host_kv(&self) -> bool {
-        self.kv_caches.first().is_some_and(|c| c.seq_len > 0)
+        // ROWS: the question is whether K/V actually landed in the
+        // host buffer, which a device-resident backend leaves empty.
+        self.kv_caches.first().is_some_and(|c| c.rows() > 0)
     }
 
     /// How many tokens of history this drafter's KV currently holds.
@@ -205,7 +207,9 @@ impl DraftModelSpeculator {
         // counter there truncated to 7 rows of a cache holding 0 and
         // panicked on a real Metal run. That is the same lesson as the
         // batched prefill: read the cursor, do not keep a copy of it.
-        let held = self.kv_caches.first().map_or(0, |c| c.seq_len);
+        // ROWS, for the same reason: this bounds what can be kept by
+        // what is really there, not by what the counter believes.
+        let held = self.kv_caches.first().map_or(0, |c| c.rows());
         let keep = self.synced.min(history.len() - 1).min(held);
         self.truncate_to(keep);
         self.synced = keep;
@@ -376,7 +380,8 @@ mod tests {
         d.propose(&[1, 2, 3, block.tokens()[0]], &[], 4);
 
         assert_eq!(
-            d.kv_caches[0].seq_len, d.synced,
+            d.kv_caches[0].positions(),
+            d.synced,
             "every layer's cache agrees with the drafter's own count"
         );
         assert_eq!(
@@ -395,7 +400,7 @@ mod tests {
 
         d.propose(&[1, 2], &[], 1);
         assert_eq!(d.synced, 3, "2 of history plus 1 drafted");
-        assert_eq!(d.kv_caches[0].seq_len, 3);
+        assert_eq!(d.kv_caches[0].positions(), 3);
     }
 
     /// Drafting stops when the drafter's own probability for the token

--- a/crates/ferrox-models/src/gemma4_engine.rs
+++ b/crates/ferrox-models/src/gemma4_engine.rs
@@ -326,7 +326,7 @@ impl Engine for Gemma4Engine {
                         n_heads,
                         n_kv,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                         hp.sliding_window,
                     )
                 } else {
@@ -337,7 +337,7 @@ impl Engine for Gemma4Engine {
                         n_heads,
                         n_kv,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                     )
                 }
             } else {
@@ -359,7 +359,7 @@ impl Engine for Gemma4Engine {
                         n_heads,
                         n_kv,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                         hp.sliding_window,
                     )
                 } else {
@@ -370,7 +370,7 @@ impl Engine for Gemma4Engine {
                         n_heads,
                         n_kv,
                         head_dim,
-                        cache.seq_len,
+                        cache.rows(),
                     )
                 }
             };

--- a/crates/ferrox-models/src/prefix_cache.rs
+++ b/crates/ferrox-models/src/prefix_cache.rs
@@ -514,7 +514,7 @@ mod tests {
         // And the KV cache state itself must match too, not just the
         // final logits (in case a later request extends even further).
         for (restored, fresh) in restored_caches.iter().zip(fresh_caches.iter()) {
-            assert_eq!(restored.seq_len, fresh.seq_len);
+            assert_eq!(restored.positions(), fresh.positions());
             for (a, b) in restored.k.iter().zip(fresh.k.iter()) {
                 assert!((a - b).abs() < 1e-3);
             }

--- a/crates/ferrox-models/src/speculative.rs
+++ b/crates/ferrox-models/src/speculative.rs
@@ -548,7 +548,8 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
     assert!(!prompt_tokens.is_empty(), "prompt must not be empty");
     for cache in kv_caches.iter() {
         assert_eq!(
-            cache.seq_len, options.start_pos,
+            cache.positions(),
+            options.start_pos,
             "start_pos must be the caches' current length: they hold exactly the \
              context preceding the prompt"
         );
@@ -673,7 +674,8 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
                 cache.truncate(committed_len);
             }
         }
-        debug_assert!(kv_caches.iter().all(|c| c.seq_len == committed_len));
+        // POSITIONS: `committed_len` is absolute, offset by start_pos.
+        debug_assert!(kv_caches.iter().all(|c| c.positions() == committed_len));
 
         target_hidden = batch_hidden[accepted].clone();
         pending = match replacement {
@@ -1348,7 +1350,7 @@ mod tests {
 
         let mut kv = caches(&decoder);
         decoder.forward_batch(&context, 0, &mut kv);
-        assert_eq!(kv[0].seq_len, context.len());
+        assert_eq!(kv[0].positions(), context.len());
 
         let result = speculative_decode_with(
             &decoder,
@@ -1369,7 +1371,7 @@ mod tests {
         let expected = context.len() + prompt.len() + result.tokens_generated - 1;
         for cache in kv.iter() {
             assert_eq!(
-                cache.seq_len,
+                cache.positions(),
                 expected,
                 "cache length must be absolute: context {} + prompt {} + generated {} - 1",
                 context.len(),

--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -1950,7 +1950,8 @@ mod tests {
         }
 
         assert_eq!(
-            caches[0].seq_len, fresh_caches[0].seq_len,
+            caches[0].positions(),
+            fresh_caches[0].positions(),
             "must not push any position beyond the real prompt length"
         );
         // Tolerance, not bit equality. `forward_token` goes through

--- a/crates/ferrox-server/src/serving/batch/row.rs
+++ b/crates/ferrox-server/src/serving/batch/row.rs
@@ -56,7 +56,7 @@ impl RowKv {
     /// mutably; nothing here is modified.
     pub(super) fn positions_written(&mut self) -> usize {
         match self {
-            RowKv::Contiguous(caches) => caches.first().map_or(0, |c| c.seq_len),
+            RowKv::Contiguous(caches) => caches.first().map_or(0, |c| c.positions()),
             RowKv::Paged(lease) => lease.caches_mut().first().map_or(0, |c| c.seq_len()),
         }
     }


### PR DESCRIPTION
Step 1 of #61, and the step that carries all of that issue's risk.

`seq_len` meant both **rows resident in k/v** and **positions this sequence has consumed**. Equal today because nothing evicts; not equal the moment a windowed layer drops a position behind its window, which is what #61 exists to do. The field is now private and there is no `seq_len`: `positions()` is what RoPE, a resume point and a truncate target mean; `rows()` is what attention iterates and what the bytes cost.

`rows()` is **derived from the buffer**, not counted beside it — a test sets the counter to a lie and asserts `rows()` still reports the truth. Same rule the batched prefill learned in #37.

**Two bugs already came from these being one field**, which is why this is worth doing before the eviction it prepares for: `PrefillState` read the KV's length as a resume position (#37), and `DraftModelSpeculator` trusted a counter beside a cache that a device-resident backend leaves empty.

Every call site was read and classified, not mechanically renamed. The pattern that decided most: a count passed alongside `&cache.k`/`&cache.v` is rows; a count compared against `start_pos` or a committed length is positions. Metal's sync checks were the fiddliest.

## What this PR cannot prove

Both accessors return the same number today, so **no test can distinguish a right choice from a wrong one**. The suite passing says the refactor is behaviour-neutral, which it must be, and says nothing about whether each site picked the accessor it will need. That evidence arrives with eviction, and it arrives as wrong logits if a choice was wrong — which is why the choices are commented rather than left to be re-derived.

Gates: 54 suites, clippy debug and release, fmt, Metal and CUDA feature builds, plus CPU and Metal generation checked by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN