### PR TITLE
docs(plans): the parity verdicts moved with the reference, not with ferrox

### DIFF
--- a/docs/plans/llama-cpp-parity-update-2026-09-03.md
+++ b/docs/plans/llama-cpp-parity-update-2026-09-03.md
@@ -29,7 +29,7 @@ cannot load the checkpoint); see reference vintage below.
 | **MATCH** | 6 | TinyLlama Q8_0, Llama-3.2-1B Q8_0/IQ4_XS, Llama-3.2-3B, Mistral-7B, OLMoE |
 | **DRIFT** | 10 | All K-quants incl. Qwen2.5 + DeepSeek-R1 + Phi-4 (expected Q8_K activation quant on K-quants — §10 gap inventory) |
 | **TIE-FLIP** | 1 | Llama-3.1-8B |
-| **WRONG** | 0 | — (Homebrew reference; Qwen2.5 WRONG on scratch only — see below) |
+| **WRONG** | 0 | none, on either reference, since #102 corrected the K-quant lm_head line |
 | Skip | 2 | Gemma-4 (Homebrew libllama cannot load checkpoint), BERT encoders |
 
 ### Reference vintage
@@ -38,15 +38,55 @@ Parity verdicts depend on which `llama_logits` binary links against. Homebrew is
 the default for CI and issue closure; scratch `.scratch/llama.cpp` is required when
 Homebrew cannot load a checkpoint or when updating the reference baseline.
 
-| Model | Homebrew | Scratch |
-|-------|----------|---------|
-| Qwen2.5-1.5B Q4_K_M | DRIFT (KL 7.7e-3) | **WRONG** (KL 2.7e-2, top-1 match) |
-| Phi-4-mini Q4_K_M | DRIFT (KL 3.8e-3) | DRIFT |
+| Model | Homebrew (b7650) | Scratch (ggml 0.18.0) |
+|-------|------------------|-----------------------|
+| Qwen2.5-1.5B Q4_K_M | DRIFT (KL 7.7e-3) | DRIFT (KL 2.7e-2, top-1 match) |
+| Phi-4-mini Q4_K_M | DRIFT (KL 1.179e-2) | DRIFT (KL 3.800e-3) |
 | DeepSeek-R1-Distill Q4_K_M | DRIFT (KL 9.2e-3) | DRIFT |
+| gemma-2-2b Q4_K_M | DRIFT (KL 6.5e-3) | TIE-FLIP (KL 1.53e-2) |
 | Gemma-4 E2B Q4_K_M | load fail | **MATCH** (KL 1.7e-4) |
 
-Qwen2.5 WRONG on scratch is pre-existing on `main`, not a PR #100 regression.
-Same untied Q6K `output.weight` graph as DeepSeek-R1 (DRIFT on both references).
+Two corrections to the first version of this table. **The Phi-4-mini
+numbers were in the wrong columns**: measured 2026-09-04, Homebrew is
+1.179e-2 and scratch 3.800e-3, not the other way round. And Qwen2.5 on
+scratch is **DRIFT**, not WRONG, since #102.
+
+### Why the verdicts moved with the reference ([#102](https://github.com/antonellof/ferrox/issues/102))
+
+Settled by taking ferrox out of the experiment: dump both references'
+logits for the same token ids and compare them TO EACH OTHER.
+
+| Pair | KL |
+|---|---|
+| llama.cpp b7650 against llama.cpp ggml 0.18.0 | **2.735e-2** |
+| b7650 against ferrox | 7.679e-3 |
+| ggml 0.18.0 against ferrox | 2.669e-2 |
+
+**The two llama.cpp builds disagree with each other by more than ferrox
+disagrees with either.** ferrox's top-1/top-2 gap (1.5488) reproduces
+b7650's (1.5505) to 0.1%; the newer build reads 1.0144. ferrox was never
+the outlier.
+
+Where it comes from: across nine checkpoints the two builds are
+**bit-identical on Q8_0** and differ on every K-quant and IQ tier. The
+newer `libggml-cpu` carries interleaved-repack kernels for `block_q5_K`
+and `block_q6_K` that the bottle lacks (261 repack symbols against 83).
+Not operator fusion: `GGML_CPU_DISABLE_FUSION=1` changes nothing.
+
+So the `vec_dot_type` difference in §10 of the gap inventory is not only
+a ferrox-versus-llama.cpp story. **llama.cpp reproduces it against
+itself**, between two of its own builds, which is the sharper statement.
+
+The consequence for the oracle: `KL_WRONG_LM_HEAD_KQUANT` was a bare
+2.5e-2, BELOW that 2.735e-2 spread, so the "these graphs disagree" line
+fired on a difference llama.cpp produces against itself. It is now
+derived from the measured spread with the ordering asserted at compile
+time. `KL_WRONG` stays at 1e-2, because the same experiment puts the
+build-to-build spread on a Q8_0 lm_head at exactly zero.
+
+Every parity row now prints the reference it used, and
+`ferrox parity --dump-logits` writes both vectors before the verdict, so
+a run keeps its evidence.
 
 ### Phi-4-mini ([#98](https://github.com/antonellof/ferrox/issues/98))
 
@@ -54,7 +94,7 @@ Same untied Q6K `output.weight` graph as DeepSeek-R1 (DRIFT on both references).
 
 ### DeepSeek-R1-Distill ([#99](https://github.com/antonellof/ferrox/issues/99))
 
-Same qwen2 family as Qwen2.5-1.5B (DRIFT 7.7e-3, same top-1 12095). Untied **Q6K** `output.weight` explains KL **2.0e-2** vs sibling — not a graph bug. Reclassified **DRIFT** with `KL_WRONG_LM_HEAD_KQUANT = 2.5e-2`.
+Same qwen2 family as Qwen2.5-1.5B (DRIFT 7.7e-3, same top-1 12095). Untied **Q6K** `output.weight` explains KL **2.0e-2** vs sibling — not a graph bug. Reclassified **DRIFT**. That threshold was `2.5e-2` when this was written and is now derived from the measured reference-build spread (#102), which is why the same verdict no longer depends on which libllama produced the reference.
 
 ### Gemma-4 ([#101](https://github.com/antonellof/ferrox/issues/101))
 


### PR DESCRIPTION
Doc delta for #108.

The finding inverts what the old table implied. Comparing the two llama.cpp builds **to each other**, with ferrox out of the experiment: they disagree by **2.735e-2**, while ferrox disagrees with either by 7.7e-3 and 2.7e-2. ferrox was never the outlier, and its top-1/top-2 gap reproduces the older build's to 0.1%.

That also localises §10's activation difference better than this project could before: the two builds are **bit-identical on Q8_0** and differ on every K-quant and IQ tier, because the newer `libggml-cpu` carries interleaved-repack kernels for `block_q5_K`/`block_q6_K` that the bottle lacks. So the `vec_dot_type` difference is not only a ferrox-versus-llama.cpp story: **llama.cpp reproduces it against itself.**

Two factual corrections:
- **The Phi-4-mini numbers were in the wrong columns.** Measured today: Homebrew 1.179e-2, scratch 3.800e-3, not the reverse.
- Qwen2.5 on scratch is DRIFT, not WRONG, since the K-quant lm_head line sat below the spread two identical graphs produce.

gemma-2-2b added as a second reference-dependent row: one example reads as a quirk, two read as a property of the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN