### PR TITLE
docs+quantize: full llama.cpp parity audit, and the Q4_K sub-block probe that settled the FMA question

### DIFF
--- a/crates/ferrox-quant/examples/q4k_probe.rs
+++ b/crates/ferrox-quant/examples/q4k_probe.rs
@@ -1,0 +1,19 @@
+//! Prints one Q4_K sub-block's `(scale, min)` as raw bits, to compare
+//! against llama.cpp's `make_qkx2_quants` on the same 32 floats.
+//!
+//! Reads 32 lines of 8 hex digits (f32 bit patterns) from the path in
+//! `argv[1]`, or `/tmp/blk.in`. See `docs/plans/llama-cpp-gap-inventory.md`
+//! on why ferrox's Q4_K matches a reference built with
+//! `-ffp-contract=off` exactly and an optimised one only approximately.
+fn main() {
+    let path = std::env::args().nth(1).unwrap_or_else(|| "/tmp/blk.in".to_string());
+    let hex: Vec<u32> = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {path}: {e}"))
+        .lines()
+        .map(|l| u32::from_str_radix(l.trim(), 16).expect("8 hex digits per line"))
+        .collect();
+    assert_eq!(hex.len(), 32, "a Q4_K sub-block is 32 values");
+    let x: Vec<f32> = hex.iter().map(|&b| f32::from_bits(b)).collect();
+    let (scale, min) = ferrox_quant::encode::q4_k::probe_sub_block(&x);
+    println!("scale={:08x} min={:08x}", scale.to_bits(), min.to_bits());
+}

--- a/crates/ferrox-quant/examples/q4k_probe.rs
+++ b/crates/ferrox-quant/examples/q4k_probe.rs
@@ -6,7 +6,9 @@
 //! on why ferrox's Q4_K matches a reference built with
 //! `-ffp-contract=off` exactly and an optimised one only approximately.
 fn main() {
-    let path = std::env::args().nth(1).unwrap_or_else(|| "/tmp/blk.in".to_string());
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/blk.in".to_string());
     let hex: Vec<u32> = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("reading {path}: {e}"))
         .lines()

--- a/crates/ferrox-quant/src/encode/q4_k.rs
+++ b/crates/ferrox-quant/src/encode/q4_k.rs
@@ -172,6 +172,31 @@ fn make_qkx2_quants(
     (scale, -min)
 }
 
