### PR TITLE
docs(cli): --samplers, and why the order is worth a flag

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -73,6 +73,7 @@ Same via explicit subcommand: `ferrox run -m …`.
 | `--hf-file` | Exact filename inside `--hf-repo`, llama.cpp's `-hff`. Skips quant resolution entirely |
 | `--repeat-last-n` | How many recent tokens the repetition / presence / frequency penalties consider. `0` = penalties off. Default `64`, llama.cpp's (`common/common.h:238`) |
 | `-s` / `--seed` | `-1` = time-based |
+| `--samplers` / `--sampler-seq` | Order the chain runs in, semicolon-separated. A sampler ferrox lacks is refused by name, see below |
 | `--grammar` | Constrain generation to a GBNF grammar, llama.cpp's `--grammar` |
 | `--grammar-file` | Read the GBNF grammar from a file, llama.cpp's `--grammar-file` |
 | `-j` / `--json-schema` | Constrain generation to a JSON Schema, converted to GBNF. llama.cpp's `-j` |
@@ -104,6 +105,24 @@ so `--ctk f16` there is accepted, ignored, and reported as ignored by
 the startup banner. That matters for memory: f32 doubles the KV bytes
 per token, which is why a model that fits at its full context on Metal
 can need `--ctx-size auto` on CPU. `ferrox inspect-plan` prices both.
+
+`--samplers` (llama.cpp's, also `--sampler-seq`) chooses the ORDER, as a
+semicolon-separated list: `--samplers "penalties;top_k;top_p;min_p;temperature"`
+is the default spelled out. llama.cpp's aliases parse, so `top-k`,
+`nucleus`, `temp` and `typical` all work.
+
+A sampler ferrox does not implement is **refused by name with the
+reason**, never skipped: `dry`, `typ_p`, `xtc` and `top_n_sigma` are
+real llama.cpp samplers, and a caller who asked for one and silently got
+a chain without it was handed a different sampler than the one they
+requested.
+
+Order is not cosmetic, which is why it is worth exposing and why getting
+it wrong is a silent quality regression rather than an error. Each
+filter renormalises over the survivors of the last, so moving a step
+changes what the next step can see. This project shipped that bug once:
+temperature ran first, and top-p then summed probabilities temperature
+had already reshaped.
 
 **The sampler chain is llama.cpp's, in llama.cpp's order.** Penalties,
 then top-k, then top-p, then min-p, and **temperature last**

--- a/docs/plans/llama-cpp-parity-review-2026-09-02.md
+++ b/docs/plans/llama-cpp-parity-review-2026-09-02.md
@@ -17,7 +17,7 @@ now carries what is true rather than what was true at breakfast.
 | Architecture coverage | **16** audited + 4 dedicated engines vs 140 llama.cpp graphs | P0, expand audited set |
 | CLI flag semantics | `-ngl` still refuses a partial count deliberately; `-e` and `--repeat-last-n` already match | P2, documented rather than divergent |
 | Server flags | **DONE**: `-c`, `--api-key`, `--api-key-file`, `--alias`, `--ctk`, `-hf`, `--hf-file`, `-cb`, `-np` | closed |
-| Sampling / grammar | **Mostly done**: GBNF, JSON Schema, forced `tool_choice`, `--presence-penalty` / `--frequency-penalty` | P2, `--samplers` ordering left |
+| Sampling / grammar | **Done**: GBNF, JSON Schema, forced `tool_choice`, the two penalties, and `--samplers` ordering with unimplemented samplers refused by name | closed, bar the samplers ferrox does not implement (`dry`, `xtc`, `typ_p`, `top_n_sigma`) |
 | Tools (quantize, perplexity) | `ferrox quantize` writes Q8_0 byte-identically; `ferrox perplexity` agrees with `llama-perplexity` to within a fifth of a standard error on five checkpoints | P1, K-quant encoders (#70); HellaSwag and the other corpus sub-tools remain |
 | Serving / batching | CB auto-on Metal; incremental CB streaming | P1, slot save/load |
 | Metal concurrency | Phase 1 shipped (#46 closed); per-request Metal KV is follow-up | P2 |


### PR DESCRIPTION
Doc delta for #91.

The prose says what the flag is *for*, because "choose the order" reads as a preference knob and it isn't: each filter renormalises over the survivors of the last, so moving a step changes what the next step can see. This project shipped that bug once.

The refusal is documented as prominently as the feature. `dry`, `typ_p`, `xtc` and `top_n_sigma` are real llama.cpp samplers ferrox does not implement, and naming one is a refusal rather than a skip.

The parity review's sampling row closes, bar those four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN