### PR TITLE
feat(rerank): run the pooler when the GGUF carries it, and say which score scale a caller is on (#82 route 1)

### DIFF
--- a/crates/ferrox-models/src/rank_head.rs
+++ b/crates/ferrox-models/src/rank_head.rs
@@ -38,6 +38,35 @@
 //! and there is no softmax. If another architecture is ever admitted,
 //! this module has to grow its branch — it must not inherit `bert`'s.
 //!
+//! # The pooler, and the two score scales (issue #82)
+//!
+//! `cls` IS HuggingFace's `bert.pooler.dense`: llama.cpp's tensor
+//! mapping renames it, and the `tanh` above is
+//! `BertPooler.activation`. A `BertForSequenceClassification` reranker
+//! was trained as `classifier(tanh(pooler(cls_hidden)))`, so the
+//! `dense` branch is not an optional flourish — it is most of the
+//! head's calibration.
+//!
+//! Every reranker GGUF in circulation is missing it, because
+//! llama.cpp's converter deletes it by name (`conversion/bert.py`,
+//! `BertModel.filter_tensors`: "we are only using BERT for embeddings
+//! so we don't need the pooling layer"). This module does the one
+//! thing an engine can do about that: it **runs the pooler when the
+//! file carries it and refuses to invent one when it does not**. There
+//! is no identity stand-in and no zero-filled `cls` — a made-up pooler
+//! is a made-up score, and the direct-projection shape is legitimate
+//! for `jina-reranker-v1-tiny-en`, so the absence cannot be refused
+//! either.
+//!
+//! What it must never do is leave the difference invisible. The two
+//! regimes differ by roughly a factor of 50 in score magnitude
+//! (about ±11 vs about ±0.2 on `ms-marco-MiniLM-L6-v2`), which changes
+//! nothing for a caller that sorts and everything for a caller that
+//! thresholds. [`RankHead::has_pooler`] and [`RankHead::graph`] are the
+//! machine-readable answer, `/v1/rerank` reports the second one on
+//! every response, and [`missing_pooler_note`] says it once at load for
+//! whoever is reading the server's log rather than its JSON.
+//!
 //! # Which float is the score
 //!
 //! `send_rerank` (`tools/server/server-context.cpp`) reads `embd[0]`:
@@ -137,6 +166,42 @@ impl RankHead {
     pub fn score(&self, pooled: &[f32]) -> f32 {
         self.apply(pooled).first().copied().unwrap_or(0.0)
     }
+
+    /// Whether `cls` — HuggingFace's `bert.pooler.dense` — is in this
+    /// checkpoint, and therefore in every score this head produces.
+    ///
+    /// The one bit that decides which of the two score scales in the
+    /// module docs a caller is reading. Everything else that reports
+    /// the regime is derived from it, so nothing can disagree with the
+    /// weights that are actually loaded.
+    pub fn has_pooler(&self) -> bool {
+        self.dense.is_some()
+    }
+
+    /// The composition [`Self::apply`] runs, as a formula over the CLS
+    /// row: `classifier(tanh(pooler(cls)))` for a head with its pooler,
+    /// `classifier(cls)` for one without.
+    ///
+    /// Built from the same three `Option`s [`Self::apply`] branches on,
+    /// in the same order, rather than restated as a table of the four
+    /// shapes — two structures that must agree about one thing is this
+    /// repo's dominant bug shape, and a *description* that has drifted
+    /// from the graph is worse than none. The test
+    /// `the_graph_names_a_tanh_exactly_when_a_tanh_is_applied` closes
+    /// the loop by checking the label against the arithmetic.
+    pub fn graph(&self) -> String {
+        let mut g = "cls".to_string();
+        if self.dense.is_some() {
+            g = format!("tanh(pooler({g}))");
+        }
+        if self.norm.is_some() {
+            g = format!("norm({g})");
+        }
+        if self.out.is_some() {
+            g = format!("classifier({g})");
+        }
+        g
+    }
 }
 
 fn refuse(what: String) -> LoadError {
@@ -169,6 +234,47 @@ fn read_labels(file: &impl TensorSource, arch: &str) -> Result<Vec<String>, Load
             "{key} is {other:?}, but it must be an array of strings"
         ))),
     }
+}
+
+/// The load-time NOTE for a sequence-classification head that arrived
+/// without its pooler — issue #82, and **not** a refusal.
+///
+/// Fires on exactly one combination: `cls.output` present, `cls`
+/// absent, and `{arch}.classifier.output_labels` declared. That triple
+/// is what a HuggingFace `BertForSequenceClassification` looks like
+/// after llama.cpp's converter has deleted `pooler.dense` by name. It
+/// is deliberately narrower than "no pooler":
+/// `jina-reranker-v1-tiny-en` is the direct-projection shape upstream
+/// documents as CORRECT, it names no labels, and warning about it
+/// would train the reader to ignore this line.
+///
+/// A refusal is not available here. The file does not carry anything
+/// that separates "trained without a pooler" from "converted without
+/// one", so refusing would also refuse the checkpoints where the shape
+/// is right — see the module docs. A note is what is left, and it is
+/// why the regime is *also* on every `/v1/rerank` response: an operator
+/// reads a log, a thresholding client reads JSON, and only the second
+/// one is in a position to act on it.
+///
+/// A free function taking three booleans rather than an `if` inside
+/// [`load_rank_head`], so that the condition can be shown to fire — and
+/// shown not to fire on the two shapes next to it — without three GGUFs.
+fn missing_pooler_note(has_dense: bool, has_out: bool, labels: &[String]) -> Option<String> {
+    if has_dense || !has_out || labels.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "ferrox: NOTE this reranker head runs classifier(cls) — it carries {CLS_OUT_W} and \
+         labels ({}) but no {CLS_W}. A HuggingFace BertForSequenceClassification was trained \
+         as classifier(tanh(pooler(cls))), and llama.cpp's converter deletes pooler.dense by \
+         name (conversion/bert.py, \"we are only using BERT for embeddings so we don't need \
+         the pooling layer\"), so this file cannot carry it. ferrox runs the pooler whenever \
+         a file DOES carry it and will not invent one. The ranking is the checkpoint's; the \
+         score SCALE is not (about ±0.2 rather than about ±11 on \
+         ms-marco-MiniLM-L6-v2), so an absolute relevance threshold will not fire. See \
+         ferrox issue #82.",
+        labels.join(", "),
+    ))
 }
 
 /// Builds the head a `bert` checkpoint carries, or `None` when it
@@ -284,6 +390,10 @@ pub fn load_rank_head(
         )));
     }
 
+    if let Some(note) = missing_pooler_note(dense.is_some(), out.is_some(), &labels) {
+        eprintln!("{note}");
+    }
+
     Ok(Some(RankHead {
         dense,
         norm,
@@ -354,6 +464,110 @@ mod tests {
         };
         // 2 * 5.0 = 10.0. A stray tanh would make this 1.0.
         assert!((head.score(&[5.0, 1.0]) - 10.0).abs() < 1e-6);
+    }
+
+    /// The label a caller reads off a response must be the arithmetic
+    /// the head performed, so this checks the two against each other
+    /// rather than checking [`RankHead::graph`] against a string
+    /// constant — a constant would still agree with itself after
+    /// [`RankHead::apply`] stopped applying the `tanh`.
+    ///
+    /// The probe is linearity. A bias-free `classifier(cls)` head is a
+    /// matrix, so `f(2x) == 2·f(x)` exactly; a `tanh` in the middle is
+    /// the head's ONLY non-linearity, so the same equality fails as
+    /// soon as one runs. `graph()` naming a `tanh` and `apply` being
+    /// linear (or the reverse) is the drift this is here for.
+    #[test]
+    fn the_graph_names_a_tanh_exactly_when_a_tanh_is_applied() {
+        let out = || {
+            Some(Dense {
+                w: WeightMatrix::F32(Tensor::new(vec![1.0, -0.5], vec![1, 2])),
+                b: None,
+            })
+        };
+        let pooler = || {
+            Some(Dense {
+                w: WeightMatrix::F32(Tensor::new(vec![0.3, 0.7, -0.2, 0.4], vec![2, 2])),
+                b: None,
+            })
+        };
+        let x = [0.5f32, 0.25];
+        let two_x = [1.0f32, 0.5];
+
+        for (head, want_graph, want_pooler) in [
+            (
+                RankHead {
+                    dense: pooler(),
+                    norm: None,
+                    out: out(),
+                    labels: vec![],
+                    eps: 1e-12,
+                },
+                "classifier(tanh(pooler(cls)))",
+                true,
+            ),
+            (
+                RankHead {
+                    dense: None,
+                    norm: None,
+                    out: out(),
+                    labels: vec![],
+                    eps: 1e-12,
+                },
+                "classifier(cls)",
+                false,
+            ),
+        ] {
+            assert_eq!(head.graph(), want_graph);
+            assert_eq!(head.has_pooler(), want_pooler);
+            // `graph()` is derived from the same `Option`s, so it can
+            // never disagree with `has_pooler` -- but the point is that
+            // neither may disagree with the numbers.
+            assert_eq!(head.graph().contains("tanh"), head.has_pooler());
+
+            let linear = (head.score(&two_x) - 2.0 * head.score(&x)).abs() < 1e-6;
+            assert_eq!(
+                linear,
+                !want_pooler,
+                "{want_graph} was {} but its graph says otherwise: f(x)={}, f(2x)={}",
+                match linear {
+                    true => "linear",
+                    false => "non-linear",
+                },
+                head.score(&x),
+                head.score(&two_x),
+            );
+        }
+    }
+
+    /// The NOTE must fire on the shape llama.cpp's converter produces
+    /// and on NOTHING else, because a note that also fires on the
+    /// legitimate direct-projection head is a note operators learn to
+    /// skip. All eight combinations, so the condition is pinned from
+    /// both sides rather than demonstrated once.
+    #[test]
+    fn the_missing_pooler_note_fires_only_on_a_labelled_head_with_no_pooler() {
+        let labelled = vec!["LABEL_0".to_string()];
+        for has_dense in [false, true] {
+            for has_out in [false, true] {
+                for labels in [&[][..], &labelled[..]] {
+                    let got = missing_pooler_note(has_dense, has_out, labels);
+                    // `ms-marco-MiniLM-L6-v2` after conversion, and
+                    // only that: cls.output, labels, no cls.
+                    let want = !has_dense && has_out && !labels.is_empty();
+                    assert_eq!(
+                        got.is_some(),
+                        want,
+                        "dense={has_dense} out={has_out} labels={labels:?} produced {got:?}"
+                    );
+                }
+            }
+        }
+        // And it says which head it is talking about, so a log line is
+        // actionable without reading this file.
+        let note = missing_pooler_note(false, true, &labelled).expect("the note fires");
+        assert!(note.contains("LABEL_0"), "{note}");
+        assert!(note.contains("#82"), "{note}");
     }
 
     /// `n_cls_out` follows the labels, and `score` is output 0 of

--- a/crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs
+++ b/crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs
@@ -50,23 +50,34 @@
 //! no torch, so it is a genuinely second implementation rather than a
 //! recording of ferrox's own output.
 //!
-//! # The one place ferrox does NOT match HuggingFace, deliberately
+//! # The one place ferrox does NOT match HuggingFace, and why (#82)
 //!
 //! llama.cpp's converter drops `bert.pooler.dense` ("we are only using
 //! BERT for embeddings so we don't need the pooling layer",
-//! `conversion/bert.py`), so the GGUF does not contain it and the head
+//! `conversion/bert.py`), so THIS GGUF does not contain it and the head
 //! runs as `classifier(cls_hidden)` instead of
 //! `classifier(tanh(pooler(cls_hidden)))`. No engine can apply a tensor
 //! that is not in the file. The measured effect is on the score SCALE
 //! (about +-0.2 rather than about +-11), not on which document wins;
 //! the reference script prints both columns so the difference stays
-//! visible. The assertions below are against the column ferrox can
-//! actually reach, plus the *ordering* of the full HuggingFace
+//! visible. Most of the assertions below are against the column ferrox
+//! can actually reach, plus the *ordering* of the full HuggingFace
 //! reference.
+//!
+//! What changed with #82's route 1 is the "cannot" in that paragraph:
+//! it is a property of the FILE, not of ferrox. When a GGUF does carry
+//! `cls`, ferrox runs it, and
+//! [`the_head_reproduces_huggingface_when_the_gguf_carries_the_pooler`]
+//! proves that against the `hf` column by splicing the checkpoint's own
+//! pooler back in. ferrox still refuses to INVENT one — see
+//! [`the_shipped_checkpoint_is_the_unpooled_regime_and_says_so`], which
+//! is the regression bar for every reranker GGUF in circulation.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use ferrox_models::{pool, EmbeddingModel, PoolingType};
+use ferrox_gguf::{GgmlType, GgufValue, GgufWriter, ShardedGguf, TensorPlan};
+use ferrox_models::{load_rank_head, pool, EmbeddingModel, PoolingType};
 
 /// The Q8_0 conversion of `cross-encoder/ms-marco-MiniLM-L6-v2`.
 ///
@@ -108,8 +119,17 @@ const REFERENCE_SCORES: [f32; 5] = [-0.027210, 0.073057, -0.172285, -0.245995, 0
 
 /// `scripts/rerank_reference_ms_marco.py`, `hf` row: the ordering the
 /// checkpoint's full HuggingFace head produces. ferrox must reproduce
-/// this ORDER even though it cannot reproduce those scores.
+/// this ORDER from the shipped GGUF even though that file cannot carry
+/// the scores.
 const REFERENCE_ORDER: [usize; 5] = [1, 4, 0, 2, 3];
+
+/// `scripts/rerank_reference_ms_marco.py`, `hf` row: the SCORES of the
+/// checkpoint's full head, `classifier(tanh(pooler(cls)))`.
+///
+/// About fifty times wider than [`REFERENCE_SCORES`], which is the
+/// whole of issue #82: the ordering is the same and an absolute
+/// threshold is not.
+const HF_REFERENCE_SCORES: [f32; 5] = [-4.320078, 8.60714, -11.101217, -11.18758, 0.636921];
 
 /// Q8_0 weights against an f64 reference. The largest deviation
 /// measured across all four query sets in the script is 1.7e-3.
@@ -301,4 +321,233 @@ fn scoring_both_halves_as_segment_zero_ranks_the_relevant_document_last() {
          scripts/rerank_reference_ms_marco.py before relaxing this"
     );
     assert_ne!(order, REFERENCE_ORDER.to_vec());
+}
+
+/// `bert.pooler.dense.{weight,bias}` as dumped by
+/// `scripts/rerank_reference_ms_marco.py --dump-pooler`: the eight-byte
+/// magic, `[out, in]` as two little-endian `u32`, then `out * in`
+/// float32 in row-major `[out][in]` order, then `out` float32 of bias.
+///
+/// Absence is a failure for the same reason the checkpoint's is — see
+/// the module docs.
+fn pooler_weights() -> (usize, usize, Vec<u8>, Vec<u8>) {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../models/ms-marco-MiniLM-L6-v2-pooler.bin");
+    assert!(
+        path.exists(),
+        "{} is missing. It is the checkpoint's own pooler, which the GGUF does not carry \
+         (issue #82), dumped from the safetensors by the same NumPy reference this file's \
+         golden values come from:\n    \
+         python3 scripts/rerank_reference_ms_marco.py --dump-pooler \
+         models/ms-marco-MiniLM-L6-v2-pooler.bin",
+        path.display()
+    );
+    let raw = std::fs::read(&path).expect("read the pooler dump");
+    assert!(
+        raw.len() >= 16 && &raw[..8] == b"FXPOOL01",
+        "{} is not a --dump-pooler file (magic is {:?})",
+        path.display(),
+        &raw[..raw.len().min(8)]
+    );
+    let u32_at = |o: usize| u32::from_le_bytes(raw[o..o + 4].try_into().unwrap()) as usize;
+    let (out, inp) = (u32_at(8), u32_at(12));
+    let w_end = 16 + out * inp * 4;
+    let b_end = w_end + out * 4;
+    assert_eq!(
+        raw.len(),
+        b_end,
+        "{} is {} bytes but [{out}, {inp}] + [{out}] needs {b_end}",
+        path.display(),
+        raw.len()
+    );
+    (
+        out,
+        inp,
+        raw[16..w_end].to_vec(),
+        raw[w_end..b_end].to_vec(),
+    )
+}
+
+/// Writes a GGUF carrying ONLY a classification head: this
+/// checkpoint's own `cls.output` bytes, copied verbatim with their
+/// dtype and shape, plus the `cls` the converter deleted.
+///
+/// A head-only file rather than a rewritten 25 MB checkpoint, because
+/// the encoder half is already proven against the real weights by every
+/// other test here — what has never run is the loader finding `cls` in
+/// a file and orienting it. `load_rank_head` takes the architecture and
+/// the width as parameters, so it needs no hparams and no encoder
+/// tensors to do that.
+fn write_pooled_head_gguf(
+    file: &ShardedGguf,
+    out: usize,
+    inp: usize,
+    w: &[u8],
+    b: &[u8],
+) -> PathBuf {
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "general.architecture".to_string(),
+        GgufValue::String("bert".to_string()),
+    );
+    metadata.insert(
+        "bert.classifier.output_labels".to_string(),
+        GgufValue::Array(vec![GgufValue::String("LABEL_0".to_string())]),
+    );
+
+    // GGUF's `ne[]` is fastest-dimension-first, so a `[out, in]` matrix
+    // is stored `[in, out]`. Getting this backwards is caught by
+    // `load_rank_head`'s own width check, and the pooler is square, so
+    // it is stated rather than relied upon.
+    let mut plan = vec![
+        TensorPlan {
+            name: "cls.weight".to_string(),
+            shape: vec![inp as u64, out as u64],
+            dtype: GgmlType::F32,
+            byte_len: w.len(),
+        },
+        TensorPlan {
+            name: "cls.bias".to_string(),
+            shape: vec![out as u64],
+            dtype: GgmlType::F32,
+            byte_len: b.len(),
+        },
+    ];
+    let copied: Vec<(&str, Vec<u8>)> = ["cls.output.weight", "cls.output.bias"]
+        .iter()
+        .map(|name| {
+            let info = file
+                .find_tensor(name)
+                .unwrap_or_else(|| panic!("the checkpoint carries {name}"));
+            let bytes = file.tensor_bytes(name).expect("read the tensor").to_vec();
+            plan.push(TensorPlan {
+                name: (*name).to_string(),
+                shape: info.shape.clone(),
+                dtype: info.dtype,
+                byte_len: bytes.len(),
+            });
+            (*name, bytes)
+        })
+        .collect();
+
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    std::fs::create_dir_all(&dir).expect("create the fixture directory");
+    let path = dir.join(format!("ms-marco-head-pooled-{}.gguf", std::process::id()));
+    let sink = std::fs::File::create(&path).expect("create the fixture");
+    let mut writer = GgufWriter::create(sink, &metadata, plan).expect("write the header");
+    writer.write_tensor("cls.weight", w).expect("write cls");
+    writer.write_tensor("cls.bias", b).expect("write cls.bias");
+    for (name, bytes) in &copied {
+        writer.write_tensor(name, bytes).expect("copy cls.output");
+    }
+    writer.finish().expect("finish the fixture");
+    path
+}
+
+/// **The regression bar for every reranker GGUF that exists today.**
+///
+/// The shipped checkpoint has no pooler, and #82's route 1 must not
+/// have changed a single thing about how it scores: no invented
+/// identity pooler, no zero-filled `cls`, the same numbers this file
+/// has asserted since #44. A fabricated pooler would be worse than the
+/// uncalibrated score, because it would be a number no checkpoint ever
+/// produced, reported under the model's own name.
+///
+/// It also pins the other half of route 1: which regime a caller is in
+/// has to be VISIBLE, because the two differ by about fifty times and
+/// nothing errors in between. `graph()` is what `/v1/rerank` puts on
+/// every response as `ferrox_score_head`.
+#[test]
+#[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf"]
+fn the_shipped_checkpoint_is_the_unpooled_regime_and_says_so() {
+    let model = EmbeddingModel::from_gguf_path(checkpoint()).expect("load the reranker");
+    let head = model.rank_head().expect("head is present");
+    assert!(
+        !head.has_pooler(),
+        "llama.cpp's converter deletes pooler.dense, so this file cannot carry a cls.weight; \
+         if it now does, the GGUF changed and HF_REFERENCE_SCORES is the golden set"
+    );
+    assert_eq!(head.graph(), "classifier(cls)");
+
+    let scores: Vec<f32> = DOCUMENTS
+        .iter()
+        .map(|d| {
+            let pair = model.rerank_input(QUERY, d).expect("pair input");
+            model.rerank_score(&pair).expect("score")
+        })
+        .collect();
+    for (i, (got, want)) in scores.iter().zip(REFERENCE_SCORES).enumerate() {
+        assert!(
+            (got - want).abs() < TOLERANCE,
+            "document {i}: ferrox {got}, NumPy reference {want} -- the unpooled path moved"
+        );
+    }
+}
+
+/// **What route 1 of #82 buys.** Splice the checkpoint's own
+/// `bert.pooler.dense` back in, and ferrox reproduces the `hf` column
+/// of `scripts/rerank_reference_ms_marco.py` -- the scores the
+/// cross-encoder was trained to produce -- with no change to ferrox
+/// beyond reading a tensor that is present.
+///
+/// This is the evidence for the claim route 1 exists to make: a
+/// converter that keeps `pooler.dense` needs no second change here. It
+/// was a claim about a code path that had never executed, because every
+/// published reranker GGUF is missing the tensor.
+///
+/// The encoder is the real Q8_0 one and the reference is f64, so the
+/// tolerance is looser than [`TOLERANCE`] in absolute terms and much
+/// tighter relative to a +-11 range. The assertion that carries the
+/// point is the one against [`REFERENCE_SCORES`]: the same hidden
+/// states, through the pooled head, are about FIFTY times larger.
+#[test]
+#[ignore = "needs models/ms-marco-MiniLM-L6-v2-Q8_0.gguf and its --dump-pooler sidecar"]
+fn the_head_reproduces_huggingface_when_the_gguf_carries_the_pooler() {
+    let model = EmbeddingModel::from_gguf_path(checkpoint()).expect("load the reranker");
+    let (out, inp, w, b) = pooler_weights();
+    assert_eq!((out, inp), (model.n_embd(), model.n_embd()));
+
+    let source = ShardedGguf::open(checkpoint()).expect("reopen the checkpoint");
+    let path = write_pooled_head_gguf(&source, out, inp, &w, &b);
+    let spliced = ShardedGguf::open(&path).expect("open the head fixture");
+    let head = load_rank_head(&spliced, "bert", model.n_embd(), 1e-12)
+        .expect("the head loads")
+        .expect("the fixture carries a head");
+    assert!(head.has_pooler());
+    assert_eq!(head.graph(), "classifier(tanh(pooler(cls)))");
+
+    let pooled: Vec<f32> = DOCUMENTS
+        .iter()
+        .map(|d| {
+            let pair = model.rerank_input(QUERY, d).expect("pair input");
+            let hidden = model.pair_hidden_states(&pair).expect("hidden states");
+            let cls = pool(&hidden, model.n_embd(), PoolingType::Cls).expect("cls row");
+            head.score(&cls)
+        })
+        .collect();
+    std::fs::remove_file(&path).ok();
+
+    // Q8_0 weights against an f64 reference, on a +-11 range: the
+    // largest deviation measured across these five documents is 0.011,
+    // i.e. 0.1% -- tighter in relative terms than TOLERANCE is on the
+    // unpooled +-0.2 range.
+    const POOLED_TOLERANCE: f32 = 0.02;
+    for (i, (got, want)) in pooled.iter().zip(HF_REFERENCE_SCORES).enumerate() {
+        assert!(
+            (got - want).abs() < POOLED_TOLERANCE,
+            "document {i}: ferrox with the pooler {got}, HuggingFace {want}"
+        );
+    }
+    assert_eq!(ranking(&pooled), REFERENCE_ORDER.to_vec());
+
+    // And the size of what #82 is about: the same encoder, the same
+    // documents, one tensor's presence, fifty times the range.
+    let widest = |v: &[f32]| v.iter().fold(0.0f32, |m, s| m.max(s.abs()));
+    let unpooled = widest(&REFERENCE_SCORES);
+    assert!(
+        widest(&pooled) > 20.0 * unpooled,
+        "the pooled head's range ({}) is not the calibration difference #82 describes \
+         against the unpooled {unpooled}",
+        widest(&pooled)
+    );
 }

--- a/crates/ferrox-models/tests/rerank_pooler_present.rs
+++ b/crates/ferrox-models/tests/rerank_pooler_present.rs
@@ -1,0 +1,230 @@
+//! `load_rank_head` reads the pooler **when the file carries it**, and
+//! runs `classifier(tanh(pooler(cls)))` when it does — issue #82.
+//!
+//! # Why this file exists
+//!
+//! `cls` in a GGUF is HuggingFace's `bert.pooler.dense`, and llama.cpp's
+//! converter deletes it by name (`conversion/bert.py`,
+//! `BertModel.filter_tensors`: "we are only using BERT for embeddings so
+//! we don't need the pooling layer"). Every reranker GGUF anyone has
+//! downloaded is therefore missing it, `ms-marco-MiniLM-L6-v2-Q8_0`
+//! included — which is exactly why the `dense` branch of
+//! [`ferrox_models::RankHead`] had **no end-to-end evidence at all**.
+//! It was unit-tested against a hand-built `RankHead`, and the loader
+//! path that has to find `cls.weight` in a file and orient it correctly
+//! had never once run.
+//!
+//! That matters more than an untested branch usually does, because the
+//! whole point of route 1 of #82 is the promise that "a converter which
+//! keeps `pooler.dense` immediately works, with no second change to
+//! ferrox". A promise about a code path nobody has executed is a guess.
+//!
+//! # Why the fixture is synthetic
+//!
+//! `crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs` covers
+//! the real checkpoint, and its
+//! `the_head_reproduces_huggingface_when_the_gguf_carries_the_pooler`
+//! covers the real *pooler* — but both need `models/`, so both are
+//! `#[ignore]`d and CI never runs them. These tests run everywhere, on a GGUF they write
+//! themselves, so the regression bar for "ferrox reads a pooler" does
+//! not depend on a 25 MB download.
+//!
+//! Every expected number below is a closed-form expression over the
+//! fixture's own constants rather than a recorded float: a value copied
+//! out of a previous run agrees with whatever the code does today,
+//! including the wrong thing.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use ferrox_gguf::{GgmlType, GgufValue, GgufWriter, ShardedGguf, TensorPlan};
+use ferrox_models::load_rank_head;
+
+/// The head's input width: the encoder's `n_embd`, and the number
+/// `cls.weight` must take as its INPUT.
+const N_EMBD: usize = 3;
+
+/// The pooler, `[out=2, in=3]` in ferrox's row-major orientation. It is
+/// deliberately NOT square: GGUF stores `ne[]` fastest-dimension-first,
+/// so this tensor's on-disk shape is `[3, 2]` and a loader that forgot
+/// to reverse it would build a `[2, 3]`-shaped matrix and be caught by
+/// `load_rank_head`'s own `cols() != n_embd` check. A square fixture
+/// would pass either way.
+const POOLER_W: [f32; 6] = [0.5, -0.25, 1.0, -1.5, 0.75, 0.25];
+const POOLER_B: [f32; 2] = [0.1, -0.2];
+
+/// `cls.output` for the pooled head: `[out=1, in=2]`, stored with
+/// `n_dims = 1` the way `cross-encoder/ms-marco-MiniLM-L6-v2` stores
+/// its own — ggml's trailing dimensions are implicitly 1, and reading
+/// that back as a 1-D vector instead of a `1 x n` matrix is the defect
+/// that made the real checkpoint unloadable (see the ordering test's
+/// module docs).
+const CLASSIFIER_W_POOLED: [f32; 2] = [2.0, -3.0];
+/// `cls.output` for the head with no pooler: `[out=1, in=3]`, because
+/// there the classifier reads the CLS row directly.
+const CLASSIFIER_W_DIRECT: [f32; 3] = [2.0, -3.0, 0.5];
+const CLASSIFIER_B: [f32; 1] = [0.25];
+
+/// The CLS row fed to the head. Signed and not symmetric, so a sign
+/// error or a reversed row survives nothing.
+const CLS_ROW: [f32; N_EMBD] = [1.0, -2.0, 0.5];
+
+fn f32_bytes(v: &[f32]) -> Vec<u8> {
+    v.iter().flat_map(|x| x.to_le_bytes()).collect()
+}
+
+/// Writes a `bert` GGUF carrying nothing but a classification head.
+///
+/// `load_rank_head` is given the architecture and the width as
+/// parameters, so it needs no hparams and no encoder tensors — which is
+/// the point: this exercises the head loader alone, and the encoder is
+/// already covered against a real checkpoint elsewhere.
+///
+/// `tensors` is `(name, gguf_shape, data)`, and `gguf_shape` is written
+/// verbatim, so a test can store a `1 x n` projection as `[n]` exactly
+/// as the real converter does.
+fn write_head_gguf(name: &str, tensors: &[(&str, Vec<u64>, Vec<f32>)]) -> PathBuf {
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "general.architecture".to_string(),
+        GgufValue::String("bert".to_string()),
+    );
+    metadata.insert(
+        "bert.classifier.output_labels".to_string(),
+        GgufValue::Array(vec![GgufValue::String("LABEL_0".to_string())]),
+    );
+
+    let plan: Vec<TensorPlan> = tensors
+        .iter()
+        .map(|(n, shape, data)| TensorPlan {
+            name: (*n).to_string(),
+            shape: shape.clone(),
+            dtype: GgmlType::F32,
+            byte_len: data.len() * 4,
+        })
+        .collect();
+
+    // `target/` rather than the system temp dir: a leftover file is
+    // then swept by `cargo clean` and is never mistaken for a
+    // checkpoint. The pid keeps two concurrent `cargo test` runs apart.
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    std::fs::create_dir_all(&dir).expect("create the fixture directory");
+    let path = dir.join(format!("{name}-{}.gguf", std::process::id()));
+    let file = std::fs::File::create(&path).expect("create the fixture");
+    let mut w = GgufWriter::create(file, &metadata, plan).expect("write the header");
+    for (n, _, data) in tensors {
+        w.write_tensor(n, &f32_bytes(data)).expect("write a tensor");
+    }
+    w.finish().expect("finish the fixture");
+    path
+}
+
+/// `tanh(POOLER_W · CLS_ROW + POOLER_B)`, written out rather than
+/// looped, so this is a second statement of the arithmetic and not a
+/// second call into the code under test.
+fn expected_pooled() -> [f32; 2] {
+    let p0 = 0.5 * CLS_ROW[0] + -0.25 * CLS_ROW[1] + 1.0 * CLS_ROW[2] + POOLER_B[0];
+    let p1 = -1.5 * CLS_ROW[0] + 0.75 * CLS_ROW[1] + 0.25 * CLS_ROW[2] + POOLER_B[1];
+    [p0.tanh(), p1.tanh()]
+}
+
+/// **The point of the file.** A GGUF that carries `cls.weight` /
+/// `cls.bias` loads them, and the score is
+/// `classifier(tanh(pooler(cls)))` — the composition the checkpoint was
+/// trained as.
+///
+/// The assertion is against the hand-written composition AND against
+/// the same composition with the `tanh` removed, because the tanh is
+/// the entire difference between the two score regimes of #82. Dropping
+/// it still produces a plausible signed relevance logit -- on the real
+/// checkpoint about fifty times bigger, which is exactly what a
+/// thresholding client silently gets wrong.
+#[test]
+fn a_gguf_carrying_a_pooler_runs_classifier_tanh_pooler() {
+    let path = write_head_gguf(
+        "rerank-head-pooled",
+        &[
+            ("cls.weight", vec![3, 2], POOLER_W.to_vec()),
+            ("cls.bias", vec![2], POOLER_B.to_vec()),
+            // `n_dims = 1`, as the real converter writes a 1 x n head.
+            ("cls.output.weight", vec![2], CLASSIFIER_W_POOLED.to_vec()),
+            ("cls.output.bias", vec![1], CLASSIFIER_B.to_vec()),
+        ],
+    );
+    let file = ShardedGguf::open(&path).expect("open the fixture");
+    let head = load_rank_head(&file, "bert", N_EMBD, 1e-12)
+        .expect("the head loads")
+        .expect("the fixture carries a head");
+
+    assert!(head.has_pooler(), "cls.weight is in the file");
+    assert_eq!(head.graph(), "classifier(tanh(pooler(cls)))");
+    assert_eq!(head.n_cls_out(), 1);
+    assert_eq!(head.labels(), ["LABEL_0"]);
+
+    let t = expected_pooled();
+    let want = CLASSIFIER_W_POOLED[0] * t[0] + CLASSIFIER_W_POOLED[1] * t[1] + CLASSIFIER_B[0];
+    let got = head.score(&CLS_ROW);
+    assert!(
+        (got - want).abs() < 1e-6,
+        "head produced {got}, hand-computed classifier(tanh(pooler(cls))) is {want}"
+    );
+
+    // The same graph with the tanh deleted. It is a different number by
+    // a wide margin, so "the tanh ran" is asserted and not assumed.
+    let p0 = 0.5 * CLS_ROW[0] + -0.25 * CLS_ROW[1] + 1.0 * CLS_ROW[2] + POOLER_B[0];
+    let p1 = -1.5 * CLS_ROW[0] + 0.75 * CLS_ROW[1] + 0.25 * CLS_ROW[2] + POOLER_B[1];
+    let no_tanh = CLASSIFIER_W_POOLED[0] * p0 + CLASSIFIER_W_POOLED[1] * p1 + CLASSIFIER_B[0];
+    assert!(
+        (got - no_tanh).abs() > 1.0,
+        "a head with no tanh would have scored {no_tanh}, and {got} is indistinguishable"
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// **The regression bar for every reranker GGUF that exists today.**
+/// A file with no `cls.weight` is scored EXACTLY as it was before #82's
+/// route 1: `classifier(cls)`, with no invented identity pooler and no
+/// zero-filled `cls`.
+///
+/// A fabricated pooler is the one outcome worse than the uncalibrated
+/// score, because it would be a number no checkpoint ever produced,
+/// reported under the model's name. This is the test that says ferrox
+/// did not do that.
+#[test]
+fn a_gguf_with_no_pooler_still_projects_the_cls_row_directly() {
+    let path = write_head_gguf(
+        "rerank-head-direct",
+        &[
+            ("cls.output.weight", vec![3], CLASSIFIER_W_DIRECT.to_vec()),
+            ("cls.output.bias", vec![1], CLASSIFIER_B.to_vec()),
+        ],
+    );
+    let file = ShardedGguf::open(&path).expect("open the fixture");
+    let head = load_rank_head(&file, "bert", N_EMBD, 1e-12)
+        .expect("the head loads")
+        .expect("the fixture carries a head");
+
+    assert!(!head.has_pooler(), "cls.weight is NOT in the file");
+    assert_eq!(head.graph(), "classifier(cls)");
+
+    let want = CLASSIFIER_W_DIRECT[0] * CLS_ROW[0]
+        + CLASSIFIER_W_DIRECT[1] * CLS_ROW[1]
+        + CLASSIFIER_W_DIRECT[2] * CLS_ROW[2]
+        + CLASSIFIER_B[0];
+    let got = head.score(&CLS_ROW);
+    assert!(
+        (got - want).abs() < 1e-6,
+        "head produced {got}, hand-computed classifier(cls) is {want}"
+    );
+    // Linear, exactly: a stray tanh anywhere would break this, and it
+    // is the property `classifier(cls)` names.
+    let doubled: Vec<f32> = CLS_ROW.iter().map(|v| v * 2.0).collect();
+    let unbiased = |s: f32| s - CLASSIFIER_B[0];
+    assert!(
+        (unbiased(head.score(&doubled)) - 2.0 * unbiased(got)).abs() < 1e-6,
+        "the head with no pooler is not linear, so something applied a non-linearity"
+    );
+
+    std::fs::remove_file(&path).ok();
+}

--- a/crates/ferrox-server/src/rerank.rs
+++ b/crates/ferrox-server/src/rerank.rs
@@ -39,6 +39,27 @@
 //! and it is invisible in the easy cases — a one-document request, or
 //! any input that happened to arrive already ordered — so
 //! [`ranking`] carries it and is tested directly.
+//!
+//! # `relevance_score` has two possible scales, and the response says which
+//!
+//! `ferrox_score_head` on every response is the checkpoint's head as a
+//! formula: `classifier(tanh(pooler(cls)))` when the GGUF carries
+//! `cls` (HuggingFace's `bert.pooler.dense`), `classifier(cls)` when it
+//! does not. Those two differ by roughly a factor of FIFTY in score
+//! magnitude — about ±11 against about ±0.2 on
+//! `ms-marco-MiniLM-L6-v2` — because the pooler and its `tanh` are
+//! most of what calibrates a `BertForSequenceClassification` head.
+//!
+//! llama.cpp's converter deletes `pooler.dense` by name, so every
+//! reranker GGUF in circulation is the second kind (issue #82). ferrox
+//! runs the pooler whenever a file carries one and never invents one,
+//! which leaves this route with a real obligation: a client sorting by
+//! `relevance_score` is unaffected either way, and a client applying
+//! `relevance_score > 0.5` — the Cohere/Jina idiom — is in a range
+//! where that threshold can simply never fire. Nothing errors. So the
+//! regime travels with the scores rather than living only in the
+//! server's log, because the log is read by an operator and the
+//! threshold is written by a client.
 
 use std::sync::Arc;
 
@@ -347,6 +368,13 @@ async fn rerank_inner(
     let score_label = encoder
         .rank_head()
         .and_then(|h| h.labels().first().cloned());
+    // Which of the two score scales in the module docs this response
+    // is on. Taken from the head that is about to run, not from a
+    // second opinion about what a reranker checkpoint contains:
+    // `RankHead::graph` is derived from the same `Option`s
+    // `RankHead::apply` branches on, so the label cannot describe a
+    // graph other than the one that produced these numbers.
+    let score_head = encoder.rank_head().map(|h| h.graph());
 
     let documents = Arc::new(req.documents);
     let (scores, prompt_tokens) =
@@ -364,6 +392,9 @@ async fn rerank_inner(
     });
     if let Some(label) = score_label {
         body["ferrox_score_label"] = serde_json::json!(label);
+    }
+    if let Some(head) = score_head {
+        body["ferrox_score_head"] = serde_json::json!(head);
     }
     Ok((body, prompt_tokens))
 }

--- a/scripts/rerank_reference_ms_marco.py
+++ b/scripts/rerank_reference_ms_marco.py
@@ -33,6 +33,20 @@ not on the `hf` column.
 
 `seg0` is the one that was wrong: it puts the RELEVANT document LAST in
 three of these four rankings.
+
+# Dumping the pooler, so Rust can reach the `hf` column too
+
+    python3 scripts/rerank_reference_ms_marco.py --dump-pooler \
+        models/ms-marco-MiniLM-L6-v2-pooler.bin
+
+writes `bert.pooler.dense.{weight,bias}` as raw little-endian float32
+behind an eight-byte magic and two u32 dimensions. ferrox cannot invent
+that tensor, but it CAN run one that is present (issue #82, route 1),
+and `crates/ferrox-models/tests/rerank_cross_encoder_ordering.rs`
+splices this file into a head-only GGUF to prove it reproduces the `hf`
+column above rather than merely running. The dump is the checkpoint's
+own weights, not a re-derivation, so the Rust side is still checked
+against THIS script's arithmetic and not against its own.
 """
 
 import json
@@ -206,8 +220,40 @@ VARIANTS = [
     ("seg0  ", dict(pooler=False, segment_ids=False)),
 ]
 
+# The Rust reader checks this before anything else, so a truncated or
+# unrelated file is a named failure rather than 590 KB of garbage
+# floats. Bump the digits if the layout below ever changes.
+POOLER_MAGIC = b"FXPOOL01"
+
+
+def dump_pooler(path):
+    """Write `bert.pooler.dense.{weight,bias}` for the Rust fixture.
+
+    Layout: the magic, then the weight's `[out, in]` as two
+    little-endian u32, then `out * in` float32 in C order (which is
+    exactly ggml's row-major `[out][in]`, so the bytes go into a GGUF
+    `cls.weight` verbatim), then `out` float32 of bias.
+    """
+    w = np.ascontiguousarray(W["bert.pooler.dense.weight"], dtype="<f4")
+    b = np.ascontiguousarray(W["bert.pooler.dense.bias"], dtype="<f4")
+    out, inp = w.shape
+    if b.shape != (out,):
+        raise SystemExit(f"pooler bias is {b.shape}, expected ({out},)")
+    with open(path, "wb") as f:
+        f.write(POOLER_MAGIC)
+        f.write(np.array([out, inp], dtype="<u4").tobytes())
+        f.write(w.tobytes())
+        f.write(b.tobytes())
+    print(f"wrote {path}: pooler.dense [{out}, {inp}] + bias [{out}]")
+
 
 def main():
+    if "--dump-pooler" in sys.argv:
+        i = sys.argv.index("--dump-pooler")
+        if i + 1 >= len(sys.argv):
+            raise SystemExit("--dump-pooler needs a path")
+        dump_pooler(sys.argv[i + 1])
+        return 0
     for query, documents in CASES:
         print(f"\nQ: {query}")
         for label, kwargs in VARIANTS:


### PR DESCRIPTION
Route 1 of #82, and only route 1. No converter (route 2), no llama.cpp
patch (route 3), and **#82 stays open**: no GGUF in the wild carries the
tensor yet, so this changes no score anyone is reading today.

## What is wrong

`cls` in a GGUF IS HuggingFace's `bert.pooler.dense`. llama.cpp's
converter deletes it by name (`conversion/bert.py`,
`BertModel.filter_tensors`, "we are only using BERT for embeddings so we
don't need the pooling layer"), so every `BertForSequenceClassification`
reranker GGUF runs as `classifier(cls)` where the checkpoint was trained
as `classifier(tanh(pooler(cls)))`. Calibration, not ordering: about
±0.2 instead of about ±11. A client that sorts is fine; a client that
thresholds on `relevance_score > 0.5` — the Cohere/Jina idiom — gets a
threshold that can never fire, and nothing errors.

ferrox cannot invent the tensor and this does not try to. It makes the
engine right about the model, so whoever fixes the FILE needs no second
change here.

## What changed

- **`RankHead::has_pooler` / `RankHead::graph`.** `graph` is built from
  the same three `Option`s `apply` branches on, in the same order, so
  the description cannot drift from the arithmetic.
- **`/v1/rerank` reports `ferrox_score_head`** on every response, beside
  the existing `ferrox_score_label`, derived from that one accessor.
- **A load-time NOTE, not a refusal**, on exactly the shape the
  converter produces: `cls.output` present, `cls` absent, and
  `{arch}.classifier.output_labels` declared. Refusing is not available
  — the file carries nothing separating "trained without a pooler" from
  "converted without one", and `jina-reranker-v1-tiny-en` is the
  direct-projection shape upstream documents as correct.

Both surfaces on purpose: an operator reads a log, a thresholding client
reads JSON, and only the second is in a position to act on the regime.

**Absent behaviour is unchanged.** No invented identity pooler, no
zero-filled `cls`. A fabricated pooler would be a number no checkpoint
ever produced, reported under the model's name — strictly worse than an
uncalibrated one.

## Evidence

The `dense` branch had **no end-to-end evidence at all** before this. It
was unit-tested against a hand-built `RankHead`; the loader path that
finds `cls.weight` in a file and orients it correctly had never
executed, because no published reranker GGUF carries the tensor. That is
precisely the promise route 1 makes.

- `tests/rerank_pooler_present.rs` (runs in CI): writes two head-only
  GGUFs with `ferrox-gguf`'s writer, one with a pooler and one without,
  and checks each score against a closed-form expression over the
  fixture's own constants. The pooler is deliberately **non-square**, so
  a loader that forgot to reverse GGUF's fastest-dimension-first `ne[]`
  is caught rather than passing on a symmetry.
- `tests/rerank_cross_encoder_ordering.rs`, two new `#[ignore]`d tests
  on the real checkpoint:
  - splice the checkpoint's OWN `bert.pooler.dense` back into a
    head-only GGUF → ferrox reproduces the `hf` column of
    `scripts/rerank_reference_ms_marco.py` to within **0.011 on a ±11
    range**, in the reference's order, with the pooled range more than
    20× the unpooled one;
  - the regression bar: the shipped GGUF is still `classifier(cls)`,
    still the same five numbers, and now says so through `graph()`.
- `scripts/rerank_reference_ms_marco.py --dump-pooler <path>` writes
  those weights for the Rust side, so the expected numbers come from the
  NumPy reference rather than from a ferrox run.
- Live check of both surfaces, `FERROX_MODEL_PATH=ms-marco-…-Q8_0.gguf`:

  ```
  {"ferrox_score_head":"classifier(cls)","ferrox_score_label":"LABEL_0",…}
  ferrox: NOTE this reranker head runs classifier(cls) — it carries
  cls.output.weight and labels (LABEL_0) but no cls.weight. …
  ```

## What would have to be true for this to be wrong

- That `cls` is not `pooler.dense` under llama.cpp's naming. The issue's
  own route 1 ("keeps `pooler.dense` and writes it as `cls`") says it
  is, and `cls.output` = `classifier.out_proj` on the same checkpoint
  agrees. **No HF-spelled alias (`bert.pooler.dense.weight`) was added**
  — a read keyed on a spelling no converter writes is the dead gate this
  repo has already shipped once.
- That a formula string is the wrong shape for the regime. It is one
  field derived from one bool, not two fields that must agree.

## Sabotage

Every test was made red once and restored: deleting the `tanh`, making
`load_rank_head` ignore `cls.weight`, hard-coding `has_pooler` to true,
and dropping the labels clause from the note's condition. The five
existing ordering tests pass unchanged with `models/` symlinked into the
worktree and the runtime watched — an `#[ignore]`d test resolving
`../../models` passes in 0.00 s where there is no `models/`.

## Doc delta, not in this PR

`docs/API.md`'s reranking section describes only the unpooled behaviour
and #82. It now also needs the `ferrox_score_head` field and the
two-scale rule. `docs/` is owned by another agent this session, so it is
stated here rather than edited.

## Gates

`cargo build --workspace`, `cargo test --workspace`, `cargo clippy
--workspace --all-targets -- -D warnings`, the same `--release`, and
`cargo fmt --all --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
