### PR TITLE
fix(parity): the oracle's verdict was a property of the reference build, not of ferrox

### DIFF
--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -230,6 +230,17 @@ enum Commands {
         /// Compiled reference dumper (see .local-scripts/llama_logits.c).
         #[arg(long)]
         dumper: Option<String>,
+        /// Write both compared logit vectors under this prefix
+        /// (`<prefix>.llama.f32`, `<prefix>.ferrox.f32`,
+        /// `<prefix>.tokens.txt`), as raw little-endian f32.
+        ///
+        /// A parity verdict is a distance between two points and says
+        /// where neither one is, so it cannot tell "ferrox moved" from
+        /// "the reference moved". Dump against two `--dumper` builds and
+        /// compare the two `.llama.f32` files to each other: that
+        /// comparison has no ferrox in it.
+        #[arg(long)]
+        dump_logits: Option<String>,
     },
     /// Corpus perplexity, llama.cpp's `perplexity` tool.
     ///
@@ -954,6 +965,7 @@ fn main() -> anyhow::Result<()> {
             prompt_tokens,
             top_k,
             dumper,
+            dump_logits,
         } => {
             return parity::run(parity::ParityArgs {
                 model,
@@ -961,6 +973,7 @@ fn main() -> anyhow::Result<()> {
                 prompt_tokens,
                 top_k,
                 dumper,
+                dump_logits,
             });
         }
         Commands::Perplexity {

--- a/crates/ferrox-cli/src/parity.rs
+++ b/crates/ferrox-cli/src/parity.rs
@@ -40,6 +40,7 @@
 //! re-reading the format spec. A reference you re-implemented is not a
 //! reference. Build it with `tools/build_llama_logits.sh`.
 
+mod dump;
 mod tokenize;
 
 use anyhow::Context;
@@ -69,9 +70,92 @@ const KL_NOISE: f64 = 1e-3;
 /// is the "wrong graph" line.
 const KL_WRONG: f64 = 1e-2;
 
+/// How far two BUILDS OF THE REFERENCE disagree with each other on a
+/// K-quant checkpoint. Not a ferrox number: measured with ferrox out of
+/// the experiment entirely.
+///
+/// Measured 2026-09-04 on the fixed parity prompt, comparing the logits
+/// of `llama_logits` linked against Homebrew libllama b7650 with the
+/// same program linked against `.scratch/llama.cpp` (ggml 0.18.0):
+///
+/// | checkpoint | KL(b7650 ‖ newer) |
+/// |---|---|
+/// | Llama-3.2-1B **Q8_0** | **0.0 — bit-identical** |
+/// | TinyLlama-1.1B **Q8_0** | **0.0 — bit-identical** |
+/// | Llama-3.2-1B IQ4_XS | 2.9e-4 |
+/// | Llama-3.2-1B Q6_K | 1.3e-3 |
+/// | Llama-3.2-1B Q4_K_M | 2.1e-3 |
+/// | Llama-3.2-1B Q5_K_M | 2.1e-3 |
+/// | Phi-4-mini Q4_K_M | 5.3e-3 |
+/// | DeepSeek-R1-Distill Q4_K_M | 1.6e-2 |
+/// | **Qwen2.5-1.5B Q4_K_M** | **2.735e-2** |
+///
+/// The Q8_0 rows are the control and they are exact zeros: the two
+/// builds are the same program for weights llama.cpp dots against
+/// Q8_0 activations. Every K-quant row moves, and the newer build's
+/// `libggml-cpu` carries interleaved-repack kernels for `block_q5_K`
+/// and `block_q6_K` that the bottle does not, which is a change in
+/// exactly the arithmetic §10 of the gap inventory is about.
+///
+/// This constant is here so [`KL_WRONG_LM_HEAD_KQUANT`] is derived from
+/// a measurement instead of restated beside one. See
+/// [#102](https://github.com/antonellof/ferrox/issues/102).
+const KL_REFERENCE_BUILD_SPREAD_KQUANT: f64 = 2.735e-2;
+
 /// Untied lm_head on a K-quant uses Q8_K activation dots; logits KL is
 /// noisier than a single matvec but still same top-1 (DeepSeek-R1 #99).
-const KL_WRONG_LM_HEAD_KQUANT: f64 = 2.5e-2;
+///
+/// It is DERIVED from the measured spread above rather than restated
+/// beside it, so the two cannot drift apart: the only way to put the
+/// line back under the reference's own spread is to edit
+/// [`KL_WRONG_LM_HEAD_KQUANT_MARGIN`] below 1, which reads as the
+/// mistake it is. It was 2.5e-2, a bare constant BELOW that spread, and
+/// the consequence was not hypothetical: Qwen2.5-1.5B
+/// Q4_K_M read DRIFT (KL 7.7e-3) against the bottle and WRONG (KL
+/// 2.7e-2) against the newer build, from the same ferrox. A line drawn
+/// under the reference's own build-to-build spread cannot mean "the
+/// graphs disagree", because two binaries with an IDENTICAL graph cross
+/// it. Whatever else 2.5e-2 was measuring, it was not that.
+///
+/// Raising it costs the sensitivity to a real K-quant lm_head bug in
+/// the band 2.5e-2..3.0e-2, which is a real cost. It buys a verdict
+/// that does not change with the reference's vintage, and a run whose
+/// WRONG can be believed. Note what is NOT raised: [`KL_WRONG`], for
+/// everything else, stays at 1e-2, because the same experiment puts the
+/// reference's build-to-build spread on a Q8_0 lm_head at exactly zero.
+const KL_WRONG_LM_HEAD_KQUANT: f64 =
+    KL_REFERENCE_BUILD_SPREAD_KQUANT * KL_WRONG_LM_HEAD_KQUANT_MARGIN;
+
+/// How far above the measured reference spread the WRONG line sits.
+///
+/// A judgement, not a measurement, and deliberately thin: the spread is
+/// the largest of nine checkpoints, so a tenth could exceed it, but
+/// every point of headroom is sensitivity to a real lm_head bug thrown
+/// away. Widen it only with a checkpoint that measured wider.
+const KL_WRONG_LM_HEAD_KQUANT_MARGIN: f64 = 1.1;
+
+/// The verdict ladder, checked at COMPILE time.
+///
+/// These four constants have to agree about an ordering and until
+/// 2026-09-04 nothing made them: `KL_WRONG_LM_HEAD_KQUANT` was a bare
+/// 2.5e-2 sitting BELOW the 2.735e-2 that two builds of llama.cpp
+/// produce from an identical graph, so the "the graphs disagree" line
+/// fired on a difference llama.cpp reproduces against itself, and one
+/// real row (#102) read DRIFT or WRONG depending on which bottle was
+/// installed. Tightening it again now fails the build rather than
+/// quietly re-arming that.
+const _: () = {
+    assert!(KL_NOISE < KL_WRONG, "MATCH must be tighter than DRIFT");
+    assert!(
+        KL_WRONG < KL_WRONG_LM_HEAD_KQUANT,
+        "the K-quant lm_head allowance must be a relaxation, not a tightening"
+    );
+    assert!(
+        KL_WRONG_LM_HEAD_KQUANT > KL_REFERENCE_BUILD_SPREAD_KQUANT,
+        "a WRONG line under the reference's own build-to-build spread cannot mean \
+         `the graphs disagree`: two binaries with an identical graph cross it"
+    );
+};
 
 pub struct ParityArgs {
     pub model: String,
@@ -80,6 +164,10 @@ pub struct ParityArgs {
     pub top_k: usize,
     /// Path to the compiled reference dumper.
     pub dumper: Option<String>,
+    /// Prefix to write both compared logit vectors under, so the same
+    /// comparison can be redone against a DIFFERENT reference build
+    /// without ferrox in the middle. See [`dump`].
+    pub dump_logits: Option<String>,
 }
 
 pub fn run(args: ParityArgs) -> anyhow::Result<()> {
@@ -126,7 +214,8 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
         );
     }
 
-    let ref_logits = reference_logits(&dumper, &path, &tokens)?;
+    let reference = reference_logits(&dumper, &path, &tokens)?;
+    let ref_logits = reference.logits;
 
     if ref_logits.len() != ferrox_logits.len() {
         // Not a tolerance question: the two engines disagree about how
@@ -138,6 +227,18 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
             ref_logits.len(),
             ferrox_logits.len()
         );
+    }
+
+    // Dumped BEFORE the verdict is computed, so a run that ends in the
+    // `bail!` below still leaves the evidence behind. The whole reason
+    // to dump is to investigate a bad verdict; losing the vectors
+    // exactly when the verdict is bad would defeat it.
+    if let Some(prefix) = args.dump_logits.as_deref() {
+        let paths = dump::write(prefix, &tokens, &ref_logits, &ferrox_logits)?;
+        println!("wrote {}", paths[0].display());
+        println!("wrote {}", paths[1].display());
+        println!("wrote {}", paths[2].display());
+        println!();
     }
 
     let gguf = ferrox_gguf::GgufFile::open(&path).ok();
@@ -157,6 +258,7 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
         args.top_k,
         backend.as_str(),
         quant,
+        reference.libllama.as_deref(),
         &report,
     );
 
@@ -206,7 +308,48 @@ struct Report {
     ref_top1_rank_in_ferrox: usize,
     /// p1 - p2 in the reference distribution: how close the call was.
     ref_top2_margin: f64,
+    /// The same call in LOGIT space, on both sides, and how many
+    /// representable f32 values separate the reference's two
+    /// candidates.
+    ///
+    /// A TIE-FLIP verdict is a claim about magnitude — "the two
+    /// candidates are closer than the arithmetic can resolve" — and
+    /// probability margin does not settle it, because softmax over a
+    /// 128k vocabulary turns a wide logit gap into a small probability
+    /// gap whenever the distribution is flat. The gap in ulps is the
+    /// claim's own units: single digits is a tie, millions is a
+    /// difference that happens to sit near the argmax
+    /// ([#103](https://github.com/antonellof/ferrox/issues/103)).
+    ref_top2_logit_gap: f32,
+    ref_top2_logit_gap_ulps: i64,
+    /// The same gap as ferrox sees it, signed by the reference's
+    /// ordering: negative means ferrox ranks them the other way round.
+    ferrox_gap_on_ref_pair: f32,
     topk_overlap: usize,
+}
+
+/// Distance between two f32 in representable values.
+///
+/// `(a - b).abs()` cannot answer "is this a tie": near 3.0 an absolute
+/// gap of 1e-6 is about four ulps, near 3e-8 the same gap is the whole
+/// number. The count of representable values between two floats is the
+/// only scale-free way to say how close a float comparison was, and a
+/// tie-flip verdict is exactly that claim.
+///
+/// Works by mapping f32 to a monotone integer key: for non-negative
+/// values the bit pattern already increases with the value, and for
+/// negative values it increases as the value decreases, so the
+/// magnitude bits are negated.
+fn ulps_between(a: f32, b: f32) -> i64 {
+    fn key(x: f32) -> i64 {
+        let bits = i64::from(x.to_bits() & 0x7fff_ffff);
+        if x.is_sign_negative() {
+            -bits
+        } else {
+            bits
+        }
+    }
+    (key(a) - key(b)).abs()
 }
 
 fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, kl_wrong: f64) -> Report {
@@ -241,11 +384,20 @@ fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, kl_wrong: f64) -
     let top1_ref = ref_order[0];
     let top1_ferrox = fx_order[0];
     let ref_top1_rank_in_ferrox = fx_order.iter().position(|&i| i == top1_ref).unwrap_or(0);
-    let ref_top2_margin = if ref_order.len() > 1 {
-        p[ref_order[0]] - p[ref_order[1]]
-    } else {
-        1.0
-    };
+    let (ref_top2_margin, ref_top2_logit_gap, ref_top2_logit_gap_ulps, ferrox_gap_on_ref_pair) =
+        if ref_order.len() > 1 {
+            let (i1, i2) = (ref_order[0], ref_order[1]);
+            (
+                p[i1] - p[i2],
+                ref_logits[i1] - ref_logits[i2],
+                ulps_between(ref_logits[i1], ref_logits[i2]),
+                // Same pair, ferrox's numbers, keeping the reference's
+                // order: the sign is the flip itself.
+                ferrox_logits[i1] - ferrox_logits[i2],
+            )
+        } else {
+            (1.0, 0.0, 0, 0.0)
+        };
 
     let k = k.min(ref_order.len());
     let ref_top: std::collections::HashSet<usize> = ref_order[..k].iter().copied().collect();
@@ -279,6 +431,9 @@ fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, kl_wrong: f64) -
         top1_ferrox,
         ref_top1_rank_in_ferrox,
         ref_top2_margin,
+        ref_top2_logit_gap,
+        ref_top2_logit_gap_ulps,
+        ferrox_gap_on_ref_pair,
         topk_overlap,
     }
 }
@@ -365,6 +520,7 @@ fn print_report(
     k: usize,
     backend: &str,
     quant: Option<&str>,
+    libllama: Option<&str>,
     r: &Report,
 ) {
     let name = Path::new(model)
@@ -381,6 +537,16 @@ fn print_report(
         "parity {name}: {verdict} ({n_tokens}-token prompt, first-token distribution, \
          ferrox {backend} vs llama.cpp cpu)"
     );
+    // Named on every row, not only when it surprises. Two libllama
+    // builds gave the same checkpoint DRIFT and WRONG (#102), and the
+    // difference between the runs was invisible in this report.
+    match libllama {
+        Some(p) => println!("  reference         {p}"),
+        None => println!(
+            "  reference         (this dumper predates the `libllama` line — rebuild with \
+             tools/build_llama_logits.sh to have the verdict name its reference)"
+        ),
+    }
     println!(
         "  KL(llama||ferrox) {:.3e} nats   KL(ferrox||llama) {:.3e} nats",
         r.kl_ref_ferrox, r.kl_ferrox_ref
@@ -396,6 +562,14 @@ fn print_report(
     println!(
         "  top-{k} overlap    {}/{k}          llama top-2 margin {:.3e}",
         r.topk_overlap, r.ref_top2_margin
+    );
+    // Printed for every verdict, not only TIE-FLIP: how close the
+    // argmax call was is what says whether the NEXT prompt would flip
+    // too, and a row that did not flip is the evidence that a row which
+    // did was one prompt's luck.
+    println!(
+        "  top-1/top-2 gap   {:+.3e} logits ({} ulps)   ferrox on the same pair {:+.3e}",
+        r.ref_top2_logit_gap, r.ref_top2_logit_gap_ulps, r.ferrox_gap_on_ref_pair
     );
     match r.verdict {
         Verdict::Match => println!("  same distribution to within f32 accumulation-order noise."),
@@ -415,11 +589,23 @@ fn print_report(
                  explains — worth a per-layer divergence run before trusting this row."
             ),
         },
-        Verdict::TieFlip => println!(
-            "  top-1 differs, but llama's own top-2 margin ({:.3e}) is under the observed \
-             per-token noise ({:.3e}): a tie swapped, not a wrong graph.",
-            r.ref_top2_margin, r.max_prob_delta
-        ),
+        Verdict::TieFlip => {
+            println!(
+                "  top-1 differs, but llama's own top-2 margin ({:.3e}) is under the observed \
+                 per-token noise ({:.3e}): a tie swapped, not a wrong graph.",
+                r.ref_top2_margin, r.max_prob_delta
+            );
+            // The magnitude, in the units the claim is made in. Without
+            // it "tie" is an assertion; with it a reader can check
+            // whether the two candidates really are inseparable or
+            // whether a real difference merely landed near the argmax.
+            println!(
+                "  the two candidates are {} ulps apart in llama's logits ({:+.3e} absolute); \
+                 ferrox puts the same pair {:+.3e} apart, so the flip is a sign change of a gap \
+                 this size — not a redistribution.",
+                r.ref_top2_logit_gap_ulps, r.ref_top2_logit_gap, r.ferrox_gap_on_ref_pair
+            );
+        }
         Verdict::Wrong => println!(
             "  the graphs disagree. This is not sampling noise and not a tie: something in \
              the forward pass differs."
@@ -482,9 +668,26 @@ fn dumper_path(explicit: Option<&str>) -> anyhow::Result<PathBuf> {
     )
 }
 
+/// What the reference said, and which library said it.
+struct Reference {
+    logits: Vec<f32>,
+    /// The libllama the dumper actually loaded, as it reported itself.
+    ///
+    /// `None` when the dumper predates the line — an older binary is
+    /// still usable, it just cannot be attributed, and that is worth
+    /// saying rather than guessing a path from the dumper's own.
+    libllama: Option<String>,
+}
+
+/// Prefix the dumper uses to report the library it loaded. Spelled once
+/// here and once in `tools/llama_logits.c`; the parse is tolerant of
+/// its absence precisely because those two are the only things that
+/// have to agree and nothing links them.
+const LIBLLAMA_LINE: &str = "libllama ";
+
 /// Runs the reference dumper on the SAME token ids and reads back its
 /// logit vector.
-fn reference_logits(dumper: &Path, model: &str, tokens: &[u32]) -> anyhow::Result<Vec<f32>> {
+fn reference_logits(dumper: &Path, model: &str, tokens: &[u32]) -> anyhow::Result<Reference> {
     let out_path = std::env::temp_dir().join(format!("ferrox-parity-{}.bin", std::process::id()));
     let mut cmd = Command::new(dumper);
     cmd.arg(model).arg(&out_path);
@@ -507,12 +710,25 @@ fn reference_logits(dumper: &Path, model: &str, tokens: &[u32]) -> anyhow::Resul
     if bytes.len() % 4 != 0 {
         anyhow::bail!("reference logits file is not a whole number of f32");
     }
-    Ok(bytes
-        .as_chunks::<4>()
-        .0
-        .iter()
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect())
+    Ok(Reference {
+        logits: bytes
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+        libllama: parse_libllama(&String::from_utf8_lossy(&out.stdout)),
+    })
+}
+
+/// Picks the `libllama <path>` line out of the dumper's stdout.
+fn parse_libllama(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix(LIBLLAMA_LINE))
+        .map(str::trim)
+        .filter(|p| !p.is_empty() && *p != "unknown")
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -575,10 +791,124 @@ mod tests {
         assert_eq!(r.verdict, Verdict::Match);
     }
 
+    /// Adjacent floats are one ulp apart wherever they sit on the line,
+    /// and the count is scale-free.
+    ///
+    /// This is the measurement a TIE-FLIP verdict rests on. An absolute
+    /// difference cannot make the claim: `3.0` and its neighbour differ
+    /// by 2.4e-7 while `3e-8` and its neighbour differ by 1e-15, and
+    /// both are one ulp. A tie-flip reported in absolute units is
+    /// therefore unfalsifiable, which is what #103 pointed at.
+    #[test]
+    fn ulps_between_counts_representable_values_not_absolute_distance() {
+        for anchor in [3.0f32, 3e-8, -3.0, 1.0, 65_536.0] {
+            let next = f32::from_bits(if anchor.is_sign_negative() {
+                anchor.to_bits() - 1
+            } else {
+                anchor.to_bits() + 1
+            });
+            assert_eq!(
+                ulps_between(anchor, next),
+                1,
+                "{anchor} and its neighbour {next} must be one ulp apart"
+            );
+        }
+        // Symmetric, and zero for equal values.
+        assert_eq!(ulps_between(1.5, 1.5), 0);
+        assert_eq!(ulps_between(2.0, 1.0), ulps_between(1.0, 2.0));
+        // Crossing zero must not wrap: -0.0 and +0.0 are the same
+        // value, and a naive bit subtraction would call them 2^31
+        // apart, which would turn every sign change into "not a tie".
+        assert_eq!(ulps_between(-0.0, 0.0), 0);
+        // The two representable values either side of zero are two
+        // steps apart, not 2^32: a naive bit subtraction makes any sign
+        // change look maximally far, which would turn every flipped
+        // near-tie into "not a tie".
+        let tiny = f32::from_bits(1);
+        assert_eq!(ulps_between(-tiny, tiny), 2);
+        // A gap that is genuinely large stays large: 1.0 and 2.0 are a
+        // whole binade apart, which is 2^23 representable values.
+        assert_eq!(ulps_between(1.0, 2.0), 1 << 23);
+    }
+
+    /// The reported top-1/top-2 gap describes the pair the REFERENCE
+    /// picked, on both sides, so the flip shows up as a sign change.
+    ///
+    /// Reporting ferrox's own top-2 pair instead would compare two
+    /// different questions and could print two positive gaps for a run
+    /// whose whole finding is that the order reversed.
+    #[test]
+    fn the_reported_gap_is_the_same_pair_on_both_sides_and_flips_sign() {
+        let a = vec![-10.0f32, 2.000_01, 2.0];
+        let b = vec![-10.0f32, 2.0, 2.000_01];
+        let r = compare(&a, &b, 2, KL_WRONG);
+        assert_eq!(r.verdict, Verdict::TieFlip);
+        assert!(
+            r.ref_top2_logit_gap > 0.0,
+            "the reference ranks its own pair the right way round"
+        );
+        assert!(
+            r.ferrox_gap_on_ref_pair < 0.0,
+            "ferrox ranks the SAME pair the other way: gap {}",
+            r.ferrox_gap_on_ref_pair
+        );
+        assert!(
+            r.ref_top2_logit_gap_ulps > 0 && r.ref_top2_logit_gap_ulps < 1_000,
+            "a tie must be a handful of ulps, got {}",
+            r.ref_top2_logit_gap_ulps
+        );
+    }
+
     #[test]
     fn kquant_lm_head_uses_a_higher_wrong_threshold() {
         assert_eq!(wrong_kl_threshold(Some("Q6K")), KL_WRONG_LM_HEAD_KQUANT);
         assert_eq!(wrong_kl_threshold(Some("Q8_0")), KL_WRONG);
+    }
+
+    /// EVERY quantization that routes to the K-quant allowance gets a
+    /// WRONG line above the reference's own build-to-build spread.
+    ///
+    /// The ordering of the constants is checked at compile time; this
+    /// walks the PREDICATE, which is the half that can silently stop
+    /// agreeing with them. A spelling dropped from
+    /// `llama_dots_this_against_q8k` sends that quantization back to
+    /// `KL_WRONG` = 1e-2, which is a quarter of the spread two llama.cpp
+    /// builds show on exactly these types — the row would read WRONG and
+    /// the constants would still look right.
+    #[test]
+    fn every_q8k_dotted_lm_head_clears_the_references_build_to_build_spread() {
+        for kind in [
+            "Q2K", "Q3K", "Q4K", "Q5K", "Q6K", "IQ2XXS", "IQ2XS", "IQ2S", "IQ3XXS", "IQ3S", "IQ1S",
+            "IQ1M", "IQ4XS",
+        ] {
+            let line = wrong_kl_threshold(Some(kind));
+            assert!(
+                line > KL_REFERENCE_BUILD_SPREAD_KQUANT,
+                "{kind} gets a WRONG line of {line:e}, under the {KL_REFERENCE_BUILD_SPREAD_KQUANT:e} \
+                 two builds of llama.cpp produce from an identical graph"
+            );
+        }
+        // And the non-K-quant line is deliberately NOT raised: the same
+        // experiment measured the reference's Q8_0 spread at exactly
+        // zero, so there is nothing there to make room for.
+        assert_eq!(wrong_kl_threshold(Some("Q8_0")), 1e-2);
+    }
+
+    /// The dumper's self-report is read, and its absence is not
+    /// mistaken for a library called "unknown".
+    #[test]
+    fn the_reference_identity_is_parsed_and_its_absence_is_not_invented() {
+        assert_eq!(
+            parse_libllama("libllama /opt/homebrew/lib/libllama.dylib\nn_vocab 32000\n").as_deref(),
+            Some("/opt/homebrew/lib/libllama.dylib")
+        );
+        // An older dumper prints no such line: report that, do not guess.
+        assert_eq!(parse_libllama("n_vocab 32000\n"), None);
+        // The dumper says "unknown" when dladdr fails; that is an
+        // absence too, and passing it through would print a reference
+        // path of "unknown" as though it were one.
+        assert_eq!(parse_libllama("libllama unknown\nn_vocab 32000\n"), None);
+        assert_eq!(parse_libllama("libllama   \n"), None);
     }
 
     /// The Q8_K predicate is spelled in `GgmlType`'s variant names, not

--- a/crates/ferrox-cli/src/parity/dump.rs
+++ b/crates/ferrox-cli/src/parity/dump.rs
@@ -1,0 +1,138 @@
+//! Writing the two logit vectors a parity run compared, so the
+//! comparison can be redone without either engine.
+//!
+//! Why this exists: `parity` prints ONE number per run, KL(reference ||
+//! ferrox), and that number is a distance between two points without
+//! saying where either point is. When the same checkpoint scored DRIFT
+//! against one libllama and WRONG against another
+//! ([#102](https://github.com/antonellof/ferrox/issues/102)) there was
+//! no way, from parity's output alone, to tell "ferrox moved" from "the
+//! reference moved" — the two hypotheses produce the same printed line.
+//!
+//! Dumping the vectors makes the third comparison possible, and it is
+//! the one that settles it: reference-A against reference-B, with ferrox
+//! out of the experiment entirely. On Qwen2.5-1.5B Q4_K_M that
+//! comparison read KL 2.73e-2 between two llama.cpp builds, larger than
+//! either build's disagreement with ferrox — which is a fact about
+//! llama.cpp and could not have been discovered by running `parity`
+//! more times.
+//!
+//! The files are raw little-endian f32, the same wire
+//! `tools/llama_logits.c` writes, so a dumped ferrox vector and a
+//! dumped reference vector are interchangeable inputs to anything that
+//! reads one.
+
+use anyhow::Context;
+use std::path::{Path, PathBuf};
+
+/// Suffixes appended to the caller's prefix. Kept in one place because
+/// the point of the dump is that a later run can find the earlier run's
+/// files, and a suffix spelled twice is a suffix that drifts.
+const REFERENCE_SUFFIX: &str = ".llama.f32";
+const FERROX_SUFFIX: &str = ".ferrox.f32";
+const TOKENS_SUFFIX: &str = ".tokens.txt";
+
+/// Writes both logit vectors and the token ids they were computed from.
+///
+/// The token ids travel with the vectors because they are the only part
+/// of the experiment that is not in the file names: two dumps of the
+/// same checkpoint taken with different prompts are not comparable, and
+/// nothing else would say so.
+pub fn write(
+    prefix: &str,
+    tokens: &[u32],
+    reference: &[f32],
+    ferrox: &[f32],
+) -> anyhow::Result<[PathBuf; 3]> {
+    let ref_path = PathBuf::from(format!("{prefix}{REFERENCE_SUFFIX}"));
+    let fx_path = PathBuf::from(format!("{prefix}{FERROX_SUFFIX}"));
+    let tok_path = PathBuf::from(format!("{prefix}{TOKENS_SUFFIX}"));
+
+    write_f32(&ref_path, reference)?;
+    write_f32(&fx_path, ferrox)?;
+
+    let ids = tokens
+        .iter()
+        .map(|t| t.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    std::fs::write(&tok_path, format!("{ids}\n"))
+        .with_context(|| format!("writing {}", tok_path.display()))?;
+
+    Ok([ref_path, fx_path, tok_path])
+}
+
+fn write_f32(path: &Path, values: &[f32]) -> anyhow::Result<()> {
+    let mut bytes = Vec::with_capacity(values.len() * 4);
+    for v in values {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    std::fs::write(path, &bytes).with_context(|| format!("writing {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A dumped vector must read back bit-for-bit, because the whole
+    /// use of the dump is comparing it against a vector produced by a
+    /// DIFFERENT build months later. A dump that rounds is a dump that
+    /// invents the divergence it is meant to measure.
+    #[test]
+    fn a_dumped_vector_reads_back_bit_for_bit() {
+        let dir = std::env::temp_dir().join(format!("ferrox-dump-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let prefix = dir.join("case").to_string_lossy().into_owned();
+
+        // Values chosen to break a naive round-trip: a denormal, a
+        // negative zero, and a value whose f32 -> f64 -> f32 trip is
+        // only exact if nothing in between is text.
+        let reference = vec![
+            0.1f32,
+            -0.0,
+            f32::MIN_POSITIVE,
+            3.402_823_5e38,
+            -1.234_567_8e-9,
+        ];
+        let ferrox = vec![0.2f32, 1.0, -5.5, 0.0, 7.7];
+        let paths = write(&prefix, &[1, 2, 3], &reference, &ferrox).unwrap();
+
+        let back = std::fs::read(&paths[0]).unwrap();
+        let read: Vec<f32> = back
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| f32::from_le_bytes(*c))
+            .collect();
+        assert_eq!(read.len(), reference.len());
+        for (a, b) in read.iter().zip(&reference) {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "dumped {b} came back as {a}: the dump is not bit-exact"
+            );
+        }
+
+        let ids = std::fs::read_to_string(&paths[2]).unwrap();
+        assert_eq!(ids.trim(), "1 2 3");
+
+        for p in &paths {
+            let _ = std::fs::remove_file(p);
+        }
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    /// The reference and ferrox dumps must land in different files.
+    ///
+    /// They are the same length and the same wire format, so a shared
+    /// suffix would silently leave one overwriting the other and the
+    /// resulting "reference vs reference" KL would be exactly zero —
+    /// which reads as "the two builds agree" and is the one answer this
+    /// tool must never fabricate.
+    #[test]
+    fn the_two_vectors_do_not_share_a_file_name() {
+        assert_ne!(REFERENCE_SUFFIX, FERROX_SUFFIX);
+        assert_ne!(REFERENCE_SUFFIX, TOKENS_SUFFIX);
+        assert_ne!(FERROX_SUFFIX, TOKENS_SUFFIX);
+    }
+}

--- a/tools/llama_logits.c
+++ b/tools/llama_logits.c
@@ -46,7 +46,10 @@
 //
 // Usage:
 //   llama_logits <model.gguf> <out.bin> <tok0> <tok1> ...
-//       Writes n_vocab f32 to <out.bin> and prints "n_vocab <N>".
+//       Writes n_vocab f32 to <out.bin> and prints "libllama <path>"
+//       followed by "n_vocab <N>". The path is the library that
+//       actually answered — see print_reference_identity below for why
+//       a verdict without it is only half an experiment.
 //
 //   llama_logits --tokenize <model.gguf> <cases.bin> <out.bin>
 //       Reads an FXTK case file, writes an FXTK result file, and prints
@@ -77,12 +80,20 @@
 // confound two differences. The tokenize mode loads vocab_only, so it
 // touches no backend at all.
 
+// dladdr is a GNU extension on glibc; harmless elsewhere.
+#define _GNU_SOURCE
+
 #include "llama.h"
 
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if defined(__APPLE__) || defined(__linux__)
+#  include <dlfcn.h>
+#  define FX_HAVE_DLADDR 1
+#endif
 
 #define FXTK_MAGIC "FXTK"
 #define FXTK_VERSION 1u
@@ -93,6 +104,33 @@
 // that cannot tell the two apart has to either ignore real failures or
 // report a missing reference as a defect.
 #define EXIT_MODEL_UNSUPPORTED 3
+
+// Prints WHICH libllama actually answered, as `libllama <path>`.
+//
+// A parity verdict is not a property of ferrox alone: the same
+// checkpoint scored DRIFT against one libllama and WRONG against
+// another, and the printed report said nothing that distinguished the
+// two runs (issue #102). The two builds turned out to differ in the
+// K-quant path -- their Q8_0 answers are bit-identical, their Q4_K/Q6_K
+// answers are not -- so a report that omits the reference's identity is
+// omitting half the experiment.
+//
+// The path is taken from the LOADED image rather than from the compile
+// -time -L flag, because an rpath, a DYLD_LIBRARY_PATH or a Homebrew
+// relink can all make those two different, and the one that computed
+// the logits is the one that matters.
+static void print_reference_identity(void) {
+#ifdef FX_HAVE_DLADDR
+    Dl_info info;
+    // Any exported llama symbol identifies the image; this one exists in
+    // every version the dumper can be built against.
+    if (dladdr((void *) (uintptr_t) &llama_backend_init, &info) != 0 && info.dli_fname) {
+        printf("libllama %s\n", info.dli_fname);
+        return;
+    }
+#endif
+    printf("libllama unknown\n");
+}
 
 static uint32_t rd_u32(const unsigned char * p) {
     return (uint32_t) p[0] | ((uint32_t) p[1] << 8) | ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 24);
@@ -362,6 +400,7 @@ static int cmd_logits(const char * model_path, const char * out_path, int n_toke
     fwrite(logits, sizeof(float), (size_t) n_vocab, f);
     fclose(f);
 
+    print_reference_identity();
     printf("n_vocab %d\n", n_vocab);
 
     llama_batch_free(batch);


### PR DESCRIPTION
Closes #102. Answers #103 with a measurement; leaving it open is fine if you disagree with the reading, but the numbers are here.

## What was wrong

`ferrox parity` gave **the same ferrox** two different verdicts for Qwen2.5-1.5B Q4_K_M: DRIFT (KL 7.7e-3) against Homebrew libllama b7650, WRONG (KL 2.7e-2) against `.scratch/llama.cpp`. Nothing in the printed report distinguished the two runs, so the disagreement read as a ferrox defect.

## The measurement that settles it

Dump both references' logits for the same token ids and compare them **to each other**, with ferrox out of the experiment:

| pair | KL |
|---|---|
| llama.cpp b7650 ‖ llama.cpp (newer) | **2.735e-2** |
| llama.cpp b7650 ‖ ferrox | 7.679e-3 |
| llama.cpp (newer) ‖ ferrox | 2.669e-2 |

The two llama.cpp builds disagree **with each other** by 3.6x more than ferrox disagrees with either. ferrox's own top-1/top-2 logit gap (1.5488) reproduces b7650's (1.5505) to 0.1%; the newer build reads 1.0144. ferrox is not the outlier — the reference moved. Candidate 2 in #102, not 1 and not 3.

**Where** it moved is checkable. Same prompt, nine checkpoints, two builds:

| checkpoint | KL(b7650 ‖ newer) |
|---|---|
| Llama-3.2-1B **Q8_0** | **0.0 — bit-identical** |
| TinyLlama-1.1B **Q8_0** | **0.0 — bit-identical** |
| Llama-3.2-1B IQ4_XS | 2.9e-4 |
| Llama-3.2-1B Q6_K | 1.3e-3 |
| Llama-3.2-1B Q4_K_M | 2.1e-3 |
| Llama-3.2-1B Q5_K_M | 2.1e-3 |
| Phi-4-mini Q4_K_M | 5.3e-3 |
| DeepSeek-R1-Distill Q4_K_M | 1.6e-2 |
| Qwen2.5-1.5B Q4_K_M | 2.735e-2 |

The Q8_0 rows are the control and they are exact zeros. Every K-quant/IQ row moves. The newer `libggml-cpu` carries interleaved-repack kernels for `block_q5_K` and `block_q6_K` that the bottle does not (`nm | grep repack`: 261 symbols vs 83). That is a change in the K-quant activation arithmetic of §10, on llama.cpp's side. `GGML_CPU_DISABLE_FUSION=1` changes nothing, so it is not graph fusion.

## What changed

* **`tools/llama_logits.c` reports the libllama it actually loaded**, via `dladdr` on the running image rather than the compile-time `-L`, and `parity` prints it on every row. A verdict that omits its reference omits half the experiment. Rows now read `reference /opt/homebrew/Cellar/llama.cpp/7650/lib/libllama.0.0.7650.dylib`.

* **`parity --dump-logits <prefix>`** writes both compared vectors as raw f32 plus the token ids. Reference-against-reference is the comparison that settles a "did ferrox move or did llama.cpp move" question, and it was not runnable before. Written *before* the verdict, so a failing run still leaves its evidence.

* **`KL_WRONG_LM_HEAD_KQUANT` 2.5e-2 → 3.008e-2, derived.** The old value sat *below* the 2.735e-2 that two identical graphs produce, so the "the graphs disagree" line fired on a difference llama.cpp reproduces against itself — it would report llama.cpp WRONG against llama.cpp. It is now `KL_REFERENCE_BUILD_SPREAD_KQUANT * KL_WRONG_LM_HEAD_KQUANT_MARGIN`, the measurement times a named 1.1, with the ordering as a **compile-time** assert: tightening it fails the build, it does not merely fail a test.

* **`KL_WRONG` (1e-2, everything else) is NOT raised.** The same experiment puts the reference's spread on a Q8_0 lm_head at exactly zero, so there is nothing there to make room for. If this were threshold-fitting, both would have moved.

* **The report prints the top-1/top-2 gap in logits AND IN ULPS on every row** (#103, below).

## Blast radius

Re-swept 17 checkpoints on both references (Qwen1.5-MoE skipped for time). **The threshold change flips exactly one row**: Qwen2.5-1.5B on the newer reference, WRONG → DRIFT, on unchanged numbers. On Homebrew the largest K-quant KL in the sweep is Phi-4-mini at 1.18e-2, nowhere near either line. Zero WRONG on either reference now.

## #103: the tie is real, but it is not a floating-point tie

Llama-3.1-8B, the fixed prompt:

* gap **+3.554e-2 logits = 37,271 ulps**. Four orders of magnitude from an ulp. "Tie" understated it.
* ferrox puts the same pair at **-3.006e-2**: a sign change, not a redistribution. The two engines disagree about this gap by 6.56e-2.
* the ferrox-vs-llama.cpp logit perturbation on this checkpoint is **rms 3.5e-2 across the top-10** (max 5.8e-2). The gap is ~1 sigma of it. A coin flip.
* **1 of 10 prompts flips**, and it is exactly the one whose gap falls in that band. The other nine have gaps of 0.80 to 8.93 logits — 20x to 250x the perturbation — and none flip.
* both llama.cpp builds still pick 12366, but they move this same gap by 1.63e-2 between themselves, half of what is needed to flip it.

So TIE-FLIP is the right classification (not a wrong graph), the criterion (`ref_top2_margin <= max_delta`) is correct and unchanged, and the report now carries the magnitude so the claim is auditable rather than asserted. Control: a Q8_0 checkpoint shows a comparable top-10 perturbation (rms 5.7e-2) while reading MATCH, so this is engine-to-engine logit noise reaching a genuinely undecided argmax, not something specific to the K-quant path.

## Tests

Six new assertions, each sabotaged once and confirmed red (one is a compile error, which is stronger):

| sabotage | result |
|---|---|
| `KL_WRONG_LM_HEAD_KQUANT_MARGIN` → 0.9 | **E0080, build fails** |
| drop `"Q6K"` from `llama_dots_this_against_q8k` | `every_q8k_dotted_lm_head_clears_…` red |
| `ulps_between` → naive bit subtraction | `ulps_between_counts_representable_values_…` red |
| report ferrox's own top-2 pair, not the reference's | `the_reported_gap_is_the_same_pair_…` red |
| pass `"unknown"` through as a reference path | `the_reference_identity_is_parsed_…` red |
| dump the two vectors to one file name | `the_two_vectors_do_not_share_a_file_name` red |
| dump through a lossy text round-trip | `a_dumped_vector_reads_back_bit_for_bit` red |

Gates: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, the same `--release`, `cargo fmt --all --check`. All pass.

## What would have to be true for this to be wrong

The newer llama.cpp is the *correct* one and ferrox + b7650 share a bug. Showing that needs a third reference that is not llama.cpp; ferrox keeping activations in f32 makes it the least lossy of the three, which is evidence but not proof. Raising the line also costs sensitivity to a real K-quant lm_head bug in 2.5e-2..3.0e-2 — a real cost, taken because a WRONG that moves with the reference's vintage cannot be believed at any value.

## Known limit, not fixed here

`wrong_kl_threshold` keys on the **lm_head** quant alone, while the DRIFT explanation keys on `lm_head.or(dominant)`. A checkpoint with a Q8_0 lm_head over K-quant layers gets the 1e-2 line while its layers still go through the changed arithmetic. No checkpoint in `models/` has that shape, so it is unmeasured rather than known-benign. Two structures that must agree about one thing — worth its own issue.

## Doc delta (not applied; `docs/` was out of scope)

* `docs/plans/llama-cpp-parity-update-2026-09-03.md` "Reference vintage" table: Qwen2.5 scratch is now **DRIFT**, not WRONG. Add gemma-2-2b as a second reference-dependent row (DRIFT 6.5e-3 on Homebrew, TIE-FLIP 1.53e-2 on scratch).
* Same file: the vintage table says Phi-4-mini Homebrew KL is 3.8e-3, and the §Phi-4-mini section says 1.2e-2. Measured today on Homebrew: **1.179e-2**. The 3.8e-3 appears to be the *scratch* number (measured today: 3.800e-3) in the Homebrew column.
* `tools/build_llama_logits.sh`'s header comment records the Qwen2.5 DRIFT/WRONG split as an open hazard; it is now explained, and the comment could say the two builds differ in the K-quant path and are bit-identical on Q8_0. Left alone to keep the diff to the finding.
* `CLAUDE.md` / gap inventory §10: the K-quant activation difference is not only ferrox-vs-llama.cpp — it is llama.cpp-vs-llama.cpp too, and that is the sharper way to state it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
