### PR TITLE
feat(cli): ferrox perplexity, the quality axis nothing measured

### DIFF
--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -13,6 +13,7 @@ mod host_state;
 mod http;
 mod layer_divergence;
 mod parity;
+mod perplexity;
 mod pull;
 mod quant_sensitivity;
 mod quantize;
@@ -228,6 +229,29 @@ enum Commands {
         /// Compiled reference dumper (see .local-scripts/llama_logits.c).
         #[arg(long)]
         dumper: Option<String>,
+    },
+    /// Corpus perplexity, llama.cpp's `perplexity` tool.
+    ///
+    /// `parity` compares one distribution and `verify` compares text;
+    /// neither says whether a quantized checkpoint is WORSE. This scores
+    /// a whole corpus in non-overlapping `--ctx-size` windows, scoring
+    /// only each window's second half, and reports `exp(mean nll)` with
+    /// a standard error — upstream's method, so the number is
+    /// comparable to a published one.
+    Perplexity {
+        /// GGUF to score.
+        #[arg(short = 'm', long)]
+        model: String,
+        /// Plain-text corpus. `crates/ferrox-cli/tests/corpus/` has one.
+        #[arg(short = 'f', long)]
+        file: String,
+        /// Window length. 512 is llama.cpp's `perplexity` default, and a
+        /// perplexity at another context is not comparable to one at 512.
+        #[arg(short = 'c', long = "ctx-size", default_value_t = perplexity::DEFAULT_CTX)]
+        ctx_size: usize,
+        /// Stop after this many windows (default: as many as fit).
+        #[arg(long)]
+        chunks: Option<usize>,
     },
     /// Find the layer where a GPU backend starts disagreeing with the
     /// CPU reference, rather than the token.
@@ -494,6 +518,7 @@ const SUBCOMMANDS: &[&str] = &[
     "quant-sensitivity",
     "quantize",
     "parity",
+    "perplexity",
     "speculative",
     "run-kimi",
     "help",
@@ -609,6 +634,12 @@ fn instance_target(command: &Commands) -> Option<(&'static str, Option<String>)>
         Commands::QuantSensitivity { model, .. } => {
             Some(("quant-sensitivity", Some(model.clone())))
         }
+        // Registered for the same reason `quant-sensitivity` is: it holds
+        // a whole checkpoint resident for as long as the corpus takes,
+        // which is the case the one-model-per-host rule exists for. It is
+        // not a timing, so `--allow-multiple-instances` costs nothing but
+        // the words.
+        Commands::Perplexity { model, .. } => Some(("perplexity", Some(model.clone()))),
         Commands::Bench {
             model,
             suite,
@@ -929,6 +960,19 @@ fn main() -> anyhow::Result<()> {
                 prompt_tokens,
                 top_k,
                 dumper,
+            });
+        }
+        Commands::Perplexity {
+            model,
+            file,
+            ctx_size,
+            chunks,
+        } => {
+            return perplexity::run(perplexity::PerplexityArgs {
+                model,
+                file,
+                ctx_size,
+                chunks,
             });
         }
         Commands::LayerDivergence {

--- a/crates/ferrox-cli/src/perplexity.rs
+++ b/crates/ferrox-cli/src/perplexity.rs
@@ -1,0 +1,591 @@
+//! `ferrox perplexity` — corpus perplexity, llama.cpp's `perplexity` tool.
+//!
+//! # Why this exists
+//!
+//! Every quality claim in this repo was, until this command, either a
+//! token-for-token comparison (`ferrox verify`) or a single-position
+//! distribution comparison (`ferrox parity`). Neither answers the
+//! question a quantization change actually raises: *is this file worse,
+//! and by how much*. A K-quant encoder that rounds badly produces a GGUF
+//! that loads, tokenizes, and generates fluent text; the only cheap
+//! signal that it is worse is a corpus perplexity that moved.
+//!
+//! So the number here is not for bragging. It is an acceptance test with
+//! a scale.
+//!
+//! # The method, and why it is copied rather than invented
+//!
+//! A perplexity is only comparable to another perplexity computed the
+//! same way. Change the stride, the scored fraction, or whether a BOS is
+//! injected, and the number still looks like a perplexity while being
+//! incomparable to every published figure — which is worse than having
+//! no command, because someone will compare it anyway.
+//!
+//! This follows `.scratch/llama.cpp/tools/perplexity/perplexity.cpp`,
+//! function `perplexity()` (the `ppl_stride == 0` path, which is the
+//! default), read at ggml commit present in that checkout:
+//!
+//! - **Tokenize the whole file once**, with the checkpoint's BOS added
+//!   at the front if the checkpoint adds one
+//!   (`common_tokenize(ctx, prompt, /*add_special=*/true)`).
+//! - **Refuse below `2 * n_ctx` tokens.** Upstream errors out with
+//!   exactly that bound.
+//! - **Non-overlapping windows of `n_ctx`.** The stride *is* `n_ctx`;
+//!   `n_chunk_max = n_tokens / n_ctx`. (Upstream's `--ppl-stride` picks
+//!   a different, overlapping algorithm — `perplexity_v2` — and is not
+//!   implemented here. See "Deviations".)
+//! - **The first token of every window is overwritten with BOS**, when
+//!   the checkpoint adds one. The KV cache is cleared between windows,
+//!   so each window starts from nothing.
+//! - **Only the second half is scored.** `first = n_ctx / 2`, and the
+//!   logits at window positions `first ..= n_ctx - 2` are scored against
+//!   the tokens at `first + 1 ..= n_ctx - 1`. That is `n_ctx - first - 1`
+//!   scored tokens per window — 255 at the default `n_ctx = 512`, not
+//!   256, because the last position has no successor inside the window.
+//!   The first half exists only to give the model context.
+//! - **Natural log throughout.** `nll` sums `-log_softmax(logits)[target]`
+//!   in nats and the report is `exp(nll / count)` — an *unweighted mean
+//!   over scored tokens*, pooled across windows, not a mean of per-window
+//!   perplexities.
+//! - **`+/-` is the standard error of that mean, pushed through `exp`**:
+//!   `sqrt((E[v²] - E[v]²) / (count - 1)) * ppl`. Upstream computes it
+//!   from the same two running sums.
+//!
+//! `n_ctx` defaults to 512 here because upstream's `main` sets
+//! `params.n_ctx = 512` before parsing argv, overriding the 4096 that
+//! every other llama.cpp tool defaults to. A perplexity quoted without
+//! its context length is meaningless, so the value is printed.
+//!
+//! # Deviations from upstream, stated because they are the whole risk
+//!
+//! 1. **No `n_batch` split and no parallel sequences.** Upstream cuts a
+//!    window into `n_batch`-sized decodes, and packs `n_batch / n_ctx`
+//!    windows into one batch as separate sequences. Here one window is
+//!    one [`Decoder::forward_batch`] call. Attention is causal and the
+//!    KV cache is cleared per window either way, so every scored
+//!    position sees exactly the same context; only the grouping of f32
+//!    reductions differs, at the same scale as the accumulation-order
+//!    noise `ferrox parity` already calls a match.
+//! 2. **The output head runs at every position, not only the scored
+//!    ones.** Upstream sets `batch.logits[idx] = pos >= first`, so it
+//!    projects roughly half as many rows to vocabulary. That is a cost
+//!    difference, not a numeric one — and it is why this command holds
+//!    `n_ctx * n_vocab` f32s at once (100 MB at SmolLM2's 49k vocab,
+//!    260 MB at Llama-3's 128k).
+//! 3. **`--ppl-stride` / `perplexity_v2`, HellaSwag, WinoGrande,
+//!    multiple-choice and KL-divergence are not implemented.** None of
+//!    them shares this code path upstream either.
+//! 4. **Tokenization is ferrox's.** Upstream tokenizes with libllama.
+//!    The evidence that these agree is `ferrox parity`'s tokenizer half,
+//!    which compares the two on every local checkpoint libllama can
+//!    load. Special-token markup in the corpus is *not* parsed on either
+//!    side (upstream leaves `parse_special` false).
+
+use anyhow::Context;
+use ferrox_core::cache::KvCache;
+use ferrox_gguf::ShardedGguf;
+use std::path::Path;
+
+/// llama.cpp's `perplexity` sets `params.n_ctx = 512` before argv is
+/// parsed, unlike every other tool in that repo. Matching it is what
+/// makes a ferrox number comparable to a published one without both
+/// sides having to name the context length.
+pub const DEFAULT_CTX: usize = 512;
+
+pub struct PerplexityArgs {
+    pub model: String,
+    /// Plain-text corpus, read whole. `-f` upstream.
+    pub file: String,
+    pub ctx_size: usize,
+    /// Stop after this many windows. `--chunks` upstream.
+    pub chunks: Option<usize>,
+}
+
+/// How the corpus is cut up. Computed from the token count alone, before
+/// any weights are touched, so an impossible request fails in
+/// milliseconds instead of after a model load.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Plan {
+    /// Window length. Upstream's `n_ctx`.
+    n_ctx: usize,
+    /// First window position whose logits are scored. Upstream's `first`.
+    first: usize,
+    /// Scored tokens per window: `n_ctx - first - 1`.
+    per_window: usize,
+    /// Windows actually run.
+    n_window: usize,
+}
+
+impl Plan {
+    fn scored_total(&self) -> usize {
+        self.per_window * self.n_window
+    }
+
+    /// Where window `i` starts in the token stream.
+    ///
+    /// This is the STRIDE, and it lives here rather than inline in
+    /// [`run`] because a stride is invisible to a test that only checks
+    /// how many windows there are: halving it doubles the overlap,
+    /// scores every token twice, and still produces the same window
+    /// count from `plan`. Sabotaging the inline version turned nothing
+    /// red, which is how it ended up as a method with a test of its own.
+    ///
+    /// Upstream: `const int start = i * n_ctx;`.
+    pub(crate) fn window_start(&self, window: usize) -> usize {
+        window * self.n_ctx
+    }
+
+    /// The window positions whose logits are scored, as an inclusive
+    /// range over `first ..= n_ctx - 2`. The target for position `p` is
+    /// the token at `p + 1`, which is why the last position is excluded.
+    pub(crate) fn scored_positions(&self) -> std::ops::Range<usize> {
+        self.first..self.first + self.per_window
+    }
+}
+
+/// Cut `n_tokens` into llama.cpp's windows, or say why it cannot be done.
+///
+/// Every refusal here names both numbers, because "not enough tokens" on
+/// its own sends the user off to guess which of the two to change.
+pub(crate) fn plan(n_tokens: usize, n_ctx: usize, chunks: Option<usize>) -> anyhow::Result<Plan> {
+    // Upstream refuses `n_ctx <= 0`; the extra bound is `per_window >= 1`,
+    // which `n_ctx = 2` violates (first = 1, and position 1 has no
+    // successor inside the window). Without it the mean divides by zero
+    // and reports NaN as if it were a measurement.
+    let first = n_ctx / 2;
+    let per_window = n_ctx.saturating_sub(first).saturating_sub(1);
+    if per_window == 0 {
+        anyhow::bail!(
+            "--ctx-size {n_ctx} scores no tokens: llama.cpp scores window positions \
+             {first}..{} against their successors, which is empty below --ctx-size 3",
+            n_ctx.saturating_sub(1)
+        );
+    }
+    // The `2 * n_ctx` floor is upstream's, verbatim: with one window the
+    // "second half only" rule has nothing to average over and the
+    // standard error is undefined.
+    if n_tokens < 2 * n_ctx {
+        anyhow::bail!(
+            "corpus is {n_tokens} tokens; llama.cpp needs at least 2 * --ctx-size = {} \
+             to evaluate perplexity at --ctx-size {n_ctx}. Use a longer corpus or a \
+             smaller --ctx-size",
+            2 * n_ctx
+        );
+    }
+    let n_window_max = n_tokens / n_ctx;
+    let n_window = match chunks {
+        Some(0) => anyhow::bail!("--chunks 0 would score nothing"),
+        Some(want) => want.min(n_window_max),
+        None => n_window_max,
+    };
+    Ok(Plan {
+        n_ctx,
+        first,
+        per_window,
+        n_window,
+    })
+}
+
+/// `-log softmax(logits)[token]`, in nats.
+///
+/// Deliberately mirrors llama.cpp's `log_softmax()` term by term,
+/// including where it narrows to f32 and where it widens to f64: the
+/// exponentials are `expf` on f32 differences and are summed in a
+/// double, and `logits[tok] - max_logit` is an f32 subtraction before it
+/// meets the f64 `log(sum_exp)`. Doing the whole thing in f64 is more
+/// accurate and would put a systematic bias between the two engines'
+/// numbers, which is the one thing this command exists not to have.
+pub(crate) fn nll_nats(logits: &[f32], token: usize) -> anyhow::Result<f64> {
+    let logit = *logits.get(token).with_context(|| {
+        format!(
+            "token id {token} is outside this model's {} logits",
+            logits.len()
+        )
+    })?;
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut sum_exp = 0.0f64;
+    for &l in logits {
+        sum_exp += (l - max).exp() as f64;
+    }
+    Ok(-((logit - max) as f64 - sum_exp.ln()))
+}
+
+/// The running estimate: llama.cpp's `nll`, `nll2` and `count`.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct Estimate {
+    nll: f64,
+    nll2: f64,
+    count: usize,
+}
+
+impl Estimate {
+    fn observe(&mut self, nll: f64) {
+        self.nll += nll;
+        self.nll2 += nll * nll;
+        self.count += 1;
+    }
+
+    /// `exp(mean nll)`. `None` before anything has been scored, so a
+    /// caller cannot print `NaN` and have it read as a measurement.
+    pub(crate) fn ppl(&self) -> Option<f64> {
+        (self.count > 0).then(|| (self.nll / self.count as f64).exp())
+    }
+
+    /// llama.cpp's `+/-`: the standard error of the mean nll, pushed
+    /// through `exp` by multiplying by the perplexity itself.
+    ///
+    /// `None` when upstream also declines to print one — fewer than two
+    /// observations, or a variance that came out non-positive (which
+    /// upstream reports as "Unexpected negative standard deviation").
+    pub(crate) fn stderr(&self) -> Option<f64> {
+        if self.count < 2 {
+            return None;
+        }
+        let n = self.count as f64;
+        let mean = self.nll / n;
+        let var = self.nll2 / n - mean * mean;
+        if var <= 0.0 {
+            return None;
+        }
+        Some((var / (n - 1.0)).sqrt() * mean.exp())
+    }
+}
+
+pub fn run(args: PerplexityArgs) -> anyhow::Result<()> {
+    let path = crate::pull::resolve_model_path(&args.model)?;
+    let text = std::fs::read_to_string(&args.file)
+        .with_context(|| format!("reading corpus {}", args.file))?;
+
+    // Loading and tokenizing go through the same helper `ferrox verify`
+    // and `ferrox parity` use, so the tokenizer this number is computed
+    // over is the one `parity` proves against llama.cpp. A second
+    // spelling of "encode, then add BOS if the checkpoint says to" is
+    // exactly the drift that makes two numbers incomparable.
+    let (decoder, tokens, _eos) =
+        crate::verify_engine::load_and_tokenize(Path::new(&path), &text, None)
+            .context("loading the model and tokenizing the corpus")?;
+
+    // The per-window BOS reset needs the id itself, and needs to know
+    // whether this checkpoint uses one at all. Same predicate as the
+    // tokenizer above — called, not restated.
+    let file = ShardedGguf::open(&path)?;
+    let bos = if ferrox_models::tokenizer::should_add_bos_token(&file) {
+        file.metadata_u64("tokenizer.ggml.bos_token_id")
+            .map(|v| v as usize)
+    } else {
+        None
+    };
+    drop(file);
+
+    let plan = plan(tokens.len(), args.ctx_size, args.chunks)?;
+
+    println!(
+        "perplexity: {} tokens, n_ctx = {}, {} windows, scoring {} tokens each ({} total)",
+        tokens.len(),
+        plan.n_ctx,
+        plan.n_window,
+        plan.per_window,
+        plan.scored_total()
+    );
+    println!(
+        "perplexity: window positions {}..{} are scored; BOS reset per window: {}",
+        plan.first,
+        plan.n_ctx - 1,
+        match bos {
+            Some(b) => format!("yes (id {b})"),
+            None => "no (this checkpoint does not add BOS)".to_string(),
+        }
+    );
+
+    let mut est = Estimate::default();
+    for window in 0..plan.n_window {
+        let start = plan.window_start(window);
+        let mut ids = tokens[start..start + plan.n_ctx].to_vec();
+        if let Some(b) = bos {
+            ids[0] = b;
+        }
+
+        // A fresh cache per window is llama.cpp's `llama_memory_clear`:
+        // windows are independent, and a carried-over cache would let
+        // window N attend over window N-1 and quietly lower the number.
+        let mut caches: Vec<KvCache> = (0..decoder.layers.len())
+            .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
+            .collect();
+        let logits = decoder.forward_batch(&ids, 0, &mut caches);
+        anyhow::ensure!(
+            logits.len() == plan.n_ctx,
+            "forward_batch returned {} logit rows for a {}-token window",
+            logits.len(),
+            plan.n_ctx
+        );
+
+        for pos in plan.scored_positions() {
+            // The target comes from the ORIGINAL token stream, not from
+            // the BOS-substituted copy — upstream restores the token it
+            // overwrote before scoring for the same reason.
+            est.observe(nll_nats(&logits[pos], tokens[start + pos + 1])?);
+        }
+
+        // llama.cpp prints `[n]ppl,` per chunk. Same shape, so a run of
+        // both can be diffed line for line.
+        match est.ppl() {
+            Some(p) => println!("[{}]{p:.4}", window + 1),
+            None => unreachable!("a window always scores at least one token"),
+        }
+    }
+
+    let ppl = est
+        .ppl()
+        .context("no tokens were scored, so there is no perplexity to report")?;
+    match est.stderr() {
+        Some(se) => println!("Final estimate: PPL = {ppl:.4} +/- {se:.5}"),
+        None => println!("Final estimate: PPL = {ppl:.4} (no standard error: too few tokens)"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{nll_nats, plan, Estimate, DEFAULT_CTX};
+
+    /// The corpus fixture has to survive in the tree AND stay long
+    /// enough for the default context: `plan` refuses below `2 * n_ctx`
+    /// tokens, and a fixture trimmed below that would turn every
+    /// perplexity run into a refusal with nothing to say it used to
+    /// work. Bytes are a proxy for tokens here, and a deliberately
+    /// generous one: English averages well under 5 bytes per token on
+    /// every tokenizer in this repo, so 2 * 512 * 5 bytes is a floor no
+    /// real tokenizer can fall through.
+    #[test]
+    fn the_committed_corpus_is_long_enough_for_the_default_context() {
+        const CORPUS: &str = include_str!("../tests/corpus/alice-ch1-2.txt");
+        let floor = 2 * DEFAULT_CTX * 5;
+        assert!(
+            CORPUS.len() >= floor,
+            "corpus is {} bytes, below the {floor} that guarantees 2 * {DEFAULT_CTX} tokens",
+            CORPUS.len()
+        );
+    }
+
+    /// The scored window is llama.cpp's, and getting it wrong is the
+    /// failure this whole command is written to avoid: a number that
+    /// looks like a perplexity and is not comparable to any published
+    /// one. 512 scores 255 tokens starting at position 256 — not 256,
+    /// because the last position in the window has no successor in it.
+    #[test]
+    fn the_default_window_scores_the_second_half_minus_one() {
+        let p = plan(4096, DEFAULT_CTX, None).unwrap();
+        assert_eq!(p.first, 256);
+        assert_eq!(p.per_window, 255);
+        assert_eq!(p.n_window, 8);
+        assert_eq!(p.scored_total(), 2040);
+    }
+
+    /// Windows do not overlap: the stride is the full context. A stride
+    /// of half the context would score every token twice and report a
+    /// different, lower-variance number under the same name.
+    ///
+    /// The window COUNT is checked here and the window OFFSETS in the
+    /// test below, because they fail independently: this assertion
+    /// survived a sabotage that halved the stride, since halving a
+    /// stride does not change how many windows `plan` reports.
+    #[test]
+    fn windows_tile_the_corpus_without_overlap() {
+        // 5 * 64 = 320 tokens, 63 spare: 5 windows, not 6 and not 9.
+        let p = plan(383, 64, None).unwrap();
+        assert_eq!(p.n_window, 5);
+        assert_eq!(p.n_ctx, 64);
+        assert_eq!(p.per_window, 31);
+    }
+
+    /// The stride itself: window `i` starts at `i * n_ctx`, so
+    /// consecutive windows abut exactly — no gap, no overlap, and the
+    /// last one ends within the corpus.
+    #[test]
+    fn consecutive_windows_abut_exactly_and_stay_inside_the_corpus() {
+        let n_tokens = 383;
+        let p = plan(n_tokens, 64, None).unwrap();
+        assert_eq!(p.window_start(0), 0);
+        for w in 0..p.n_window {
+            let start = p.window_start(w);
+            assert_eq!(
+                start % p.n_ctx,
+                0,
+                "window {w} starts mid-stride at {start}"
+            );
+            if w > 0 {
+                // Abutting: the previous window's end IS this start.
+                assert_eq!(p.window_start(w - 1) + p.n_ctx, start);
+            }
+            assert!(
+                start + p.n_ctx <= n_tokens,
+                "window {w} runs past the corpus"
+            );
+        }
+    }
+
+    /// The scored positions, spelled out, because "the second half" is
+    /// off by one from what the phrase suggests: the last position in a
+    /// window has no successor inside it, so it cannot be scored, and
+    /// every target sits strictly after its own position.
+    #[test]
+    fn every_scored_position_has_its_successor_inside_the_window() {
+        let p = plan(4096, DEFAULT_CTX, None).unwrap();
+        let scored: Vec<usize> = p.scored_positions().collect();
+        assert_eq!(scored.first().copied(), Some(256));
+        assert_eq!(scored.last().copied(), Some(510));
+        assert_eq!(scored.len(), p.per_window);
+        for pos in scored {
+            assert!(pos + 1 < p.n_ctx, "position {pos} has no target");
+        }
+    }
+
+    #[test]
+    fn odd_context_sizes_round_the_scored_half_down() {
+        // first = 7/2 = 3, so positions 3..=5 are scored: 3 tokens.
+        let p = plan(64, 7, None).unwrap();
+        assert_eq!(p.first, 3);
+        assert_eq!(p.per_window, 3);
+    }
+
+    /// Upstream's floor, kept verbatim. Below it there is one window,
+    /// and a single window's "second half" has no second window to
+    /// average against.
+    #[test]
+    fn a_corpus_shorter_than_two_contexts_is_refused() {
+        let err = plan(1023, 512, None).unwrap_err().to_string();
+        assert!(err.contains("1023"), "{err}");
+        assert!(err.contains("1024"), "{err}");
+        assert!(plan(1024, 512, None).is_ok());
+    }
+
+    /// `--ctx-size 2` scores nothing: `first` is 1 and position 1 has no
+    /// successor. Without this refusal the mean divides by zero and the
+    /// command prints NaN as though it had measured something.
+    #[test]
+    fn a_context_that_scores_nothing_is_refused_rather_than_reported_as_nan() {
+        assert!(plan(100_000, 2, None).is_err());
+        assert!(plan(100_000, 1, None).is_err());
+        assert!(plan(100_000, 3, None).is_ok());
+    }
+
+    #[test]
+    fn chunks_clamps_down_but_never_up_and_zero_is_refused() {
+        assert_eq!(plan(4096, 512, Some(3)).unwrap().n_window, 3);
+        // Asking for more windows than the corpus holds must not invent
+        // them: upstream takes min(n_chunks, n_chunk_max).
+        assert_eq!(plan(4096, 512, Some(99)).unwrap().n_window, 8);
+        assert!(plan(4096, 512, Some(0)).is_err());
+    }
+
+    /// A uniform distribution over `v` tokens has `-log p = ln(v)` for
+    /// every target, so the perplexity of a corpus the model is
+    /// completely ignorant of is the vocabulary size. This pins the log
+    /// BASE: in base 2 the same input would give 2.0 for a 4-way tie.
+    #[test]
+    fn a_uniform_distribution_costs_the_natural_log_of_the_vocabulary() {
+        let flat = vec![0.0f32; 4];
+        for token in 0..4 {
+            let v = nll_nats(&flat, token).unwrap();
+            assert!((v - 4.0f64.ln()).abs() < 1e-9, "{v}");
+        }
+        let mut est = Estimate::default();
+        for token in 0..4 {
+            est.observe(nll_nats(&flat, token).unwrap());
+        }
+        assert!((est.ppl().unwrap() - 4.0).abs() < 1e-9);
+    }
+
+    /// The softmax is shift-invariant, and llama.cpp leans on that by
+    /// subtracting the max logit before exponentiating. A constant
+    /// offset must not move the answer, or a model whose logits happen
+    /// to sit high would score differently from the same model shifted
+    /// down.
+    ///
+    /// The offset is +200 on purpose. `expf(200)` is `+inf` in f32, so
+    /// dropping the max subtraction makes this NaN — at +40 the
+    /// unstable version still lands on a finite, correct-looking answer
+    /// and the test passes while the guard is gone.
+    #[test]
+    fn adding_a_constant_to_every_logit_does_not_move_the_score() {
+        let a = [1.0f32, -2.0, 0.5, 3.25, -0.75];
+        let b: Vec<f32> = a.iter().map(|v| v + 200.0).collect();
+        for token in 0..a.len() {
+            let (x, y) = (nll_nats(&a, token).unwrap(), nll_nats(&b, token).unwrap());
+            assert!(y.is_finite(), "token {token}: shifted score is {y}");
+            assert!((x - y).abs() < 1e-6, "token {token}: {x} vs {y}");
+        }
+    }
+
+    /// A confident, correct prediction costs almost nothing; a confident
+    /// wrong one costs a lot. Directionality is worth a test because a
+    /// dropped minus sign still produces a plausible-looking positive
+    /// perplexity.
+    #[test]
+    fn confidence_in_the_right_token_costs_less_than_confidence_in_the_wrong_one() {
+        let logits = [10.0f32, 0.0, 0.0];
+        let right = nll_nats(&logits, 0).unwrap();
+        let wrong = nll_nats(&logits, 1).unwrap();
+        assert!(right > 0.0 && right < 0.01, "{right}");
+        assert!(wrong > 9.0, "{wrong}");
+    }
+
+    /// The report is `exp` of the mean of the per-token nll, NOT the
+    /// mean of the per-token perplexities and NOT the mean of per-window
+    /// perplexities. Those three differ by Jensen's inequality, and only
+    /// the first is what "perplexity" means.
+    #[test]
+    fn the_estimate_exponentiates_the_mean_rather_than_averaging_exponentials() {
+        let mut est = Estimate::default();
+        est.observe(0.0);
+        est.observe(4.0);
+        let geometric = (2.0f64).exp();
+        assert!((est.ppl().unwrap() - geometric).abs() < 1e-12);
+        let arithmetic = (0.0f64.exp() + 4.0f64.exp()) / 2.0;
+        assert!((est.ppl().unwrap() - arithmetic).abs() > 1.0);
+    }
+
+    /// llama.cpp's `+/-`, term for term: the standard error of the mean
+    /// nll times the perplexity. Checked against the closed form on a
+    /// three-sample set rather than against a recomputation of the same
+    /// expression.
+    #[test]
+    fn the_standard_error_is_the_error_of_the_mean_pushed_through_exp() {
+        let mut est = Estimate::default();
+        for v in [1.0, 2.0, 3.0] {
+            est.observe(v);
+        }
+        // mean 2, population variance 2/3, /(n-1) = 1/3, sqrt = 0.57735…
+        let expected = (2.0f64 / 3.0 / 2.0).sqrt() * 2.0f64.exp();
+        assert!((est.stderr().unwrap() - expected).abs() < 1e-12, "{est:?}");
+    }
+
+    /// Zero and one observations have no standard error, and a variance
+    /// that lands at exactly zero (every token equally surprising) has
+    /// none either. Upstream declines to print one in all three cases;
+    /// printing 0.00000 instead would read as a perfectly precise
+    /// measurement.
+    #[test]
+    fn too_few_or_identical_observations_report_no_standard_error() {
+        assert_eq!(Estimate::default().ppl(), None);
+        assert_eq!(Estimate::default().stderr(), None);
+        let mut one = Estimate::default();
+        one.observe(1.5);
+        assert!(one.ppl().is_some());
+        assert_eq!(one.stderr(), None);
+        let mut flat = Estimate::default();
+        flat.observe(1.5);
+        flat.observe(1.5);
+        assert_eq!(flat.stderr(), None);
+    }
+
+    /// A target id past the end of the logit row is a corpus/model
+    /// mismatch, not something to index into. It must name the id, since
+    /// the only way it happens is a tokenizer emitting ids the head does
+    /// not cover.
+    #[test]
+    fn a_target_outside_the_logit_row_is_refused_by_name() {
+        let err = nll_nats(&[0.0, 1.0], 7).unwrap_err().to_string();
+        assert!(err.contains('7'), "{err}");
+    }
+}

--- a/crates/ferrox-cli/tests/corpus/alice-ch1-2.txt
+++ b/crates/ferrox-cli/tests/corpus/alice-ch1-2.txt
@@ -1,0 +1,384 @@
+Alice's Adventures in Wonderland, by Lewis Carroll (1865), chapters I
+and II, transcribed from Project Gutenberg ebook #11. The work is in
+the public domain in the United States; the Project Gutenberg header,
+footer and licence text are NOT part of this file, and the trademark is
+not used. Kept verbatim -- curly quotes and em dashes included --
+because a perplexity corpus that has been normalised is no longer the
+text every published figure was measured on.
+
+CHAPTER I.
+Down the Rabbit-Hole
+
+
+Alice was beginning to get very tired of sitting by her sister on the
+bank, and of having nothing to do: once or twice she had peeped into
+the book her sister was reading, but it had no pictures or
+conversations in it, “and what is the use of a book,” thought Alice
+“without pictures or conversations?”
+
+So she was considering in her own mind (as well as she could, for the
+hot day made her feel very sleepy and stupid), whether the pleasure of
+making a daisy-chain would be worth the trouble of getting up and
+picking the daisies, when suddenly a White Rabbit with pink eyes ran
+close by her.
+
+There was nothing so _very_ remarkable in that; nor did Alice think it
+so _very_ much out of the way to hear the Rabbit say to itself, “Oh
+dear! Oh dear! I shall be late!” (when she thought it over afterwards,
+it occurred to her that she ought to have wondered at this, but at the
+time it all seemed quite natural); but when the Rabbit actually _took a
+watch out of its waistcoat-pocket_, and looked at it, and then hurried
+on, Alice started to her feet, for it flashed across her mind that she
+had never before seen a rabbit with either a waistcoat-pocket, or a
+watch to take out of it, and burning with curiosity, she ran across the
+field after it, and fortunately was just in time to see it pop down a
+large rabbit-hole under the hedge.
+
+In another moment down went Alice after it, never once considering how
+in the world she was to get out again.
+
+The rabbit-hole went straight on like a tunnel for some way, and then
+dipped suddenly down, so suddenly that Alice had not a moment to think
+about stopping herself before she found herself falling down a very
+deep well.
+
+Either the well was very deep, or she fell very slowly, for she had
+plenty of time as she went down to look about her and to wonder what
+was going to happen next. First, she tried to look down and make out
+what she was coming to, but it was too dark to see anything; then she
+looked at the sides of the well, and noticed that they were filled with
+cupboards and book-shelves; here and there she saw maps and pictures
+hung upon pegs. She took down a jar from one of the shelves as she
+passed; it was labelled “ORANGE MARMALADE”, but to her great
+disappointment it was empty: she did not like to drop the jar for fear
+of killing somebody underneath, so managed to put it into one of the
+cupboards as she fell past it.
+
+“Well!” thought Alice to herself, “after such a fall as this, I shall
+think nothing of tumbling down stairs! How brave they’ll all think me
+at home! Why, I wouldn’t say anything about it, even if I fell off the
+top of the house!” (Which was very likely true.)
+
+Down, down, down. Would the fall _never_ come to an end? “I wonder how
+many miles I’ve fallen by this time?” she said aloud. “I must be
+getting somewhere near the centre of the earth. Let me see: that would
+be four thousand miles down, I think—” (for, you see, Alice had learnt
+several things of this sort in her lessons in the schoolroom, and
+though this was not a _very_ good opportunity for showing off her
+knowledge, as there was no one to listen to her, still it was good
+practice to say it over) “—yes, that’s about the right distance—but
+then I wonder what Latitude or Longitude I’ve got to?” (Alice had no
+idea what Latitude was, or Longitude either, but thought they were nice
+grand words to say.)
+
+Presently she began again. “I wonder if I shall fall right _through_
+the earth! How funny it’ll seem to come out among the people that walk
+with their heads downward! The Antipathies, I think—” (she was rather
+glad there _was_ no one listening, this time, as it didn’t sound at all
+the right word) “—but I shall have to ask them what the name of the
+country is, you know. Please, Ma’am, is this New Zealand or Australia?”
+(and she tried to curtsey as she spoke—fancy _curtseying_ as you’re
+falling through the air! Do you think you could manage it?) “And what
+an ignorant little girl she’ll think me for asking! No, it’ll never do
+to ask: perhaps I shall see it written up somewhere.”
+
+Down, down, down. There was nothing else to do, so Alice soon began
+talking again. “Dinah’ll miss me very much to-night, I should think!”
+(Dinah was the cat.) “I hope they’ll remember her saucer of milk at
+tea-time. Dinah my dear! I wish you were down here with me! There are
+no mice in the air, I’m afraid, but you might catch a bat, and that’s
+very like a mouse, you know. But do cats eat bats, I wonder?” And here
+Alice began to get rather sleepy, and went on saying to herself, in a
+dreamy sort of way, “Do cats eat bats? Do cats eat bats?” and
+sometimes, “Do bats eat cats?” for, you see, as she couldn’t answer
+either question, it didn’t much matter which way she put it. She felt
+that she was dozing off, and had just begun to dream that she was
+walking hand in hand with Dinah, and saying to her very earnestly,
+“Now, Dinah, tell me the truth: did you ever eat a bat?” when suddenly,
+thump! thump! down she came upon a heap of sticks and dry leaves, and
+the fall was over.
+
+Alice was not a bit hurt, and she jumped up on to her feet in a moment:
+she looked up, but it was all dark overhead; before her was another
+long passage, and the White Rabbit was still in sight, hurrying down
+it. There was not a moment to be lost: away went Alice like the wind,
+and was just in time to hear it say, as it turned a corner, “Oh my ears
+and whiskers, how late it’s getting!” She was close behind it when she
+turned the corner, but the Rabbit was no longer to be seen: she found
+herself in a long, low hall, which was lit up by a row of lamps hanging
+from the roof.
+
+There were doors all round the hall, but they were all locked; and when
+Alice had been all the way down one side and up the other, trying every
+door, she walked sadly down the middle, wondering how she was ever to
+get out again.
+
+Suddenly she came upon a little three-legged table, all made of solid
+glass; there was nothing on it except a tiny golden key, and Alice’s
+first thought was that it might belong to one of the doors of the hall;
+but, alas! either the locks were too large, or the key was too small,
+but at any rate it would not open any of them. However, on the second
+time round, she came upon a low curtain she had not noticed before, and
+behind it was a little door about fifteen inches high: she tried the
+little golden key in the lock, and to her great delight it fitted!
+
+Alice opened the door and found that it led into a small passage, not
+much larger than a rat-hole: she knelt down and looked along the
+passage into the loveliest garden you ever saw. How she longed to get
+out of that dark hall, and wander about among those beds of bright
+flowers and those cool fountains, but she could not even get her head
+through the doorway; “and even if my head would go through,” thought
+poor Alice, “it would be of very little use without my shoulders. Oh,
+how I wish I could shut up like a telescope! I think I could, if I only
+knew how to begin.” For, you see, so many out-of-the-way things had
+happened lately, that Alice had begun to think that very few things
+indeed were really impossible.
+
+There seemed to be no use in waiting by the little door, so she went
+back to the table, half hoping she might find another key on it, or at
+any rate a book of rules for shutting people up like telescopes: this
+time she found a little bottle on it, (“which certainly was not here
+before,” said Alice,) and round the neck of the bottle was a paper
+label, with the words “DRINK ME,” beautifully printed on it in large
+letters.
+
+It was all very well to say “Drink me,” but the wise little Alice was
+not going to do _that_ in a hurry. “No, I’ll look first,” she said,
+“and see whether it’s marked ‘_poison_’ or not”; for she had read
+several nice little histories about children who had got burnt, and
+eaten up by wild beasts and other unpleasant things, all because they
+_would_ not remember the simple rules their friends had taught them:
+such as, that a red-hot poker will burn you if you hold it too long;
+and that if you cut your finger _very_ deeply with a knife, it usually
+bleeds; and she had never forgotten that, if you drink much from a
+bottle marked “poison,” it is almost certain to disagree with you,
+sooner or later.
+
+However, this bottle was _not_ marked “poison,” so Alice ventured to
+taste it, and finding it very nice, (it had, in fact, a sort of mixed
+flavour of cherry-tart, custard, pine-apple, roast turkey, toffee, and
+hot buttered toast,) she very soon finished it off.
+
+*      *      *      *      *      *      *
+
+    *      *      *      *      *      *
+
+*      *      *      *      *      *      *
+
+
+“What a curious feeling!” said Alice; “I must be shutting up like a
+telescope.”
+
+And so it was indeed: she was now only ten inches high, and her face
+brightened up at the thought that she was now the right size for going
+through the little door into that lovely garden. First, however, she
+waited for a few minutes to see if she was going to shrink any further:
+she felt a little nervous about this; “for it might end, you know,”
+said Alice to herself, “in my going out altogether, like a candle. I
+wonder what I should be like then?” And she tried to fancy what the
+flame of a candle is like after the candle is blown out, for she could
+not remember ever having seen such a thing.
+
+After a while, finding that nothing more happened, she decided on going
+into the garden at once; but, alas for poor Alice! when she got to the
+door, she found she had forgotten the little golden key, and when she
+went back to the table for it, she found she could not possibly reach
+it: she could see it quite plainly through the glass, and she tried her
+best to climb up one of the legs of the table, but it was too slippery;
+and when she had tired herself out with trying, the poor little thing
+sat down and cried.
+
+“Come, there’s no use in crying like that!” said Alice to herself,
+rather sharply; “I advise you to leave off this minute!” She generally
+gave herself very good advice, (though she very seldom followed it),
+and sometimes she scolded herself so severely as to bring tears into
+her eyes; and once she remembered trying to box her own ears for having
+cheated herself in a game of croquet she was playing against herself,
+for this curious child was very fond of pretending to be two people.
+“But it’s no use now,” thought poor Alice, “to pretend to be two
+people! Why, there’s hardly enough of me left to make _one_ respectable
+person!”
+
+Soon her eye fell on a little glass box that was lying under the table:
+she opened it, and found in it a very small cake, on which the words
+“EAT ME” were beautifully marked in currants. “Well, I’ll eat it,” said
+Alice, “and if it makes me grow larger, I can reach the key; and if it
+makes me grow smaller, I can creep under the door; so either way I’ll
+get into the garden, and I don’t care which happens!”
+
+She ate a little bit, and said anxiously to herself, “Which way? Which
+way?”, holding her hand on the top of her head to feel which way it was
+growing, and she was quite surprised to find that she remained the same
+size: to be sure, this generally happens when one eats cake, but Alice
+had got so much into the way of expecting nothing but out-of-the-way
+things to happen, that it seemed quite dull and stupid for life to go
+on in the common way.
+
+So she set to work, and very soon finished off the cake.
+
+*      *      *      *      *      *      *
+
+    *      *      *      *      *      *
+
+*      *      *      *      *      *      *
+
+
+
+
+CHAPTER II.
+The Pool of Tears
+
+
+“Curiouser and curiouser!” cried Alice (she was so much surprised, that
+for the moment she quite forgot how to speak good English); “now I’m
+opening out like the largest telescope that ever was! Good-bye, feet!”
+(for when she looked down at her feet, they seemed to be almost out of
+sight, they were getting so far off). “Oh, my poor little feet, I
+wonder who will put on your shoes and stockings for you now, dears? I’m
+sure _I_ shan’t be able! I shall be a great deal too far off to trouble
+myself about you: you must manage the best way you can;—but I must be
+kind to them,” thought Alice, “or perhaps they won’t walk the way I
+want to go! Let me see: I’ll give them a new pair of boots every
+Christmas.”
+
+And she went on planning to herself how she would manage it. “They must
+go by the carrier,” she thought; “and how funny it’ll seem, sending
+presents to one’s own feet! And how odd the directions will look!
+
+     _Alice’s Right Foot, Esq., Hearthrug, near the Fender,_ (_with
+     Alice’s love_).
+
+Oh dear, what nonsense I’m talking!”
+
+Just then her head struck against the roof of the hall: in fact she was
+now more than nine feet high, and she at once took up the little golden
+key and hurried off to the garden door.
+
+Poor Alice! It was as much as she could do, lying down on one side, to
+look through into the garden with one eye; but to get through was more
+hopeless than ever: she sat down and began to cry again.
+
+“You ought to be ashamed of yourself,” said Alice, “a great girl like
+you,” (she might well say this), “to go on crying in this way! Stop
+this moment, I tell you!” But she went on all the same, shedding
+gallons of tears, until there was a large pool all round her, about
+four inches deep and reaching half down the hall.
+
+After a time she heard a little pattering of feet in the distance, and
+she hastily dried her eyes to see what was coming. It was the White
+Rabbit returning, splendidly dressed, with a pair of white kid gloves
+in one hand and a large fan in the other: he came trotting along in a
+great hurry, muttering to himself as he came, “Oh! the Duchess, the
+Duchess! Oh! won’t she be savage if I’ve kept her waiting!” Alice felt
+so desperate that she was ready to ask help of any one; so, when the
+Rabbit came near her, she began, in a low, timid voice, “If you please,
+sir—” The Rabbit started violently, dropped the white kid gloves and
+the fan, and skurried away into the darkness as hard as he could go.
+
+Alice took up the fan and gloves, and, as the hall was very hot, she
+kept fanning herself all the time she went on talking: “Dear, dear! How
+queer everything is to-day! And yesterday things went on just as usual.
+I wonder if I’ve been changed in the night? Let me think: was I the
+same when I got up this morning? I almost think I can remember feeling
+a little different. But if I’m not the same, the next question is, Who
+in the world am I? Ah, _that’s_ the great puzzle!” And she began
+thinking over all the children she knew that were of the same age as
+herself, to see if she could have been changed for any of them.
+
+“I’m sure I’m not Ada,” she said, “for her hair goes in such long
+ringlets, and mine doesn’t go in ringlets at all; and I’m sure I can’t
+be Mabel, for I know all sorts of things, and she, oh! she knows such a
+very little! Besides, _she’s_ she, and _I’m_ I, and—oh dear, how
+puzzling it all is! I’ll try if I know all the things I used to know.
+Let me see: four times five is twelve, and four times six is thirteen,
+and four times seven is—oh dear! I shall never get to twenty at that
+rate! However, the Multiplication Table doesn’t signify: let’s try
+Geography. London is the capital of Paris, and Paris is the capital of
+Rome, and Rome—no, _that’s_ all wrong, I’m certain! I must have been
+changed for Mabel! I’ll try and say ‘_How doth the little_—’” and she
+crossed her hands on her lap as if she were saying lessons, and began
+to repeat it, but her voice sounded hoarse and strange, and the words
+did not come the same as they used to do:—
+
+“How doth the little crocodile
+    Improve his shining tail,
+And pour the waters of the Nile
+    On every golden scale!
+
+“How cheerfully he seems to grin,
+    How neatly spread his claws,
+And welcome little fishes in
+    With gently smiling jaws!”
+
+
+“I’m sure those are not the right words,” said poor Alice, and her eyes
+filled with tears again as she went on, “I must be Mabel after all, and
+I shall have to go and live in that poky little house, and have next to
+no toys to play with, and oh! ever so many lessons to learn! No, I’ve
+made up my mind about it; if I’m Mabel, I’ll stay down here! It’ll be
+no use their putting their heads down and saying ‘Come up again, dear!’
+I shall only look up and say ‘Who am I then? Tell me that first, and
+then, if I like being that person, I’ll come up: if not, I’ll stay down
+here till I’m somebody else’—but, oh dear!” cried Alice, with a sudden
+burst of tears, “I do wish they _would_ put their heads down! I am so
+_very_ tired of being all alone here!”
+
+As she said this she looked down at her hands, and was surprised to see
+that she had put on one of the Rabbit’s little white kid gloves while
+she was talking. “How _can_ I have done that?” she thought. “I must be
+growing small again.” She got up and went to the table to measure
+herself by it, and found that, as nearly as she could guess, she was
+now about two feet high, and was going on shrinking rapidly: she soon
+found out that the cause of this was the fan she was holding, and she
+dropped it hastily, just in time to avoid shrinking away altogether.
+
+“That _was_ a narrow escape!” said Alice, a good deal frightened at the
+sudden change, but very glad to find herself still in existence; “and
+now for the garden!” and she ran with all speed back to the little
+door: but, alas! the little door was shut again, and the little golden
+key was lying on the glass table as before, “and things are worse than
+ever,” thought the poor child, “for I never was so small as this
+before, never! And I declare it’s too bad, that it is!”
+
+As she said these words her foot slipped, and in another moment,
+splash! she was up to her chin in salt water. Her first idea was that
+she had somehow fallen into the sea, “and in that case I can go back by
+railway,” she said to herself. (Alice had been to the seaside once in
+her life, and had come to the general conclusion, that wherever you go
+to on the English coast you find a number of bathing machines in the
+sea, some children digging in the sand with wooden spades, then a row
+of lodging houses, and behind them a railway station.) However, she
+soon made out that she was in the pool of tears which she had wept when
+she was nine feet high.
+
+“I wish I hadn’t cried so much!” said Alice, as she swam about, trying
+to find her way out. “I shall be punished for it now, I suppose, by
+being drowned in my own tears! That _will_ be a queer thing, to be
+sure! However, everything is queer to-day.”
+
+Just then she heard something splashing about in the pool a little way
+off, and she swam nearer to make out what it was: at first she thought
+it must be a walrus or hippopotamus, but then she remembered how small
+she was now, and she soon made out that it was only a mouse that had
+slipped in like herself.
+
+“Would it be of any use, now,” thought Alice, “to speak to this mouse?
+Everything is so out-of-the-way down here, that I should think very
+likely it can talk: at any rate, there’s no harm in trying.” So she
+began: “O Mouse, do you know the way out of this pool? I am very tired
+of swimming about here, O Mouse!” (Alice thought this must be the right
+way of speaking to a mouse: she had never done such a thing before, but
+she remembered having seen in her brother’s Latin Grammar, “A mouse—of
+a mouse—to a mouse—a mouse—O mouse!”) The Mouse looked at her rather
+inquisitively, and seemed to her to wink with one of its little eyes,
+but it said nothing.
+
+“Perhaps it doesn’t understand English,” thought Alice; “I daresay it’s
+a French mouse, come over with William the Conqueror.” (For, with all
+her knowledge of history, Alice had no very clear notion how long ago
+anything had happened.) So she began again: “Où est ma chatte?” which
+was the first sentence in her French lesson-book. The Mouse gave a
+sudden leap out of the water, and seemed to quiver all over with
+fright. “Oh, I beg your pardon!” cried Alice hastily, afraid that she
+had hurt the poor animal’s feelings. “I quite forgot you didn’t like
+cats.”


### PR DESCRIPTION
## What

`ferrox perplexity`, llama.cpp's `perplexity` tool. Listed under missing
tools in `docs/plans/llama-cpp-parity-review-2026-09-02.md`.

```
ferrox perplexity -m model.gguf -f crates/ferrox-cli/tests/corpus/alice-ch1-2.txt
perplexity: 5460 tokens, n_ctx = 512, 10 windows, scoring 255 tokens each (2550 total)
perplexity: window positions 256..511 are scored; BOS reset per window: no (this checkpoint does not add BOS)
[1]14.3198
...
Final estimate: PPL = 14.7284 +/- 0.70266
```

## Why

`parity` compares one distribution and `verify` compares text. Neither
says whether a quantized checkpoint is WORSE. `quantize` now writes Q8_0
byte-identically to llama.cpp (#83) and K-quant encoders are next (#70);
a naive K-quant writes a file that loads, tokenizes and generates fluent
text. Perplexity is how that gets caught, and it is the standard axis, so
the number is comparable to published ones rather than only to itself.

## The method, and how it was checked

Read line by line against
`.scratch/llama.cpp/tools/perplexity/perplexity.cpp::perplexity()`, the
`ppl_stride == 0` default path. The three things the task called out:

| | upstream | here |
|---|---|---|
| stride | `start = i * n_ctx` — windows do NOT overlap | same |
| scored fraction | `first = n_ctx/2`, `count += n_ctx - first - 1` (255 at 512, not 256) | same |
| BOS | added at the front of the whole corpus, then the first token of EACH window is overwritten with it | same |
| first token of a window | never scored — it is in the unscored first half | same |
| mean | `exp(nll / count)`, unweighted over scored tokens pooled across windows | same |
| log base | natural | same |
| `+/-` | `sqrt((E[v²]-E[v]²)/(count-1)) * ppl` | same |
| default `--ctx-size` | 512, set in `main` before argv (not the 4096 every other tool uses) | same |

## Evidence

Route taken: **built the real `llama-perplexity` binary.** The tracked
`.scratch/llama.cpp/build` has `LLAMA_BUILD_TOOLS=OFF`, so a second build
dir was configured with it ON rather than re-implementing the reference.
Same corpus, same checkpoint, both engines on CPU:

| checkpoint | ferrox | llama.cpp | gap |
|---|---|---|---|
| SmolLM2-135M Q8_0 | 14.7284 +/- 0.70266 | 14.7529 +/- 0.70359 | -0.17% |
| SmolLM2-135M Q4_K_M | 15.0896 +/- 0.71200 | 15.1274 +/- 0.71469 | -0.25% |
| SmolLM2-135M IQ3_M | 16.5144 +/- 0.79962 | 16.6004 +/- 0.80411 | -0.52% |
| Qwen3-0.6B Q8_0 (4 windows) | 19.9805 +/- 1.74716 | 19.9799 +/- 1.74641 | +0.003% |
| TinyLlama-1.1B Q8_0 (4 windows) | 11.9852 +/- 1.17386 | 12.0190 +/- 1.17878 | -0.28% |

Every gap is under a fifth of one standard error. The per-window running
estimates track each other window for window, which is what says the
tokenization and the chunking agree — a different token stream moves the
window boundaries and the sequence would not track.

**The gaps are not noise, and that is the interesting part.** ferrox is
BELOW llama.cpp on every checkpoint, by an amount that grows as the quant
gets coarser (Q8_0 0.17% → IQ3_M 0.52%). That is the known `vec_dot_type`
difference (`docs/plans/llama-cpp-gap-inventory.md` §10): llama.cpp
quantizes the activation to the weight's vec_dot type before the dot
product and ferrox keeps it in f32, so ferrox is slightly more accurate
and therefore slightly less surprised. Qwen3 is the control — its
per-window numbers straddle llama's instead of sitting under them, and a
METHOD difference would not change sign per model.

TinyLlama exercises the path the others do not: SPM tokenizer,
`add_bos_token` true, so the per-window BOS overwrite actually fires
("BOS reset per window: yes (id 1)").

## Corpus fixture

`crates/ferrox-cli/tests/corpus/alice-ch1-2.txt` — *Alice's Adventures in
Wonderland* chapters I–II, Project Gutenberg ebook #11, public domain in
the US. The Gutenberg header, footer and licence text are excluded and
the trademark is not used; a header comment in the file says so. 21 KB,
~5.2–5.8k tokens depending on tokenizer, 10 windows at the default
context. Kept verbatim including curly quotes and em dashes: a normalised
corpus is a different corpus.

## Deviations from upstream

Stated in the module doc, because they are the whole risk of a number
that looks comparable and is not.

1. **No `n_batch` split, no parallel sequences.** Upstream cuts a window
   into `n_batch` decodes and packs `n_batch / n_ctx` windows into one
   batch as separate sequences. Here one window is one `forward_batch`.
   Causal attention and a per-window KV clear mean every scored position
   sees the same context either way; only f32 reduction grouping differs.
   The measured agreement above is what backs that claim.
2. **The output head runs at every position**, not only the scored half
   (upstream sets `batch.logits[idx] = pos >= first`). Cost, not
   numerics — and it is why the command holds `n_ctx * n_vocab` f32s at
   once, 100 MB at SmolLM2's vocab and 260 MB at Llama-3's.
3. **Not implemented:** `--ppl-stride` / `perplexity_v2`, HellaSwag,
   WinoGrande, multiple-choice, KL-divergence. None shares this code path
   upstream either.
4. **Tokenization is ferrox's**, via the same `load_and_tokenize` helper
   `verify` and `parity` use, so it is the tokenizer `parity`'s
   tokenizer half proves against llama.cpp.

## Tests

16, in `#[cfg(test)]` beside the code, all sabotaged and confirmed red.
Two survived the first pass and changed the code rather than the test:

- **Halving the stride turned NOTHING red.** The window COUNT `plan`
  reports is unchanged by overlap, and the stride was inline in `run()`
  where no test could reach it. It is now `Plan::window_start`, with a
  test that consecutive windows abut exactly; the scored range is
  likewise `Plan::scored_positions`, with a test that every scored
  position's target is inside the window. Both go red now.
- **Deleting the max-logit subtraction turned nothing red.** The
  shift-invariance test offset logits by +40, and `expf(40)` is finite,
  so the numerically unstable form still produced the right answer. It
  offsets by +200 now, where the unstable form is `+inf`, and asserts
  finiteness as well as equality.

## What would have to be true for this to be wrong

That ferrox and llama.cpp disagree about the token stream in a way the
per-window tracking hides, or that deviation 1 is not the reduction-order
difference it is claimed to be. The second would show as a gap that does
not scale with quant coarseness; it does.

## Doc delta (not in this PR — `docs/` is another agent's)

- `docs/CLI.md` needs a `ferrox perplexity` entry: `-m`, `-f`,
  `--ctx-size` (default 512, and why 512), `--chunks`.
- `docs/FEATURES.md` should list corpus perplexity as a capability.
- `docs/plans/llama-cpp-parity-review-2026-09-02.md` should move
  `perplexity` out of "missing tools", noting `--ppl-stride`,
  HellaSwag/WinoGrande/multiple-choice and KL-divergence remain missing.
- The comparison table above belongs somewhere durable — it is the first
  quality-axis number this repo has against llama.cpp, and it names the
  `vec_dot_type` sign that `llama-cpp-gap-inventory.md` §10 predicts.

## What I did NOT do

- No `--ppl-stride` / `perplexity_v2`, HellaSwag, WinoGrande,
  multiple-choice, KL-divergence, or `--logits-file`.
- No GPU run. Every number above is CPU on both sides, so a Metal or CUDA
  perplexity is unmeasured. The command works there, it is just not
  evidenced.
- No large-checkpoint run. Nothing above 1.1B, because the corpus times
  are dominated by the model and an agent should not tie up the host.
- No docs, per the file ownership for this task. See the delta above.
- No `benchmarks/RESULTS.md` row: this is not a speed measurement and no
  tok/s is reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
