### PR TITLE
docs: Q4_K, and why its bytes differ from llama.cpp's on purpose

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -573,9 +573,30 @@ multimodal patch tables and audio codebooks. `token_embd.weight` and
 output head to Q6_K in other mixes is gated on the target not being
 Q8_0.
 
-K-quants, the IQ tiers, MXFP4 and imatrix are not implemented, and each
-is refused by name rather than approximated. Tracked as
+`Q4_K_S` and `Q4_K_M` are also written, with `--pure`. Everything else
+(the remaining K-quants, the IQ tiers, MXFP4, imatrix) is refused by
+name rather than approximated. Tracked as
 [#70](https://github.com/antonellof/ferrox/issues/70).
+
+**Q4_K is not byte-identical to llama.cpp's, and cannot be.** Compared
+tensor by tensor against `llama-quantize --pure`, 113 of 311 tensors
+match exactly and 198 differ in about 0.05% of their bytes. The cause is
+not the algorithm: `ggml-quants.c.o` carries 1957 FMA instructions
+because clang contracts `a*b+c` into a fused multiply-add by default for
+C, and Rust does not, so `quantize_row_q4_K_ref`'s exact output is a
+property of the compiler that built the reference. llama.cpp built with
+contraction off would not reproduce it either. Q8_0 IS byte-identical,
+because its arithmetic has no accumulated multiply-add to contract.
+
+What is equal is the thing that matters. Perplexity of the two files, on
+the same corpus through the same engine: **25.1444** for ferrox's
+against **25.1805** for llama.cpp's, 2.4% of one standard error apart.
+
+One refusal to know about: a tensor whose row width is not a multiple of
+256 stops the run. llama.cpp answers that case by changing the tensor's
+TYPE, to Q5_0 or F16, and ferrox has neither encoder; padding the row
+would shift every following row on decode. SmolLM2-135M cannot be Q4_K
+quantized here for that reason, its embedding being 576 wide.
 
 ## Hugging Face Hub (`download`, `pull`)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -128,7 +128,10 @@ llama.cpp's method, agreeing with `llama-perplexity` to within a fifth
 of one standard error on five checkpoints. Where the two differ, the gap
 is monotone in the quant and has the sign the documented `vec_dot_type`
 difference predicts. `ferrox quantize` writes `Q8_0` byte-identically to
-`llama_model_quantize()` and refuses every other target by name. See
+`llama_model_quantize()`, plus `Q4_K_S` and `Q4_K_M` with `--pure`, and
+refuses every other target by name. Q4_K is not byte-identical and
+cannot be, because the C reference is compiled with FP contraction; it
+matches on perplexity instead. See
 [`CLI.md`](CLI.md).
 
 The sampler flags carry llama.cpp's own defaults on `--temp` (0.8),


### PR DESCRIPTION
Doc delta for #93.

The larger part is the paragraph explaining why Q4_K is **not** byte-identical while Q8_0 **is** — because someone comparing the two files will find the difference and reasonably assume ferrox got it wrong. It didn't: clang contracts `a*b+c` by default for C (1957 FMA instructions in `ggml-quants.c.o`), Rust doesn't, so the reference's exact output is a property of the compiler that built it.

"Not byte-identical but fine" is worth nothing without a measurement, so the number that *is* equal sits beside it: 25.1444 vs 25.1805 perplexity, 2.4% of one standard error.

The refusal a user will actually hit is documented with its reason: a row not a multiple of 256 stops the run, and SmolLM2-135M is named because it's small enough that people reach for it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN