### PR TITLE
feat(kv): a windowed layer's CPU KV cache drops rows behind its window (#61 step 2)

### DIFF
--- a/crates/ferrox-core/src/cache.rs
+++ b/crates/ferrox-core/src/cache.rs
@@ -19,6 +19,8 @@
 
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use crate::kv_swa::KvWindow;
+
 /// Returned by `KvCache::push` (and `with_pool`) when a pool-backed
 /// cache needs another block but its shared `KvBlockPool` has none
 /// free. Caches built with `new`/`with_capacity` never return this --
@@ -153,6 +155,17 @@ pub struct KvCache {
     /// pool and how many blocks this cache currently holds, so its
     /// blocks can be returned on drop.
     pool_state: Option<PooledState>,
+    /// `Some` once a windowed layer's cache has been told it may drop
+    /// rows behind its window (#61). `None` -- the default, and what
+    /// every constructor produces -- means this cache keeps every
+    /// position it was ever pushed, which is what every store in this
+    /// engine did before.
+    ///
+    /// Armed by the decoder, never by a constructor, because the fact
+    /// that a layer is windowed lives in `ModelConfig` and the decision
+    /// that eviction is *safe for this run* lives in
+    /// `ferrox_models::decoder::kv_window`. See [`Self::arm_window`].
+    window: Option<KvWindow>,
 }
 
 /// Cloning a pool-backed cache detaches the clone from pool accounting
@@ -171,6 +184,11 @@ impl Clone for KvCache {
             positions: self.positions,
             planned_capacity: self.planned_capacity,
             pool_state: None,
+            // Carried, not reset: a clone of a cache that has already
+            // dropped rows is a cache that has already dropped rows,
+            // and pretending otherwise would let the clone's
+            // `positions` be read as a row count again.
+            window: self.window,
         }
     }
 }
@@ -251,6 +269,7 @@ impl KvCache {
             positions: 0,
             planned_capacity: None,
             pool_state: None,
+            window: None,
         }
     }
 
@@ -267,6 +286,7 @@ impl KvCache {
             positions: 0,
             planned_capacity: Some(max_seq_len),
             pool_state: None,
+            window: None,
         }
     }
 
@@ -312,6 +332,7 @@ impl KvCache {
                 block_size,
                 blocks_held: blocks_needed,
             }),
+            window: None,
         })
     }
 
@@ -328,7 +349,11 @@ impl KvCache {
         let elems_per_position = self.n_kv_heads * self.head_dim;
         if let Some(state) = &mut self.pool_state {
             let capacity_positions = self.k.capacity() / elems_per_position;
-            if self.positions == capacity_positions {
+            // ROWS, not positions: this asks whether the buffer is
+            // full, and an evicting cache's buffer is shorter than its
+            // position count. Equal for a cache that never evicts.
+            let rows = self.k.len() / elems_per_position;
+            if rows == capacity_positions {
                 if !state.pool.lock().unwrap().try_acquire(1) {
                     return Err(KvPoolExhausted);
                 }
@@ -383,16 +408,110 @@ impl KvCache {
     /// already pushed during batched verification, and rejection means
     /// removing them so the next real decode step continues from the
     /// last *accepted* position, not the last *attempted* one.
+    /// Rolls the cache back to exactly `new_seq_len` POSITIONS.
+    ///
+    /// A windowed cache can only roll back into rows it still holds. A
+    /// target further back than [`Self::rows`] names a position this
+    /// cache dropped behind its window, and there is no honest thing to
+    /// return for it -- so it stops, rather than silently rolling back
+    /// to the oldest row it happens to have and answering the next
+    /// token out of a history with a hole in it.
+    ///
+    /// Unreachable for a cache that has not been armed by
+    /// [`Self::arm_window`], which is every cache unless
+    /// `FERROX_KV_WINDOW` is on: `rows == positions` there, so the
+    /// second precondition is implied by the first.
     pub fn truncate(&mut self, new_seq_len: usize) {
         assert!(
             new_seq_len <= self.positions,
             "truncate target {new_seq_len} must not exceed current seq_len {}",
             self.positions
         );
+        let rows = self.rows();
+        let dropped = self.positions - new_seq_len;
+        assert!(
+            dropped <= rows,
+            "truncate target {new_seq_len} is {dropped} positions back but only {rows} rows \
+             are resident: this cache evicted behind a {:?} window (#61). Turn off \
+             FERROX_KV_WINDOW for a workload that rolls the KV cache back this far.",
+            self.window.map(|w| w.window())
+        );
         let elems_per_position = self.n_kv_heads * self.head_dim;
-        self.k.truncate(new_seq_len * elems_per_position);
-        self.v.truncate(new_seq_len * elems_per_position);
+        let keep_rows = rows - dropped;
+        self.k.truncate(keep_rows * elems_per_position);
+        self.v.truncate(keep_rows * elems_per_position);
         self.positions = new_seq_len;
+    }
+
+    /// Tells this cache it may drop rows that have fallen behind
+    /// `window` (#61 step 2).
+    ///
+    /// Arming alone drops nothing: [`Self::evict_behind_window`] is what
+    /// drops, and the holder calls it at a point where it knows nothing
+    /// is mid-read. That split is deliberate. `push` is the obvious
+    /// place to evict and it is the wrong one: `Decoder::forward_batch`
+    /// writes a whole prefill batch into the cache and only then reads
+    /// it back, against a row offset it captured BEFORE the writes.
+    /// Evicting inside `push` would move every row out from under that
+    /// offset, and the prompt would be attended over shifted keys. So
+    /// eviction is something the holder asks for, and asking for it too
+    /// rarely only costs memory -- over-retention is always correct,
+    /// under-retention is wrong logits.
+    ///
+    /// Idempotent; a second call with a different window replaces the
+    /// first, and rows already dropped stay dropped.
+    pub fn arm_window(&mut self, window: KvWindow) {
+        self.window = Some(window);
+    }
+
+    /// The window this cache evicts behind, or `None` if it keeps
+    /// everything.
+    pub fn window(&self) -> Option<KvWindow> {
+        self.window
+    }
+
+    /// Drops rows that have fallen behind the armed window, returning
+    /// how many rows went. Zero, always, for an unarmed cache.
+    ///
+    /// The rows dropped are the OLDEST ones, so what remains is still a
+    /// contiguous suffix of the sequence: row `i` of `rows` holds
+    /// absolute position `positions - rows + i`. Every windowed
+    /// attention kernel reads the last `window` rows and nothing else,
+    /// and [`KvWindow::rows_after`] guarantees at least that many
+    /// survive, so the set of rows a kernel reads is byte-for-byte the
+    /// set it would have read with no eviction at all.
+    pub fn evict_behind_window(&mut self) -> usize {
+        let Some(window) = self.window else {
+            return 0;
+        };
+        let elems_per_position = self.n_kv_heads * self.head_dim;
+        if elems_per_position == 0 {
+            return 0;
+        }
+        let rows = self.k.len() / elems_per_position;
+        let keep = window.rows_after(self.positions).min(rows);
+        let drop_rows = rows - keep;
+        if drop_rows == 0 {
+            return 0;
+        }
+        // One `drain` per eviction, not one per token: the whole reason
+        // `KvWindow` carries slack. This moves `keep` rows down, and it
+        // happens once every `slack + 1` positions.
+        let drop_elems = drop_rows * elems_per_position;
+        self.k.drain(..drop_elems);
+        self.v.drain(..drop_elems);
+        // `drain` frees no memory, and the saving this exists for is
+        // memory. A cache that just absorbed a 32k-token prefill holds
+        // 32k rows of capacity behind `window + slack` rows of data
+        // until something hands it back. Only when the excess is large
+        // enough to be worth a realloc-and-copy: shrinking on every
+        // eviction would trade the block drain for a full copy.
+        let want = window.max_rows() * elems_per_position;
+        if self.k.capacity() > want.saturating_mul(2) {
+            self.k.shrink_to(want);
+            self.v.shrink_to(want);
+        }
+        drop_rows
     }
 
     /// Bytes currently resident for this cache's K and V buffers
@@ -410,8 +529,11 @@ impl KvCache {
     pub fn is_within_planned_capacity(&self) -> bool {
         match self.planned_capacity {
             Some(cap) => {
+                // POSITIONS against the plan (the plan was made in
+                // positions), ROWS against the buffer (the buffer holds
+                // rows). Equal unless this cache evicts.
                 self.positions <= cap
-                    && self.k.capacity() >= self.positions * self.n_kv_heads * self.head_dim
+                    && self.k.capacity() >= self.rows() * self.n_kv_heads * self.head_dim
             }
             None => false,
         }
@@ -1750,5 +1872,187 @@ mod tests {
         assert_eq!(cache.positions(), 2);
         assert_eq!(cache.rows(), 2);
         assert_eq!(cache.k.len(), 4, "two positions of two elements each");
+    }
+
+    /// The store's rule must be *the* rule, not a second copy of it.
+    ///
+    /// `KvWindow::rows_after` is what `ferrox_models::kv_budget` prices
+    /// against. If the store drained to anything else the budget would
+    /// be describing a cache that does not exist, which is #33 again.
+    #[test]
+    fn a_windowed_cache_holds_exactly_what_the_rule_says_it_holds() {
+        let window = KvWindow::new(8, 3).expect("positive window");
+        let mut cache = KvCache::new(2, 4);
+        cache.arm_window(window);
+        let step = vec![1.0f32; 8];
+        for p in 1..=200usize {
+            cache.push(&step, &step).expect("unbounded growth");
+            cache.evict_behind_window();
+            assert_eq!(cache.positions(), p);
+            assert_eq!(
+                cache.rows(),
+                window.rows_after(p),
+                "at {p} positions the store and the rule disagree"
+            );
+        }
+    }
+
+    /// The point of the issue: positions keep counting, rows do not.
+    #[test]
+    fn a_windowed_layers_resident_rows_stop_growing() {
+        let window = KvWindow::with_default_slack(16).expect("positive window");
+        let mut cache = KvCache::new(2, 4);
+        cache.arm_window(window);
+        let step = vec![0.5f32; 8];
+        for _ in 0..2000 {
+            cache.push(&step, &step).expect("unbounded growth");
+            cache.evict_behind_window();
+        }
+        assert_eq!(cache.positions(), 2000);
+        assert!(
+            cache.rows() <= window.max_rows(),
+            "{} rows resident after 2000 positions",
+            cache.rows()
+        );
+        // And the bytes really went back, not just the length: `drain`
+        // frees nothing, and memory is the whole point.
+        assert!(
+            cache.allocated_bytes() <= window.max_rows() * 8 * 2 * 4 * 2,
+            "capacity was never handed back: {} bytes",
+            cache.allocated_bytes()
+        );
+    }
+
+    /// **The correctness argument, measured.**
+    ///
+    /// Eviction is only allowed to be token-identical because the rows a
+    /// windowed kernel reads -- the last `window` of them -- are the
+    /// same bytes whether or not anything behind them was dropped. This
+    /// pushes distinguishable rows into an evicting cache and a plain
+    /// one and compares exactly that slice.
+    #[test]
+    fn the_rows_a_windowed_kernel_reads_are_identical_with_and_without_eviction() {
+        let window = KvWindow::new(6, 2).expect("positive window");
+        let (n_kv_heads, head_dim) = (2usize, 4usize);
+        let per = n_kv_heads * head_dim;
+        let mut evicting = KvCache::new(n_kv_heads, head_dim);
+        evicting.arm_window(window);
+        let mut plain = KvCache::new(n_kv_heads, head_dim);
+
+        for p in 0..120usize {
+            // A row nothing else could produce, so a misplaced row is
+            // not merely a different number but an identifiable one.
+            let k: Vec<f32> = (0..per).map(|i| (p * 100 + i) as f32).collect();
+            let v: Vec<f32> = k.iter().map(|x| -x).collect();
+            evicting.push(&k, &v).expect("unbounded growth");
+            evicting.evict_behind_window();
+            plain.push(&k, &v).expect("unbounded growth");
+
+            let read = window.window().min(p + 1);
+            let e_start = (evicting.rows() - read) * per;
+            let p_start = (plain.rows() - read) * per;
+            assert_eq!(
+                &evicting.k[e_start..],
+                &plain.k[p_start..],
+                "K read set diverged at position {p}"
+            );
+            assert_eq!(
+                &evicting.v[e_start..],
+                &plain.v[p_start..],
+                "V read set diverged at position {p}"
+            );
+            assert_eq!(evicting.positions(), plain.positions());
+        }
+    }
+
+    /// An unarmed cache is the cache this engine has always had.
+    #[test]
+    fn an_unarmed_cache_never_drops_a_row() {
+        let mut cache = KvCache::new(2, 4);
+        let step = vec![1.0f32; 8];
+        for _ in 0..64 {
+            cache.push(&step, &step).expect("unbounded growth");
+            assert_eq!(cache.evict_behind_window(), 0);
+        }
+        assert_eq!(cache.rows(), 64);
+        assert_eq!(cache.positions(), 64);
+        assert!(cache.window().is_none());
+    }
+
+    /// Speculative decoding rolls the cache back by the number of
+    /// rejected draft tokens. That is representable while the target is
+    /// still resident.
+    #[test]
+    fn truncate_still_works_inside_the_resident_window() {
+        let window = KvWindow::new(8, 3).expect("positive window");
+        let mut cache = KvCache::new(1, 2);
+        cache.arm_window(window);
+        let step = vec![1.0f32; 2];
+        for _ in 0..50 {
+            cache.push(&step, &step).expect("unbounded growth");
+            cache.evict_behind_window();
+        }
+        let rows_before = cache.rows();
+        cache.truncate(46);
+        assert_eq!(cache.positions(), 46);
+        assert_eq!(cache.rows(), rows_before - 4);
+    }
+
+    /// ...and stops, loudly, when it is not. A cache that rolled back to
+    /// the oldest row it happened to have would answer the next token
+    /// out of a history with a hole in it.
+    #[test]
+    #[should_panic(expected = "rows are resident")]
+    fn truncate_refuses_to_roll_back_past_what_the_window_kept() {
+        let window = KvWindow::new(4, 1).expect("positive window");
+        let mut cache = KvCache::new(1, 2);
+        cache.arm_window(window);
+        let step = vec![1.0f32; 2];
+        for _ in 0..50 {
+            cache.push(&step, &step).expect("unbounded growth");
+            cache.evict_behind_window();
+        }
+        cache.truncate(3);
+    }
+
+    /// A clone of an evicting cache is still an evicting cache. Reset
+    /// the window on clone and `positions` becomes a row count again in
+    /// whatever reads the clone.
+    #[test]
+    fn a_clone_carries_the_window() {
+        let window = KvWindow::new(4, 1).expect("positive window");
+        let mut cache = KvCache::new(1, 2);
+        cache.arm_window(window);
+        let step = vec![1.0f32; 2];
+        for _ in 0..20 {
+            cache.push(&step, &step).expect("unbounded growth");
+            cache.evict_behind_window();
+        }
+        let copy = cache.clone();
+        assert_eq!(copy.window(), Some(window));
+        assert_eq!(copy.rows(), cache.rows());
+        assert_eq!(copy.positions(), cache.positions());
+    }
+
+    /// A pool-backed cache grows when its BUFFER is full, not when its
+    /// position counter reaches the buffer's size. Those are the same
+    /// number until something evicts, and an evicting pooled cache keyed
+    /// on positions would acquire a block per token forever and exhaust
+    /// the pool.
+    #[test]
+    fn a_pooled_windowed_cache_stops_acquiring_blocks() {
+        let pool = Arc::new(Mutex::new(KvBlockPool::new(4, 8)));
+        let mut cache =
+            KvCache::with_pool(1, 2, Arc::clone(&pool), 8).expect("the pool was sized for this");
+        cache.arm_window(KvWindow::new(4, 1).expect("positive window"));
+        let step = vec![1.0f32; 2];
+        for _ in 0..64 {
+            cache
+                .push(&step, &step)
+                .expect("the buffer never fills again");
+            cache.evict_behind_window();
+        }
+        assert_eq!(cache.positions(), 64);
+        assert!(cache.rows() <= 5);
     }
 }

--- a/crates/ferrox-core/src/kv_swa.rs
+++ b/crates/ferrox-core/src/kv_swa.rs
@@ -165,6 +165,90 @@ impl BlockLayout {
     }
 }
 
+/// How many rows a *contiguous* windowed KV cache keeps resident, and
+/// when it drops the ones behind the window.
+///
+/// [`BlockLayout`] above is the same question for the block/paged tier,
+/// where the eviction unit is a block. This is the answer for
+/// `ferrox_core::cache::KvCache`, where the eviction unit is a row and
+/// the only thing stopping a per-token drain is arithmetic.
+///
+/// # Why there is slack
+///
+/// Dropping exactly one row per push moves every remaining row down by
+/// one every single token: `window * n_kv_heads * head_dim` floats per
+/// layer per token, about a megabyte per token per layer on Gemma-3-4B.
+/// So the cache is allowed to run `slack` rows past the window and then
+/// drops `slack + 1` at once, which amortises the move to roughly
+/// `window / (slack + 1)` rows per token.
+///
+/// # Why this is a type and not two lines in `push`
+///
+/// The store keeps these rows and the budget
+/// (`ferrox_models::kv_budget`) has to price exactly what the store
+/// keeps. #33 is the record of what happens when those two are separate
+/// statements of the same rule: the budget capped a sliding layer that
+/// no store ever capped, `-c auto` approved a context that did not fit,
+/// and the failure arrived as an OOM. [`KvWindow::rows_after`] is the
+/// single rule; the store calls it to decide and the budget calls it to
+/// price, so there is nothing left for them to disagree about.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KvWindow {
+    window: usize,
+    slack: usize,
+}
+
+impl KvWindow {
+    /// `None` for a zero window, for [`BlockLayoutError::ZeroWindow`]'s
+    /// reason: a query that attends to nothing is not a model.
+    pub fn new(window: usize, slack: usize) -> Option<Self> {
+        (window > 0).then_some(KvWindow { window, slack })
+    }
+
+    /// The slack a caller gets when it has no opinion: half a window,
+    /// so the cache peaks at 1.5x the window and moves roughly two rows
+    /// per token instead of `window` of them.
+    pub fn with_default_slack(window: usize) -> Option<Self> {
+        Self::new(window, (window / 2).max(1))
+    }
+
+    pub fn window(&self) -> usize {
+        self.window
+    }
+
+    pub fn slack(&self) -> usize {
+        self.slack
+    }
+
+    /// The most rows this window ever leaves resident.
+    pub fn max_rows(&self) -> usize {
+        self.window + self.slack
+    }
+
+    /// **The rule.** Rows resident once the sequence has consumed
+    /// `positions` positions and the holder has evicted at every step.
+    ///
+    /// Grows one per position up to `window + slack`, then drops back to
+    /// `window` and climbs again, so the resident count cycles through
+    /// `[window, window + slack]` with period `slack + 1`.
+    ///
+    /// The invariant every reader depends on is
+    /// `rows_after(p) >= min(p, window)`: the rows kept are always at
+    /// least the last `window` positions, which is exactly the set a
+    /// windowed attention kernel reads. Everything above that is slack
+    /// the kernel skips, so evicting can only ever change *where* a row
+    /// sits, never *whether* it is read. That is why turning eviction on
+    /// is token-identical rather than approximately so, and it is
+    /// asserted in this module's tests rather than argued here.
+    pub fn rows_after(&self, positions: usize) -> usize {
+        let peak = self.window + self.slack;
+        if positions <= peak {
+            return positions;
+        }
+        self.window + (positions - peak - 1) % (self.slack + 1)
+    }
+}
+
 /// The largest block size no greater than `desired` that satisfies the
 /// rule for `window`.
 ///
@@ -302,5 +386,94 @@ mod tests {
     fn no_window_leaves_the_desired_size_alone() {
         assert_eq!(aligned_block_size(48, None), 48);
         assert_eq!(aligned_block_size(0, None), 1);
+    }
+
+    /// A window of zero would mean a query attends to nothing.
+    #[test]
+    fn a_zero_window_is_not_a_window() {
+        assert!(KvWindow::new(0, 4).is_none());
+        assert!(KvWindow::with_default_slack(0).is_none());
+        assert!(KvWindow::new(1, 0).is_some());
+    }
+
+    /// The closed form must agree with the loop it stands for.
+    ///
+    /// `rows_after` is a formula and the store is a loop that pushes one
+    /// row and drops back to the formula's answer. Two statements of one
+    /// rule is this repo's dominant bug shape, so the formula is checked
+    /// against a simulation of the loop rather than against hand-written
+    /// numbers that were themselves derived from the formula.
+    #[test]
+    fn the_closed_form_matches_a_step_by_step_simulation() {
+        for window in 1..=9usize {
+            for slack in 0..=7usize {
+                let w = KvWindow::new(window, slack).expect("positive window");
+                let mut rows = 0usize;
+                for positions in 1..=200usize {
+                    // What the store does: append one row, then drop
+                    // back to whatever the rule allows.
+                    rows += 1;
+                    rows = rows.min(w.rows_after(positions));
+                    assert_eq!(
+                        rows,
+                        w.rows_after(positions),
+                        "window {window} slack {slack} at {positions} positions"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The property attention depends on, and the only reason evicting
+    /// is allowed to be token-identical: whatever else it drops, a
+    /// windowed cache still holds the last `min(positions, window)`
+    /// positions.
+    #[test]
+    fn the_last_window_positions_are_always_still_resident() {
+        for window in 1..=9usize {
+            for slack in 0..=7usize {
+                let w = KvWindow::new(window, slack).expect("positive window");
+                for positions in 0..=200usize {
+                    let rows = w.rows_after(positions);
+                    assert!(
+                        rows >= positions.min(window),
+                        "window {window} slack {slack} at {positions}: kept {rows} rows, \
+                         which is fewer than the {} the kernel reads",
+                        positions.min(window)
+                    );
+                    assert!(rows <= positions, "cannot keep rows that were never pushed");
+                    assert!(rows <= w.max_rows(), "resident rows must stay bounded");
+                }
+            }
+        }
+    }
+
+    /// The point of the whole exercise: resident rows STOP GROWING.
+    #[test]
+    fn a_windowed_layer_stops_growing_while_positions_do_not() {
+        let w = KvWindow::with_default_slack(1024).expect("positive window");
+        assert_eq!(w.rows_after(512), 512);
+        assert!(w.rows_after(32_768) <= w.max_rows());
+        assert_eq!(w.max_rows(), 1024 + 512);
+        // 21x fewer rows than positions at a 32k context.
+        assert!(w.rows_after(32_768) * 20 < 32_768);
+    }
+
+    /// Slack is what makes the drain a block move instead of a per-token
+    /// one: with `slack` rows of headroom the cache only actually drops
+    /// rows once every `slack + 1` positions.
+    #[test]
+    fn rows_are_dropped_once_per_slack_plus_one_positions() {
+        let w = KvWindow::new(8, 3).expect("positive window");
+        let drops = (1..=400usize)
+            .filter(|p| w.rows_after(*p) < w.rows_after(p - 1) + 1)
+            .count();
+        // The first drop is at position 12 (the first that would take
+        // the cache past `window + slack` = 11), then one every
+        // `slack + 1` = 4 positions.
+        assert_eq!(drops, (400 - 12) / 4 + 1);
+        // The same statement the other way round: 400 positions cost 98
+        // block moves, not 400 per-token ones.
+        assert!(drops * 4 <= 400);
     }
 }

--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -14,6 +14,7 @@
 
 mod attn_block;
 mod ffn_act;
+pub mod kv_window;
 mod lm_head;
 mod qk_norm;
 mod rope;
@@ -26,6 +27,7 @@ use ferrox_core::attention::{
 };
 use ferrox_core::cache::{KvCache, PagedKvCache, PagedStoreExhausted, SharedPagedKv};
 use ferrox_core::matmul::rms_norm;
+pub use kv_window::{KvWindowPolicy, KV_WINDOW_ENV};
 #[cfg(feature = "metal")]
 use lm_head::FoldedLmHead;
 use lm_head::Logits;
@@ -427,6 +429,12 @@ pub struct Decoder {
     /// policy). Built once; hot path must not re-resolve architecture
     /// strings. See [`crate::execution_plan`].
     pub execution_plan: crate::execution_plan::ExecutionPlan,
+    /// May a windowed layer's host [`KvCache`] drop rows that have
+    /// fallen behind its window? Off unless `FERROX_KV_WINDOW` says
+    /// otherwise; see [`kv_window`] for what else turns it off. A field
+    /// rather than a cached global so a test can run both arms in one
+    /// process and compare tokens.
+    pub kv_window: KvWindowPolicy,
     /// Cache key hit → fused caps last used for that geometry (enables
     /// decode/prefill plan reuse without rebuilding residency).
     pub plan_cache: std::sync::Mutex<
@@ -681,6 +689,7 @@ impl Decoder {
             #[cfg(feature = "metal")]
             metal_attn_kv: std::sync::Mutex::new(None),
             execution_plan,
+            kv_window: KvWindowPolicy::from_env(),
             plan_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
         }
     }
@@ -4225,6 +4234,21 @@ impl Decoder {
                     window,
                 )
             };
+
+            // Every query in this batch has now been answered, so the
+            // rows behind the window are rows nothing will read again
+            // (#61). This is why eviction is not inside `KvCache::push`:
+            // `base_seq_len` above was captured BEFORE the batch's
+            // pushes and every query's KV length is derived from it, so
+            // a drop between the push loop and here would attend the
+            // whole prompt over shifted keys.
+            //
+            // Per layer rather than after the stack, and that is where
+            // most of the prefill saving is: a windowed layer hands its
+            // prompt rows back before the next layer allocates its own,
+            // so a 32k prompt holds ONE layer's full history at a time
+            // instead of every windowed layer's at once.
+            self.evict_layer_kv(l, cache);
 
             let mut projected_batch = layer.attn.o_proj.apply_batch(&attn_out_batch, batch_size);
             if let Some(oai) = oai {

--- a/crates/ferrox-models/src/decoder/attn_block.rs
+++ b/crates/ferrox-models/src/decoder/attn_block.rs
@@ -185,8 +185,8 @@ impl Decoder {
                 cache
                     .push(k, v)
                     .expect("unbounded/planned KvCache growth is infallible");
-                if let Some(oai) = oai {
-                    return ferrox_core::causal_gqa_attention_sinks(
+                let out = if let Some(oai) = oai {
+                    ferrox_core::causal_gqa_attention_sinks(
                         q,
                         &cache.k,
                         &cache.v,
@@ -196,41 +196,51 @@ impl Decoder {
                         cache.rows(),
                         window,
                         &oai.attn_sinks,
-                    );
-                }
-                match (window, cuda_resident_layer) {
-                    (Some(window), _) => causal_gqa_attention_windowed_softcap(
-                        q,
-                        &cache.k,
-                        &cache.v,
-                        n_heads,
-                        n_kv_heads,
-                        head_dim,
-                        cache.rows(),
-                        window,
-                        self.config.attn_logit_softcap,
-                    ),
-                    (None, Some(l)) => self.gqa_attention(
-                        l,
-                        q,
-                        &cache.k,
-                        &cache.v,
-                        n_heads,
-                        n_kv_heads,
-                        head_dim,
-                        cache.rows(),
-                    ),
-                    (None, None) => causal_gqa_attention_softcap(
-                        q,
-                        &cache.k,
-                        &cache.v,
-                        n_heads,
-                        n_kv_heads,
-                        head_dim,
-                        cache.rows(),
-                        self.config.attn_logit_softcap,
-                    ),
-                }
+                    )
+                } else {
+                    match (window, cuda_resident_layer) {
+                        (Some(window), _) => causal_gqa_attention_windowed_softcap(
+                            q,
+                            &cache.k,
+                            &cache.v,
+                            n_heads,
+                            n_kv_heads,
+                            head_dim,
+                            cache.rows(),
+                            window,
+                            self.config.attn_logit_softcap,
+                        ),
+                        (None, Some(l)) => self.gqa_attention(
+                            l,
+                            q,
+                            &cache.k,
+                            &cache.v,
+                            n_heads,
+                            n_kv_heads,
+                            head_dim,
+                            cache.rows(),
+                        ),
+                        (None, None) => causal_gqa_attention_softcap(
+                            q,
+                            &cache.k,
+                            &cache.v,
+                            n_heads,
+                            n_kv_heads,
+                            head_dim,
+                            cache.rows(),
+                            self.config.attn_logit_softcap,
+                        ),
+                    }
+                };
+                // AFTER the read, never inside `push`: the rows this
+                // drops are rows every kernel above has finished with
+                // (#61). A no-op unless `FERROX_KV_WINDOW` is on and
+                // this layer is windowed -- and note that it is the same
+                // `window` the kernels just used, taken from the same
+                // `ModelConfig`, because keeping fewer rows than the
+                // kernel reads would answer out of a truncated history.
+                self.evict_layer_kv(layer_idx, cache);
+                out
             }
             KvStep::Paged { cache, stores } => {
                 // Write guard for the push alone, then a read guard for

--- a/crates/ferrox-models/src/decoder/kv_window.rs
+++ b/crates/ferrox-models/src/decoder/kv_window.rs
@@ -1,0 +1,183 @@
+//! Whether a windowed layer's host KV cache may drop rows behind its
+//! window, and which window it drops behind.
+//!
+//! [`ferrox_core::kv_swa::KvWindow`] is the arithmetic -- how many rows
+//! survive N positions. This module is the *decision*: which layers get
+//! one at all, and whether this particular run is one where dropping a
+//! row is safe. Those are different questions with different owners, and
+//! keeping them apart is what stops the budget from pricing a saving the
+//! store did not take (#33) or the store from taking one the budget did
+//! not price.
+//!
+//! # Off by default
+//!
+//! `FERROX_KV_WINDOW=1` turns it on, and nothing else does. The switch
+//! exists in the shape `FERROX_CPU_POOL` established: one env var, so
+//! the before and the after are one word apart and reverting costs
+//! nothing.
+//!
+//! # What the switch refuses to do
+//!
+//! Eviction is the contiguous host store on the CPU path, and only that
+//! (#61 steps 3 and 4 are the GPU stores and the paged one). Two things
+//! it therefore turns itself off for:
+//!
+//! - **Metal attention.** `Decoder`'s Metal arms compare
+//!   `MetalKvBuffers::seq_len` against the host cache's `rows()` and its
+//!   `positions()` in five places, and take the two as interchangeable.
+//!   They are, until a host cache evicts. So a run with
+//!   `FERROX_METAL_ATTN` on does not evict, and says so here rather than
+//!   in five separate conditions that would drift apart.
+//! - **Full-attention layers**, obviously, and that is the interesting
+//!   half of the saving rather than a caveat: an alternating-SWA model
+//!   keeps every position in its dense layers no matter what this
+//!   switch says. The Gemma-3 figure in #61 is a per-layer number, not
+//!   a whole-model one.
+//!
+//! CUDA needs no exclusion: the resident-KV decode hook in
+//! `Decoder::gqa_attention` is reachable only from the `window == None`
+//! arm of `push_and_attend_row`, so it never sees a cache that evicts.
+
+use ferrox_core::cache::KvCache;
+use ferrox_core::kv_swa::KvWindow;
+
+use super::Decoder;
+
+/// Whether this run may evict, decided once at load time.
+///
+/// A `Copy` value on the `Decoder` rather than a cached global, so a
+/// test can build a decoder that evicts and one that does not in the
+/// same process and compare their tokens. A global read once per
+/// process would need a subprocess per arm to say the same thing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvWindowPolicy {
+    enabled: bool,
+}
+
+/// The one spelling of the switch.
+pub const KV_WINDOW_ENV: &str = "FERROX_KV_WINDOW";
+
+impl KvWindowPolicy {
+    /// Never evicts. What every cache in this engine did before #61, and
+    /// what a run gets unless [`KV_WINDOW_ENV`] says otherwise.
+    pub const fn off() -> Self {
+        KvWindowPolicy { enabled: false }
+    }
+
+    /// Always evicts, where the layer has a window. For tests and for a
+    /// caller that has already made the decision itself.
+    pub const fn on() -> Self {
+        KvWindowPolicy { enabled: true }
+    }
+
+    /// Reads [`KV_WINDOW_ENV`], then subtracts the runs that must not
+    /// evict. See the module doc for which and why.
+    pub fn from_env() -> Self {
+        let on = matches!(
+            std::env::var(KV_WINDOW_ENV).ok().as_deref(),
+            Some("1") | Some("on") | Some("true") | Some("yes")
+        );
+        #[cfg(feature = "metal")]
+        let on = on && !ferrox_metal::attn::metal_attn_enabled();
+        KvWindowPolicy { enabled: on }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// The window a layer's cache evicts behind, given the window that
+    /// layer's attention actually reads.
+    ///
+    /// **These two must be the same number.** The kernel reads the last
+    /// `window` rows; keeping fewer answers out of a truncated history,
+    /// and this is the only place that says so, so there is nowhere for
+    /// a second opinion to live.
+    pub fn window_for(&self, attention_window: Option<usize>) -> Option<KvWindow> {
+        if !self.enabled {
+            return None;
+        }
+        KvWindow::with_default_slack(attention_window?)
+    }
+}
+
+impl Default for KvWindowPolicy {
+    fn default() -> Self {
+        Self::off()
+    }
+}
+
+impl Decoder {
+    /// The window layer `layer_idx`'s host cache may evict behind, or
+    /// `None` when it must keep everything.
+    ///
+    /// One predicate, shared by the decode path, the prefill path and
+    /// `kv_budget`'s residency, because four spellings of one
+    /// eligibility check is exactly how the GPU-router gate drifted four
+    /// ways.
+    pub fn kv_window_for_layer(&self, layer_idx: usize) -> Option<KvWindow> {
+        self.kv_window
+            .window_for(self.config.layer_sliding_window(layer_idx))
+    }
+
+    /// Arms `cache` for layer `layer_idx` if this run evicts, then drops
+    /// whatever has fallen behind the window. A no-op otherwise.
+    ///
+    /// Called after the layer's attention has been computed, never
+    /// before: the rows this drops are rows the kernel has finished
+    /// with, and `forward_batch` reads a whole prefill batch back
+    /// against an offset captured before its pushes.
+    pub(crate) fn evict_layer_kv(&self, layer_idx: usize, cache: &mut KvCache) {
+        let Some(window) = self.kv_window_for_layer(layer_idx) else {
+            return;
+        };
+        if cache.window() != Some(window) {
+            cache.arm_window(window);
+        }
+        cache.evict_behind_window();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The switch is off unless it is on, and "off" means no window for
+    /// any layer however windowed the model is.
+    #[test]
+    fn the_default_policy_evicts_nothing() {
+        let off = KvWindowPolicy::off();
+        assert!(!off.enabled());
+        assert_eq!(off.window_for(Some(1024)), None);
+        assert_eq!(KvWindowPolicy::default(), off);
+    }
+
+    /// The eviction window IS the attention window. A policy that
+    /// narrowed it to save more memory would be answering out of a
+    /// shorter history than the model asks for, which is a different
+    /// model.
+    #[test]
+    fn the_eviction_window_equals_the_window_attention_reads() {
+        let on = KvWindowPolicy::on();
+        let w = on.window_for(Some(1024)).expect("a windowed layer");
+        assert_eq!(w.window(), 1024);
+        // Slack is headroom above the window, never below it.
+        assert!(w.max_rows() >= 1024);
+    }
+
+    /// A full-attention layer has no window to evict behind, switch on
+    /// or off. This is the half of an alternating-SWA model that keeps
+    /// costing what it always did.
+    #[test]
+    fn a_full_attention_layer_never_evicts() {
+        assert_eq!(KvWindowPolicy::on().window_for(None), None);
+        assert_eq!(KvWindowPolicy::off().window_for(None), None);
+    }
+
+    /// A zero window is not a window; it must not become one here by
+    /// arithmetic.
+    #[test]
+    fn a_zero_window_does_not_become_an_evicting_window() {
+        assert_eq!(KvWindowPolicy::on().window_for(Some(0)), None);
+    }
+}

--- a/crates/ferrox-models/src/decoder/kv_window.rs
+++ b/crates/ferrox-models/src/decoder/kv_window.rs
@@ -99,6 +99,21 @@ impl KvWindowPolicy {
         }
         KvWindow::with_default_slack(attention_window?)
     }
+
+    /// The window layer `layer_idx` of `config` evicts behind.
+    ///
+    /// The ONE expression that answers it, for the decoder
+    /// (`Decoder::kv_window_for_layer`) and for the budget
+    /// (`crate::kv_budget::KvResidency::from_config`) alike. Those two
+    /// have to agree about which layers keep how much or the budget is
+    /// pricing a cache that does not exist, which is #33.
+    pub fn layer_window(
+        &self,
+        config: &crate::config::ModelConfig,
+        layer_idx: usize,
+    ) -> Option<KvWindow> {
+        self.window_for(config.layer_sliding_window(layer_idx))
+    }
 }
 
 impl Default for KvWindowPolicy {
@@ -116,8 +131,7 @@ impl Decoder {
     /// eligibility check is exactly how the GPU-router gate drifted four
     /// ways.
     pub fn kv_window_for_layer(&self, layer_idx: usize) -> Option<KvWindow> {
-        self.kv_window
-            .window_for(self.config.layer_sliding_window(layer_idx))
+        self.kv_window.layer_window(&self.config, layer_idx)
     }
 
     /// Arms `cache` for layer `layer_idx` if this run evicts, then drops

--- a/crates/ferrox-models/src/draft_model.rs
+++ b/crates/ferrox-models/src/draft_model.rs
@@ -134,14 +134,22 @@ impl DraftModelSpeculator {
 
     /// Fails when the two checkpoints cannot be compared token for
     /// token. See [`VocabMismatch`].
+    /// `decoder` is taken by value and has its KV-window policy turned
+    /// OFF (#61). [`Self::sync`] rolls the draft cache back to an
+    /// arbitrary committed length -- potentially the whole history,
+    /// after a long run of rejections -- and a windowed cache cannot
+    /// represent a rollback past the rows it kept. The drafter is a
+    /// small model whose KV is a small fraction of the target's, so
+    /// this gives up almost none of the saving.
     pub fn new(
-        decoder: Decoder,
+        mut decoder: Decoder,
         target_config: &ModelConfig,
         sampling: SamplingParams,
         seed: u64,
         max_draft: usize,
         min_prob: f32,
     ) -> Result<Self, VocabMismatch> {
+        decoder.kv_window = crate::decoder::KvWindowPolicy::off();
         let draft_vocab = decoder.config.vocab_size;
         let target_vocab = target_config.vocab_size;
         if draft_vocab != target_vocab {

--- a/crates/ferrox-models/src/kv_budget.rs
+++ b/crates/ferrox-models/src/kv_budget.rs
@@ -989,11 +989,18 @@ mod tests {
         let residency = KvResidency::from_config(&cfg, KvWindowPolicy::on());
         let resting = shape.resident_kv_bytes_for_tokens(tokens, &residency);
         let peak = shape.peak_kv_bytes_for_tokens(tokens, &residency);
-        // Six of the 34 layers are full attention and still hold every
-        // position; they are most of what is left.
-        assert!(resting * 4 < full, "resting {resting} vs full {full}");
-        assert!(peak < full);
-        assert!(peak > resting);
+        // Pinned rather than bounded, so a change to the default slack
+        // shows up as a memory number moving rather than as nothing.
+        // 5 of the 34 layers are full attention (`swa_pattern` 6) and
+        // still hold every position; at 1.34 GB they are most of what is
+        // left. The 29 windowed ones hold 1475 rows each instead of
+        // 32768.
+        assert_eq!(resting, 1_692_590_080, "5.4x less than the 9.13 GB above");
+        assert_eq!(
+            peak, 1_948_942_336,
+            "resting plus the one windowed layer still mid-prefill"
+        );
+        assert!(peak < full && peak > resting);
     }
 
     /// The pool-backed store is the other thing a server allocates, and

--- a/crates/ferrox-models/src/kv_budget.rs
+++ b/crates/ferrox-models/src/kv_budget.rs
@@ -65,13 +65,34 @@
 //! admitted and then arrives as an OOM instead of the refusal this
 //! engine exists to give.
 //!
-//! There is deliberately no window field left to fill in. Making a
-//! store actually evict is real work and is tracked as #61 (per-layer
-//! page groups, and eviction inside the prompt region); when one does,
-//! the number it keeps belongs to the STORE, and this module should take
-//! it from there rather than restate a rule the store does not follow.
+//! # ...unless the store evicts, which it now can
+//!
+//! #61 step 2 taught the contiguous `KvCache` to drop rows behind a
+//! layer's sliding window, behind `FERROX_KV_WINDOW`. So the paragraph
+//! above is still the default and no longer the only case, and the
+//! difference is expressed the way #33 said it had to be: **the number
+//! the store keeps belongs to the store.** [`KvResidency`] carries the
+//! per-layer windows, [`KvShape::resident_kv_bytes_for_tokens`] prices
+//! them through `ferrox_core::kv_swa::KvWindow::rows_after`, and
+//! `KvCache::evict_behind_window` calls the same function to decide what
+//! to drop. There is no second statement of the rule here to drift.
+//!
+//! Two numbers, not one, and admission wants the larger:
+//! [`KvShape::peak_kv_bytes_for_tokens`] adds the one layer that is
+//! still mid-prefill and holding the whole prompt, because
+//! `Decoder::forward_batch` evicts per layer rather than after the
+//! stack. `resident_` is what a measurement of the caches finds at rest;
+//! `peak_` is what the machine has to survive.
+//!
+//! What is NOT priced here, because no store does it yet: eviction
+//! inside the paged store (#61 step 4) and eviction of the prompt region
+//! while the prompt is still being written (#61 step 5). Both stay at
+//! the full every-layer-every-position number.
+
+use ferrox_core::kv_swa::KvWindow;
 
 use crate::config::ModelConfig;
+use crate::decoder::KvWindowPolicy;
 
 /// Element width of one cached K/V scalar, per backend store.
 ///
@@ -246,11 +267,16 @@ impl KvLayout {
 
 /// The KV shape of a whole model: enough to price any context length.
 ///
-/// Every layer keeps every position. That is a statement about the
-/// STORES this engine allocates, not about the architectures it runs --
-/// see the module doc's "Why a sliding window is not a saving here", and
-/// the test that measures a real `ferrox_core::cache::KvCache` rather
-/// than restating this multiplication.
+/// How big one position is, times how many layers. How many positions
+/// each of those layers still HOLDS is [`KvResidency`], and it is a
+/// separate value because it is a property of the run rather than of
+/// the model: by default every layer keeps every position, and behind
+/// `FERROX_KV_WINDOW` a windowed layer does not (#61).
+///
+/// That is a statement about the STORES this engine allocates, not
+/// about the architectures it runs -- see the module doc, and the two
+/// tests that measure real `ferrox_core::cache::KvCache`s rather than
+/// restating this multiplication.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KvShape {
     pub n_layers: usize,
@@ -262,9 +288,13 @@ impl KvShape {
     /// Reads the shape off a config.
     ///
     /// `config.sliding_window` / `config.swa_pattern` are deliberately
-    /// NOT read: they describe what attention *reads*, and this module
-    /// prices what the store *keeps*. Nothing here evicts (#33), so a
-    /// windowed layer costs exactly what a full-attention one does.
+    /// NOT read HERE: they describe what attention *reads*, and this
+    /// module prices what the store *keeps*. The default store keeps
+    /// everything (#33), so a windowed layer costs exactly what a
+    /// full-attention one does. When a run evicts, that is what
+    /// [`KvResidency::from_config`] is for -- and it reaches the window
+    /// through the same `KvWindowPolicy` the decoder evicts with, not by
+    /// reading those two fields a second time.
     ///
     /// Always produces a [`KvLayout::Gqa`] layout, because
     /// `ModelConfig` describes the generic GQA decoder -- the MLA
@@ -328,6 +358,55 @@ impl KvShape {
             .saturating_mul(self.elem.bytes_for(per_layer.saturating_mul(tokens as u64)))
     }
 
+    /// Bytes one request's KV costs at `tokens` of context when the
+    /// stores EVICT behind a window (#61 step 2), once every layer has
+    /// been through -- the number a measurement of the caches finds.
+    ///
+    /// The row counts come from [`KvWindow::rows_after`], which is the
+    /// store's own rule and not a restatement of it: `KvCache` calls the
+    /// same function to decide what to drop. Equal to
+    /// [`Self::kv_bytes_for_tokens`] when `residency` keeps everything,
+    /// which is what the default policy produces and what a test below
+    /// asserts rather than assumes.
+    ///
+    /// [`Self::peak_kv_bytes_for_tokens`] is the number to ADMIT on;
+    /// this one is smaller, and the difference is prefill.
+    pub fn resident_kv_bytes_for_tokens(&self, tokens: usize, residency: &KvResidency) -> u64 {
+        let per_layer = self.layout.elems_per_token_per_layer();
+        residency
+            .rows_per_layer(self.n_layers, tokens)
+            .map(|rows| self.elem.bytes_for(per_layer.saturating_mul(rows as u64)))
+            .fold(0u64, |acc, b| acc.saturating_add(b))
+    }
+
+    /// The number an admission decision must use: the resting cost, plus
+    /// the one layer that is still mid-prefill.
+    ///
+    /// `Decoder::forward_batch` writes a whole prompt into layer `l`'s
+    /// cache, attends over it, and only then hands the rows behind the
+    /// window back -- before layer `l + 1` allocates any. So a long
+    /// prompt costs ONE windowed layer's full history at a time rather
+    /// than every windowed layer's at once, and that transient is real
+    /// memory that has to be budgeted for. Charging only the resting
+    /// number would be #33 in the other direction: an admitted request
+    /// whose peak exceeds the estimate arrives as an OOM.
+    ///
+    /// The extra term is the largest single windowed layer's shortfall,
+    /// because layers are prefilled one at a time.
+    pub fn peak_kv_bytes_for_tokens(&self, tokens: usize, residency: &KvResidency) -> u64 {
+        let per_layer = self.layout.elems_per_token_per_layer();
+        let full = self.elem.bytes_for(per_layer.saturating_mul(tokens as u64));
+        let transient = residency
+            .rows_per_layer(self.n_layers, tokens)
+            .map(|rows| {
+                full.saturating_sub(self.elem.bytes_for(per_layer.saturating_mul(rows as u64)))
+            })
+            .max()
+            .unwrap_or(0);
+        self.resident_kv_bytes_for_tokens(tokens, residency)
+            .saturating_add(transient)
+    }
+
     /// The sentence a user should be able to read and reproduce with a
     /// calculator.
     pub fn describe(&self) -> String {
@@ -338,6 +417,77 @@ impl KvShape {
             self.elem.as_str(),
             self.per_token_kv_bytes()
         )
+    }
+}
+
+/// What the stores really keep, per layer.
+///
+/// [`KvShape`] answers "how big is one position, times how many layers".
+/// This answers "how many positions does each of those layers still
+/// hold", which used to be "all of them" for every layer of every model
+/// and now depends on whether `FERROX_KV_WINDOW` is on (#61).
+///
+/// **Deliberately not a field on `KvShape`.** `KvShape` is `Copy`, is
+/// built by struct literal in more than one crate, and is the thing
+/// every existing caller already has; a new field there would make the
+/// no-eviction default a thing every caller restates. A residency is
+/// asked for by the callers that price an evicting run, and the ones
+/// that do not keep the number they always had.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvResidency {
+    /// One entry per layer, in layer order. `None` means that layer
+    /// keeps every position it was ever given.
+    per_layer: Vec<Option<KvWindow>>,
+}
+
+impl KvResidency {
+    /// Every layer keeps every position: the engine before #61, and the
+    /// engine today unless the switch is on.
+    pub fn keeps_everything(n_layers: usize) -> Self {
+        KvResidency {
+            per_layer: vec![None; n_layers],
+        }
+    }
+
+    /// What `policy` will make the stores of `config` keep.
+    ///
+    /// Goes through [`KvWindowPolicy::layer_window`], which is the same
+    /// call `Decoder::kv_window_for_layer` makes to decide what to
+    /// evict. One expression, so there is nothing for the budget and the
+    /// store to disagree about -- the disagreement being #33, where the
+    /// budget capped a sliding layer no store ever capped and `-c auto`
+    /// approved a context that did not fit.
+    pub fn from_config(config: &ModelConfig, policy: KvWindowPolicy) -> Self {
+        KvResidency {
+            per_layer: (0..config.n_layers)
+                .map(|l| policy.layer_window(config, l))
+                .collect(),
+        }
+    }
+
+    /// True when no layer evicts, i.e. this prices exactly what
+    /// [`KvShape::kv_bytes_for_tokens`] prices.
+    pub fn keeps_every_position(&self) -> bool {
+        self.per_layer.iter().all(Option::is_none)
+    }
+
+    /// The window layer `layer_idx` evicts behind, if any.
+    pub fn layer_window(&self, layer_idx: usize) -> Option<KvWindow> {
+        self.per_layer.get(layer_idx).copied().flatten()
+    }
+
+    /// Rows each of `n_layers` layers holds at `tokens` of context.
+    ///
+    /// `n_layers` comes from the [`KvShape`] being priced rather than
+    /// from `self`, and a layer this residency says nothing about keeps
+    /// everything. A shape and a residency built from different configs
+    /// is a caller error; charging the full cost is the safe way to be
+    /// wrong about it.
+    fn rows_per_layer(&self, n_layers: usize, tokens: usize) -> impl Iterator<Item = usize> + '_ {
+        (0..n_layers).map(move |l| match self.layer_window(l) {
+            Some(w) => w.rows_after(tokens),
+            None => tokens,
+        })
     }
 }
 
@@ -716,6 +866,134 @@ mod tests {
         );
         // The store kept every position in every layer, window or not.
         assert_eq!(allocated, shape.per_token_kv_bytes() * tokens as u64);
+        // And the two entry points agree when nothing evicts, rather
+        // than being two independent multiplications that happen to
+        // match today.
+        assert_eq!(
+            shape
+                .resident_kv_bytes_for_tokens(tokens, &KvResidency::keeps_everything(cfg.n_layers)),
+            allocated
+        );
+    }
+
+    /// **The same property, measured again, now that a store evicts.**
+    ///
+    /// The sibling above is the default and stays the default. This is
+    /// the `FERROX_KV_WINDOW` case, and it is asserted the same way for
+    /// the same reason: by pushing real positions into real
+    /// `ferrox_core::cache::KvCache`s, evicting them the way
+    /// `Decoder::evict_layer_kv` does, and comparing the bytes they hold
+    /// against the budget's number. If the budget restated the window
+    /// rule instead of taking it from `KvWindow::rows_after`, this test
+    /// would pass while the two drifted -- which is exactly how #33
+    /// survived long enough to approve a context that did not fit.
+    #[test]
+    fn the_budget_prices_exactly_what_an_evicting_kv_store_holds() {
+        let cfg = alternating_swa_config();
+        let tokens = 64;
+        let residency = KvResidency::from_config(&cfg, KvWindowPolicy::on());
+        assert!(
+            !residency.keeps_every_position(),
+            "the fixture must have windowed layers, or this proves nothing"
+        );
+        assert!(
+            (0..cfg.n_layers).any(|l| residency.layer_window(l).is_none()),
+            "the fixture must ALSO have dense layers: they are the half that keeps costing"
+        );
+
+        let mut caches: Vec<ferrox_core::cache::KvCache> = (0..cfg.n_layers)
+            .map(|_| ferrox_core::cache::KvCache::new(cfg.n_kv_heads, cfg.head_dim))
+            .collect();
+        for (l, cache) in caches.iter_mut().enumerate() {
+            if let Some(w) = residency.layer_window(l) {
+                cache.arm_window(w);
+            }
+        }
+        let step = vec![0f32; cfg.n_kv_heads * cfg.head_dim];
+        for _ in 0..tokens {
+            for cache in caches.iter_mut() {
+                cache
+                    .push(&step, &step)
+                    .expect("a cache built with `new` always accepts a push");
+                cache.evict_behind_window();
+            }
+        }
+        let held: u64 = caches
+            .iter()
+            .map(|c| (c.k.len() + c.v.len()) as u64 * std::mem::size_of::<f32>() as u64)
+            .sum();
+
+        let shape = KvShape::from_config(&cfg, KvElem::F32);
+        assert_eq!(
+            shape.resident_kv_bytes_for_tokens(tokens, &residency),
+            held,
+            "the budget must price what the evicting store holds"
+        );
+        // The saving is real: strictly less than pricing every position.
+        assert!(
+            held < shape.kv_bytes_for_tokens(tokens),
+            "eviction saved nothing: {held} vs {}",
+            shape.kv_bytes_for_tokens(tokens)
+        );
+        // And the number to admit on is above the number at rest, because
+        // one layer holds the whole prompt while it is being prefilled.
+        assert!(shape.peak_kv_bytes_for_tokens(tokens, &residency) > held);
+        // ...but never above pricing every layer at every position,
+        // which is what the engine costs today.
+        assert!(
+            shape.peak_kv_bytes_for_tokens(tokens, &residency) <= shape.kv_bytes_for_tokens(tokens)
+        );
+    }
+
+    /// The default policy prices exactly what it always did. A switch
+    /// that is off must be invisible to the arithmetic.
+    #[test]
+    fn the_default_policy_prices_every_layer_at_every_position() {
+        let cfg = alternating_swa_config();
+        let residency = KvResidency::from_config(&cfg, KvWindowPolicy::off());
+        assert!(residency.keeps_every_position());
+        let shape = KvShape::from_config(&cfg, KvElem::F32);
+        for tokens in [0usize, 1, 63, 64, 4096] {
+            assert_eq!(
+                shape.resident_kv_bytes_for_tokens(tokens, &residency),
+                shape.kv_bytes_for_tokens(tokens)
+            );
+            assert_eq!(
+                shape.peak_kv_bytes_for_tokens(tokens, &residency),
+                shape.kv_bytes_for_tokens(tokens)
+            );
+        }
+    }
+
+    /// The headline number from #61, priced through the residency rather
+    /// than asserted: Gemma-3-4B at a 32k context.
+    ///
+    /// 34 layers, 4 kv-heads, head_dim 256, host f32, a 1024-position
+    /// window on five layers out of every six. The full price is the
+    /// 9.13 GB the issue measured; the windowed one is what the store
+    /// now holds.
+    #[test]
+    fn gemma3_4b_at_32k_costs_a_fraction_of_what_it_did() {
+        let mut cfg = crate::config::test_dense_fixture();
+        cfg.n_layers = 34;
+        cfg.n_kv_heads = 4;
+        cfg.head_dim = 256;
+        cfg.sliding_window = Some(1024);
+        cfg.swa_pattern = Some(6);
+        let shape = KvShape::from_config(&cfg, KvElem::F32);
+        let tokens = 32_768;
+
+        let full = shape.kv_bytes_for_tokens(tokens);
+        assert_eq!(full, 9_126_805_504, "the number #61 measured");
+
+        let residency = KvResidency::from_config(&cfg, KvWindowPolicy::on());
+        let resting = shape.resident_kv_bytes_for_tokens(tokens, &residency);
+        let peak = shape.peak_kv_bytes_for_tokens(tokens, &residency);
+        // Six of the 34 layers are full attention and still hold every
+        // position; they are most of what is left.
+        assert!(resting * 4 < full, "resting {resting} vs full {full}");
+        assert!(peak < full);
+        assert!(peak > resting);
     }
 
     /// The pool-backed store is the other thing a server allocates, and

--- a/crates/ferrox-models/src/lib.rs
+++ b/crates/ferrox-models/src/lib.rs
@@ -94,8 +94,8 @@ pub use engine_factory::{
 pub use execution_plan::{ExecutionPlan, FusedOpCaps, MemoryPlan, PlanGeometry};
 pub use gemma4_engine::{Gemma4Engine, Gemma4Hparams, GEMMA4_ARCHES};
 pub use kv_budget::{
-    Ceiling, ContextCap, ContextFit, KvBudget, KvBudgetError, KvElem, KvLayout, KvShape,
-    CTX_AUTO_GRANULARITY,
+    Ceiling, ContextCap, ContextFit, KvBudget, KvBudgetError, KvElem, KvLayout, KvResidency,
+    KvShape, CTX_AUTO_GRANULARITY,
 };
 pub use loader::LoadError;
 pub use output_projection::grouped_output_projection;

--- a/crates/ferrox-models/src/loader.rs
+++ b/crates/ferrox-models/src/loader.rs
@@ -2381,6 +2381,7 @@ impl Decoder {
             #[cfg(feature = "metal")]
             metal_attn_kv: std::sync::Mutex::new(None),
             execution_plan,
+            kv_window: crate::decoder::KvWindowPolicy::from_env(),
             plan_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
         };
         // Resolve every kernel the model will need while we still have a

--- a/crates/ferrox-models/src/prefix_cache.rs
+++ b/crates/ferrox-models/src/prefix_cache.rs
@@ -186,7 +186,17 @@ impl PrefixCache {
     /// the most reused, so FIFO evicted the one entry worth keeping as
     /// soon as `max_entries` newer prompts arrived, and the next
     /// request off that system prompt recomputed all of it.
+    /// A cache that has evicted rows behind a sliding window (#61,
+    /// `FERROX_KV_WINDOW`) is REFUSED rather than stored. A stored
+    /// prefix is handed back truncated to an arbitrary common length,
+    /// and a windowed cache no longer holds the rows an arbitrary
+    /// truncation names -- so storing one would trade a cheap recompute
+    /// for a request that stops. Refusing loses the prefix cache for
+    /// the run, which is what the switch's documentation says it costs.
     pub fn store(&mut self, tokens: Vec<usize>, kv_caches: Vec<KvCache>, pending_logits: Vec<f32>) {
+        if kv_caches.iter().any(|c| c.window().is_some()) {
+            return;
+        }
         if self.entries.len() >= self.max_entries {
             // An O(n) scan, over the same vector the lookup above
             // already scans linearly -- so this costs nothing the

--- a/crates/ferrox-models/tests/kv_window_eviction.rs
+++ b/crates/ferrox-models/tests/kv_window_eviction.rs
@@ -20,8 +20,9 @@
 //! tokens in and every assertion below is about eviction rather than
 //! about how long the test is willing to run.
 //!
-//! `kv_window_real_checkpoint.rs` is the same comparison on a real
-//! checkpoint, and is `#[ignore]`d because it costs a 4k-token prefill.
+//! `kv_window_real_checkpoint.rs` is the same comparison through
+//! gemma-2-2b's real Q4_K_M tensors, narrowing the window for the same
+//! reason and skipping when the checkpoint is absent.
 
 use ferrox_core::cache::KvCache;
 use ferrox_models::config::{test_dense_fixture, ModelConfig};

--- a/crates/ferrox-models/tests/kv_window_eviction.rs
+++ b/crates/ferrox-models/tests/kv_window_eviction.rs
@@ -1,0 +1,246 @@
+//! Turning KV-window eviction on must not change a single token.
+//!
+//! #61 step 2 lets a windowed layer's host `KvCache` drop rows that have
+//! fallen behind its window. The argument that this is free is short --
+//! a windowed kernel reads the last `window` rows and eviction never
+//! drops one of those -- and short arguments about attention are exactly
+//! the ones this repo has been wrong about before. So it is measured:
+//! the same decoder, the same weights, the same prompt, greedily, with
+//! the switch off and on, token for token.
+//!
+//! # Why a synthetic model and not gemma-2-2b
+//!
+//! The local alternating-SWA checkpoints have windows of 4096 (Gemma-2)
+//! and 1024 (Gemma-3). Eviction cannot fire below that, so a test on one
+//! of them would need a >4k-token prompt to prove anything and would
+//! otherwise pass while exercising nothing -- the "the fixture has no
+//! sliding layers" trap in a different costume. The window is a config
+//! number, not a weights number, so this uses a real decoder with real
+//! (random) weights and a 6-position window, where eviction fires 7
+//! tokens in and every assertion below is about eviction rather than
+//! about how long the test is willing to run.
+//!
+//! `kv_window_real_checkpoint.rs` is the same comparison on a real
+//! checkpoint, and is `#[ignore]`d because it costs a 4k-token prefill.
+
+use ferrox_core::cache::KvCache;
+use ferrox_models::config::{test_dense_fixture, ModelConfig};
+use ferrox_models::decoder::{Decoder, KvWindowPolicy};
+
+const N_LAYERS: usize = 6;
+const VOCAB: usize = 24;
+const WINDOW: usize = 6;
+/// Every third layer is full attention, so the test covers both halves
+/// of an alternating model: the layers that must evict and the layers
+/// that must not.
+const SWA_PERIOD: usize = 3;
+
+fn alternating_swa_config() -> ModelConfig {
+    let mut cfg = test_dense_fixture();
+    cfg.n_layers = N_LAYERS;
+    cfg.n_kv_heads = 2;
+    cfg.n_heads = 4;
+    cfg.head_dim = 8;
+    cfg.hidden_dim = 32;
+    cfg.sliding_window = Some(WINDOW);
+    cfg.swa_pattern = Some(SWA_PERIOD);
+    cfg
+}
+
+fn caches(cfg: &ModelConfig) -> Vec<KvCache> {
+    (0..cfg.n_layers)
+        .map(|_| KvCache::new(cfg.n_kv_heads, cfg.head_dim))
+        .collect()
+}
+
+fn argmax(logits: &[f32]) -> usize {
+    logits
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).expect("logits are finite"))
+        .map(|(i, _)| i)
+        .expect("non-empty logits")
+}
+
+/// One decode run: the argmax at every step, every logit vector behind
+/// those argmaxes, and the caches it left behind.
+struct Run {
+    tokens: Vec<usize>,
+    /// Every step's full logit vector, not just the argmax.
+    ///
+    /// The ids are the headline; the logits are the instrument. An
+    /// argmax survives changes the distribution did not.
+    logits: Vec<Vec<f32>>,
+    caches: Vec<KvCache>,
+}
+
+/// Prefill through `forward_batch`, then `forward_token` per step --
+/// exactly the shape the CLI drives.
+///
+/// The decode steps are TEACHER-FORCED from a fixed script rather than
+/// fed their own argmax, and that is load-bearing rather than
+/// convenient. A random-weight model collapses onto one repeated token
+/// within a few steps, and once every row inside the window holds the
+/// same token at nearly the same state, attending over five of them and
+/// over six gives an answer too close to tell apart. A varied script
+/// keeps consecutive keys distinguishable, which is the only condition
+/// under which "one row short" is detectable at all.
+///
+/// Sabotaged to keep two rows fewer than the rule allows, this test goes
+/// red. Sabotaged by ONE row it does not, and that is not a gap: because
+/// eviction runs after the read, keeping `window - 1` rows and then
+/// pushing this step's own row leaves exactly `window` -- the correct
+/// set. `the_windowed_layers_stop_growing_and_the_dense_ones_do_not`
+/// catches the one-row case, by asserting the store's own residency.
+fn run(policy: KvWindowPolicy, prompt: &[usize], script: &[usize]) -> Run {
+    let cfg = alternating_swa_config();
+    let mut decoder = Decoder::new_random_small(cfg.clone(), N_LAYERS, VOCAB);
+    decoder.kv_window = policy;
+    let mut kv = caches(&decoder.config);
+
+    let prefill = decoder.forward_batch(prompt, 0, &mut kv);
+    let mut last = prefill.last().expect("non-empty prompt").clone();
+    let mut logits = vec![last.clone()];
+    let mut tokens = vec![argmax(&last)];
+    for (step, fed) in script.iter().enumerate() {
+        last = decoder.forward_token(*fed, prompt.len() + step, &mut kv);
+        tokens.push(argmax(&last));
+        logits.push(last.clone());
+    }
+    Run {
+        tokens,
+        logits,
+        caches: kv,
+    }
+}
+
+/// A varied, deterministic decode script: consecutive positions must
+/// hold DIFFERENT keys, or a window that is one row short reads a row
+/// identical to the one it should have read and nothing is detectable.
+fn script(steps: usize) -> Vec<usize> {
+    (0..steps).map(|i| (i * 7 + 5) % VOCAB).collect()
+}
+
+fn prompt() -> Vec<usize> {
+    (0..11usize).map(|i| (i * 3) % VOCAB).collect()
+}
+
+/// **The test that matters.** Same weights, same prompt, temperature 0,
+/// switch off versus on: the token ids must be equal.
+///
+/// Not "close" and not "same perplexity". Eviction either drops rows
+/// nothing reads, in which case the arithmetic is untouched and the ids
+/// are identical, or it drops a row something reads, in which case the
+/// model answers out of a history with a hole in it and no softer
+/// assertion would be honest about that.
+#[test]
+fn evicting_behind_the_window_does_not_change_a_single_token() {
+    let prompt = prompt();
+    let script = script(40);
+    let without = run(KvWindowPolicy::off(), &prompt, &script);
+    let with = run(KvWindowPolicy::on(), &prompt, &script);
+    assert_eq!(
+        without.tokens, with.tokens,
+        "eviction changed the generated tokens: it dropped a row the kernel reads"
+    );
+    // And bit-for-bit on the distributions behind them. See `Run::logits`.
+    assert_eq!(without.logits.len(), with.logits.len());
+    for (step, (a, b)) in without.logits.iter().zip(with.logits.iter()).enumerate() {
+        assert_eq!(a, b, "logits diverged at step {step}");
+    }
+}
+
+/// **The test that stops the one above passing for the wrong reason.**
+///
+/// If nothing evicted, the identity above is a tautology. So: the
+/// windowed layers' resident rows must have STOPPED GROWING while the
+/// position counter kept going, and the full-attention layers must NOT
+/// have stopped, because they still read position 0.
+#[test]
+fn the_windowed_layers_stop_growing_and_the_dense_ones_do_not() {
+    let prompt = prompt();
+    let steps = 40usize;
+    let total = prompt.len() + steps;
+    let kv = run(KvWindowPolicy::on(), &prompt, &script(steps)).caches;
+    let cfg = alternating_swa_config();
+
+    let mut windowed = 0usize;
+    let mut dense = 0usize;
+    for (l, cache) in kv.iter().enumerate() {
+        assert_eq!(
+            cache.positions(),
+            total,
+            "layer {l} lost track of the sequence length"
+        );
+        match cfg.layer_sliding_window(l) {
+            Some(w) => {
+                windowed += 1;
+                assert_eq!(w, WINDOW);
+                let window = cache.window().expect("a windowed layer must be armed");
+                assert!(
+                    cache.rows() <= window.max_rows(),
+                    "layer {l} holds {} rows after {total} positions; it should have \
+                     stopped at {}",
+                    cache.rows(),
+                    window.max_rows()
+                );
+                assert!(
+                    cache.rows() >= WINDOW,
+                    "layer {l} holds {} rows, fewer than the {WINDOW} the kernel reads",
+                    cache.rows()
+                );
+            }
+            None => {
+                dense += 1;
+                assert_eq!(
+                    cache.rows(),
+                    total,
+                    "layer {l} attends over the whole context and must keep all of it"
+                );
+                assert!(cache.window().is_none());
+            }
+        }
+    }
+    assert!(
+        windowed > 0 && dense > 0,
+        "the fixture must alternate, or this test proves nothing \
+         ({windowed} windowed, {dense} dense)"
+    );
+}
+
+/// The switch is off unless it is turned on, and off is byte-for-byte
+/// the store this engine had before #61.
+#[test]
+fn the_default_policy_keeps_every_row_in_every_layer() {
+    let prompt = prompt();
+    let steps = 40usize;
+    let total = prompt.len() + steps;
+    let kv = run(KvWindowPolicy::off(), &prompt, &script(steps)).caches;
+    for (l, cache) in kv.iter().enumerate() {
+        assert!(cache.window().is_none(), "layer {l} was armed by default");
+        assert_eq!(cache.rows(), total, "layer {l} dropped a row by default");
+        assert_eq!(cache.positions(), total);
+    }
+}
+
+/// What the saving actually is, on this fixture: the windowed layers
+/// cost a constant instead of a per-position term.
+///
+/// The number is read off the stores rather than computed, for the same
+/// reason `kv_budget`'s acceptance test reads them: a restated rule is
+/// how #33 happened.
+#[test]
+fn a_windowed_layer_costs_a_constant_and_a_dense_one_costs_the_context() {
+    let prompt = prompt();
+    let steps = 240usize;
+    let evicting = run(KvWindowPolicy::on(), &prompt, &script(steps)).caches;
+    let plain = run(KvWindowPolicy::off(), &prompt, &script(steps)).caches;
+
+    let bytes = |kv: &[KvCache]| -> usize { kv.iter().map(|c| c.allocated_bytes()).sum() };
+    let evicting_bytes = bytes(&evicting);
+    let plain_bytes = bytes(&plain);
+    assert!(
+        evicting_bytes * 2 < plain_bytes,
+        "eviction saved less than half: {evicting_bytes} vs {plain_bytes} bytes"
+    );
+}

--- a/crates/ferrox-models/tests/kv_window_real_checkpoint.rs
+++ b/crates/ferrox-models/tests/kv_window_real_checkpoint.rs
@@ -1,0 +1,169 @@
+//! The eviction identity, on a real checkpoint's weights.
+//!
+//! `kv_window_eviction.rs` proves it on a synthetic decoder, where every
+//! weight is `Lcg` output. This runs the same comparison through
+//! gemma-2-2b's real Q4_K_M tensors, its real alternating-SWA layout,
+//! its real logit softcap and its real fused dequant-dot kernels -- the
+//! things a synthetic F32 decoder does not exercise.
+//!
+//! # The window is narrowed, on purpose, and this says so
+//!
+//! Gemma-2's window is 4096. Eviction cannot fire below that, so this
+//! test at the checkpoint's own window would need a >4k-token prefill to
+//! drop a single row, and would otherwise pass having exercised nothing
+//! -- the "the fixture has no sliding layers" trap wearing a real
+//! checkpoint as a disguise.
+//!
+//! The window is a `ModelConfig` number, not a weights number, so both
+//! arms are loaded with `sliding_window` set to [`WINDOW`]. That makes
+//! the model a different model from the one on disk, and it does NOT
+//! make the comparison weaker: what is compared is the same narrowed
+//! model with eviction off and on. A row dropped that the kernel reads
+//! shows up here exactly as it would at 4096, and 64 positions in rather
+//! than 4097.
+//!
+//! Skipped when the checkpoint is absent (a worktree does not carry the
+//! ignored `models/` directory). `FERROX_TEST_GEMMA2_GGUF` overrides the
+//! path, which is the same escape hatch `gemma2_metal_quality_gate.rs`
+//! offers.
+
+use std::path::{Path, PathBuf};
+
+use ferrox_core::cache::KvCache;
+use ferrox_gguf::ShardedGguf;
+use ferrox_models::config::ModelConfig;
+use ferrox_models::decoder::{Decoder, KvWindowPolicy};
+
+/// Small enough that eviction fires inside a short prompt, and still
+/// several times the number of decode steps below, so the test is
+/// exercising a saturated window rather than a growing one.
+const WINDOW: usize = 64;
+const PROMPT_LEN: usize = 96;
+const STEPS: usize = 48;
+
+fn gguf_path() -> PathBuf {
+    if let Ok(p) = std::env::var("FERROX_TEST_GEMMA2_GGUF") {
+        return PathBuf::from(p);
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../models/gemma-2-2b-it-Q4_K_M.gguf")
+}
+
+fn argmax(logits: &[f32]) -> usize {
+    logits
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).expect("logits are finite"))
+        .map(|(i, _)| i)
+        .expect("non-empty logits")
+}
+
+/// Varied, deterministic token ids. Consecutive positions must hold
+/// DIFFERENT keys or a window one row short reads a row identical to the
+/// one it should have read, and nothing is detectable -- the same reason
+/// `kv_window_eviction.rs` teacher-forces from a script.
+fn ids(count: usize, seed: usize, vocab: usize) -> Vec<usize> {
+    (0..count)
+        .map(|i| (seed + i * 4099) % (vocab - 1) + 1)
+        .collect()
+}
+
+struct Run {
+    tokens: Vec<usize>,
+    logits: Vec<Vec<f32>>,
+    caches: Vec<KvCache>,
+}
+
+fn run(path: &Path, policy: KvWindowPolicy) -> Run {
+    let file = ShardedGguf::open(path).expect("open GGUF");
+    let mut config = ModelConfig::from_gguf(&file).expect("model config");
+    assert!(
+        config.sliding_window.is_some(),
+        "this checkpoint has no sliding-window layers, so it proves nothing here"
+    );
+    config.sliding_window = Some(WINDOW);
+    let mut decoder = Decoder::from_gguf(path, config.clone()).expect("load decoder");
+    decoder.kv_window = policy;
+
+    let prompt = ids(PROMPT_LEN, 7, config.vocab_size);
+    let script = ids(STEPS, 1234, config.vocab_size);
+    let mut caches: Vec<KvCache> = (0..config.n_layers)
+        .map(|_| KvCache::new(config.n_kv_heads, config.head_dim))
+        .collect();
+
+    let mut last = decoder.forward_batch_last(&prompt, 0, &mut caches);
+    let mut logits = vec![last.clone()];
+    let mut tokens = vec![argmax(&last)];
+    for (step, fed) in script.iter().enumerate() {
+        last = decoder.forward_token(*fed, prompt.len() + step, &mut caches);
+        tokens.push(argmax(&last));
+        logits.push(last.clone());
+    }
+    Run {
+        tokens,
+        logits,
+        caches,
+    }
+}
+
+/// Same weights, same tokens, eviction off versus on: identical ids and
+/// identical logits.
+#[test]
+fn evicting_behind_the_window_changes_no_token_on_a_real_checkpoint() {
+    let path = gguf_path();
+    if !path.exists() {
+        eprintln!("skipping: {} not present", path.display());
+        return;
+    }
+    let without = run(&path, KvWindowPolicy::off());
+    let with = run(&path, KvWindowPolicy::on());
+
+    assert_eq!(
+        without.tokens, with.tokens,
+        "eviction changed the tokens: it dropped a row the kernel reads"
+    );
+    for (step, (a, b)) in without.logits.iter().zip(with.logits.iter()).enumerate() {
+        assert_eq!(a, b, "logits diverged at step {step}");
+    }
+
+    // ...and it actually evicted, or the assertions above are a
+    // tautology. Gemma-2 alternates, so both halves must be present.
+    let total = PROMPT_LEN + STEPS;
+    let cfg = {
+        let file = ShardedGguf::open(&path).expect("open GGUF");
+        let mut c = ModelConfig::from_gguf(&file).expect("model config");
+        c.sliding_window = Some(WINDOW);
+        c
+    };
+    let (mut windowed, mut dense) = (0usize, 0usize);
+    for (l, cache) in with.caches.iter().enumerate() {
+        assert_eq!(cache.positions(), total);
+        match cfg.layer_sliding_window(l) {
+            Some(_) => {
+                windowed += 1;
+                let w = cache.window().expect("a windowed layer must be armed");
+                assert!(cache.rows() <= w.max_rows(), "layer {l} kept growing");
+                assert!(
+                    cache.rows() >= WINDOW,
+                    "layer {l} kept fewer rows than it reads"
+                );
+            }
+            None => {
+                dense += 1;
+                assert_eq!(cache.rows(), total, "layer {l} must keep every position");
+            }
+        }
+    }
+    assert!(
+        windowed > 0 && dense > 0,
+        "Gemma-2 alternates; {windowed} windowed and {dense} dense means the \
+         SWA pattern was not read"
+    );
+
+    // The bytes really went back.
+    let evicting: usize = with.caches.iter().map(|c| c.allocated_bytes()).sum();
+    let plain: usize = without.caches.iter().map(|c| c.allocated_bytes()).sum();
+    assert!(
+        evicting < plain,
+        "eviction freed nothing: {evicting} vs {plain} bytes"
+    );
+}


### PR DESCRIPTION
Step 2 of #61: a windowed layer's contiguous host KV cache now drops rows
that have fallen behind its window. Step 1 (#88) split `seq_len` into
`positions` and `rows` so the two *could* stop being equal; this makes
them stop being equal.

Scope is the contiguous `KvCache` on the CPU path. Not the GPU stores
(step 3), not the paged store (step 4), not eviction inside the prompt
region while it is being written (step 5). #61 stays open.

## What it costs now

Gemma-3-4B, 32768 tokens, host f32, priced by `kv_budget` and pinned in
`gemma3_4b_at_32k_costs_a_fraction_of_what_it_did`:

| | bytes |
|---|---|
| today (every layer, every position) | 9,126,805,504 (the issue's 9.13 GB) |
| eviction on, at rest | 1,692,590,080 |
| eviction on, prefill peak | 1,948,942,336 |

5 of the 34 layers are full attention and still hold all 32768
positions -- 1.34 GB, most of what is left. The 29 windowed ones hold
1475 rows each. The peak is above the resting number because
`forward_batch` evicts per layer, so one layer holds the whole prompt
while it is being prefilled; that placement is also why the peak is
1.95 GB and not 9.13, since the layers before and after it have already
handed their prompt rows back.

## How the tokens are shown to be unchanged

Three levels, each of which goes red when the store is sabotaged:

1. `ferrox-core`, unit: the read set of an evicting cache compared
   byte-for-byte against a plain one at every position, plus the
   invariant the whole thing rests on (`rows_after(p) >= min(p, window)`)
   over a 9x8x200 grid, plus the closed form checked against a
   step-by-step simulation of the loop it stands for.
2. `tests/kv_window_eviction.rs`, synthetic decoder: same weights, same
   prompt, same script, switch off vs on -- identical argmax ids AND
   identical full logit vectors at every step. Beside it, the assertion
   that stops that one passing for the wrong reason: the windowed
   layers' rows STOPPED GROWING while the dense layers' did not.
3. `tests/kv_window_real_checkpoint.rs`, gemma-2-2b-it-Q4_K_M: the same
   comparison through real quantized tensors, the real SWA layout and
   the real logit softcap. 96-token prompt + 48 decode steps, identical
   ids and identical logits, 13 layers evicting and 13 holding
   everything. **The window is narrowed to 64 in both arms**, and the
   file says so at the top: Gemma-2's is 4096, so at the checkpoint's own
   number this would need a 4k prefill to drop one row and would
   otherwise pass having exercised nothing. The window is a config number
   rather than a weights number, and what is compared is the same
   narrowed model with eviction off and on.

Sabotage results, for the record. Keeping two rows fewer than the rule
allows turns (2) and (3) red. Keeping ONE row fewer does not, and that is
not a gap: eviction runs after the read, so `window - 1` rows plus this
step's own row is exactly `window`. The residency assertion in (2) is
what catches that case. A self-feeding greedy run also does not catch it,
because a random-weight model collapses onto one token and then cannot
tell a six-row window from a five-row one -- which is why the decode
steps are teacher-forced from a varied script.

## Default: OFF

`FERROX_KV_WINDOW=1`, in the shape `FERROX_CPU_POOL` established, so the
before and the after are one word apart. Off because the evidence above
covers the CPU contiguous path and this branch has not touched Metal,
CUDA or the paged store, which is where three of the five remaining
steps live.

The switch turns itself off for two more cases rather than trusting the
operator:

- **Metal attention.** Five sites in `decoder.rs` compare
  `MetalKvBuffers::seq_len` against the host cache's `rows()` and its
  `positions()` and take them as interchangeable, which they are until a
  host cache evicts. One condition, in `decoder::kv_window`, rather than
  five that would drift.
- **`DraftModelSpeculator`**, which rolls its draft cache back to an
  arbitrary committed length. It turns the policy off on the decoder it
  owns.

`PrefixCache::store` refuses a windowed cache for the same reason: a
stored prefix is handed back truncated to an arbitrary common length,
which a windowed cache can no longer represent. Refusing costs the prefix
cache for the run; storing would cost a request. CUDA needs no exclusion
-- the resident-KV hook is reachable only from the `window == None` arm.

## What would have to be true for this to be wrong

- That some CPU reader treats a `KvCache` row index as an absolute
  position. `positions()`/`rows()` was audited for this in #88 and the
  remaining CPU-path readers are `rows()`-correct; two counters that
  were latently wrong are fixed here (the pooled `push` asked whether its
  BUFFER was full while keying on positions, and
  `is_within_planned_capacity` compared a buffer against a position
  count).
- That a window can be armed on a run whose Metal KV mirror is live. The
  policy is decided once, at `Decoder` construction, from
  `metal_attn_enabled()`.
- That `truncate` is called further back than the resident rows. It now
  refuses, naming the switch, rather than rolling back to the oldest row
  it happens to hold. Reachable callers are speculative decoding (bounded
  by the draft length) and the two opted out above.

## The budget

#33's rule was that when a store learns to evict, the number it keeps
belongs to the STORE. `KvResidency` carries the per-layer windows and
`KvShape::resident_kv_bytes_for_tokens` prices them through
`KvWindow::rows_after` -- the same function `KvCache::evict_behind_window`
calls to decide what to drop, and the windows come from the same
`KvWindowPolicy::layer_window` the decoder evicts with. The acceptance
test is the sibling of the one #33 left behind: it pushes real positions
into real caches, evicts them the way `evict_layer_kv` does, and asserts
the budget equals the bytes they hold. Sabotaged to price `max_rows`
instead of `rows_after`, it goes red.

`KvResidency` is deliberately not a field on `KvShape` -- `KvShape` is
`Copy` and is built by struct literal in more than one crate.

## Not done

- **`ferrox-server` admission is not wired to the new number.** It prices
  with `kv_bytes_for_tokens`, the full every-layer-every-position figure,
  which is the safe direction and is correct while the switch is off.
  Wiring it needs `ferrox-server`, which this branch does not own.
- **`docs/CONFIG.md` needs `FERROX_KV_WINDOW`** (off by default; CPU
  contiguous store only; disables itself under `FERROX_METAL_ATTN`;
  disables the prefix cache and does not apply to the draft model). Not
  edited here because `docs/` is another agent's.
- Steps 3, 4 and 5 of #61: the GPU stores, the paged store's per-layer
  page groups, and eviction inside the prompt region.
- No benchmarks. The memory numbers above are arithmetic over what the
  stores hold, not timings.

Refs #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