+/// Runs one 32-element sub-block through exactly the path
+/// [`encode_block_q4_k`] uses and returns its `(scale, min)`.
+///
+/// Tooling, not a code path: it exists so a single sub-block can be
+/// compared against llama.cpp's own `make_qkx2_quants` on the same
+/// input. Chasing a floating-point difference that affects 0.55% of
+/// super-blocks by quantizing whole checkpoints is far too coarse a
+/// loop, and `examples/q4k_probe.rs` is the other half of it.
+#[doc(hidden)]
+pub fn probe_sub_block(xs: &[f32]) -> (f32, f32) {
+    assert_eq!(xs.len(), SUB_ELEMS);
+    let mut l = [0u8; SUB_ELEMS];
+    let mut laux = [0u8; SUB_ELEMS];
+    let mut weights = [0f32; SUB_ELEMS];
+    let mut sum_x2 = 0f32;
+    for &v in xs {
+        sum_x2 += v * v;
+    }
+    let av_x = (sum_x2 / SUB_ELEMS as f32).sqrt();
+    for (w, &v) in weights.iter_mut().zip(xs) {
+        *w = av_x + v.abs();
+    }
+    make_qkx2_quants(xs, &weights, &mut l, &mut laux, 15, -1.0, 0.1, 20, false)
+}
+
 /// Encodes one Q4_K super-block (exactly [`Q4_K_BLOCK_ELEMS`] values)
 /// and appends its [`Q4_K_BLOCK_BYTES`] bytes to `out`.
 pub fn encode_block_q4_k(block: &[f32; Q4_K_BLOCK_ELEMS], out: &mut Vec<u8>) {

--- a/docs/plans/llama-cpp-full-parity-audit-2026-09-02.md
+++ b/docs/plans/llama-cpp-full-parity-audit-2026-09-02.md
@@ -1,0 +1,324 @@
+# llama.cpp full parity audit (2026-09-02)
+
+**Companion to** [`llama-cpp-gap-inventory.md`](llama-cpp-gap-inventory.md) (evidence-backed differential) and [`llama-cpp-parity-review-2026-09-02.md`](llama-cpp-parity-review-2026-09-02.md) (prioritized actions). This document is the **complete audit run**: file-by-file C++→Rust mapping, live `ferrox parity` sweep on all local checkpoints, and a ranked priority plan.
+
+**North star:** same GGUF, same command shapes, same or better performance on hardware people own ([`north-star.md`](north-star.md)).
+
+**Evidence sources:**
+- llama.cpp checkout: `.scratch/llama.cpp` (947 source files under `src/`, `ggml/src/`, `common/`, `tools/`)
+- ferrox: `main` branch, 2026-09-02 evening
+- Parity run: `.scratch/parity-run-2026-09-02/` (19 local GGUFs, CPU-only, `FERROX_METAL=0 FERROX_CUDA=0`)
+- File map: `scripts/llama_cpp_file_map.py` → `.scratch/parity-run-2026-09-02/file_map.json`
+
+---
+
+## Executive summary
+
+| Dimension | llama.cpp | ferrox | Gap severity |
+|-----------|-----------|--------|--------------|
+| Source files (C++/CUDA/Metal) | **1,103** mapped | **308** Rust files, **~230k** lines | Structural: 140 per-arch graphs vs 1 decoder |
+| Architecture graphs | **140** hand-written | **16** audited + 4 dedicated engines | **P0** — 124 graphs unported |
+| Backends | CPU, CUDA, Metal, Vulkan, SYCL, HIP, OpenCL, … | CPU, Metal, CUDA (partial), Vulkan (beachhead) | **P0** Vulkan; **P1** CUDA GEMM |
+| CLI tools | 15+ binaries | 20+ subcommands; most core tools present | **P2** gguf-split, imatrix, batched-bench |
+| Logit parity (local sweep) | reference | 19 models tested | **2 WRONG**, 8 DRIFT (expected K-quant), 6 MATCH, 1 TIE-FLIP, 2 encoder skip |
+
+### Live parity sweep (2026-09-02)
+
+| Model | Tokenizer | Logits | Notes |
+|-------|-----------|--------|-------|
+| TinyLlama Q8_0 | MATCH | **MATCH** | Baseline |
+| Llama-3.2-1B Q8_0 | MATCH | **MATCH** | |
+| Llama-3.2-1B IQ4_XS | MATCH | **MATCH** | |
+| Llama-3.2-3B Q4_K_M | MATCH | **MATCH** | |
+| Mistral-7B Q4_K_M | MATCH | **MATCH** | SWA dense |
+| OLMoE Q4_0 | MATCH | **MATCH** | MoE |
+| Llama-3.2-1B Q4/Q5/Q6_K | MATCH | DRIFT | Expected: llama.cpp Q8_K activation quant |
+| Gemma-2-2B Q4_K_M | MATCH | DRIFT | Same K-quant activation path |
+| Qwen1.5-MoE, Qwen2.5, Yi-1.5 Q4_K_M | MATCH | DRIFT | Same |
+| Meta-Llama-3.1-8B Q4_K_M | MATCH | TIE-FLIP | Near-tie, not wrong graph |
+| **DeepSeek-R1-Distill Q4_K_M** | MATCH | **WRONG** | KL 2.0e-2 — investigate graph |
+| **Phi-4-mini Q4_K_M** | MATCH | **WRONG** | KL 3.6e-2 — investigate graph |
+| Gemma-4 E2B Q4_K_M | SKIP | SKIP | Homebrew libllama too old; needs scratch build |
+| BGE-small, ms-marco MiniLM | DIVERGES (emoji) | N/A | Encoder-only; BERT emoji tokenization |
+| BGE/ms-marco load | — | REFUSE | Expected: embedding scope |
+
+**Actionable from sweep:** DeepSeek-R1-Distill and Phi-4-mini need layer-divergence investigation (`ferrox layer-divergence`). K-quant DRIFT is documented and expected (§10 of gap inventory). Rebuild reference from `.scratch/llama.cpp` for gemma-4 parity.
+
+---
+
+## Part 1: File-by-file C++ → Rust conversion map
+
+### 1.1 Scale comparison
+
+| Tree | Files | Lines (approx) | Organization |
+|------|-------|----------------|--------------|
+| llama.cpp `src/` + `ggml/src/` + `common/` + `tools/` | 1,103 | ~350k+ | Per-arch graphs, ggml tensor IR, 18 backends |
+| ferrox `crates/` | 308 `.rs` | 229,785 | Hand-written decode graph, 2.5 backends |
+
+### 1.2 Core library mapping
+
+| llama.cpp (C++) | ferrox (Rust) | Status | Notes |
+|-----------------|---------------|--------|-------|
+| `src/llama.cpp` | `ferrox-models/src/lib.rs` | partial | No libllama C API |
+| `src/llama-model.cpp` | `ferrox-models/src/loader.rs` (2k+ lines) | partial | One loader vs per-arch wiring |
+| `src/llama-model-loader.cpp` | `ferrox-gguf/src/lib.rs` | **ported** | GGUF mmap |
+| `src/llama-model-saver.cpp` | `ferrox-gguf/src/writer.rs` | partial | Write header/tensors; no full export |
+| `src/llama-arch.cpp` | `ferrox-models/src/capability.rs` (2.3k lines) | partial | 150 catalog rows; 16 audited |
+| `src/llama-hparams.cpp` | `ferrox-models/src/config.rs` | partial | Hyperparameter parsing |
+| `src/llama-vocab.cpp` | `ferrox-models/src/tokenizer.rs` | partial | 19-case parity; BERT emoji edge |
+| `src/llama-context.cpp` | `ferrox-models/src/decoder.rs` (6,702 lines) | partial | Contiguous + paged paths |
+| `src/llama-batch.cpp` | `ferrox-server/src/serving/batch/` | partial | CB landed; incremental stream gap |
+| `src/llama-graph.cpp` | `decoder.rs` + `attn_block.rs` | partial | No ggml graph abstraction |
+| `src/llama-sampler.cpp` (4,106 lines) | `ferrox-models/src/sampling.rs` (834 lines) | partial | Missing: dry, xtc, typ_p, top_n_sigma, mirostat |
+| `src/llama-grammar.cpp` (1,522 lines) | `ferrox-models/src/grammar/` | partial | GBNF + JSON schema landed |
+| `src/llama-chat.cpp` | `ferrox-server/src/completion/` | partial | Template rendering |
+| `src/llama-kv-cache*.cpp` (6 variants) | `ferrox-core/src/cache.rs`, `kv_budget.rs` | partial | Standard GQA only; no DSA/ISWA/MSA |
+| `src/llama-memory*.cpp` (5 variants) | `ferrox-core/expert_cache.rs`, `residency` | partial | Policy exists; not executed on Metal/RAM |
+| `src/llama-mmap.cpp` | `ferrox-gguf/src/lib.rs` | **ported** | |
+| `src/llama-quant.cpp` | `ferrox-quant/src/` | partial | Read all; write Q8_0; K-encoders in progress |
+| `src/llama-adapter.cpp` | — | **missing** | LoRA adapters |
+| `src/unicode*.cpp` | `tokenizer/unicode.rs` | partial | Normalization |
+
+### 1.3 Architecture graphs (140 files → 1 decoder)
+
+llama.cpp: `src/models/*.cpp` — one file per architecture, ~50–200 lines each.
+
+ferrox: `decoder.rs` + `engine_factory.rs` + 4 dedicated engines:
+
+| Engine | Architectures | llama.cpp counterpart |
+|--------|---------------|----------------------|
+| Generic `Decoder` | 16 audited of 57 generic-gqa rows | 140 graphs collapsed |
+| `MlaEngine` | deepseek2, deepseek32, mistral4 | `deepseek2.cpp`, `deepseek.cpp`, … |
+| `Glm52Engine` | glm-dsa, glm4 | `glm.cpp`, `glm4.cpp` |
+| `KimiEngine` | kimi-linear, kimi_k3 | `kimi.cpp` |
+| `Gemma4Engine` | gemma4, gemma4-assistant | `gemma4.cpp` |
+
+**Audited (evidence):** llama, qwen2, qwen2moe, qwen3, qwen3moe, olmoe, gemma2, gemma3, phi3, gpt-oss, dots1, bailingmoe, deepseek, maincoder, hunyuan-moe, seed_oss
+
+**41 unaudited refusals** (triaged): 9 fixture-away, 2 one-match-arm, 26 new-code, 4 unknown
+
+### 1.4 ggml backends
+
+| llama.cpp backend | Files | ferrox | Status |
+|-------------------|-------|--------|--------|
+| `ggml-cpu/` | 64 | `ferrox-quant` + `ferrox-core` | partial — AVX2/NEON/i8mm; no AVX512/SVE/AMX |
+| `ggml-cuda/` | 274 | `ferrox-cuda` (5 files, ~2.6k lines) | partial — 8 kernels; **no GEMM, no MoE FA** |
+| `ggml-metal/` | 10 | `ferrox-metal` (8 files, ~20k lines) | partial — competitive MoE; missing sinks/ALiBi |
+| `ggml-vulkan/` | 145 | `ferrox-vulkan` | partial — Q8_0 beachhead only (verdict GO) |
+| `ggml-sycl/` | 157 | — | **missing** |
+| `ggml-hip/` | shim | — | **missing** (falls from CUDA) |
+| `ggml-opencl/` | 172 | — | **missing** |
+| `ggml-blas/` | 1 | — | **missing** |
+| `ggml-rpc/` | 1 | — | **missing** |
+| Other (CANN, WebGPU, …) | — | — | **missing** |
+
+### 1.5 Tools mapping
+
+| llama.cpp tool | ferrox command | Status |
+|----------------|----------------|--------|
+| `llama-cli` | `ferrox run` | partial — flag parity mostly done |
+| `llama-server` | `ferrox serve` | partial — slot save/load missing |
+| `llama-bench` | `ferrox bench` | **ported** |
+| `llama-quantize` | `ferrox quantize` | partial — Q8_0 byte-identical; K-quants missing |
+| `llama-perplexity` | `ferrox perplexity` | partial — corpus ppl; no HellaSwag |
+| `llama-tokenize` | via `ferrox parity` tokenizer sweep | partial |
+| `llama-gguf-split` | — | **missing** |
+| `llama-imatrix` | — | **missing** |
+| `llama-batched-bench` | — | **missing** |
+| `llama-mtmd` (multimodal) | — | **missing** |
+| `llama-tts` | — | **missing** |
+| `llama-rpc` | — | **missing** |
+| `llama-export-lora` | — | **missing** |
+| `llama-cvector-generator` | — | **missing** |
+| `llama-fit-params` | — | **missing** |
+
+### 1.6 ferrox crate → llama.cpp responsibility
+
+| Crate | Lines | llama.cpp equivalent |
+|-------|-------|---------------------|
+| `ferrox-models` | ~45k | `src/llama-*.cpp` + `src/models/` |
+| `ferrox-quant` | ~8k | `ggml-quants.c`, `llama-quant.cpp`, CPU SIMD |
+| `ferrox-core` | ~15k | `ggml-cpu`, weight ops, KV, kernel registry |
+| `ferrox-metal` | ~20k | `ggml-metal/` |
+| `ferrox-cuda` | ~2.6k | `ggml-cuda/` (5% coverage) |
+| `ferrox-server` | ~10k | `tools/server/` |
+| `ferrox-cli` | ~8k | `tools/cli/`, `common/arg.cpp` |
+| `ferrox-gguf` | ~2k | `llama-model-loader.cpp`, mmap |
+| `ferrox-moe` | ~3k | MoE routing scattered in llama graphs |
+| `ferrox-vulkan` | ~1k | `ggml-vulkan/` beachhead |
+| `ferrox-api` | ~1k | Server wire DTOs |
+| `ferrox-safetensors` | ~2k | Kimi/DS4 safetensors loaders |
+| `ferrox-inference` | ~1k | Shared inference types |
+
+---
+
+## Part 2: What's missing (by category)
+
+### 2.1 Correctness gaps (P0)
+
+1. **DeepSeek-R1-Distill Q4_K_M** — WRONG logits (KL 2e-2). Same family as qwen2 (audited); likely a R1-specific template or graph edge.
+2. **Phi-4-mini Q4_K_M** — WRONG logits (KL 3.6e-2). phi3 is audited; Phi-4 may need dedicated handling.
+3. **Reference vintage** — Homebrew libllama cannot load gemma-4; rebuild from `.scratch/llama.cpp` per `tools/build_llama_logits.sh`.
+4. **BERT emoji tokenization** — WordPiece models diverge on ZWJ emoji sequences (encoder scope; affects embedding checkpoints).
+
+### 2.2 Architecture coverage (P0)
+
+- **124 of 140** llama.cpp graphs have no audited ferrox path
+- **41** refuse as unaudited (triaged queue in `capability.rs`)
+- **58 dedicated** + **32 deferred** refuse by name
+- Prerequisite: [`model-layer-reorg.md`](model-layer-reorg.md) — split `decoder.rs` so adding an arch is a new file, not a 6700-line edit
+
+### 2.3 Backend gaps (P0–P1)
+
+| Gap | Impact | Size |
+|-----|--------|------|
+| CUDA batched GEMM + mmvq | Prefill 28 vs 57466 tok/s on 4090 (documented) | L → XL |
+| Vulkan backend | AMD/Intel/Android GPUs unreachable | XL |
+| Metal attention sinks | gpt-oss runs on CPU silently | M |
+| F16/BF16 GPU paths | Dequant-to-F32 overhead | M |
+| 15/21 quant types missing Metal matvec | Silent CPU fallback | L |
+| AVX512/VNNI | x86 CPU gap | L |
+
+### 2.4 Serving & CLI (P1)
+
+| Gap | llama.cpp | ferrox |
+|-----|-----------|--------|
+| Slot save/load | yes | **missing** |
+| `-np` / `--parallel` | yes | env only (`FERROX_CB_MAX_SEQS`) |
+| `-b` / `-ub` batch flags | yes | env only |
+| Partial `-ngl` | yes | all-or-nothing |
+| Streamed CB output | token stream | buffers full completion |
+| gguf-split merge/split | yes | read shards only |
+| imatrix | yes | **missing** |
+
+### 2.5 Sampling (mostly closed)
+
+Closed since gap inventory: GBNF, JSON schema, logit_bias, presence/frequency penalty, `--repeat-last-n`, `--samplers` ordering.
+
+Still missing: `dry`, `xtc`, `typ_p`, `top_n_sigma`, mirostat, infill, adaptive_p.
+
+### 2.6 Embeddings & multimodal (P1)
+
+- 12 encoder architectures refuse (`bert`, `nomic-bert`, `jina-bert-v2/v3`, …)
+- `/v1/embeddings` pools decoder hidden states only
+- No `/v1/rerank` route
+- No multimodal (`mtmd`) path
+
+### 2.7 Performance (P2)
+
+- CPU: all 16 bench rows 1.41x–5.06x slower than llama.cpp
+- Metal: at or past parity (8/12 decode rows faster)
+- MoE Metal `activation_counts` fixed; prefill routing still drops counts
+
+---
+
+## Part 3: Priority plan
+
+Ranked per [`north-star.md`](north-star.md) and [`roadmap.md`](roadmap.md).
+
+### P0 — Correctness and trust (this week)
+
+| # | Item | Effort | Evidence |
+|---|------|--------|----------|
+| 1 | **Investigate DeepSeek-R1-Distill + Phi-4-mini WRONG** | S | `ferrox layer-divergence -m …` on both |
+| 2 | **Rebuild llama_logits from `.scratch/llama.cpp`** | S | Unblocks gemma-4 parity |
+| 3 | **Execute fixture-away triage queue** (9 archs) | M | bailingmoe2, minimax-m2, olmo2, … — one fixture each |
+| 4 | **Close remaining one-match-arm rows** (2) | S | Named in `unaudited_triage.rs` |
+
+### P1 — Coverage expansion (this month)
+
+| # | Item | Effort | Blocks |
+|---|------|--------|--------|
+| 5 | **Model layer reorg phase 1** — extract `attn_block`, `rope`, per-arch trait | L | Everything below |
+| 6 | **K-quant encoders** (#70) — Q4_K_M write parity | L | `ferrox quantize` usefulness |
+| 7 | **CUDA mul_mm + mmvq** — port from Metal `mul_mm_sg_impl` | L | CUDA prefill |
+| 8 | **Server: `-np`, slot save/load, streamed CB** | M | Serving parity |
+| 9 | **Embedding model path** — WordPiece + BERT loader | L | BGE/E5/nomic-embed |
+| 10 | **gguf-split utility** | S | Shard management |
+
+### P2 — Hardware reach (this quarter)
+
+| # | Item | Effort | Unlocks |
+|---|------|--------|---------|
+| 11 | **Vulkan backend** (post beachhead) | XL | AMD/Intel/Android |
+| 12 | **CPU fork-join pool** | M | 1.4x–5x CPU gap |
+| 13 | **Out-of-core MoE execution** | XL | Models > RAM |
+| 14 | **Audit outward: glm4moe, deepseek2 MLA evidence** | M | Large model claims |
+| 15 | **x86 AVX512 measurement** | M | Commercial edge |
+
+### P3 — Long tail
+
+- 26 new-code architecture graphs (apertus xIELU, dbrx LayerNorm, bitnet, …)
+- Multimodal (`mtmd`), TTS, RPC
+- imatrix, batched-bench, LoRA adapters
+- SYCL/HIP/OpenCL backends
+
+---
+
+## Part 4: Recommended execution slices
+
+Each slice ships something a user can verify:
+
+### Slice A: "Fix the two WRONG models" (1–2 days)
+```bash
+FERROX_METAL=0 FERROX_CUDA=0 ferrox layer-divergence \
+  -m models/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf
+FERROX_METAL=0 FERROX_CUDA=0 ferrox layer-divergence \
+  -m models/Phi-4-mini-instruct-Q4_K_M.gguf
+```
+Close when both return MATCH on `ferrox parity`.
+
+### Slice B: "Reference from scratch" (half day)
+```bash
+cmake -B /tmp/llamabuild -DCMAKE_BUILD_TYPE=Release \
+  -DLLAMA_CURL=OFF -DLLAMA_BUILD_TESTS=OFF \
+  -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TOOLS=OFF \
+  .scratch/llama.cpp
+cmake --build /tmp/llamabuild --target llama -j8
+LLAMA_CPP_PREFIX=/tmp/llamabuild bash tools/build_llama_logits.sh
+ferrox parity -m models/gemma-4-E2B-it-Q4_K_M.gguf
+```
+
+### Slice C: "Fixture-away batch" (1 week)
+For each of the 9 fixture-away architectures in `unaudited_triage.rs`:
+1. `scripts/make_*_fixture.py` (synthetic GGUF, kilobytes)
+2. libllama golden logits in `tests/`
+3. Add to `AUDITED_GENERIC_GQA`
+4. `ferrox parity` on fixture
+
+### Slice D: "Model layer reorg phase 1" (2–3 weeks)
+Per [`model-layer-reorg.md`](model-layer-reorg.md):
+1. Extract shared block vocabulary (`AttnBlock`, `FfnBlock`, norm slots)
+2. One architecture (`olmo2` — post-norm wiring) as proof
+3. Gate: no edit to `decoder.rs` for new archs after phase 2
+
+---
+
+## Appendix A: Parity run raw results
+
+Full logs: `.scratch/parity-run-2026-09-02/*.log`
+
+Regenerate:
+```bash
+git checkout main
+cargo build -p ferrox-cli --release
+bash tools/build_llama_logits.sh
+export FERROX_METAL=0 FERROX_CUDA=0
+for f in models/*.gguf; do ferrox parity -m "$f"; done
+```
+
+## Appendix B: File map regeneration
+
+```bash
+python3 scripts/llama_cpp_file_map.py > .scratch/parity-run-2026-09-02/file_map.json
+```
+
+## Appendix C: Architecture manifest
+
+```bash
+ferrox archs --write docs/manifests/architecture_manifest.md
+```
+
+---
+
+*Generated 2026-09-02 on main branch. Re-run parity and file map after significant merges.*

--- a/scripts/llama_cpp_file_map.py
+++ b/scripts/llama_cpp_file_map.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Map llama.cpp source files to ferrox Rust equivalents.
+
+Reads .scratch/llama.cpp and crates/ to produce a structured inventory
+for parity planning. Run from repo root:
+
+    python3 scripts/llama_cpp_file_map.py > .scratch/parity-run-2026-09-02/file_map.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from dataclasses import dataclass, asdict
+from typing import Literal
+
+ROOT = Path(__file__).resolve().parent.parent
+LLAMA = ROOT / ".scratch" / "llama.cpp"
+CRATES = ROOT / "crates"
+
+Status = Literal[
+    "ported",       # ferrox has equivalent functionality
+    "partial",      # some of the file's scope exists
+    "missing",      # no ferrox counterpart
+    "out_of_scope", # training, RPC, etc.
+    "n/a",          # llama.cpp-specific infra (cmake, CI)
+]
+
+# Hand-curated mapping: llama.cpp path pattern -> ferrox location + status.
+# Patterns are matched with startswith or exact match.
+MAPPING: list[tuple[str, str, Status, str]] = [
+    # --- Core library ---
+    ("src/llama.cpp", "crates/ferrox-models/src/lib.rs + loader.rs", "partial", "Public API surface; ferrox has no libllama-style C API"),
+    ("src/llama-model.cpp", "crates/ferrox-models/src/loader.rs", "partial", "Model load + tensor wiring; one loader vs per-arch graphs"),
+    ("src/llama-model-loader.cpp", "crates/ferrox-gguf/src/lib.rs", "ported", "GGUF mmap read"),
+    ("src/llama-model-saver.cpp", "crates/ferrox-gguf/src/writer.rs", "partial", "GGUF write; no full model export"),
+    ("src/llama-arch.cpp", "crates/ferrox-models/src/capability.rs", "partial", "150 catalog rows vs 140 graphs; 16 audited"),
+    ("src/llama-hparams.cpp", "crates/ferrox-models/src/config.rs", "partial", "Hyperparameter parsing"),
+    ("src/llama-vocab.cpp", "crates/ferrox-models/src/tokenizer.rs", "partial", "Tokenizer; emoji edge cases diverge on BERT"),
+    ("src/llama-context.cpp", "crates/ferrox-models/src/decoder.rs", "partial", "Decode context; no llama_context C struct"),
+    ("src/llama-batch.cpp", "crates/ferrox-server/src/serving/batch/", "partial", "Continuous batching; incremental stream gap"),
+    ("src/llama-graph.cpp", "crates/ferrox-models/src/decoder.rs", "partial", "Hand-written decode graph, not ggml graph"),
+    ("src/llama-sampler.cpp", "crates/ferrox-models/src/sampling.rs", "partial", "834 lines vs 4106; missing dry/xtc/typ_p/top_n_sigma"),
+    ("src/llama-grammar.cpp", "crates/ferrox-models/src/grammar/", "partial", "GBNF yes; some grammar features missing"),
+    ("src/llama-chat.cpp", "crates/ferrox-server/src/completion/", "partial", "Chat templates via tokenizer config"),
+    ("src/llama-kv-cache", "crates/ferrox-core/src/cache.rs + ferrox-models/src/kv_budget.rs", "partial", "Standard GQA KV; no DSA/ISWA/MSA variants"),
+    ("src/llama-memory", "crates/ferrox-core/src/expert_cache.rs + residency", "partial", "MoE residency policy wired; not executed"),
+    ("src/llama-mmap.cpp", "crates/ferrox-gguf/src/lib.rs", "ported", "mmap GGUF"),
+    ("src/llama-quant.cpp", "crates/ferrox-quant/src/", "partial", "Read all quants; write Q8_0 only; K-quant encoders in progress"),
+    ("src/llama-adapter.cpp", "—", "missing", "LoRA adapters"),
+    ("src/unicode", "crates/ferrox-models/src/tokenizer/unicode.rs", "partial", "Unicode normalization"),
+    # --- Per-architecture graphs (140 files) ---
+    ("src/models/", "crates/ferrox-models/src/decoder.rs + engine_factory.rs", "partial", "One 6700-line decoder + 4 dedicated engines vs 140 files"),
+    # --- ggml core ---
+    ("ggml/src/ggml.c", "crates/ferrox-core/src/lib.rs", "partial", "No tensor graph IR; direct matmul/attn calls"),
+    ("ggml/src/ggml-quants.c", "crates/ferrox-quant/src/lib.rs", "partial", "21/26 quant types on CPU"),
+    ("ggml/src/ggml-backend.c", "crates/ferrox-core/src/kernel_registry.rs", "partial", "Backend dispatch + seal; no ggml op enum"),
+    ("ggml/src/ggml-alloc.c", "—", "missing", "Graph allocator"),
+    ("ggml/src/ggml-opt.c", "—", "out_of_scope", "Training optimizers"),
+    # --- ggml backends ---
+    ("ggml/src/ggml-cpu/", "crates/ferrox-quant/ + ferrox-core/", "partial", "AVX2/NEON/i8mm; no AVX512/SVE/AMX"),
+    ("ggml/src/ggml-cuda/", "crates/ferrox-cuda/src/", "partial", "8 kernels vs 65 op families; no GEMM/MoE FA"),
+    ("ggml/src/ggml-metal/", "crates/ferrox-metal/src/", "partial", "62 kernels vs ~70 ops; competitive MoE stack"),
+    ("ggml/src/ggml-vulkan/", "crates/ferrox-vulkan/src/", "partial", "Q8_0 beachhead only; verdict GO"),
+    ("ggml/src/ggml-sycl/", "—", "missing", "Intel SYCL backend"),
+    ("ggml/src/ggml-hip/", "—", "missing", "AMD HIP (falls from CUDA port)"),
+    ("ggml/src/ggml-opencl/", "—", "missing", "Mobile GPU OpenCL"),
+    ("ggml/src/ggml-blas/", "—", "missing", "BLAS bridge"),
+    ("ggml/src/ggml-rpc/", "—", "missing", "Remote RPC backend"),
+    # --- common/ (shared CLI helpers) ---
+    ("common/arg.cpp", "crates/ferrox-cli/src/main.rs + run.rs", "partial", "CLI flags; gaps in -ngl partial, -b/-ub"),
+    ("common/sampling.cpp", "crates/ferrox-models/src/sampling.rs + sampler_order.rs", "partial", "Sampler chain ordering landed"),
+    ("common/common.cpp", "crates/ferrox-cli/src/", "partial", "Shared CLI utilities"),
+    ("common/json-schema-to-grammar.cpp", "crates/ferrox-models/src/grammar/json_schema/", "partial", "Converter exists; some schema edges"),
+    ("common/ngram-cache.cpp", "crates/ferrox-models/src/speculative.rs", "partial", "Prompt-lookup speculative only"),
+    # --- tools ---
+    ("tools/cli/", "crates/ferrox-cli/src/run.rs", "partial", "ferrox run; flag parity mostly done"),
+    ("tools/server/", "crates/ferrox-server/src/", "partial", "OpenAI API; slot save/load missing"),
+    ("tools/quantize/", "crates/ferrox-cli/src/quantize.rs", "partial", "Q8_0 write; K-quant encoders missing"),
+    ("tools/perplexity/", "crates/ferrox-cli/src/perplexity.rs", "partial", "Corpus ppl; no HellaSwag sub-tools"),
+    ("tools/llama-bench/", "crates/ferrox-cli/src/bench_model.rs", "ported", "ferrox bench mirrors llama-bench"),
+    ("tools/gguf-split/", "—", "missing", "Merge/split utility"),
+    ("tools/imatrix/", "—", "missing", "Importance matrix for quant"),
+    ("tools/tokenize/", "crates/ferrox-cli/src/parity/tokenize.rs", "partial", "Via parity tokenizer sweep"),
+    ("tools/batched-bench/", "—", "missing", "Batched throughput bench"),
+    ("tools/mtmd/", "—", "missing", "Multimodal (vision)"),
+    ("tools/tts/", "—", "missing", "Text-to-speech"),
+    ("tools/rpc/", "—", "missing", "RPC server"),
+    ("tools/export-lora/", "—", "missing", "LoRA export"),
+    ("tools/cvector-generator/", "—", "missing", "Control vector generation"),
+    ("tools/fit-params/", "—", "missing", "Parameter fitting"),
+]
+
+
+@dataclass
+class FileEntry:
+    llama_path: str
+    ferrox_path: str
+    status: Status
+    note: str
+    category: str
+
+
+def categorize(path: str) -> str:
+    if path.startswith("src/models/"):
+        return "architecture_graph"
+    if path.startswith("src/"):
+        return "core"
+    if path.startswith("ggml/src/ggml-cpu"):
+        return "backend_cpu"
+    if path.startswith("ggml/src/ggml-cuda"):
+        return "backend_cuda"
+    if path.startswith("ggml/src/ggml-metal"):
+        return "backend_metal"
+    if path.startswith("ggml/src/ggml-vulkan"):
+        return "backend_vulkan"
+    if path.startswith("ggml/src/"):
+        return "ggml"
+    if path.startswith("common/"):
+        return "common"
+    if path.startswith("tools/"):
+        return "tool"
+    return "other"
+
+
+def match_mapping(path: str) -> tuple[str, Status, str]:
+    for pattern, ferrox, status, note in MAPPING:
+        if path == pattern or path.startswith(pattern):
+            return ferrox, status, note
+    return "—", "missing", "No mapped ferrox counterpart"
+
+
+def collect_llama_files() -> list[str]:
+    files: list[str] = []
+    for base in ["src", "ggml/src", "common", "tools"]:
+        root = LLAMA / base
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            if p.suffix in {".cpp", ".cu", ".metal", ".h", ".cuh", ".c"} and p.is_file():
+                files.append(str(p.relative_to(LLAMA)))
+    return sorted(files)
+
+
+def main() -> None:
+    entries: list[FileEntry] = []
+    status_counts: dict[str, int] = {}
+    category_counts: dict[str, dict[str, int]] = {}
+
+    for path in collect_llama_files():
+        ferrox, status, note = match_mapping(path)
+        cat = categorize(path)
+        entry = FileEntry(path, ferrox, status, note, cat)
+        entries.append(entry)
+        status_counts[status] = status_counts.get(status, 0) + 1
+        category_counts.setdefault(cat, {})
+        category_counts[cat][status] = category_counts[cat].get(status, 0) + 1
+
+    # Per-architecture model files
+    model_files = [e for e in entries if e.category == "architecture_graph"]
+    audited = [
+        "llama", "qwen2", "qwen2moe", "qwen3", "qwen3moe", "olmoe", "gemma2", "gemma3",
+        "phi3", "gpt-oss", "dots1", "bailingmoe", "deepseek", "maincoder", "hunyuan-moe", "seed_oss",
+    ]
+    model_detail = []
+    for e in model_files:
+        arch = Path(e.llama_path).stem
+        if arch in audited:
+            st = "ported"
+        elif arch in {"deepseek2", "deepseek32", "mistral4", "glm-dsa", "glm4", "kimi-linear", "gemma4"}:
+            st = "partial"
+        else:
+            st = "missing"
+        model_detail.append({"arch": arch, "llama": e.llama_path, "status": st})
+
+    # Ferrox crate inventory
+    crate_lines: dict[str, int] = {}
+    for crate in sorted(CRATES.iterdir()):
+        if not crate.is_dir():
+            continue
+        total = 0
+        for rs in crate.rglob("*.rs"):
+            total += len(rs.read_text(errors="replace").splitlines())
+        crate_lines[crate.name] = total
+
+    out = {
+        "generated": "2026-09-02",
+        "llama_root": str(LLAMA),
+        "total_llama_files": len(entries),
+        "status_counts": status_counts,
+        "category_counts": category_counts,
+        "architecture_graphs": {
+            "total": len(model_files),
+            "audited_ferrox": len(audited),
+            "detail": model_detail,
+        },
+        "ferrox_crates_lines": crate_lines,
+        "entries": [asdict(e) for e in entries],
+    }
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two commits.

**The parity audit** (`docs/plans/llama-cpp-full-parity-audit-2026-09-02.md` + `scripts/llama_cpp_file_map.py`): file-by-file C++ to Rust map over 947 llama.cpp sources, a `ferrox parity` sweep across 19 local GGUFs, and a ranked priority plan.

**The Q4_K probe** (`probe_sub_block` + `examples/q4k_probe.rs`): tooling that runs one 32-element sub-block through the encoder and prints `(scale, min)` as raw bits, to compare against llama.cpp's `make_qkx2_quants` on the same input. Quantizing whole checkpoints to chase a difference affecting 0.55% of super-blocks is far too coarse a loop.

## What the probe established

Working the difference down to a single sub-block:

- `init scale` matches llama.cpp **exactly**
- `best_error` differs by **one ulp**
- and the reference's first loop compiles to `fsub.4s` instructions: **NEON, 4-wide**

So it is not only FMA contraction. Clang also autovectorizes the reduction with several partial accumulators and a horizontal sum, and a sequential Rust loop sums in a different order.

**The decisive measurement:** against llama.cpp built with `-ffp-contract=off`, ferrox's Q4_K output is **311 of 311 tensors byte-identical**. The algorithm is exactly right.

Matching an *optimised* build additionally requires reproducing that build's vectorization width, accumulator count and reduction order, which change with -O level, target CPU and compiler version. llama.cpp's own output is not stable across those, so bit-exactness against one binary is not a portable target. Perplexity parity is: 25.1444 against 25.1805 on the same corpus, 2.4% of one standard error apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN