### PR TITLE
docs: 23 architectures proven, 34 unaudited, and the two defects the fixtures found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,20 +12,27 @@ same command shapes, same or better performance, on the hardware people
 actually own. `docs/plans/north-star.md` is the ranking every other plan
 is read through, and `docs/plans/README.md` is the index.
 
-Honest position, re-audited 2026-09-02. **16** architectures run with
+Honest position, re-audited 2026-09-03. **23** architectures run with
 evidence (`capability::AUDITED_GENERIC_GQA`), 4 more have dedicated
 engines, and everything else REFUSES. The "loads and is WRONG" class is
 closed: the generic path is opt-in, so an unaudited architecture stops
 instead of guessing.
 
-The 41 unaudited refusals are now TRIAGED, and the refusal says which of
-three things is missing: 9 are a fixture away (implemented, unevidenced),
-2 need one named match arm, 26 need new code, 4 are unknown with the
-question stated. Five one-match-arm rows were closed on 2026-09-02, each
-with a libllama-golden fixture, which is what moved 46 to 41.
-`unaudited_triage` carries the verdict and the llama.cpp line that
-decides it. llama.cpp hand-writes 140
-per-architecture graphs; `decoder.rs` is 6702 lines and that is why the
+The 34 unaudited refusals are now TRIAGED, and the refusal says which of
+three things is missing: 1 is a fixture away (implemented, unevidenced),
+3 need one named match arm, 26 need new code, 4 are unknown with the
+question stated. Five one-match-arm rows closed on 2026-09-02 and seven
+fixture-away rows on 2026-09-03, each with a libllama-golden fixture,
+which is what moved 46 to 41 to 34. Building those fixtures found two
+defects worth more than the admissions: `plamo3` could never have loaded
+a real checkpoint, because it is the only architecture upstream whose
+post-norms use the two-argument `LLM_TN` overload and ferrox asked for
+the wrong spelling; and a gate refused every file carrying
+`attention.sliding_window_pattern` as unimplemented while the feature
+was already implemented, which made the loader's own read of that key
+unreachable. `unaudited_triage` carries the verdict and the llama.cpp
+line that decides it. llama.cpp hand-writes 140
+per-architecture graphs; `decoder.rs` is 6752 lines and that is why the
 counts differ.
 
 Do not read the architecture catalog as a support matrix. `ferrox
@@ -97,20 +104,20 @@ style preference, it is the repo's most expensive lesson. Measured
 
 | File | Lines |
 |---|---|
-| `ferrox-server/src/lib.rs` | 9580 |
-| `ferrox-metal/src/attn.rs` | 8860 |
-| `ferrox-metal/src/gpu.rs` | 8700 |
-| `ferrox-quant/src/lib.rs` | 8230 |
-| `ferrox-models/src/decoder.rs` | 6702 |
+| `ferrox-server/src/lib.rs` | 9628 |
+| `ferrox-metal/src/attn.rs` | 9331 |
+| `ferrox-metal/src/gpu.rs` | 8935 |
+| `ferrox-quant/src/lib.rs` | 8239 |
+| `ferrox-models/src/decoder.rs` | 6752 |
 
-Re-measured 2026-09-02. `ferrox-server/src/lib.rs` took the top spot by
-GROWING 1839 lines in a day, which is the rule being broken while the
-rule is written down two paragraphs below. `decoder.rs` shrank for the
-first time (6875 to 6702), because the Gemma RoPE work went into
-`decoder/rope.rs` instead of a sixth branch.
+Re-measured 2026-09-03. Every one of these grew again, and
+`ferrox-metal/src/attn.rs` grew most (8860 to 9331). `decoder.rs` has
+started creeping back up (6702 to 6752) after its one shrink. The rule
+is written down two paragraphs below and is being broken while it is
+written.
 
-Those files are why llama.cpp has 140 architectures and ferrox has 16
-proven. Adding a model means editing a 6700-line file, so nobody adds
+Those files are why llama.cpp has 140 architectures and ferrox has 23
+proven. Adding a model means editing a 6750-line file, so nobody adds
 one. The same decode layer used to be written out about ELEVEN times
 across `decoder.rs` and `attn.rs`, which has already lost EIGHT model
 features one at a time, each silently:

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -186,14 +186,14 @@ only, and 1B is neither 27B nor rope-scaled, so it is untouched by all
 of this. The speed recovery from returning to the fused path is
 unmeasured, because measuring it needs a quiet host.
 
-   `gemma2`, `gemma3`, `phi3`, `gpt-oss`, `dots1`). The other **41**
+   `gemma2`, `gemma3`, `phi3`, `gpt-oss`, `dots1`). The other **34**
    stop with `UnauditedArchitecture`. `FERROX_ALLOW_UNAUDITED_ARCH=1`
    runs one anyway; compare the output against llama.cpp yourself
    before you trust it.
 
 ### What "unaudited" costs you, per architecture
 
-"Unaudited" is not one thing. Some of the 41 are one fixture away from
+"Unaudited" is not one thing. One of the 34 is a fixture away from
 running and some need an attention implementation, so the refusal says
 which, with the `llama.cpp/src/models/*.cpp` line that decides it:
 
@@ -204,7 +204,7 @@ which, with the `llama.cpp/src/models/*.cpp` line that decides it:
 | `NEW CODE` | A different attention or residual structure. Not close. |
 | `UNKNOWN` | Reading both trees did not settle it. The message says what would. |
 
-All 41 have now been read on both sides (`ferrox_models::capability`,
+All 34 have now been read on both sides (`ferrox_models::capability`,
 pinned by `crates/ferrox-models/tests/unaudited_triage.rs`). The
 distribution is the headline answer to "how far is Ferrox from llama.cpp
 on models":

--- a/docs/manifests/architecture_manifest.md
+++ b/docs/manifests/architecture_manifest.md
@@ -6,20 +6,20 @@ Source of truth for names: pinned llama.cpp `LLM_ARCH_NAMES`.
 | GGUF arch | Scope | Family | Memory | Path |
 |---|---|---|---|---|
 | `llama` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `internlm2` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `bailingmoe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `deepseek` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `maincoder` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `baichuan` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `ernie4_5` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `internlm2` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `xverse` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `ernie4_5-moe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `granite` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `granitemoe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `granite-moe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `xverse` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `baichuan` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `chatglm` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `deci` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `olmo` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `maincoder` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `bailingmoe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `arctic` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `mistral3` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `nanbeige` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
@@ -30,16 +30,16 @@ Source of truth for names: pinned llama.cpp `LLM_ARCH_NAMES`.
 | `qwen2moe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `gpt-oss` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `dots1` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `olmo2` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `exaone4` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `hunyuan-moe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `seed_oss` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `exaone` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `bailingmoe2` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `hunyuan-moe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `plamo3` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `olmo2` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
+| `exaone4` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `mellum` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `talkie` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `mimo2` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
-| `plamo3` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `afmoe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `apertus` | TextGeneration | StandardGqa | KvGqa | generic-gqa |
 | `exaone-moe` | TextGeneration | StandardGqa | KvGqa | generic-gqa |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -56,9 +56,9 @@ rather than by whether the architecture name is known:
 
 | Outcome | Count |
 |---|---|
-| Runs, **with evidence** | **16** (`capability::AUDITED_GENERIC_GQA`) |
+| Runs, **with evidence** | **23** (`capability::AUDITED_GENERIC_GQA`) |
 | Loads on a dedicated engine, no cross-engine evidence | 4 engines (`Mla`, `Glm52`, `Kimi`, `Gemma4`) |
-| Refuses as **unaudited**, now triaged | 41 |
+| Refuses as **unaudited**, now triaged | 34 |
 | Off the generic path: refuses by name, or reaches one of those 4 engines | 90 (58 `dedicated` + 32 `deferred` in the manifest) |
 | **Loads and is WRONG** | **closed** |
 
@@ -74,7 +74,7 @@ position embeddings as though they were NEOX RoPE (`gpt2`, `mpt`,
 `refact`, `bloom`, `jais`) are `DedicatedOnly` refusals, pinned by a
 test that they can never be re-listed as audited.
 
-The 41 unaudited refusals split 9 fixture-away / 2 one-match-arm /
+The 34 unaudited refusals split 1 fixture-away / 3 one-match-arm /
 26 new-code / 4 unknown, each naming the `llama.cpp/src/models/*.cpp`
 line that decides it. Five of the seven one-match-arm rows were closed on
 2026-09-02 (`seed_oss`, `maincoder`, `bailingmoe`, `deepseek`,
@@ -82,7 +82,7 @@ line that decides it. Five of the seven one-match-arm rows were closed on
 
 | | llama.cpp | ferrox |
 |---|---|---|
-| Per-architecture graphs | 140 hand-written | 150 catalog rows, **16 proven** |
+| Per-architecture graphs | 140 hand-written | 150 catalog rows, **23 proven** |
 | Metal `pp512` | baseline | 0.98x-1.10x, at parity |
 | Metal `tg128` | baseline | **8 of 12 rows faster** |
 | CPU, all rows | baseline | **1.41x-5.06x slower** |

--- a/docs/plans/llama-cpp-parity-update-2026-09-03.md
+++ b/docs/plans/llama-cpp-parity-update-2026-09-03.md
@@ -72,7 +72,7 @@ Scratch-built `llama_logits` from `.scratch/llama.cpp` loads gemma-4; tokenizer 
 | 2 | DeepSeek-R1-Distill reclassification | **Done** — PR #100 |
 | 3 | Gemma-4 parity via Gemma4Engine | **Done** — PR #100 |
 | 4 | Rebuild `llama_logits` from `.scratch/llama.cpp` | **Done** — `build_llama_logits.sh` cmake layout |
-| 5 | Fixture-away triage (9 archs) | **Open** |
+| 5 | Fixture-away triage | **Done** (2026-09-03) -- seven admitted with libllama-golden fixtures, `chatglm` reclassified ONE MATCH ARM. Audited 16 to 23, unaudited 41 to 34 |
 
 ### P1 — Unchanged from audit
 


### PR DESCRIPTION
Doc delta for #106.

Audited generic **16 → 23**, unaudited **41 → 34**, distribution now 1 fixture-away / 3 one-match-arm / 26 new-code / 4 unknown. Three files restate those counts so all three move together; manifest regenerated; the 2026-09-03 parity update's P0 item 5 marked Done.

CLAUDE.md also records the **two defects**, because they're worth more than the seven admissions and are invisible in the counts:

- `plamo3` could never have loaded a real checkpoint — the only architecture upstream whose post-norms use the two-argument `LLM_TN` overload, so ferrox asked for the wrong spelling. Only findable by writing a fixture from the *converter's* spelling rather than ferrox's loader.
- A gate refused every file carrying `attention.sliding_window_pattern` as unimplemented while the feature was implemented and gpt-oss ran on it — making the loader's own read of that key unreachable.

The file-size table is **re-measured**: every file grew, `ferrox-metal/src/attn.rs` most (8860 → 9331), and `decoder.rs` has started creeping back up after its one shrink. The rule about file size sits two paragraphs below that table and is being broken while it's written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN