### PR TITLE
fix(parity): the WRONG line is measured per checkpoint, not fitted once

### DIFF
--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -227,18 +227,29 @@ enum Commands {
         /// How many top tokens to intersect between the two engines.
         #[arg(long, default_value_t = 10)]
         top_k: usize,
-        /// Compiled reference dumper (see .local-scripts/llama_logits.c).
+        /// Compiled reference dumper (see tools/llama_logits.c).
+        ///
+        /// REPEATABLE, and repeating it is what makes a WRONG verdict
+        /// believable. The first is the reference every printed number
+        /// is about; each further one must be built against a DIFFERENT
+        /// libllama (`LLAMA_CPP_PREFIX=… tools/build_llama_logits.sh`),
+        /// and `parity` measures how far those builds are from each
+        /// other on this checkpoint to decide what "the graphs
+        /// disagree" is allowed to mean. Two builds have been measured
+        /// 3.5e-2 apart in KL from an identical graph, above the
+        /// constant that used to be the WRONG line, so with only one
+        /// reference no K-quant checkpoint can be called WRONG at all.
         #[arg(long)]
-        dumper: Option<String>,
-        /// Write both compared logit vectors under this prefix
-        /// (`<prefix>.llama.f32`, `<prefix>.ferrox.f32`,
-        /// `<prefix>.tokens.txt`), as raw little-endian f32.
+        dumper: Vec<String>,
+        /// Write every compared logit vector under this prefix
+        /// (`<prefix>.llama.f32`, `<prefix>.llama2.f32`, …,
+        /// `<prefix>.ferrox.f32`, `<prefix>.tokens.txt`), as raw
+        /// little-endian f32.
         ///
         /// A parity verdict is a distance between two points and says
         /// where neither one is, so it cannot tell "ferrox moved" from
-        /// "the reference moved". Dump against two `--dumper` builds and
-        /// compare the two `.llama.f32` files to each other: that
-        /// comparison has no ferrox in it.
+        /// "the reference moved". The `.llama*.f32` files compared to
+        /// each other answer that, with no ferrox in the comparison.
         #[arg(long)]
         dump_logits: Option<String>,
     },

--- a/crates/ferrox-cli/src/parity.rs
+++ b/crates/ferrox-cli/src/parity.rs
@@ -39,11 +39,21 @@
 //! IQ-tier goldens, which link ggml's own `ggml-quants.c` rather than
 //! re-reading the format spec. A reference you re-implemented is not a
 //! reference. Build it with `tools/build_llama_logits.sh`.
+//!
+//! `--dumper` may be given MORE THAN ONCE, each pointing at a dumper
+//! built against a different libllama. That is not a convenience: it is
+//! what turns the WRONG verdict from a fitted constant into a
+//! measurement this run makes for itself. See [`calibration`].
 
+mod calibration;
 mod dump;
+mod metrics;
+mod quant;
 mod tokenize;
 
 use anyhow::Context;
+use calibration::{Band, WrongLine, KL_WRONG};
+use quant::DominantQuant;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -63,102 +73,26 @@ const PROMPT: &str = "The capital of France is";
 /// f32 accumulation-order noise. Chosen as the scale at which a
 /// reordered reduction over a few thousand terms lands: it is a noise
 /// floor, not a quality target.
+///
+/// A statement about the PRIMARY reference, unlike the WRONG line: the
+/// report's numbers are that reference's, and "indistinguishable from
+/// the reference you named" is what MATCH has always meant.
 const KL_NOISE: f64 = 1e-3;
-
-/// Above this KL the distributions differ by more than accumulation
-/// order — a different rope base, a missing bias, a skipped norm. This
-/// is the "wrong graph" line.
-const KL_WRONG: f64 = 1e-2;
-
-/// How far two BUILDS OF THE REFERENCE disagree with each other on a
-/// K-quant checkpoint. Not a ferrox number: measured with ferrox out of
-/// the experiment entirely.
-///
-/// Measured 2026-09-04 on the fixed parity prompt, comparing the logits
-/// of `llama_logits` linked against Homebrew libllama b7650 with the
-/// same program linked against `.scratch/llama.cpp` (ggml 0.18.0):
-///
-/// | checkpoint | KL(b7650 ‖ newer) |
-/// |---|---|
-/// | Llama-3.2-1B **Q8_0** | **0.0 — bit-identical** |
-/// | TinyLlama-1.1B **Q8_0** | **0.0 — bit-identical** |
-/// | Llama-3.2-1B IQ4_XS | 2.9e-4 |
-/// | Llama-3.2-1B Q6_K | 1.3e-3 |
-/// | Llama-3.2-1B Q4_K_M | 2.1e-3 |
-/// | Llama-3.2-1B Q5_K_M | 2.1e-3 |
-/// | Phi-4-mini Q4_K_M | 5.3e-3 |
-/// | DeepSeek-R1-Distill Q4_K_M | 1.6e-2 |
-/// | **Qwen2.5-1.5B Q4_K_M** | **2.735e-2** |
-///
-/// The Q8_0 rows are the control and they are exact zeros: the two
-/// builds are the same program for weights llama.cpp dots against
-/// Q8_0 activations. Every K-quant row moves, and the newer build's
-/// `libggml-cpu` carries interleaved-repack kernels for `block_q5_K`
-/// and `block_q6_K` that the bottle does not, which is a change in
-/// exactly the arithmetic §10 of the gap inventory is about.
-///
-/// This constant is here so [`KL_WRONG_Q8K_DOTTED`] is derived from
-/// a measurement instead of restated beside one. See
-/// [#102](https://github.com/antonellof/ferrox/issues/102).
-const KL_REFERENCE_BUILD_SPREAD_KQUANT: f64 = 2.735e-2;
-
-/// The WRONG line for a checkpoint whose arithmetic llama.cpp dots
-/// against Q8_K-quantized activations; logits KL is noisier than a
-/// single matvec but still same top-1 (DeepSeek-R1 #99).
-///
-/// It was called `KL_WRONG_LM_HEAD_KQUANT` and applied on the strength
-/// of the OUTPUT HEAD's quantization. That was the wrong tensor, and
-/// [`DominantQuant`] carries the measurement that says so.
-///
-/// It is DERIVED from the measured spread above rather than restated
-/// beside it, so the two cannot drift apart: the only way to put the
-/// line back under the reference's own spread is to edit
-/// [`KL_WRONG_Q8K_DOTTED_MARGIN`] below 1, which reads as the
-/// mistake it is. It was 2.5e-2, a bare constant BELOW that spread, and
-/// the consequence was not hypothetical: Qwen2.5-1.5B
-/// Q4_K_M read DRIFT (KL 7.7e-3) against the bottle and WRONG (KL
-/// 2.7e-2) against the newer build, from the same ferrox. A line drawn
-/// under the reference's own build-to-build spread cannot mean "the
-/// graphs disagree", because two binaries with an IDENTICAL graph cross
-/// it. Whatever else 2.5e-2 was measuring, it was not that.
-///
-/// Raising it costs the sensitivity to a real K-quant graph bug in
-/// the band 2.5e-2..3.0e-2, which is a real cost. It buys a verdict
-/// that does not change with the reference's vintage, and a run whose
-/// WRONG can be believed. Note what is NOT raised: [`KL_WRONG`], for
-/// everything else, stays at 1e-2, because the same experiment puts the
-/// reference's build-to-build spread on a Q8_0 checkpoint at exactly
-/// zero.
-const KL_WRONG_Q8K_DOTTED: f64 = KL_REFERENCE_BUILD_SPREAD_KQUANT * KL_WRONG_Q8K_DOTTED_MARGIN;
-
-/// How far above the measured reference spread the WRONG line sits.
-///
-/// A judgement, not a measurement, and deliberately thin: the spread is
-/// the largest of nine checkpoints, so a tenth could exceed it, but
-/// every point of headroom is sensitivity to a real graph bug thrown
-/// away. Widen it only with a checkpoint that measured wider.
-const KL_WRONG_Q8K_DOTTED_MARGIN: f64 = 1.1;
 
 /// The verdict ladder, checked at COMPILE time.
 ///
-/// These four constants have to agree about an ordering and until
-/// 2026-09-04 nothing made them: `KL_WRONG_Q8K_DOTTED` was a bare
-/// 2.5e-2 sitting BELOW the 2.735e-2 that two builds of llama.cpp
-/// produce from an identical graph, so the "the graphs disagree" line
-/// fired on a difference llama.cpp reproduces against itself, and one
-/// real row (#102) read DRIFT or WRONG depending on which bottle was
-/// installed. Tightening it again now fails the build rather than
-/// quietly re-arming that.
+/// One rung is a constant now — [`KL_WRONG`], the floor under every
+/// calibrated line — and the other is measured per checkpoint, so the
+/// only ordering left to enforce is that MATCH is tighter than the
+/// tightest possible WRONG. The three constants this assert used to
+/// hold in order (`KL_REFERENCE_BUILD_SPREAD_KQUANT`,
+/// `KL_WRONG_Q8K_DOTTED` and its 1.1 margin) are DELETED: a rule that
+/// measures its own line has no thresholds left to keep in step. See
+/// [`calibration`] for why keeping them was not an option.
 const _: () = {
-    assert!(KL_NOISE < KL_WRONG, "MATCH must be tighter than DRIFT");
     assert!(
-        KL_WRONG < KL_WRONG_Q8K_DOTTED,
-        "the Q8_K-dotted allowance must be a relaxation, not a tightening"
-    );
-    assert!(
-        KL_WRONG_Q8K_DOTTED > KL_REFERENCE_BUILD_SPREAD_KQUANT,
-        "a WRONG line under the reference's own build-to-build spread cannot mean \
-         `the graphs disagree`: two binaries with an identical graph cross it"
+        KL_NOISE < KL_WRONG,
+        "MATCH must be tighter than the tightest WRONG line"
     );
 };
 
@@ -167,11 +101,12 @@ pub struct ParityArgs {
     pub prompt: Option<String>,
     pub prompt_tokens: Option<usize>,
     pub top_k: usize,
-    /// Path to the compiled reference dumper.
-    pub dumper: Option<String>,
-    /// Prefix to write both compared logit vectors under, so the same
-    /// comparison can be redone against a DIFFERENT reference build
-    /// without ferrox in the middle. See [`dump`].
+    /// Paths to compiled reference dumpers. The first is the PRIMARY —
+    /// the one every printed number is about. Any further ones exist to
+    /// measure how much llama.cpp disagrees with itself on this
+    /// checkpoint, which is what the WRONG line is made of.
+    pub dumper: Vec<String>,
+    /// Prefix to write every compared logit vector under. See [`dump`].
     pub dump_logits: Option<String>,
 }
 
@@ -181,13 +116,15 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
     // Resolved before anything expensive runs: a missing dumper is the
     // most common way this command fails, and finding that out after a
     // multi-second model load helps nobody.
-    let dumper = dumper_path(args.dumper.as_deref())?;
+    let dumpers = dumper_paths(&args.dumper)?;
 
     // The tokenizer comparison goes first. It is vocab-only on both
     // sides, so it costs a fraction of the prefill below, and a
     // divergence here means the logit numbers underneath it were
     // computed from a prompt the two engines do not even agree on.
-    let tokens_report = tokenize::run(&dumper, Path::new(&path))?;
+    // Only the primary reference tokenizes: the tokenizer half is not
+    // the half that needs calibrating.
+    let tokens_report = tokenize::run(&dumpers[0], Path::new(&path))?;
     match &tokens_report {
         Some(r) => tokenize::print_report(r),
         None => println!(
@@ -219,51 +156,36 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
         );
     }
 
-    let reference = reference_logits(&dumper, &path, &tokens)?;
-    let ref_logits = reference.logits;
-
-    if ref_logits.len() != ferrox_logits.len() {
-        // Not a tolerance question: the two engines disagree about how
-        // many tokens the model can emit, which is a loader bug on one
-        // side and makes every other number here meaningless.
-        anyhow::bail!(
-            "vocab size disagrees: llama.cpp {} vs ferrox {} — the logit vectors are not \
-             comparable, fix the loader before reading any metric",
-            ref_logits.len(),
-            ferrox_logits.len()
-        );
-    }
+    let references = collect_references(&dumpers, &path, &tokens, ferrox_logits.len())?;
 
     // Dumped BEFORE the verdict is computed, so a run that ends in the
     // `bail!` below still leaves the evidence behind. The whole reason
     // to dump is to investigate a bad verdict; losing the vectors
     // exactly when the verdict is bad would defeat it.
     if let Some(prefix) = args.dump_logits.as_deref() {
-        let paths = dump::write(prefix, &tokens, &ref_logits, &ferrox_logits)?;
-        println!("wrote {}", paths[0].display());
-        println!("wrote {}", paths[1].display());
-        println!("wrote {}", paths[2].display());
+        let logits: Vec<&[f32]> = references.iter().map(|r| r.logits.as_slice()).collect();
+        for p in dump::write(prefix, &tokens, &logits, &ferrox_logits)? {
+            println!("wrote {}", p.display());
+        }
         println!();
     }
 
-    // ONE value, read by the threshold below and by the DRIFT message
-    // in `print_report`. Deriving it twice is #109.
+    // ONE value, read by the DRIFT message and by the uncalibrated
+    // fallback of the WRONG line. Deriving it twice was #109.
     let gguf = ferrox_gguf::GgufFile::open(&path).ok();
     let quant = DominantQuant::of(gguf.as_ref().map_or(&[][..], |f| &f.tensors));
 
-    let report = compare(
-        &ref_logits,
-        &ferrox_logits,
-        args.top_k,
-        quant.wrong_kl_threshold(),
-    );
+    let ref_logits: Vec<Vec<f32>> = references.iter().map(|r| r.logits.clone()).collect();
+    let band = Band::measure(&ref_logits, &ferrox_logits, &quant);
+    let report = compare(&references[0].logits, &ferrox_logits, args.top_k, &band);
     print_report(
         &args.model,
         tokens.len(),
         args.top_k,
         backend.as_str(),
         &quant,
-        reference.libllama.as_deref(),
+        &references,
+        &band,
         &report,
     );
 
@@ -277,14 +199,70 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
     }
     if report.verdict == Verdict::Wrong {
         failures.push(format!(
-            "ferrox disagrees with llama.cpp beyond numeric noise (KL {:.3e} nats)",
-            report.kl_ref_ferrox
+            "ferrox disagrees with llama.cpp beyond numeric noise (KL {:.3e} nats to its \
+             nearest reference)",
+            band.nearest()
         ));
     }
     if !failures.is_empty() {
         anyhow::bail!("{}", failures.join("; "));
     }
     Ok(())
+}
+
+/// Runs every dumper on the same token ids and keeps the ones that
+/// answered with a comparable vector.
+///
+/// The PRIMARY reference is load-bearing and its failures are fatal. A
+/// SECONDARY one is evidence, and evidence that did not arrive leaves a
+/// narrower experiment rather than no experiment — but it is said out
+/// loud, because a run that silently lost its calibration would print a
+/// WRONG line derived from one reference while looking like a
+/// two-reference run.
+fn collect_references(
+    dumpers: &[PathBuf],
+    model: &str,
+    tokens: &[u32],
+    n_vocab: usize,
+) -> anyhow::Result<Vec<Reference>> {
+    let mut out: Vec<Reference> = Vec::new();
+    for (i, dumper) in dumpers.iter().enumerate() {
+        let primary = i == 0;
+        let reference = match reference_logits(dumper, model, tokens, i) {
+            Ok(r) => r,
+            Err(e) if primary => return Err(e),
+            Err(e) => {
+                eprintln!(
+                    "parity: reference [{i}] {} produced nothing ({e:#}); the WRONG line will be \
+                     measured without it",
+                    dumper.display()
+                );
+                continue;
+            }
+        };
+        if reference.logits.len() != n_vocab {
+            if primary {
+                // Not a tolerance question: the two engines disagree
+                // about how many tokens the model can emit, which is a
+                // loader bug on one side and makes every other number
+                // here meaningless.
+                anyhow::bail!(
+                    "vocab size disagrees: llama.cpp {} vs ferrox {n_vocab} — the logit vectors \
+                     are not comparable, fix the loader before reading any metric",
+                    reference.logits.len()
+                );
+            }
+            eprintln!(
+                "parity: reference [{i}] reports {} vocabulary entries against ferrox's \
+                 {n_vocab}; dropped from the WRONG line rather than compared to a different \
+                 distribution",
+                reference.logits.len()
+            );
+            continue;
+        }
+        out.push(reference);
+    }
+    Ok(out)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -333,59 +311,29 @@ struct Report {
     topk_overlap: usize,
 }
 
-/// Distance between two f32 in representable values.
+/// Scores ferrox against the PRIMARY reference, and takes the WRONG
+/// rung from `band`.
 ///
-/// `(a - b).abs()` cannot answer "is this a tie": near 3.0 an absolute
-/// gap of 1e-6 is about four ulps, near 3e-8 the same gap is the whole
-/// number. The count of representable values between two floats is the
-/// only scale-free way to say how close a float comparison was, and a
-/// tie-flip verdict is exactly that claim.
-///
-/// Works by mapping f32 to a monotone integer key: for non-negative
-/// values the bit pattern already increases with the value, and for
-/// negative values it increases as the value decreases, so the
-/// magnitude bits are negated.
-fn ulps_between(a: f32, b: f32) -> i64 {
-    fn key(x: f32) -> i64 {
-        let bits = i64::from(x.to_bits() & 0x7fff_ffff);
-        if x.is_sign_negative() {
-            -bits
-        } else {
-            bits
-        }
-    }
-    (key(a) - key(b)).abs()
-}
+/// The split is deliberate. MATCH and DRIFT are statements about the
+/// reference the report names — "indistinguishable from it", "differs
+/// from it by more than summation order" — and they move with it, which
+/// is correct: they describe a comparison, not a defect. WRONG is a
+/// claim about ferrox itself, so it is the one rung that must not
+/// change with which libllama happens to be installed (#102), and
+/// `band` is what makes it not.
+fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, band: &Band) -> Report {
+    let p = metrics::softmax(ref_logits);
+    let q = metrics::softmax(ferrox_logits);
 
-fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, kl_wrong: f64) -> Report {
-    let p = softmax(ref_logits);
-    let q = softmax(ferrox_logits);
+    // The primary's KL comes from the band rather than being recomputed
+    // here: one number, one owner. Two evaluations would be two places
+    // for the guarded-zero convention to drift apart.
+    let kl_pq = band.kl_to_ferrox(0);
+    let kl_qp = metrics::kl(&q, &p);
+    let (tv, max_delta) = metrics::total_variation(&p, &q);
 
-    let mut kl_pq = 0.0f64;
-    let mut kl_qp = 0.0f64;
-    let mut tv = 0.0f64;
-    let mut max_delta = 0.0f64;
-    for i in 0..p.len() {
-        let (pi, qi) = (p[i], q[i]);
-        // Terms where p is zero contribute nothing to KL(p||q) by the
-        // 0 ln 0 = 0 convention; guarding q avoids an infinity from a
-        // single underflowed float rather than from a real disagreement.
-        if pi > 0.0 {
-            kl_pq += pi * (pi.max(f64::MIN_POSITIVE) / qi.max(f64::MIN_POSITIVE)).ln();
-        }
-        if qi > 0.0 {
-            kl_qp += qi * (qi.max(f64::MIN_POSITIVE) / pi.max(f64::MIN_POSITIVE)).ln();
-        }
-        let d = (pi - qi).abs();
-        tv += d;
-        if d > max_delta {
-            max_delta = d;
-        }
-    }
-    tv *= 0.5;
-
-    let ref_order = order_desc(&p);
-    let fx_order = order_desc(&q);
+    let ref_order = metrics::order_desc(&p);
+    let fx_order = metrics::order_desc(&q);
     let top1_ref = ref_order[0];
     let top1_ferrox = fx_order[0];
     let ref_top1_rank_in_ferrox = fx_order.iter().position(|&i| i == top1_ref).unwrap_or(0);
@@ -395,7 +343,7 @@ fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, kl_wrong: f64) -
             (
                 p[i1] - p[i2],
                 ref_logits[i1] - ref_logits[i2],
-                ulps_between(ref_logits[i1], ref_logits[i2]),
+                metrics::ulps_between(ref_logits[i1], ref_logits[i2]),
                 // Same pair, ferrox's numbers, keeping the reference's
                 // order: the sign is the flip itself.
                 ferrox_logits[i1] - ferrox_logits[i2],
@@ -408,15 +356,19 @@ fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, kl_wrong: f64) -
     let ref_top: std::collections::HashSet<usize> = ref_order[..k].iter().copied().collect();
     let topk_overlap = fx_order[..k].iter().filter(|i| ref_top.contains(i)).count();
 
+    // ONE predicate, read by both branches below. They were two
+    // spellings of `kl_pq < kl_wrong` before, which is the shape this
+    // repo keeps paying for.
+    let outside = band.ferrox_is_outside();
     let verdict = if top1_ref == top1_ferrox {
         if kl_pq < KL_NOISE {
             Verdict::Match
-        } else if kl_pq < kl_wrong {
+        } else if !outside {
             Verdict::Drift
         } else {
             Verdict::Wrong
         }
-    } else if kl_pq < kl_wrong && ref_top2_margin <= max_delta {
+    } else if !outside && ref_top2_margin <= max_delta {
         // The two engines put nearly the same mass on both candidates and
         // the reference itself could barely separate them. Calling this a
         // failure would make the instrument cry wolf on exactly the case
@@ -443,186 +395,15 @@ fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, kl_wrong: f64) -
     }
 }
 
-/// The quantization of the per-layer weights, and whether llama.cpp
-/// dots it against 8-bit-quantized ACTIVATIONS.
-///
-/// This exists because a `DRIFT` verdict on a K-quant is expected rather
-/// than suspicious, and the old message sent the reader off to do a
-/// per-layer divergence run on a difference that has a known cause.
-///
-/// ggml declares a `vec_dot_type` per quantization
-/// (`ggml/src/ggml-cpu/ggml-cpu.c`). For the K-quants it is
-/// `GGML_TYPE_Q8_K`: llama.cpp quantizes the activation to 8 bits and
-/// accumulates in integers. ferrox keeps activations in f32. Both are
-/// defensible and ferrox is the more precise of the two, but they are
-/// not the same arithmetic, so the distributions differ by more than
-/// summation order.
-///
-/// Measured on five quantizations of one checkpoint: the verdict tracks
-/// this predicate on the 96 per-layer tensors exactly. See
-/// `docs/plans/llama-cpp-gap-inventory.md` §10.
-fn llama_dots_this_against_q8k(kind: &str) -> bool {
-    // Spelled as `GgmlType`'s own variant names (`Q4K`, not `Q4_K`) --
-    // these come from `format!("{:?}", dtype)`, and writing the ggml
-    // spelling here would have matched nothing while looking correct.
-    matches!(
-        kind,
-        "Q2K"
-            | "Q3K"
-            | "Q4K"
-            | "Q5K"
-            | "Q6K"
-            | "IQ2XXS"
-            | "IQ2XS"
-            | "IQ2S"
-            | "IQ3XXS"
-            | "IQ3S"
-            | "IQ1S"
-            | "IQ1M"
-            | "IQ4XS"
-    )
-}
-
-/// The most common quantization among a checkpoint's PER-LAYER tensors.
-///
-/// The FILENAME is not this. `Llama-3.2-1B-Instruct-IQ4_XS.gguf`
-/// contains no IQ4_XS tensors at all -- 96 of its per-layer weights are
-/// `IQ4_NL` -- because the name is the quantization RECIPE and the
-/// recipe falls back. Reading the tensor table is the only way to know,
-/// and mistaking the two is what made that file look like a
-/// counterexample.
-///
-/// The output head and the embedding table are EXCLUDED, so "body" here
-/// means the body and cannot be outvoted into meaning the head on a
-/// one-layer model. [`lm_head_quant`] is the other half, and
-/// [`DominantQuant`] is the single place that weighs the two.
-fn body_quant(tensors: &[ferrox_gguf::TensorInfo]) -> Option<String> {
-    use std::collections::HashMap;
-    let mut counts: HashMap<String, usize> = HashMap::new();
-    for t in tensors {
-        if t.name == "output.weight" || t.name == "token_embd.weight" {
-            continue;
-        }
-        let kind = format!("{:?}", t.dtype);
-        if kind != "F32" && kind != "F16" && kind != "BF16" {
-            *counts.entry(kind).or_default() += 1;
-        }
-    }
-    counts.into_iter().max_by_key(|(_, n)| *n).map(|(k, _)| k)
-}
-
-/// Dtype of the logits projection: untied `output.weight`, else tied embed.
-fn lm_head_quant(tensors: &[ferrox_gguf::TensorInfo]) -> Option<String> {
-    tensors
-        .iter()
-        .find(|t| t.name == "output.weight")
-        .or_else(|| tensors.iter().find(|t| t.name == "token_embd.weight"))
-        .map(|t| format!("{:?}", t.dtype))
-}
-
-/// WHICH QUANTIZATION'S ARITHMETIC DOMINATES THIS COMPARISON — the one
-/// value the WRONG threshold and the DRIFT message both read.
-///
-/// Until [#109](https://github.com/antonellof/ferrox/issues/109) they
-/// were two rules. The threshold keyed on the OUTPUT HEAD alone and the
-/// message keyed on `lm_head.or(body)`, so a `Q8_0` head over a K-quant
-/// body was judged against the line for a model containing no K-quant
-/// arithmetic at all, and told to go run a per-layer divergence for a
-/// difference §10 fully explains. They agreed on every checkpoint in
-/// `models/`, which is why it never fired there — so a checkpoint of
-/// that shape was BUILT to see what happens (`llama-quantize --pure
-/// --output-tensor-type q8_0 --token-embedding-type q8_0 … Q4_K_S`),
-/// against Homebrew libllama b7650:
-///
-/// | checkpoint | head | body | KL(llama‖ferrox) | verdict then |
-/// |---|---|---|---|---|
-/// | Qwen3-0.6B q8-head | Q8_0 | Q4_K | **1.297e-2** | **WRONG** |
-/// | Qwen3-0.6B `--pure` | Q4_K | Q4_K | 1.975e-2 | DRIFT |
-/// | Llama-3.2-1B q8-head | Q8_0 | Q4_K | 1.417e-3 | DRIFT |
-/// | Llama-3.2-1B `--pure` | Q4_K | Q4_K | 1.126e-3 | DRIFT |
-/// | Llama-3.2-1B q6-head | Q6_K | Q8_0 | **2.313e-4** | MATCH |
-///
-/// The first two rows are the same body arithmetic on the same
-/// architecture, and the row with the MORE precise head read WRONG at a
-/// SMALLER KL than the row with the K-quant head read DRIFT. `ferrox
-/// parity` exited non-zero on the more accurate of the two.
-///
-/// The last row is what settles which tensor to key on: a K-quant head
-/// over a Q8_0 body lands at 2.313e-4, three orders of magnitude below
-/// its K-quant-bodied siblings and inside the MATCH floor. **The body
-/// carries the divergence and the head barely contributes** — the body
-/// is every layer, the head is one matvec — so the body is what this
-/// answers with when it is Q8_K-dotted.
-///
-/// The head still gets to TRIGGER the relaxation when the body is not
-/// Q8_K-dotted, even though the row above says the effect is tiny. The
-/// alternative is a rule that can invent a WRONG for a checkpoint whose
-/// only Q8_K arithmetic is in the head, which is the defect being
-/// fixed, in the other direction; and the sensitivity given up sits at
-/// 2.3e-4, four orders below either line, so nothing that could be
-/// measured is being traded away. That makes this a pure relaxation of
-/// what shipped: no row can move DRIFT → WRONG because of it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DominantQuant(Option<String>);
-
-impl DominantQuant {
-    /// Reads the tensor table. An empty slice — the file could not be
-    /// opened — and a table with no quantized tensor both give `None`,
-    /// which is the unrelaxed [`KL_WRONG`] line.
-    fn of(tensors: &[ferrox_gguf::TensorInfo]) -> Self {
-        Self::weigh(
-            lm_head_quant(tensors).as_deref(),
-            body_quant(tensors).as_deref(),
-        )
-    }
-
-    /// The rule itself, taking the two halves directly so it can be
-    /// exercised on shapes no checkpoint on this disk has.
-    fn weigh(lm_head: Option<&str>, body: Option<&str>) -> Self {
-        // A Q8_K-dotted BODY wins outright: it is every layer, and the
-        // measurement above says it is what carries the divergence.
-        // Otherwise the head, which still relaxes the line when it is
-        // itself a K-quant — that fallback is the `or`, not a third
-        // branch, because "the head when it is Q8_K-dotted" and "the
-        // head as the plain label" are the same expression and writing
-        // them separately gives one arm that can never be reached.
-        let picked = if body.is_some_and(llama_dots_this_against_q8k) {
-            body
-        } else {
-            lm_head.or(body)
-        };
-        Self(picked.map(str::to_owned))
-    }
-
-    /// What to call it in the report.
-    fn label(&self) -> Option<&str> {
-        self.0.as_deref()
-    }
-
-    /// Whether llama.cpp dots this checkpoint's dominant arithmetic
-    /// against Q8_K-quantized activations. The threshold and the DRIFT
-    /// message both go through here, so they cannot disagree.
-    fn q8k_dotted(&self) -> bool {
-        self.0.as_deref().is_some_and(llama_dots_this_against_q8k)
-    }
-
-    /// The "the graphs disagree" line for this checkpoint.
-    fn wrong_kl_threshold(&self) -> f64 {
-        if self.q8k_dotted() {
-            KL_WRONG_Q8K_DOTTED
-        } else {
-            KL_WRONG
-        }
-    }
-}
-
+#[allow(clippy::too_many_arguments)]
 fn print_report(
     model: &str,
     n_tokens: usize,
     k: usize,
     backend: &str,
     quant: &DominantQuant,
-    libllama: Option<&str>,
+    references: &[Reference],
+    band: &Band,
     r: &Report,
 ) {
     let name = Path::new(model)
@@ -642,15 +423,21 @@ fn print_report(
     // Named on every row, not only when it surprises. Two libllama
     // builds gave the same checkpoint DRIFT and WRONG (#102), and the
     // difference between the runs was invisible in this report.
-    match libllama {
-        Some(p) => println!("  reference         {p}"),
-        None => println!(
-            "  reference         (this dumper predates the `libllama` line — rebuild with \
-             tools/build_llama_logits.sh to have the verdict name its reference)"
-        ),
+    for (i, reference) in references.iter().enumerate() {
+        let who = match reference.libllama.as_deref() {
+            Some(p) => p.to_string(),
+            None => "(this dumper predates the `libllama` line — rebuild with \
+                     tools/build_llama_logits.sh)"
+                .to_string(),
+        };
+        println!(
+            "  reference [{i}]     {who}   KL(llama||ferrox) {:.3e}",
+            band.kl_to_ferrox(i)
+        );
     }
+    print_wrong_line(quant, references, band);
     println!(
-        "  KL(llama||ferrox) {:.3e} nats   KL(ferrox||llama) {:.3e} nats",
+        "  KL(llama||ferrox) {:.3e} nats   KL(ferrox||llama) {:.3e} nats   [reference 0]",
         r.kl_ref_ferrox, r.kl_ferrox_ref
     );
     println!(
@@ -675,9 +462,9 @@ fn print_report(
     );
     match r.verdict {
         Verdict::Match => println!("  same distribution to within f32 accumulation-order noise."),
-        // `q8k_dotted` is the SAME predicate on the SAME value that
-        // chose the WRONG line, so the explanation and the threshold
-        // are never about different tensors (#109).
+        // `q8k_dotted` is the SAME predicate on the SAME value the
+        // uncalibrated WRONG line reads, so the explanation and the
+        // line are never about different tensors (#109).
         Verdict::Drift => match quant.label().filter(|_| quant.q8k_dotted()) {
             // Expected, with a named cause. Saying "go run a per-layer
             // divergence" here would send the reader after a bug that
@@ -718,41 +505,70 @@ fn print_report(
     }
 }
 
-fn softmax(logits: &[f32]) -> Vec<f64> {
-    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max) as f64;
-    let mut out: Vec<f64> = logits.iter().map(|&v| (v as f64 - max).exp()).collect();
-    let sum: f64 = out.iter().sum();
-    if sum > 0.0 {
-        for v in &mut out {
-            *v /= sum;
+/// The WRONG line, and where it came from.
+///
+/// Printed on EVERY row, including the ones that are nowhere near it.
+/// A verdict whose line is invisible cannot be audited, and the line is
+/// no longer a constant a reader could look up.
+fn print_wrong_line(quant: &DominantQuant, references: &[Reference], band: &Band) {
+    match band.line() {
+        WrongLine::Calibrated { spread, line } => {
+            let (a, b) = spread.between;
+            println!(
+                "  WRONG line        {line:.3e}  measured: references [{a}] and [{b}] disagree \
+                 with EACH OTHER by {:.3e} on this checkpoint",
+                spread.kl
+            );
+            println!(
+                "                    ferrox's nearest reference is {:.3e}, {:.0}% of the line",
+                band.nearest(),
+                100.0 * band.nearest() / line
+            );
+        }
+        WrongLine::Absolute(line) => println!(
+            "  WRONG line        {line:.3e}  absolute: llama.cpp's own build-to-build spread on \
+             {} is 0 to 4.6e-4, two orders under it",
+            quant.label().unwrap_or("this checkpoint")
+        ),
+        WrongLine::Uncalibrated => {
+            println!(
+                "  WRONG line        NONE — {} is dotted against Q8_K activations, and two \
+                 builds of llama.cpp disagree with EACH OTHER by up to 3.5e-2 there (#111), so \
+                 no constant can mean `the graphs disagree`.",
+                quant.label().unwrap_or("this checkpoint")
+            );
+            println!(
+                "                    Pass --dumper a second time, built against another \
+                 libllama, to measure this checkpoint's own line. ({} reference in this run.)",
+                references.len()
+            );
         }
     }
-    out
 }
 
-fn order_desc(p: &[f64]) -> Vec<usize> {
-    let mut idx: Vec<usize> = (0..p.len()).collect();
-    // Ties break by index on both sides, so a tie can never by itself
-    // make the two engines' orderings look different.
-    idx.sort_by(|&a, &b| p[b].partial_cmp(&p[a]).unwrap().then(a.cmp(&b)));
-    idx
-}
-
-fn dumper_path(explicit: Option<&str>) -> anyhow::Result<PathBuf> {
-    if let Some(e) = explicit {
-        let p = PathBuf::from(e);
-        if p.exists() {
-            return Ok(p);
-        }
-        // An explicit path that does not exist is a typo, not a reason to
-        // silently fall back to some other binary and report its answer
-        // as the reference.
-        anyhow::bail!("--dumper {} does not exist", p.display());
+/// Resolves every `--dumper`, or falls back to the single one the
+/// environment and the tree offer.
+fn dumper_paths(explicit: &[String]) -> anyhow::Result<Vec<PathBuf>> {
+    if !explicit.is_empty() {
+        return explicit
+            .iter()
+            .map(|e| {
+                let p = PathBuf::from(e);
+                // An explicit path that does not exist is a typo, not a
+                // reason to silently fall back to some other binary and
+                // report its answer as the reference.
+                if p.exists() {
+                    Ok(p)
+                } else {
+                    anyhow::bail!("--dumper {} does not exist", p.display())
+                }
+            })
+            .collect();
     }
     if let Some(e) = std::env::var_os(DUMPER_ENV) {
         let p = PathBuf::from(e);
         if p.exists() {
-            return Ok(p);
+            return Ok(vec![p]);
         }
         anyhow::bail!(
             "{DUMPER_ENV} points at {}, which does not exist",
@@ -762,7 +578,7 @@ fn dumper_path(explicit: Option<&str>) -> anyhow::Result<PathBuf> {
     for c in DUMPER_CANDIDATES {
         let p = PathBuf::from(c);
         if p.exists() {
-            return Ok(p);
+            return Ok(vec![p]);
         }
     }
     anyhow::bail!(
@@ -792,8 +608,18 @@ const LIBLLAMA_LINE: &str = "libllama ";
 
 /// Runs the reference dumper on the SAME token ids and reads back its
 /// logit vector.
-fn reference_logits(dumper: &Path, model: &str, tokens: &[u32]) -> anyhow::Result<Reference> {
-    let out_path = std::env::temp_dir().join(format!("ferrox-parity-{}.bin", std::process::id()));
+///
+/// `slot` distinguishes the temporary file per reference: two dumpers
+/// run in one process would otherwise write the same path, and the
+/// second answer would be read as the first.
+fn reference_logits(
+    dumper: &Path,
+    model: &str,
+    tokens: &[u32],
+    slot: usize,
+) -> anyhow::Result<Reference> {
+    let out_path =
+        std::env::temp_dir().join(format!("ferrox-parity-{}-{slot}.bin", std::process::id()));
     let mut cmd = Command::new(dumper);
     cmd.arg(model).arg(&out_path);
     for t in tokens {
@@ -840,10 +666,21 @@ fn parse_libllama(stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// A band from ONE reference, which is what every pre-existing
+    /// verdict test is about: the KL to that reference IS the nearest,
+    /// so these exercise the ladder and not the calibration.
+    fn one_reference(reference: &[f32], ferrox: &[f32]) -> Band {
+        Band::measure(
+            &[reference.to_vec()],
+            ferrox,
+            &DominantQuant::weigh(Some("Q8_0"), Some("Q8_0")),
+        )
+    }
+
     #[test]
     fn identical_logits_are_a_match() {
         let l = vec![0.1f32, 5.0, -2.0, 3.3];
-        let r = compare(&l, &l, 3, KL_WRONG);
+        let r = compare(&l, &l, 3, &one_reference(&l, &l));
         assert_eq!(r.verdict, Verdict::Match);
         assert!(r.kl_ref_ferrox < 1e-12, "KL was {}", r.kl_ref_ferrox);
         assert_eq!(r.top1_ref, r.top1_ferrox);
@@ -856,7 +693,7 @@ mod tests {
         // Mass moved to a different token entirely.
         let a = vec![0.0f32, 8.0, 0.0, 0.0];
         let b = vec![0.0f32, 0.0, 8.0, 0.0];
-        let r = compare(&a, &b, 2, KL_WRONG);
+        let r = compare(&a, &b, 2, &one_reference(&a, &b));
         assert_eq!(r.verdict, Verdict::Wrong);
         assert_ne!(r.top1_ref, r.top1_ferrox);
     }
@@ -867,7 +704,7 @@ mod tests {
         // whole point of measuring the distribution instead of the draw.
         let a = vec![-10.0f32, 2.000_01, 2.0];
         let b = vec![-10.0f32, 2.0, 2.000_01];
-        let r = compare(&a, &b, 2, KL_WRONG);
+        let r = compare(&a, &b, 2, &one_reference(&a, &b));
         assert_eq!(r.verdict, Verdict::TieFlip);
         assert_ne!(r.top1_ref, r.top1_ferrox);
         // Both engines still agree on WHICH two tokens are in play.
@@ -880,7 +717,7 @@ mod tests {
         // further than accumulation order explains.
         let a = vec![6.0f32, 1.0, 1.0, 1.0];
         let b = vec![6.0f32, 1.0, 1.0, 2.0];
-        let r = compare(&a, &b, 4, KL_WRONG);
+        let r = compare(&a, &b, 4, &one_reference(&a, &b));
         assert_eq!(r.verdict, Verdict::Drift);
         assert_eq!(r.top1_ref, r.top1_ferrox);
         assert!(r.kl_ref_ferrox >= KL_NOISE && r.kl_ref_ferrox < KL_WRONG);
@@ -892,48 +729,8 @@ mod tests {
         // logits: an additive constant is not a disagreement.
         let a = vec![0.5f32, 1.5, -3.0];
         let b: Vec<f32> = a.iter().map(|v| v + 7.25).collect();
-        let r = compare(&a, &b, 3, KL_WRONG);
+        let r = compare(&a, &b, 3, &one_reference(&a, &b));
         assert_eq!(r.verdict, Verdict::Match);
-    }
-
-    /// Adjacent floats are one ulp apart wherever they sit on the line,
-    /// and the count is scale-free.
-    ///
-    /// This is the measurement a TIE-FLIP verdict rests on. An absolute
-    /// difference cannot make the claim: `3.0` and its neighbour differ
-    /// by 2.4e-7 while `3e-8` and its neighbour differ by 1e-15, and
-    /// both are one ulp. A tie-flip reported in absolute units is
-    /// therefore unfalsifiable, which is what #103 pointed at.
-    #[test]
-    fn ulps_between_counts_representable_values_not_absolute_distance() {
-        for anchor in [3.0f32, 3e-8, -3.0, 1.0, 65_536.0] {
-            let next = f32::from_bits(if anchor.is_sign_negative() {
-                anchor.to_bits() - 1
-            } else {
-                anchor.to_bits() + 1
-            });
-            assert_eq!(
-                ulps_between(anchor, next),
-                1,
-                "{anchor} and its neighbour {next} must be one ulp apart"
-            );
-        }
-        // Symmetric, and zero for equal values.
-        assert_eq!(ulps_between(1.5, 1.5), 0);
-        assert_eq!(ulps_between(2.0, 1.0), ulps_between(1.0, 2.0));
-        // Crossing zero must not wrap: -0.0 and +0.0 are the same
-        // value, and a naive bit subtraction would call them 2^31
-        // apart, which would turn every sign change into "not a tie".
-        assert_eq!(ulps_between(-0.0, 0.0), 0);
-        // The two representable values either side of zero are two
-        // steps apart, not 2^32: a naive bit subtraction makes any sign
-        // change look maximally far, which would turn every flipped
-        // near-tie into "not a tie".
-        let tiny = f32::from_bits(1);
-        assert_eq!(ulps_between(-tiny, tiny), 2);
-        // A gap that is genuinely large stays large: 1.0 and 2.0 are a
-        // whole binade apart, which is 2^23 representable values.
-        assert_eq!(ulps_between(1.0, 2.0), 1 << 23);
     }
 
     /// The reported top-1/top-2 gap describes the pair the REFERENCE
@@ -946,7 +743,7 @@ mod tests {
     fn the_reported_gap_is_the_same_pair_on_both_sides_and_flips_sign() {
         let a = vec![-10.0f32, 2.000_01, 2.0];
         let b = vec![-10.0f32, 2.0, 2.000_01];
-        let r = compare(&a, &b, 2, KL_WRONG);
+        let r = compare(&a, &b, 2, &one_reference(&a, &b));
         assert_eq!(r.verdict, Verdict::TieFlip);
         assert!(
             r.ref_top2_logit_gap > 0.0,
@@ -964,204 +761,64 @@ mod tests {
         );
     }
 
-    /// Every K-quant / IQ spelling that reaches the allowance.
-    const Q8K_DOTTED: &[&str] = &[
-        "Q2K", "Q3K", "Q4K", "Q5K", "Q6K", "IQ2XXS", "IQ2XS", "IQ2S", "IQ3XXS", "IQ3S", "IQ1S",
-        "IQ1M", "IQ4XS",
-    ];
-
-    #[test]
-    fn a_kquant_checkpoint_uses_a_higher_wrong_threshold() {
-        let kq = DominantQuant::weigh(Some("Q6K"), Some("Q6K"));
-        assert_eq!(kq.wrong_kl_threshold(), KL_WRONG_Q8K_DOTTED);
-        let q8 = DominantQuant::weigh(Some("Q8_0"), Some("Q8_0"));
-        assert_eq!(q8.wrong_kl_threshold(), KL_WRONG);
-    }
-
-    /// EVERY quantization that routes to the K-quant allowance gets a
-    /// WRONG line above the reference's own build-to-build spread.
+    /// THE VERDICT THAT #102 AND #111 ARE ABOUT: one ferrox, one file,
+    /// two libllama, and the answer must not depend on which one the
+    /// report happens to name first.
     ///
-    /// The ordering of the constants is checked at compile time; this
-    /// walks the PREDICATE, which is the half that can silently stop
-    /// agreeing with them. A spelling dropped from
-    /// `llama_dots_this_against_q8k` sends that quantization back to
-    /// `KL_WRONG` = 1e-2, which is a quarter of the spread two llama.cpp
-    /// builds show on exactly these types — the row would read WRONG and
-    /// the constants would still look right.
+    /// The fixture is the shape Qwen3-0.6B `--pure` Q4_K_S has: the two
+    /// references sit further from each other than ferrox sits from the
+    /// nearer of them. Under the old absolute constant this read DRIFT
+    /// against one and WRONG against the other. It must now read the
+    /// same either way round, and it must still be a DRIFT rather than
+    /// a MATCH, because the distributions really have moved.
     #[test]
-    fn every_q8k_dotted_body_clears_the_references_build_to_build_spread() {
-        for kind in Q8K_DOTTED {
-            let line = DominantQuant::weigh(Some("Q8_0"), Some(kind)).wrong_kl_threshold();
-            assert!(
-                line > KL_REFERENCE_BUILD_SPREAD_KQUANT,
-                "{kind} gets a WRONG line of {line:e}, under the {KL_REFERENCE_BUILD_SPREAD_KQUANT:e} \
-                 two builds of llama.cpp produce from an identical graph"
-            );
-        }
-        // And the non-K-quant line is deliberately NOT raised: the same
-        // experiment measured the reference's Q8_0 spread at exactly
-        // zero, so there is nothing there to make room for.
-        assert_eq!(
-            DominantQuant::weigh(Some("Q8_0"), Some("Q8_0")).wrong_kl_threshold(),
-            1e-2
-        );
+    fn the_verdict_is_the_same_whichever_reference_the_report_names() {
+        // ferrox reproduces reference A closely; B is off on its own,
+        // and A and B are further apart than ferrox is from A.
+        let a = vec![0.0f32, 4.0, 1.0, 0.5];
+        let b = vec![0.0f32, 2.5, 1.0, 0.5];
+        let ferrox = vec![0.0f32, 3.6, 1.0, 0.5];
+        let quant = DominantQuant::weigh(Some("Q4K"), Some("Q4K"));
+
+        let ab = Band::measure(&[a.clone(), b.clone()], &ferrox, &quant);
+        let ba = Band::measure(&[b.clone(), a.clone()], &ferrox, &quant);
+
+        let first = compare(&a, &ferrox, 4, &ab);
+        let second = compare(&b, &ferrox, 4, &ba);
+        assert_eq!(first.verdict, Verdict::Drift);
+        assert_eq!(second.verdict, Verdict::Drift);
+        // Both really did drift — neither is a MATCH that would make
+        // the agreement trivial.
+        assert!(first.kl_ref_ferrox > KL_NOISE && second.kl_ref_ferrox > KL_NOISE);
+        // The printed KL is still the named reference's, which is the
+        // whole reason both numbers appear in the report.
+        assert_ne!(first.kl_ref_ferrox, second.kl_ref_ferrox);
+
+        // With ONE reference and a K-quant body there is no line at
+        // all, so the same B-vs-ferrox comparison cannot be a WRONG
+        // either — even though its KL is an order of magnitude over
+        // the 3.008e-2 constant that used to be the line.
+        let alone = Band::measure(std::slice::from_ref(&b), &ferrox, &quant);
+        let solo = compare(&b, &ferrox, 4, &alone);
+        assert!(solo.kl_ref_ferrox > 3.008e-2, "{}", solo.kl_ref_ferrox);
+        assert_eq!(solo.verdict, Verdict::Drift);
     }
 
-    /// A `Q8_0` OUTPUT HEAD OVER A K-QUANT BODY IS A K-QUANT
-    /// COMPARISON — the shape #109 is about.
+    /// A WRONG still happens, and it happens to a calibrated band.
     ///
-    /// It shipped judged as a Q8_0 one, because the threshold read the
-    /// head and never asked what the layers were. No checkpoint in
-    /// `models/` has the shape, so one was built:
-    /// `llama-quantize --pure --output-tensor-type q8_0
-    /// --token-embedding-type q8_0 Qwen3-0.6B-BF16.gguf out.gguf
-    /// Q4_K_S`. Against Homebrew libllama b7650 it measured KL
-    /// **1.297e-2** and read **WRONG** — while the same model quantized
-    /// `--pure` (K-quant head as well) measured a LARGER 1.975e-2 and
-    /// read DRIFT. Same body arithmetic, and the more precise of the two
-    /// was the one `ferrox parity` exited non-zero on.
+    /// The rule is a relaxation on the checkpoints measured here, so a
+    /// test suite that only proved things are no longer WRONG would be
+    /// consistent with a verdict that can never fire.
     #[test]
-    fn a_q8_0_head_over_a_kquant_body_is_judged_as_the_kquant_it_is() {
-        for body in Q8K_DOTTED {
-            let q = DominantQuant::weigh(Some("Q8_0"), Some(body));
-            assert!(
-                q.q8k_dotted(),
-                "a {body} body dots against Q8_K activations whatever the output head is"
-            );
-            assert_eq!(q.label(), Some(*body), "the body is what the report names");
-            assert_eq!(q.wrong_kl_threshold(), KL_WRONG_Q8K_DOTTED);
-        }
-        // The measured row, so the constant is tied to the observation
-        // rather than merely ordered against another constant.
-        let measured_kl = 1.297e-2;
-        assert!(
-            measured_kl < DominantQuant::weigh(Some("Q8_0"), Some("Q4K")).wrong_kl_threshold(),
-            "the constructed Q8_0-head/Q4_K-body checkpoint must read DRIFT, not WRONG"
-        );
-        // When BOTH halves are Q8_K-dotted the threshold is the same
-        // either way, so only the label distinguishes the rules — and
-        // the body is the honest label, because it is the layers that
-        // carry the drift (2.313e-4 for a K-quant head alone). Keying
-        // the label on the head, as the message did before #109, must
-        // be visible here rather than only in the shape that changes
-        // the verdict.
-        assert_eq!(
-            DominantQuant::weigh(Some("Q6K"), Some("Q4K")).label(),
-            Some("Q4K"),
-            "with a K-quant on both ends the report names the body"
-        );
-    }
-
-    /// The head can still TRIGGER the allowance, so no row can move
-    /// DRIFT → WRONG because of #109's fix.
-    ///
-    /// Measured cost of keeping it: a Q6_K head over a Q8_0 body
-    /// (`--pure Q8_0 --output-tensor-type q6_K`) lands at KL 2.313e-4,
-    /// four orders below either line, so the sensitivity being conceded
-    /// is not sensitivity anything could use.
-    #[test]
-    fn a_kquant_head_over_a_q8_0_body_still_relaxes_rather_than_inventing_a_wrong() {
-        let q = DominantQuant::weigh(Some("Q6K"), Some("Q8_0"));
-        assert!(q.q8k_dotted());
-        assert_eq!(q.label(), Some("Q6K"));
-        assert_eq!(q.wrong_kl_threshold(), KL_WRONG_Q8K_DOTTED);
-    }
-
-    fn tensor(name: &str, dtype: ferrox_gguf::GgmlType) -> ferrox_gguf::TensorInfo {
-        ferrox_gguf::TensorInfo {
-            name: name.to_string(),
-            shape: vec![1],
-            dtype,
-            offset: 0,
-        }
-    }
-
-    /// The body is read off the LAYERS, and the output head cannot vote
-    /// in it.
-    ///
-    /// `body_quant` counts tensors, so on a checkpoint with few layers
-    /// and a head at a different precision the head could otherwise
-    /// join the tally it is being weighed against — two roles for one
-    /// tensor, which is how the head came to decide the threshold in
-    /// the first place. This also pins the shape #109 is about end to
-    /// end, from a tensor table rather than from two strings.
-    #[test]
-    fn the_body_is_read_off_the_layers_and_the_output_head_does_not_vote_in_it() {
-        use ferrox_gguf::GgmlType;
-        // One layer, so the head would outvote it if it were counted.
-        let table = vec![
-            tensor("token_embd.weight", GgmlType::Q8_0),
-            tensor("output.weight", GgmlType::Q8_0),
-            tensor("blk.0.attn_q.weight", GgmlType::Q4K),
-            tensor("blk.0.attn_norm.weight", GgmlType::F32),
-        ];
-        assert_eq!(body_quant(&table).as_deref(), Some("Q4K"));
-        assert_eq!(lm_head_quant(&table).as_deref(), Some("Q8_0"));
-        let q = DominantQuant::of(&table);
-        assert_eq!(
-            q.label(),
-            Some("Q4K"),
-            "a Q8_0 head does not hide a Q4_K body"
-        );
-        assert_eq!(q.wrong_kl_threshold(), KL_WRONG_Q8K_DOTTED);
-
-        // A tied-embedding model: no `output.weight`, and the embedding
-        // is the head. It still must not count as the body.
-        let tied = vec![
-            tensor("token_embd.weight", GgmlType::Q8_0),
-            tensor("blk.0.ffn_up.weight", GgmlType::Q4K),
-        ];
-        assert_eq!(body_quant(&tied).as_deref(), Some("Q4K"));
-        assert_eq!(
-            DominantQuant::of(&tied).wrong_kl_threshold(),
-            KL_WRONG_Q8K_DOTTED
-        );
-
-        // An unreadable file relaxes nothing.
-        assert_eq!(DominantQuant::of(&[]).label(), None);
-        assert_eq!(DominantQuant::of(&[]).wrong_kl_threshold(), KL_WRONG);
-    }
-
-    /// The DRIFT message and the WRONG threshold read ONE value.
-    ///
-    /// This is #109's actual defect, in the repo's dominant shape: two
-    /// rules that had to agree about which quantization a verdict is
-    /// about, with nothing enforcing it. Both now go through
-    /// `q8k_dotted` on the same `DominantQuant`, and this walks every
-    /// head/body combination asserting they never part.
-    #[test]
-    fn the_drift_message_and_the_wrong_line_never_disagree_about_the_quant() {
-        let kinds: Vec<Option<&str>> = std::iter::once(None)
-            .chain(
-                ["Q8_0", "Q4_0", "Q5_0", "IQ4NL"]
-                    .into_iter()
-                    .chain(Q8K_DOTTED.iter().copied())
-                    .map(Some),
-            )
-            .collect();
-        for head in &kinds {
-            for body in &kinds {
-                let q = DominantQuant::weigh(*head, *body);
-                // The message explains the divergence as the Q8_K
-                // activation path exactly when the threshold made room
-                // for it. One is the other's condition.
-                let message_blames_q8k = q.label().filter(|_| q.q8k_dotted()).is_some();
-                let line_made_room = q.wrong_kl_threshold() == KL_WRONG_Q8K_DOTTED;
-                assert_eq!(
-                    message_blames_q8k, line_made_room,
-                    "head {head:?} body {body:?}: message says Q8_K={message_blames_q8k} but \
-                     the threshold says {line_made_room}"
-                );
-                // And the relaxation happens whenever ANY of the
-                // checkpoint's arithmetic is Q8_K-dotted, so the fix
-                // cannot move a row DRIFT -> WRONG.
-                let any_q8k = [*head, *body]
-                    .into_iter()
-                    .flatten()
-                    .any(llama_dots_this_against_q8k);
-                assert_eq!(line_made_room, any_q8k);
-            }
-        }
+    fn a_ferrox_further_from_every_reference_than_they_are_from_each_other_is_wrong() {
+        // Two references a hair apart, ferrox a long way from both.
+        let a = vec![0.0f32, 4.00, 1.0, 0.5];
+        let b = vec![0.0f32, 3.99, 1.0, 0.5];
+        let ferrox = vec![0.0f32, 1.00, 1.0, 0.5];
+        let quant = DominantQuant::weigh(Some("Q4K"), Some("Q4K"));
+        let band = Band::measure(&[a.clone(), b], &ferrox, &quant);
+        assert!(band.ferrox_is_outside());
+        assert_eq!(compare(&a, &ferrox, 4, &band).verdict, Verdict::Wrong);
     }
 
     /// The dumper's self-report is read, and its absence is not
@@ -1181,37 +838,25 @@ mod tests {
         assert_eq!(parse_libllama("libllama   \n"), None);
     }
 
-    /// The Q8_K predicate is spelled in `GgmlType`'s variant names, not
-    /// ggml's.
+    /// Every `--dumper` is resolved, in order, and a typo in ANY of them
+    /// fails the run.
     ///
-    /// `format!("{:?}", dtype)` yields `Q4K`, and ggml calls the same
-    /// thing `Q4_K`. Writing the ggml spelling here matches NOTHING
-    /// while looking exactly right, and the symptom is the generic
-    /// "go run a per-layer divergence" message on every K-quant — which
-    /// is the message this predicate exists to suppress. That mistake
-    /// was made once already; this is what catches it.
+    /// A missing secondary that fell back to the tree's default would
+    /// silently calibrate against the primary itself — a zero spread
+    /// wearing the appearance of a two-reference experiment.
     #[test]
-    fn the_q8k_predicate_uses_the_dtype_debug_spelling() {
-        for kind in ["Q2K", "Q3K", "Q4K", "Q5K", "Q6K", "IQ4XS", "IQ2S"] {
-            assert!(
-                llama_dots_this_against_q8k(kind),
-                "{kind} declares vec_dot_type = Q8_K in ggml-cpu.c"
-            );
-        }
-        // The ggml spelling must NOT match, or the underscore bug is
-        // back and invisible.
-        for wrong in ["Q4_K", "Q6_K", "IQ4_XS"] {
-            assert!(
-                !llama_dots_this_against_q8k(wrong),
-                "{wrong} is ggml's spelling, not GgmlType's -- if this now matches, the \
-                 predicate is accepting both and the next reader cannot tell which is real"
-            );
-        }
-        // Q8_0-dotted quants must stay out: these are the ones that
-        // MATCH, and claiming the divergence is expected for them would
-        // excuse a real bug.
-        for q8_0_dotted in ["Q8_0", "Q4_0", "Q5_0", "IQ4NL"] {
-            assert!(!llama_dots_this_against_q8k(q8_0_dotted));
-        }
+    fn every_dumper_is_resolved_and_a_missing_one_is_never_substituted() {
+        let me = std::env::current_exe().unwrap();
+        let me = me.to_string_lossy().into_owned();
+        let resolved = dumper_paths(&[me.clone(), me.clone()]).unwrap();
+        assert_eq!(resolved.len(), 2, "both references must survive");
+
+        let err = dumper_paths(&[me, "/nonexistent/llama_logits".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("/nonexistent/llama_logits"),
+            "a bad second dumper must name itself, got: {err}"
+        );
     }
 }

--- a/crates/ferrox-cli/src/parity.rs
+++ b/crates/ferrox-cli/src/parity.rs
@@ -162,9 +162,9 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
     // `bail!` below still leaves the evidence behind. The whole reason
     // to dump is to investigate a bad verdict; losing the vectors
     // exactly when the verdict is bad would defeat it.
+    let ref_logits: Vec<&[f32]> = references.iter().map(|r| r.logits.as_slice()).collect();
     if let Some(prefix) = args.dump_logits.as_deref() {
-        let logits: Vec<&[f32]> = references.iter().map(|r| r.logits.as_slice()).collect();
-        for p in dump::write(prefix, &tokens, &logits, &ferrox_logits)? {
+        for p in dump::write(prefix, &tokens, &ref_logits, &ferrox_logits)? {
             println!("wrote {}", p.display());
         }
         println!();
@@ -175,9 +175,8 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
     let gguf = ferrox_gguf::GgufFile::open(&path).ok();
     let quant = DominantQuant::of(gguf.as_ref().map_or(&[][..], |f| &f.tensors));
 
-    let ref_logits: Vec<Vec<f32>> = references.iter().map(|r| r.logits.clone()).collect();
     let band = Band::measure(&ref_logits, &ferrox_logits, &quant);
-    let report = compare(&references[0].logits, &ferrox_logits, args.top_k, &band);
+    let report = compare(ref_logits[0], &ferrox_logits, args.top_k, &band);
     print_report(
         &args.model,
         tokens.len(),
@@ -671,7 +670,7 @@ mod tests {
     /// so these exercise the ladder and not the calibration.
     fn one_reference(reference: &[f32], ferrox: &[f32]) -> Band {
         Band::measure(
-            &[reference.to_vec()],
+            &[reference],
             ferrox,
             &DominantQuant::weigh(Some("Q8_0"), Some("Q8_0")),
         )
@@ -780,8 +779,8 @@ mod tests {
         let ferrox = vec![0.0f32, 3.6, 1.0, 0.5];
         let quant = DominantQuant::weigh(Some("Q4K"), Some("Q4K"));
 
-        let ab = Band::measure(&[a.clone(), b.clone()], &ferrox, &quant);
-        let ba = Band::measure(&[b.clone(), a.clone()], &ferrox, &quant);
+        let ab = Band::measure(&[&a, &b], &ferrox, &quant);
+        let ba = Band::measure(&[&b, &a], &ferrox, &quant);
 
         let first = compare(&a, &ferrox, 4, &ab);
         let second = compare(&b, &ferrox, 4, &ba);
@@ -798,7 +797,7 @@ mod tests {
         // all, so the same B-vs-ferrox comparison cannot be a WRONG
         // either — even though its KL is an order of magnitude over
         // the 3.008e-2 constant that used to be the line.
-        let alone = Band::measure(std::slice::from_ref(&b), &ferrox, &quant);
+        let alone = Band::measure(&[&b], &ferrox, &quant);
         let solo = compare(&b, &ferrox, 4, &alone);
         assert!(solo.kl_ref_ferrox > 3.008e-2, "{}", solo.kl_ref_ferrox);
         assert_eq!(solo.verdict, Verdict::Drift);
@@ -828,7 +827,7 @@ mod tests {
         let quant = DominantQuant::weigh(Some("Q4K"), Some("Q4K"));
 
         // B is the primary, so B's KL is what the report carries.
-        let band = Band::measure(&[b.clone(), a], &ferrox, &quant);
+        let band = Band::measure(&[&b, &a], &ferrox, &quant);
         let line = band.line().value().expect("two references give a line");
         assert!(
             band.kl_to_ferrox(0) > line,
@@ -858,7 +857,7 @@ mod tests {
         let b = vec![0.0f32, 3.99, 1.0, 0.5];
         let ferrox = vec![0.0f32, 1.00, 1.0, 0.5];
         let quant = DominantQuant::weigh(Some("Q4K"), Some("Q4K"));
-        let band = Band::measure(&[a.clone(), b], &ferrox, &quant);
+        let band = Band::measure(&[&a, &b], &ferrox, &quant);
         assert!(band.ferrox_is_outside());
         assert_eq!(compare(&a, &ferrox, 4, &band).verdict, Verdict::Wrong);
     }

--- a/crates/ferrox-cli/src/parity.rs
+++ b/crates/ferrox-cli/src/parity.rs
@@ -178,10 +178,12 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
     let band = Band::measure(&ref_logits, &ferrox_logits, &quant);
     let report = compare(ref_logits[0], &ferrox_logits, args.top_k, &band);
     print_report(
-        &args.model,
-        tokens.len(),
-        args.top_k,
-        backend.as_str(),
+        &Run {
+            model: &args.model,
+            n_tokens: tokens.len(),
+            top_k: args.top_k,
+            backend: backend.as_str(),
+        },
         &quant,
         &references,
         &band,
@@ -394,17 +396,30 @@ fn compare(ref_logits: &[f32], ferrox_logits: &[f32], k: usize, band: &Band) -> 
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn print_report(
-    model: &str,
+/// What the run WAS, as opposed to what it found. Grouped because a
+/// print function taking eight positional arguments is one careless
+/// edit away from two of them being swapped, and `&str` next to `&str`
+/// swaps silently.
+struct Run<'a> {
+    model: &'a str,
     n_tokens: usize,
-    k: usize,
-    backend: &str,
+    top_k: usize,
+    backend: &'a str,
+}
+
+fn print_report(
+    run: &Run<'_>,
     quant: &DominantQuant,
     references: &[Reference],
     band: &Band,
     r: &Report,
 ) {
+    let Run {
+        model,
+        n_tokens,
+        top_k: k,
+        backend,
+    } = *run;
     let name = Path::new(model)
         .file_stem()
         .map(|s| s.to_string_lossy().into_owned())

--- a/crates/ferrox-cli/src/parity.rs
+++ b/crates/ferrox-cli/src/parity.rs
@@ -804,6 +804,48 @@ mod tests {
         assert_eq!(solo.verdict, Verdict::Drift);
     }
 
+    /// THE WRONG RUNG READS THE NEAREST REFERENCE, NOT THE ONE THE
+    /// REPORT NAMES.
+    ///
+    /// This is the whole change, in the one geometry that separates it
+    /// from the old rule: the KL printed against the named reference is
+    /// OVER that checkpoint's line, while ferrox is nowhere near being
+    /// the outlier — the two references disagree with each other, and
+    /// ferrox reproduces the other one to within a fiftieth of their
+    /// disagreement. Qwen3-0.6B `--pure` Q4_K_S is this shape at
+    /// smaller scale (3.889e-2 printed, 3.514e-2 spread, 1.975e-2 to
+    /// the other build), and deciding it on the printed number is what
+    /// made one file DRIFT on one bottle and WRONG on another (#102,
+    /// #111).
+    ///
+    /// The report still prints the large number. It is a true statement
+    /// about the named reference; it is just not evidence about ferrox.
+    #[test]
+    fn the_wrong_rung_is_decided_by_the_nearest_reference_not_the_one_being_reported() {
+        let a = vec![0.0f32, 4.0, 1.0, 0.5];
+        let b = vec![0.0f32, 2.0, 1.0, 0.5];
+        let ferrox = vec![0.0f32, 3.8, 0.2, 0.5];
+        let quant = DominantQuant::weigh(Some("Q4K"), Some("Q4K"));
+
+        // B is the primary, so B's KL is what the report carries.
+        let band = Band::measure(&[b.clone(), a], &ferrox, &quant);
+        let line = band.line().value().expect("two references give a line");
+        assert!(
+            band.kl_to_ferrox(0) > line,
+            "the fixture must put the PRIMARY over the line, else this proves nothing: {:.4e} \
+             against {line:.4e}",
+            band.kl_to_ferrox(0)
+        );
+        assert!(band.nearest() < line);
+
+        let r = compare(&b, &ferrox, 4, &band);
+        assert_eq!(r.verdict, Verdict::Drift);
+        assert!(
+            r.kl_ref_ferrox > line,
+            "the printed KL is still the named reference's"
+        );
+    }
+
     /// A WRONG still happens, and it happens to a calibrated band.
     ///
     /// The rule is a relaxation on the checkpoints measured here, so a

--- a/crates/ferrox-cli/src/parity/calibration.rs
+++ b/crates/ferrox-cli/src/parity/calibration.rs
@@ -523,30 +523,43 @@ mod tests {
         assert!(matches!(band.line(), WrongLine::Calibrated { .. }));
     }
 
-    /// The spread is the LARGER of the two KL directions.
+    /// The spread walks ORDERED pairs, so the larger of the two KL
+    /// directions is the one it reports.
     ///
-    /// KL is asymmetric, so a spread that took one direction would
-    /// report a band smaller than the evidence supports on every pair
-    /// where the two references have different entropies — and a band
-    /// too small is a WRONG that should not have been printed.
+    /// KL is asymmetric, so a loop over `i < j` would report a band
+    /// smaller than the evidence supports on every pair where the two
+    /// references have different entropies — and a band too small is a
+    /// WRONG that should not have been printed. The references are
+    /// deliberately ordered so that the LARGER direction is the pair
+    /// `(1, 0)`, which an `i < j` loop never visits; asserting the pair
+    /// as well as the value is what makes that visible, because the
+    /// value alone would still be right for half of all orderings.
     #[test]
     fn the_spread_is_the_larger_of_the_two_kl_directions() {
-        // A flat distribution against a peaked one: the two KL
+        // A peaked distribution against a flat one: the two KL
         // directions differ by a factor of several.
-        let flat = vec![0.0f32, 0.0, 0.0, 0.0];
         let peaked = vec![6.0f32, 0.0, 0.0, 0.0];
+        let flat = vec![0.0f32, 0.0, 0.0, 0.0];
         let ferrox = vec![0.1f32, 0.0, 0.0, 0.0];
 
-        let p = metrics::softmax(&flat);
-        let q = metrics::softmax(&peaked);
+        let p = metrics::softmax(&peaked);
+        let q = metrics::softmax(&flat);
         let (fwd, back) = (metrics::kl(&p, &q), metrics::kl(&q, &p));
-        assert!(fwd != back, "the fixture must actually be asymmetric");
+        assert!(
+            back > fwd,
+            "the fixture must put the larger direction on the reversed pair: {fwd} vs {back}"
+        );
 
-        let band = Band::measure(&[flat, peaked], &ferrox, &kquant());
+        let band = Band::measure(&[peaked, flat], &ferrox, &kquant());
         match band.line() {
             WrongLine::Calibrated { spread, .. } => {
-                assert_eq!(spread.kl, fwd.max(back));
-                assert_ne!(spread.kl, fwd.min(back));
+                assert_eq!(spread.kl, back);
+                assert_ne!(spread.kl, fwd);
+                assert_eq!(
+                    spread.between,
+                    (1, 0),
+                    "the reported pair must be the ordered one that produced the number"
+                );
             }
             other => panic!("expected a calibrated line, got {other:?}"),
         }

--- a/crates/ferrox-cli/src/parity/calibration.rs
+++ b/crates/ferrox-cli/src/parity/calibration.rs
@@ -217,7 +217,7 @@ impl Band {
     /// `references` must be non-empty and every vector the same length
     /// as `ferrox`; `run` drops any reference that disagrees about the
     /// vocabulary before getting here.
-    pub(super) fn measure(references: &[Vec<f32>], ferrox: &[f32], quant: &DominantQuant) -> Self {
+    pub(super) fn measure(references: &[&[f32]], ferrox: &[f32], quant: &DominantQuant) -> Self {
         let probs: Vec<Vec<f64>> = references.iter().map(|r| metrics::softmax(r)).collect();
         let fx = metrics::softmax(ferrox);
         let to_ferrox = probs.iter().map(|p| metrics::kl(p, &fx)).collect();
@@ -511,7 +511,7 @@ mod tests {
     fn a_pair_of_references_that_cannot_disagree_does_not_calibrate_anything() {
         let identical = vec![0.5f32, 2.0, -1.0, 7.25];
         let ferrox = vec![0.5f32, 2.9, -1.0, 7.25];
-        let band = Band::measure(&[identical.clone(), identical.clone()], &ferrox, &kquant());
+        let band = Band::measure(&[&identical, &identical], &ferrox, &kquant());
         assert_eq!(*band.line(), WrongLine::Uncalibrated);
         assert!(!band.ferrox_is_outside());
 
@@ -519,7 +519,7 @@ mod tests {
         // calibrate — otherwise this test would pass on a `measure`
         // that never calibrates at all.
         let other = vec![0.5f32, 2.4, -1.0, 7.25];
-        let band = Band::measure(&[identical, other], &ferrox, &kquant());
+        let band = Band::measure(&[&identical, &other], &ferrox, &kquant());
         assert!(matches!(band.line(), WrongLine::Calibrated { .. }));
     }
 
@@ -550,7 +550,7 @@ mod tests {
             "the fixture must put the larger direction on the reversed pair: {fwd} vs {back}"
         );
 
-        let band = Band::measure(&[peaked, flat], &ferrox, &kquant());
+        let band = Band::measure(&[&peaked, &flat], &ferrox, &kquant());
         match band.line() {
             WrongLine::Calibrated { spread, .. } => {
                 assert_eq!(spread.kl, back);

--- a/crates/ferrox-cli/src/parity/calibration.rs
+++ b/crates/ferrox-cli/src/parity/calibration.rs
@@ -1,0 +1,604 @@
+//! What "the graphs disagree" is allowed to mean — measured on THIS
+//! checkpoint, not fitted once and reused.
+//!
+//! # The defect this replaces
+//!
+//! `ferrox parity` used to call a checkpoint WRONG above an absolute KL,
+//! with a second, looser absolute KL for checkpoints llama.cpp dots
+//! against Q8_K activations. That second constant was
+//! `KL_REFERENCE_BUILD_SPREAD_KQUANT * 1.1` = 3.008e-2, derived in
+//! [#108](https://github.com/antonellof/ferrox/issues/108) from the
+//! largest reference-against-reference KL then known (2.735e-2, on
+//! Qwen2.5-1.5B). Its own doc comment named what would invalidate it:
+//! *"the spread is the largest of nine checkpoints, so a tenth could
+//! exceed it"*.
+//!
+//! A tenth did. [#111](https://github.com/antonellof/ferrox/issues/111)
+//! measured 3.514e-2 between two builds of llama.cpp on Qwen3-0.6B
+//! `--pure` Q4_K_S — above the line that was supposed to mean "two
+//! graphs disagree", produced by two binaries whose graph is IDENTICAL.
+//! So `ferrox parity` read DRIFT on that file against Homebrew b7650
+//! and WRONG against `.scratch/llama.cpp`, from the same ferrox, and
+//! exited non-zero on the second.
+//!
+//! **Raising the constant does not fix that.** Setting it to the new
+//! largest measurement puts the line at 3.865e-2 and the newer
+//! reference reads 3.889e-2, still over. The next checkpoint is wider
+//! again. The spread is not a constant of the engine at all: it is a
+//! property of the pair of llama.cpp builds and of the checkpoint, and
+//! across 21 checkpoints measured here it ranges over **five orders of
+//! magnitude**, from exactly 0 to 3.514e-2. One number cannot separate
+//! "ferrox is wrong" from "this is a checkpoint where two references
+//! disagree a lot", and it fails in BOTH directions: 3.008e-2 was
+//! simultaneously too tight for Qwen3-0.6B and 14x too loose for
+//! Llama-3.2-1B Q4_K_M, whose two references agree to 2.1e-3.
+//!
+//! # The rule
+//!
+//! Measure the references' own disagreement on this checkpoint, and ask
+//! whether ferrox is a bigger outlier than they are:
+//!
+//! > ferrox is WRONG only when it is further from EVERY reference than
+//! > the references are from EACH OTHER — and never below the absolute
+//! > [`KL_WRONG`] line, which is what a wrong graph costs regardless.
+//!
+//! `line = max(KL_WRONG, spread)`, tested against `min_i KL(ref_i ‖
+//! ferrox)`. There is **no margin constant and no fitted number**: the
+//! only constant left is [`KL_WRONG`], unchanged at 1e-2 since before
+//! any of this. Three constants are deleted, none added.
+//!
+//! Why the NEAREST reference rather than the primary: the claim a WRONG
+//! makes is "ferrox's forward pass computes something different from
+//! llama.cpp's". If ferrox reproduces build A as closely as build B
+//! reproduces A, then ferrox's graph agrees with A's as well as B's
+//! does, and calling that a different graph would convict B too. That
+//! is exactly the situation #102 and #111 describe.
+//!
+//! # The measurement, 21 checkpoints, ferrox out of the pairwise half
+//!
+//! Homebrew libllama b7650 against `.scratch/llama.cpp` (ggml 0.18.0),
+//! CPU-only, the fixed parity prompt, 2026-09-04. `spread` is the
+//! larger of the two KL directions between the references; `nearest` is
+//! `min(KL(b7650‖ferrox), KL(scratch‖ferrox))`; `ratio` is
+//! `nearest / line`.
+//!
+//! | checkpoint | spread | nearest | line | ratio |
+//! |---|---|---|---|---|
+//! | Llama-3.2-1B Q8_0 | **0.0** | 6.912e-4 | 1.000e-2 | 0.07 |
+//! | tinyllama-1.1B Q8_0 | **0.0** | 2.445e-4 | 1.000e-2 | 0.02 |
+//! | Llama-3.2-1B q6khead-q8body | 1.140e-13 | 2.313e-4 | 1.000e-2 | 0.02 |
+//! | Llama-3.2-1B IQ4_XS | 2.981e-4 | 9.208e-4 | 1.000e-2 | 0.09 |
+//! | olmoe-1b-7b Q4_0 | 4.570e-4 | 4.259e-4 | 1.000e-2 | 0.04 |
+//! | Llama-3.2-3B Q4_K_M | 7.518e-4 | 6.463e-4 | 1.000e-2 | 0.06 |
+//! | Llama-3.1-8B Q4_K_M | 7.579e-4 | 1.072e-3 | 1.000e-2 | 0.11 |
+//! | Llama-3.2-1B pure-q4ks | 1.163e-3 | 1.126e-3 | 1.000e-2 | 0.11 |
+//! | Llama-3.2-1B Q6_K | 1.280e-3 | 3.560e-3 | 1.000e-2 | 0.36 |
+//! | Mistral-7B Q4_K_M | 1.436e-3 | 4.684e-4 | 1.000e-2 | 0.05 |
+//! | Llama-3.2-1B q8head-q4ksbody | 1.857e-3 | 8.650e-4 | 1.000e-2 | 0.09 |
+//! | Llama-3.2-1B Q4_K_M | 2.118e-3 | 1.077e-3 | 1.000e-2 | 0.11 |
+//! | Llama-3.2-1B Q5_K_M | 2.174e-3 | 1.382e-3 | 1.000e-2 | 0.14 |
+//! | Phi-4-mini Q4_K_M | 5.585e-3 | 3.800e-3 | 1.000e-2 | 0.38 |
+//! | Qwen1.5-MoE-A2.7B Q4_K_M | 5.698e-3 | 4.826e-3 | 1.000e-2 | 0.48 |
+//! | Yi-1.5-6B Q4_K_M | 7.318e-3 | 2.177e-3 | 1.000e-2 | 0.22 |
+//! | DeepSeek-R1-Distill-1.5B Q4_K_M | 1.570e-2 | 9.157e-3 | 1.570e-2 | **0.58** |
+//! | gemma-2-2b Q4_K_M | 1.674e-2 | 6.511e-3 | 1.674e-2 | 0.39 |
+//! | Qwen2.5-1.5B Q4_K_M | 2.735e-2 | 7.679e-3 | 2.735e-2 | 0.28 |
+//! | **Qwen3-0.6B q8head-q4ksbody** | 2.746e-2 | 1.297e-2 | 2.746e-2 | 0.47 |
+//! | **Qwen3-0.6B pure-q4ks** | **3.514e-2** | 1.975e-2 | 3.514e-2 | 0.56 |
+//!
+//! Every row is inside its line, the worst at 58% of it. The two bold
+//! rows are the ones that read WRONG under the old constant against the
+//! newer reference (3.889e-2 and 3.519e-2 against 3.008e-2) — #111 —
+//! and they are the only two rows this rule moves.
+//!
+//! The measurement also corrects a claim #108 made from a smaller
+//! sample. "The reference's spread on Q8_0 is exactly zero" holds for
+//! VINTAGE (b7650 and ggml 0.18.0 are bit-identical on both Q8_0
+//! checkpoints) but not for COMPILER FLAGS: a third build of the same
+//! source with FMA contraction disabled differs from b7650 by 4.11e-4
+//! on tinyllama Q8_0, and Q4_0 (olmoe) already moves 4.57e-4 between
+//! vintages. All of it is two orders under [`KL_WRONG`], which is why
+//! that line is left exactly where it was.
+//!
+//! # What this costs, stated rather than hoped
+//!
+//! **A genuine ferrox bug inside a wide band is excused.** That is real
+//! and it is the price. What makes it acceptable is that the band is
+//! only wide where the reference is: 16 of the 21 rows above get the
+//! 1e-2 floor, THREE TIMES TIGHTER than the 3.008e-2 they used to be
+//! judged against. So per-checkpoint calibration raises sensitivity on
+//! most checkpoints and lowers it only on the ones where a WRONG could
+//! not have been believed anyway — on Qwen3-0.6B `--pure`, no verdict
+//! of "the graphs disagree" is available from this instrument at any
+//! threshold, because llama.cpp reproduces that difference against
+//! llama.cpp.
+//!
+//! **Two builds are two points, not a distribution.** The spread is a
+//! lower bound on how much implementation choice moves this checkpoint,
+//! measured from the two implementations to hand. It is not an estimate
+//! of dispersion and this module does not pretend otherwise; the
+//! report prints the number and the pair it came from so a reader can
+//! judge it. Adding a third reference widens the band (it is the max
+//! over pairs), so the references passed should be builds you would
+//! accept as correct.
+//!
+//! **It costs a second reference run per checkpoint**, and only when
+//! one is configured. With ONE reference there is no spread to measure
+//! and [`WrongLine::Uncalibrated`] is the honest answer for the
+//! Q8_K-dotted class: no KL can be called "the graphs disagree" when
+//! the instrument has not been shown able to tell. The top-1 half of
+//! the verdict is unaffected — it rests on no threshold — so a
+//! single-reference run still fails on a genuine argmax disagreement,
+//! and Q8_0/Q4_0/IQ4_NL checkpoints still get [`KL_WRONG`], because
+//! their measured spread is at or near zero.
+
+use super::metrics;
+use super::quant::DominantQuant;
+
+/// Above this KL two distributions differ by more than accumulation
+/// order — a different rope base, a missing bias, a skipped norm. The
+/// "wrong graph" line, and the floor under every calibrated one.
+///
+/// Unchanged, and deliberately: the reference's own build-to-build
+/// spread on the arithmetic this line governs is 0.0 (Q8_0, both
+/// vintages) to 4.6e-4 (Q4_0), so there is nothing here to make room
+/// for. It is also the floor under a calibrated line, because a pair of
+/// references that happen to agree closely on one checkpoint is not
+/// evidence that ferrox must agree with them to the same 1e-13.
+pub(super) const KL_WRONG: f64 = 1e-2;
+
+/// Two references, and how far apart they are on this checkpoint.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct Spread {
+    /// The largest KL over ORDERED pairs. Ordered because KL is
+    /// asymmetric and picking one direction would quietly report the
+    /// smaller of two equally valid numbers.
+    pub(super) kl: f64,
+    /// Indices, into the caller's reference list, of the pair that
+    /// produced it.
+    pub(super) between: (usize, usize),
+}
+
+/// The line a KL has to cross before "the graphs disagree" is a claim
+/// this instrument can make.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum WrongLine {
+    /// Measured on this checkpoint: `max(KL_WRONG, spread)`.
+    Calibrated { spread: Spread, line: f64 },
+    /// [`KL_WRONG`], for a checkpoint whose arithmetic llama.cpp dots
+    /// against Q8_0 activations. Legitimate without a second reference
+    /// because the spread there is at or near zero.
+    Absolute(f64),
+    /// NO LINE. One reference, on a checkpoint whose K-quant activation
+    /// path is exactly the thing two llama.cpp builds disagree about by
+    /// up to 3.5e-2. Any constant here would fire on differences
+    /// llama.cpp reproduces against itself (#111).
+    Uncalibrated,
+}
+
+impl WrongLine {
+    fn decide(spread: Option<Spread>, quant: &DominantQuant) -> Self {
+        match spread {
+            // `max` and not `spread` alone: see KL_WRONG's own comment.
+            Some(s) => {
+                let line = s.kl.max(KL_WRONG);
+                Self::Calibrated { spread: s, line }
+            }
+            None if quant.q8k_dotted() => Self::Uncalibrated,
+            None => Self::Absolute(KL_WRONG),
+        }
+    }
+
+    /// The number, when there is one.
+    pub(super) fn value(&self) -> Option<f64> {
+        match self {
+            Self::Calibrated { line, .. } => Some(*line),
+            Self::Absolute(v) => Some(*v),
+            Self::Uncalibrated => None,
+        }
+    }
+}
+
+/// Everything the WRONG rung of the verdict rests on.
+///
+/// Holds the KL to every reference as well as the line, so the report
+/// and the verdict read ONE set of numbers. Recomputing `KL(primary ‖
+/// ferrox)` in `compare` would be two evaluations of one quantity with
+/// nothing tying them together, which is how this repo loses things.
+#[derive(Debug, Clone)]
+pub(super) struct Band {
+    /// `KL(reference_i ‖ ferrox)`, in the order the references were
+    /// given. Never empty: a run with no reference cannot get this far.
+    to_ferrox: Vec<f64>,
+    line: WrongLine,
+}
+
+impl Band {
+    /// `references` must be non-empty and every vector the same length
+    /// as `ferrox`; `run` drops any reference that disagrees about the
+    /// vocabulary before getting here.
+    pub(super) fn measure(references: &[Vec<f32>], ferrox: &[f32], quant: &DominantQuant) -> Self {
+        let probs: Vec<Vec<f64>> = references.iter().map(|r| metrics::softmax(r)).collect();
+        let fx = metrics::softmax(ferrox);
+        let to_ferrox = probs.iter().map(|p| metrics::kl(p, &fx)).collect();
+
+        // Largest KL over ordered pairs of DISTINCT references.
+        let mut spread: Option<Spread> = None;
+        for (i, a) in probs.iter().enumerate() {
+            for (j, b) in probs.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                let kl = metrics::kl(a, b);
+                // A spread of exactly zero is not a band. It means the
+                // two references are the same program for this
+                // checkpoint — the same dumper passed twice, or two
+                // builds that are bit-identical on it — and a pair that
+                // cannot disagree bounds nothing. Calibrating on it
+                // would collapse the line onto KL_WRONG for a K-quant,
+                // which is the false-WRONG this module exists to stop.
+                if kl > 0.0 && spread.as_ref().is_none_or(|s| kl > s.kl) {
+                    spread = Some(Spread {
+                        kl,
+                        between: (i, j),
+                    });
+                }
+            }
+        }
+
+        Self {
+            line: WrongLine::decide(spread, quant),
+            to_ferrox,
+        }
+    }
+
+    /// `KL(reference_i ‖ ferrox)`.
+    pub(super) fn kl_to_ferrox(&self, i: usize) -> f64 {
+        self.to_ferrox[i]
+    }
+
+    /// How far ferrox is from the reference it agrees with best.
+    pub(super) fn nearest(&self) -> f64 {
+        self.to_ferrox.iter().copied().fold(f64::INFINITY, f64::min)
+    }
+
+    pub(super) fn line(&self) -> &WrongLine {
+        &self.line
+    }
+
+    /// THE PREDICATE. Every rung of the verdict that could read WRONG
+    /// goes through this one call, so the "same top-1" branch and the
+    /// "top-1 flipped" branch cannot come to disagree about what the
+    /// line is — they were two spellings of `kl < kl_wrong` before.
+    ///
+    /// `false` whenever there is no line: an instrument that has not
+    /// been shown able to tell does not get to convict.
+    pub(super) fn ferrox_is_outside(&self) -> bool {
+        self.line.value().is_some_and(|line| self.nearest() > line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::quant::tests::{Q8K_DOTTED, Q8_0_DOTTED};
+    use super::*;
+
+    fn kquant() -> DominantQuant {
+        DominantQuant::weigh(Some("Q4K"), Some("Q4K"))
+    }
+
+    fn q8_0() -> DominantQuant {
+        DominantQuant::weigh(Some("Q8_0"), Some("Q8_0"))
+    }
+
+    fn spread(kl: f64) -> Option<Spread> {
+        Some(Spread {
+            kl,
+            between: (0, 1),
+        })
+    }
+
+    /// EVERY measured row of the 2026-09-04 three-reference sweep, as
+    /// `(checkpoint, spread, KL to b7650, KL to scratch, q8k-dotted)`.
+    ///
+    /// This is the evidence the rule is made of, in a form that fails
+    /// the build when the rule stops agreeing with it. A doc-comment
+    /// table records what was measured; this asserts the code still
+    /// answers the same way about it.
+    const SWEEP: &[(&str, f64, f64, f64, bool)] = &[
+        ("Llama-3.2-1B-Q8_0", 0.0, 6.9121e-4, 6.9121e-4, false),
+        ("tinyllama-1.1B-Q8_0", 0.0, 2.4448e-4, 2.4448e-4, false),
+        (
+            "Llama-3.2-1B-q6khead-q8body",
+            1.1399e-13,
+            2.3131e-4,
+            2.3132e-4,
+            true,
+        ),
+        (
+            "Llama-3.2-1B-IQ4_XS",
+            2.9812e-4,
+            9.2083e-4,
+            1.4186e-3,
+            false,
+        ),
+        ("olmoe-1b-7b-Q4_0", 4.5703e-4, 4.8177e-4, 4.2587e-4, false),
+        ("Llama-3.2-3B-Q4_K_M", 7.5180e-4, 9.1456e-4, 6.4631e-4, true),
+        ("Llama-3.1-8B-Q4_K_M", 7.5787e-4, 1.0718e-3, 1.3068e-3, true),
+        (
+            "Llama-3.2-1B-pure-q4ks",
+            1.1626e-3,
+            1.1260e-3,
+            1.3212e-3,
+            true,
+        ),
+        ("Llama-3.2-1B-Q6_K", 1.2803e-3, 3.5602e-3, 6.9239e-3, true),
+        ("Mistral-7B-Q4_K_M", 1.4363e-3, 4.6836e-4, 1.0008e-3, true),
+        (
+            "Llama-3.2-1B-q8head-q4ksbody",
+            1.8567e-3,
+            1.4173e-3,
+            8.6501e-4,
+            true,
+        ),
+        ("Llama-3.2-1B-Q4_K_M", 2.1176e-3, 1.8193e-3, 1.0773e-3, true),
+        ("Llama-3.2-1B-Q5_K_M", 2.1742e-3, 3.4487e-3, 1.3816e-3, true),
+        ("Phi-4-mini-Q4_K_M", 5.5853e-3, 1.1790e-2, 3.7999e-3, true),
+        (
+            "Qwen1.5-MoE-A2.7B-Q4_K_M",
+            5.6984e-3,
+            5.0306e-3,
+            4.8256e-3,
+            true,
+        ),
+        ("Yi-1.5-6B-Q4_K_M", 7.3179e-3, 2.1770e-3, 8.0876e-3, true),
+        (
+            "DeepSeek-R1-Distill-1.5B-Q4_K_M",
+            1.5695e-2,
+            1.9874e-2,
+            9.1570e-3,
+            true,
+        ),
+        ("gemma-2-2b-Q4_K_M", 1.6736e-2, 6.5107e-3, 1.5307e-2, true),
+        ("Qwen2.5-1.5B-Q4_K_M", 2.7348e-2, 7.6786e-3, 2.6692e-2, true),
+        (
+            "Qwen3-0.6B-q8head-q4ksbody",
+            2.7459e-2,
+            1.2966e-2,
+            3.5192e-2,
+            true,
+        ),
+        (
+            "Qwen3-0.6B-pure-q4ks",
+            3.5141e-2,
+            1.9748e-2,
+            3.8885e-2,
+            true,
+        ),
+    ];
+
+    fn band_of(spread_kl: f64, kls: &[f64], quant: &DominantQuant) -> Band {
+        Band {
+            to_ferrox: kls.to_vec(),
+            line: WrongLine::decide(
+                (spread_kl > 0.0).then_some(Spread {
+                    kl: spread_kl,
+                    between: (0, 1),
+                }),
+                quant,
+            ),
+        }
+    }
+
+    /// NOT ONE of the 21 measured checkpoints is WRONG under this rule,
+    /// with two references present.
+    ///
+    /// The old constant made two of them WRONG — the two Qwen3-0.6B
+    /// rows, against `.scratch/llama.cpp` — which is #111. Everything
+    /// else must land exactly where it already did, or the fix has a
+    /// blast radius nobody measured.
+    #[test]
+    fn no_measured_checkpoint_is_wrong_when_the_references_are_calibrated() {
+        for &(name, spread_kl, kl_brew, kl_scratch, q8k) in SWEEP {
+            let quant = if q8k { kquant() } else { q8_0() };
+            let band = band_of(spread_kl, &[kl_brew, kl_scratch], &quant);
+            let line = band.line().value().expect("two references give a line");
+            assert!(
+                !band.ferrox_is_outside(),
+                "{name}: nearest {:.4e} crosses the {line:.4e} line built from a {spread_kl:.4e} \
+                 reference spread",
+                band.nearest()
+            );
+            // And the headroom is not a rounding accident: the worst
+            // row in the sweep sits at 58% of its line. A rule that
+            // only just clears every row is a rule about to fire on the
+            // next checkpoint.
+            assert!(
+                band.nearest() <= 0.6 * line,
+                "{name}: {:.4e} is {:.2} of its {line:.4e} line — the measured worst is 0.58, \
+                 so either the sweep moved or the rule did",
+                band.nearest(),
+                band.nearest() / line
+            );
+        }
+    }
+
+    /// The two rows #111 is about, and the arithmetic that settles them.
+    ///
+    /// Qwen3-0.6B `--pure` Q4_K_S: two builds of llama.cpp disagree with
+    /// EACH OTHER by 3.514e-2, above the 3.008e-2 that used to mean "the
+    /// graphs disagree". Against the newer build ferrox measured
+    /// 3.889e-2 and read WRONG; against b7650 it measured 1.975e-2 and
+    /// read DRIFT — same ferrox, same file. Raising the constant to the
+    /// new largest spread would have put the line at 3.865e-2, which
+    /// 3.889e-2 still crosses; this asserts the SHAPE fixes it and the
+    /// bump would not have.
+    #[test]
+    fn the_checkpoint_that_broke_the_constant_is_inside_its_own_measured_band() {
+        let band = band_of(3.5141e-2, &[1.9748e-2, 3.8885e-2], &kquant());
+        assert_eq!(
+            band.line().value(),
+            Some(3.5141e-2),
+            "the line is the spread itself, the floor being smaller"
+        );
+        assert!(!band.ferrox_is_outside());
+        assert_eq!(band.nearest(), 1.9748e-2);
+
+        // What the issue says would NOT have worked: the old shape with
+        // the new largest measurement in it.
+        let bumped_constant = 3.5141e-2 * 1.1;
+        assert!(
+            3.8885e-2 > bumped_constant,
+            "raising the constant to the newest spread leaves the newer reference over the \
+             line — the point of #111"
+        );
+    }
+
+    /// ONE reference cannot render a Q8_K-dotted checkpoint WRONG.
+    ///
+    /// This is the honest degradation and it is a deliberate loss of a
+    /// gate: with a single libllama there is no measurement of how much
+    /// this checkpoint's K-quant activation path moves between builds,
+    /// and every constant tried so far has been crossed by two builds
+    /// with an identical graph. `Uncalibrated` carries NO number, so
+    /// nothing downstream can quietly reintroduce one.
+    #[test]
+    fn one_reference_declines_to_convict_a_kquant_rather_than_guessing_a_line() {
+        for kind in Q8K_DOTTED {
+            let quant = DominantQuant::weigh(Some("Q8_0"), Some(kind));
+            let band = band_of(0.0, &[9.9e-1], &quant);
+            assert_eq!(*band.line(), WrongLine::Uncalibrated);
+            assert_eq!(band.line().value(), None, "{kind} must carry no number");
+            assert!(
+                !band.ferrox_is_outside(),
+                "{kind}: a KL of 0.99 is enormous, and with one reference this instrument still \
+                 cannot say it is a wrong GRAPH — the top-1 half of the verdict is what covers it"
+            );
+        }
+    }
+
+    /// ONE reference still gates everything llama.cpp dots against Q8_0
+    /// activations, at the unchanged 1e-2.
+    ///
+    /// The measured spread there is 0.0 across both vintages on Q8_0 and
+    /// 4.6e-4 on Q4_0, so an absolute line is a real line for this
+    /// class. Losing it too would have thrown away the half of the
+    /// oracle that never broke.
+    #[test]
+    fn one_reference_still_gates_a_q8_0_dotted_checkpoint_at_the_unchanged_line() {
+        for kind in Q8_0_DOTTED {
+            let quant = DominantQuant::weigh(Some(kind), Some(kind));
+            let band = band_of(0.0, &[1.1e-2], &quant);
+            assert_eq!(*band.line(), WrongLine::Absolute(1e-2));
+            assert!(
+                band.ferrox_is_outside(),
+                "{kind}: 1.1e-2 is over the 1e-2 line and nothing about this class is calibrated \
+                 away"
+            );
+            assert!(!band_of(0.0, &[9.9e-3], &quant).ferrox_is_outside());
+        }
+    }
+
+    /// TWO REFERENCES THAT AGREE EXACTLY ARE ONE REFERENCE.
+    ///
+    /// Passing `--dumper` twice with the same binary, or two builds that
+    /// happen to be bit-identical on this checkpoint, measures a spread
+    /// of 0. Treating that as a calibrated band would put the line at
+    /// the 1e-2 floor for a K-quant and manufacture exactly the WRONG
+    /// this module removes — the failure would look like a successful
+    /// calibration, which is worse than no calibration.
+    #[test]
+    fn a_pair_of_references_that_cannot_disagree_does_not_calibrate_anything() {
+        let identical = vec![0.5f32, 2.0, -1.0, 7.25];
+        let ferrox = vec![0.5f32, 2.9, -1.0, 7.25];
+        let band = Band::measure(&[identical.clone(), identical.clone()], &ferrox, &kquant());
+        assert_eq!(*band.line(), WrongLine::Uncalibrated);
+        assert!(!band.ferrox_is_outside());
+
+        // Two references that DO differ, on the same ferrox, do
+        // calibrate — otherwise this test would pass on a `measure`
+        // that never calibrates at all.
+        let other = vec![0.5f32, 2.4, -1.0, 7.25];
+        let band = Band::measure(&[identical, other], &ferrox, &kquant());
+        assert!(matches!(band.line(), WrongLine::Calibrated { .. }));
+    }
+
+    /// The spread is the LARGER of the two KL directions.
+    ///
+    /// KL is asymmetric, so a spread that took one direction would
+    /// report a band smaller than the evidence supports on every pair
+    /// where the two references have different entropies — and a band
+    /// too small is a WRONG that should not have been printed.
+    #[test]
+    fn the_spread_is_the_larger_of_the_two_kl_directions() {
+        // A flat distribution against a peaked one: the two KL
+        // directions differ by a factor of several.
+        let flat = vec![0.0f32, 0.0, 0.0, 0.0];
+        let peaked = vec![6.0f32, 0.0, 0.0, 0.0];
+        let ferrox = vec![0.1f32, 0.0, 0.0, 0.0];
+
+        let p = metrics::softmax(&flat);
+        let q = metrics::softmax(&peaked);
+        let (fwd, back) = (metrics::kl(&p, &q), metrics::kl(&q, &p));
+        assert!(fwd != back, "the fixture must actually be asymmetric");
+
+        let band = Band::measure(&[flat, peaked], &ferrox, &kquant());
+        match band.line() {
+            WrongLine::Calibrated { spread, .. } => {
+                assert_eq!(spread.kl, fwd.max(back));
+                assert_ne!(spread.kl, fwd.min(back));
+            }
+            other => panic!("expected a calibrated line, got {other:?}"),
+        }
+    }
+
+    /// ferrox is judged by the reference it agrees with BEST, and the
+    /// choice is what makes the verdict independent of which libllama
+    /// happens to be installed.
+    ///
+    /// #102's whole complaint was a verdict that changed with the
+    /// bottle. Ordering the same two references the other way round
+    /// must not change the answer.
+    #[test]
+    fn the_verdict_does_not_depend_on_which_reference_was_passed_first() {
+        for &(name, spread_kl, kl_brew, kl_scratch, q8k) in SWEEP {
+            let quant = if q8k { kquant() } else { q8_0() };
+            let forward = band_of(spread_kl, &[kl_brew, kl_scratch], &quant);
+            let reversed = band_of(spread_kl, &[kl_scratch, kl_brew], &quant);
+            assert_eq!(
+                forward.ferrox_is_outside(),
+                reversed.ferrox_is_outside(),
+                "{name}: the verdict moved when the references swapped places"
+            );
+            assert_eq!(forward.nearest(), reversed.nearest());
+            // The PRIMARY's KL still differs, which is why the report
+            // prints every reference's number and not just one.
+            assert_eq!(forward.kl_to_ferrox(0), reversed.kl_to_ferrox(1));
+        }
+    }
+
+    /// A calibrated line is never below the absolute one.
+    ///
+    /// Without the floor, a pair of references that agree to 1e-13 —
+    /// which two of the measured checkpoints do — would demand that
+    /// ferrox agree to 1e-13 too, and every row would read WRONG.
+    #[test]
+    fn a_calibrated_line_never_drops_below_the_absolute_one() {
+        for kl in [1e-13, 1e-6, 1e-3, 9.99e-3, KL_WRONG, 1e-1] {
+            let line = WrongLine::decide(spread(kl), &kquant())
+                .value()
+                .expect("a spread gives a line");
+            assert!(
+                line >= KL_WRONG,
+                "a {kl:e} reference spread produced a {line:e} line"
+            );
+            assert!(line >= kl);
+        }
+        // And above the floor the line IS the spread, with nothing
+        // added: no margin, no fitted headroom.
+        assert_eq!(
+            WrongLine::decide(spread(4.2e-2), &kquant()).value(),
+            Some(4.2e-2)
+        );
+    }
+}

--- a/crates/ferrox-cli/src/parity/dump.rs
+++ b/crates/ferrox-cli/src/parity/dump.rs
@@ -32,7 +32,19 @@ const REFERENCE_SUFFIX: &str = ".llama.f32";
 const FERROX_SUFFIX: &str = ".ferrox.f32";
 const TOKENS_SUFFIX: &str = ".tokens.txt";
 
-/// Writes both logit vectors and the token ids they were computed from.
+/// File name for reference `i`. The primary keeps the original
+/// `.llama.f32` so a dump taken before `parity` could run two
+/// references is still the same file a later one produces.
+fn reference_path(prefix: &str, i: usize) -> PathBuf {
+    if i == 0 {
+        PathBuf::from(format!("{prefix}{REFERENCE_SUFFIX}"))
+    } else {
+        PathBuf::from(format!("{prefix}.llama{}.f32", i + 1))
+    }
+}
+
+/// Writes every compared logit vector and the token ids they were
+/// computed from.
 ///
 /// The token ids travel with the vectors because they are the only part
 /// of the experiment that is not in the file names: two dumps of the
@@ -41,16 +53,21 @@ const TOKENS_SUFFIX: &str = ".tokens.txt";
 pub fn write(
     prefix: &str,
     tokens: &[u32],
-    reference: &[f32],
+    references: &[&[f32]],
     ferrox: &[f32],
-) -> anyhow::Result<[PathBuf; 3]> {
-    let ref_path = PathBuf::from(format!("{prefix}{REFERENCE_SUFFIX}"));
+) -> anyhow::Result<Vec<PathBuf>> {
+    let mut paths = Vec::with_capacity(references.len() + 2);
+    for (i, reference) in references.iter().enumerate() {
+        let p = reference_path(prefix, i);
+        write_f32(&p, reference)?;
+        paths.push(p);
+    }
+
     let fx_path = PathBuf::from(format!("{prefix}{FERROX_SUFFIX}"));
-    let tok_path = PathBuf::from(format!("{prefix}{TOKENS_SUFFIX}"));
-
-    write_f32(&ref_path, reference)?;
     write_f32(&fx_path, ferrox)?;
+    paths.push(fx_path);
 
+    let tok_path = PathBuf::from(format!("{prefix}{TOKENS_SUFFIX}"));
     let ids = tokens
         .iter()
         .map(|t| t.to_string())
@@ -58,8 +75,9 @@ pub fn write(
         .join(" ");
     std::fs::write(&tok_path, format!("{ids}\n"))
         .with_context(|| format!("writing {}", tok_path.display()))?;
+    paths.push(tok_path);
 
-    Ok([ref_path, fx_path, tok_path])
+    Ok(paths)
 }
 
 fn write_f32(path: &Path, values: &[f32]) -> anyhow::Result<()> {
@@ -95,7 +113,8 @@ mod tests {
             -1.234_567_8e-9,
         ];
         let ferrox = vec![0.2f32, 1.0, -5.5, 0.0, 7.7];
-        let paths = write(&prefix, &[1, 2, 3], &reference, &ferrox).unwrap();
+        let paths = write(&prefix, &[1, 2, 3], &[&reference], &ferrox).unwrap();
+        assert_eq!(paths.len(), 3);
 
         let back = std::fs::read(&paths[0]).unwrap();
         let read: Vec<f32> = back
@@ -122,17 +141,56 @@ mod tests {
         let _ = std::fs::remove_dir(&dir);
     }
 
-    /// The reference and ferrox dumps must land in different files.
+    /// EVERY vector lands in its own file.
     ///
     /// They are the same length and the same wire format, so a shared
-    /// suffix would silently leave one overwriting the other and the
+    /// name would silently leave one overwriting another and the
     /// resulting "reference vs reference" KL would be exactly zero —
     /// which reads as "the two builds agree" and is the one answer this
-    /// tool must never fabricate.
+    /// tool must never fabricate. With `--dumper` repeatable there are
+    /// now N of them, so this walks the naming rule rather than the
+    /// three suffixes it used to be.
     #[test]
-    fn the_two_vectors_do_not_share_a_file_name() {
+    fn no_two_dumped_vectors_share_a_file_name() {
         assert_ne!(REFERENCE_SUFFIX, FERROX_SUFFIX);
         assert_ne!(REFERENCE_SUFFIX, TOKENS_SUFFIX);
         assert_ne!(FERROX_SUFFIX, TOKENS_SUFFIX);
+
+        let dir = std::env::temp_dir().join(format!("ferrox-dump-names-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let prefix = dir.join("case").to_string_lossy().into_owned();
+
+        // Three references with DIFFERENT contents: if two shared a
+        // path the survivor's bytes would give it away.
+        let refs: Vec<Vec<f32>> = (0..3).map(|i| vec![i as f32, 1.0]).collect();
+        let borrowed: Vec<&[f32]> = refs.iter().map(Vec::as_slice).collect();
+        let paths = write(&prefix, &[7], &borrowed, &[9.0f32, 1.0]).unwrap();
+        assert_eq!(paths.len(), 5, "3 references + ferrox + the token ids");
+
+        let unique: std::collections::HashSet<_> = paths.iter().collect();
+        assert_eq!(
+            unique.len(),
+            paths.len(),
+            "two dumps share a name: {paths:?}"
+        );
+        for (i, r) in refs.iter().enumerate() {
+            let back = std::fs::read(&paths[i]).unwrap();
+            assert_eq!(
+                f32::from_le_bytes(back[..4].try_into().unwrap()),
+                r[0],
+                "reference [{i}] landed in {} with someone else's bytes",
+                paths[i].display()
+            );
+        }
+
+        // The primary keeps the name it had before `--dumper` could be
+        // repeated, so an old dump and a new one are still the same
+        // file.
+        assert!(paths[0].to_string_lossy().ends_with(REFERENCE_SUFFIX));
+
+        for p in &paths {
+            let _ = std::fs::remove_file(p);
+        }
+        let _ = std::fs::remove_dir(&dir);
     }
 }

--- a/crates/ferrox-cli/src/parity/metrics.rs
+++ b/crates/ferrox-cli/src/parity/metrics.rs
@@ -152,15 +152,45 @@ mod tests {
             kl(&q, &p),
             "if these ever agree the spread's `max over ordered pairs` is pointless"
         );
+
+        // A token the reference gives EXACTLY zero mass contributes
+        // nothing, by the `0 ln 0 = 0` convention. Over a 150k
+        // vocabulary a logit far enough below the max underflows to a
+        // true zero, so this is the ordinary case and not a corner: an
+        // unguarded `p * ln(p/q)` evaluates `0 * -inf` there and turns
+        // the whole KL into NaN, which every comparison downstream
+        // would then read as "not greater than the line".
+        let with_a_dead_token = softmax(&[0.0f32, -800.0]);
+        assert_eq!(
+            with_a_dead_token[1], 0.0,
+            "the fixture must actually contain an exact zero"
+        );
+        let uniform = softmax(&[0.0f32, 0.0]);
+        let d = kl(&with_a_dead_token, &uniform);
+        assert!(d.is_finite(), "a zero-mass token made the KL {d}");
+        assert!((d - std::f64::consts::LN_2).abs() < 1e-12, "{d}");
     }
 
-    /// An additive constant on the logits is not a disagreement.
+    /// An additive constant on the logits is not a disagreement, and it
+    /// stays not one at a magnitude where `exp` alone would overflow.
+    ///
+    /// Shift invariance is free algebraically; what is NOT free is
+    /// subtracting the max first. `exp(800)` is `inf` and `inf/inf` is
+    /// `NaN`, so a softmax without that subtraction turns a shifted
+    /// copy of a distribution into a vector of NaN and every downstream
+    /// KL into a number no comparison can be read off. The shift here
+    /// is large on purpose.
     #[test]
-    fn softmax_is_shift_invariant() {
-        let a = softmax(&[0.5f32, 1.5, -3.0]);
-        let b = softmax(&[7.75f32, 8.75, 4.25]);
+    fn softmax_is_shift_invariant_even_where_exp_would_overflow() {
+        let base = [0.5f32, 1.5, -3.0];
+        let a = softmax(&base);
+        let shifted: Vec<f32> = base.iter().map(|v| v + 800.0).collect();
+        let b = softmax(&shifted);
         for (x, y) in a.iter().zip(&b) {
+            assert!(x.is_finite() && y.is_finite(), "{x} vs {y}");
             assert!((x - y).abs() < 1e-12, "{x} vs {y}");
         }
+        assert!((a.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+        assert!((b.iter().sum::<f64>() - 1.0).abs() < 1e-12);
     }
 }

--- a/crates/ferrox-cli/src/parity/metrics.rs
+++ b/crates/ferrox-cli/src/parity/metrics.rs
@@ -1,0 +1,166 @@
+//! The distribution metrics every parity number is made of.
+//!
+//! They live in their own module because two callers need them and only
+//! one of them used to exist. `compare` scores ferrox against the
+//! reference; [`super::calibration`] scores the REFERENCES AGAINST EACH
+//! OTHER, which is the comparison that says whether a difference of a
+//! given size means anything at all. If each had its own softmax and its
+//! own KL the two halves of one verdict would be computed by two
+//! spellings of the same arithmetic — the shape this repo keeps
+//! shipping.
+
+/// Probabilities from logits, in f64.
+///
+/// Shift-invariant by construction (the max is subtracted), which is
+/// why an additive constant between two engines is not a disagreement.
+pub(super) fn softmax(logits: &[f32]) -> Vec<f64> {
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max) as f64;
+    let mut out: Vec<f64> = logits.iter().map(|&v| (v as f64 - max).exp()).collect();
+    let sum: f64 = out.iter().sum();
+    if sum > 0.0 {
+        for v in &mut out {
+            *v /= sum;
+        }
+    }
+    out
+}
+
+/// KL(p || q) in nats.
+///
+/// Terms where `p` is zero contribute nothing by the `0 ln 0 = 0`
+/// convention; clamping `q` away from zero avoids an infinity produced
+/// by a single underflowed float rather than by a real disagreement.
+pub(super) fn kl(p: &[f64], q: &[f64]) -> f64 {
+    let mut acc = 0.0f64;
+    for (&pi, &qi) in p.iter().zip(q) {
+        if pi > 0.0 {
+            acc += pi * (pi.max(f64::MIN_POSITIVE) / qi.max(f64::MIN_POSITIVE)).ln();
+        }
+    }
+    acc
+}
+
+/// Total variation distance and the largest single-token probability
+/// difference, in one pass.
+pub(super) fn total_variation(p: &[f64], q: &[f64]) -> (f64, f64) {
+    let mut tv = 0.0f64;
+    let mut max_delta = 0.0f64;
+    for (&pi, &qi) in p.iter().zip(q) {
+        let d = (pi - qi).abs();
+        tv += d;
+        if d > max_delta {
+            max_delta = d;
+        }
+    }
+    (0.5 * tv, max_delta)
+}
+
+/// Indices sorted by descending probability.
+///
+/// Ties break by index on both sides, so a tie can never by itself make
+/// two engines' orderings look different.
+pub(super) fn order_desc(p: &[f64]) -> Vec<usize> {
+    let mut idx: Vec<usize> = (0..p.len()).collect();
+    idx.sort_by(|&a, &b| p[b].partial_cmp(&p[a]).unwrap().then(a.cmp(&b)));
+    idx
+}
+
+/// Distance between two f32 in representable values.
+///
+/// `(a - b).abs()` cannot answer "is this a tie": near 3.0 an absolute
+/// gap of 1e-6 is about four ulps, near 3e-8 the same gap is the whole
+/// number. The count of representable values between two floats is the
+/// only scale-free way to say how close a float comparison was, and a
+/// tie-flip verdict is exactly that claim.
+///
+/// Works by mapping f32 to a monotone integer key: for non-negative
+/// values the bit pattern already increases with the value, and for
+/// negative values it increases as the value decreases, so the
+/// magnitude bits are negated.
+pub(super) fn ulps_between(a: f32, b: f32) -> i64 {
+    fn key(x: f32) -> i64 {
+        let bits = i64::from(x.to_bits() & 0x7fff_ffff);
+        if x.is_sign_negative() {
+            -bits
+        } else {
+            bits
+        }
+    }
+    (key(a) - key(b)).abs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Adjacent floats are one ulp apart wherever they sit on the line,
+    /// and the count is scale-free.
+    ///
+    /// This is the measurement a TIE-FLIP verdict rests on. An absolute
+    /// difference cannot make the claim: `3.0` and its neighbour differ
+    /// by 2.4e-7 while `3e-8` and its neighbour differ by 1e-15, and
+    /// both are one ulp. A tie-flip reported in absolute units is
+    /// therefore unfalsifiable, which is what #103 pointed at.
+    #[test]
+    fn ulps_between_counts_representable_values_not_absolute_distance() {
+        for anchor in [3.0f32, 3e-8, -3.0, 1.0, 65_536.0] {
+            let next = f32::from_bits(if anchor.is_sign_negative() {
+                anchor.to_bits() - 1
+            } else {
+                anchor.to_bits() + 1
+            });
+            assert_eq!(
+                ulps_between(anchor, next),
+                1,
+                "{anchor} and its neighbour {next} must be one ulp apart"
+            );
+        }
+        // Symmetric, and zero for equal values.
+        assert_eq!(ulps_between(1.5, 1.5), 0);
+        assert_eq!(ulps_between(2.0, 1.0), ulps_between(1.0, 2.0));
+        // Crossing zero must not wrap: -0.0 and +0.0 are the same
+        // value, and a naive bit subtraction would call them 2^31
+        // apart, which would turn every sign change into "not a tie".
+        assert_eq!(ulps_between(-0.0, 0.0), 0);
+        // The two representable values either side of zero are two
+        // steps apart, not 2^32: a naive bit subtraction makes any sign
+        // change look maximally far, which would turn every flipped
+        // near-tie into "not a tie".
+        let tiny = f32::from_bits(1);
+        assert_eq!(ulps_between(-tiny, tiny), 2);
+        // A gap that is genuinely large stays large: 1.0 and 2.0 are a
+        // whole binade apart, which is 2^23 representable values.
+        assert_eq!(ulps_between(1.0, 2.0), 1 << 23);
+    }
+
+    /// KL is ZERO for identical distributions and ASYMMETRIC otherwise.
+    ///
+    /// Both halves matter to the caller: [`super::super::calibration`]
+    /// takes the reference spread as the largest KL over ORDERED pairs
+    /// precisely because `kl(a, b)` and `kl(b, a)` are different
+    /// numbers, and a spread that quietly picked one direction would be
+    /// a smaller band than the evidence supports.
+    #[test]
+    fn kl_is_zero_for_identical_distributions_and_asymmetric_otherwise() {
+        let p = softmax(&[0.1f32, 5.0, -2.0, 3.3]);
+        assert_eq!(kl(&p, &p), 0.0);
+
+        let q = softmax(&[0.1f32, 5.0, -2.0, 1.0]);
+        assert!(kl(&p, &q) > 0.0 && kl(&q, &p) > 0.0);
+        assert_ne!(
+            kl(&p, &q),
+            kl(&q, &p),
+            "if these ever agree the spread's `max over ordered pairs` is pointless"
+        );
+    }
+
+    /// An additive constant on the logits is not a disagreement.
+    #[test]
+    fn softmax_is_shift_invariant() {
+        let a = softmax(&[0.5f32, 1.5, -3.0]);
+        let b = softmax(&[7.75f32, 8.75, 4.25]);
+        for (x, y) in a.iter().zip(&b) {
+            assert!((x - y).abs() < 1e-12, "{x} vs {y}");
+        }
+    }
+}

--- a/crates/ferrox-cli/src/parity/quant.rs
+++ b/crates/ferrox-cli/src/parity/quant.rs
@@ -1,0 +1,319 @@
+//! Which quantization a parity verdict is about.
+//!
+//! One value, read by everything that needs to know: the DRIFT message
+//! that explains a divergence, and [`super::calibration`] when it has to
+//! decide whether a WRONG line exists at all. Deriving it twice was
+//! [#109](https://github.com/antonellof/ferrox/issues/109).
+
+/// The quantization of the per-layer weights, and whether llama.cpp
+/// dots it against 8-bit-quantized ACTIVATIONS.
+///
+/// This exists because a `DRIFT` verdict on a K-quant is expected rather
+/// than suspicious, and the old message sent the reader off to do a
+/// per-layer divergence run on a difference that has a known cause.
+///
+/// ggml declares a `vec_dot_type` per quantization
+/// (`ggml/src/ggml-cpu/ggml-cpu.c`). For the K-quants it is
+/// `GGML_TYPE_Q8_K`: llama.cpp quantizes the activation to 8 bits and
+/// accumulates in integers. ferrox keeps activations in f32. Both are
+/// defensible and ferrox is the more precise of the two, but they are
+/// not the same arithmetic, so the distributions differ by more than
+/// summation order.
+///
+/// Measured on five quantizations of one checkpoint: the verdict tracks
+/// this predicate on the 96 per-layer tensors exactly. See
+/// `docs/plans/llama-cpp-gap-inventory.md` §10.
+pub(super) fn llama_dots_this_against_q8k(kind: &str) -> bool {
+    // Spelled as `GgmlType`'s own variant names (`Q4K`, not `Q4_K`) --
+    // these come from `format!("{:?}", dtype)`, and writing the ggml
+    // spelling here would have matched nothing while looking correct.
+    matches!(
+        kind,
+        "Q2K"
+            | "Q3K"
+            | "Q4K"
+            | "Q5K"
+            | "Q6K"
+            | "IQ2XXS"
+            | "IQ2XS"
+            | "IQ2S"
+            | "IQ3XXS"
+            | "IQ3S"
+            | "IQ1S"
+            | "IQ1M"
+            | "IQ4XS"
+    )
+}
+
+/// The most common quantization among a checkpoint's PER-LAYER tensors.
+///
+/// The FILENAME is not this. `Llama-3.2-1B-Instruct-IQ4_XS.gguf`
+/// contains no IQ4_XS tensors at all -- 96 of its per-layer weights are
+/// `IQ4_NL` -- because the name is the quantization RECIPE and the
+/// recipe falls back. Reading the tensor table is the only way to know,
+/// and mistaking the two is what made that file look like a
+/// counterexample.
+///
+/// The output head and the embedding table are EXCLUDED, so "body" here
+/// means the body and cannot be outvoted into meaning the head on a
+/// one-layer model. [`lm_head_quant`] is the other half, and
+/// [`DominantQuant`] is the single place that weighs the two.
+pub(super) fn body_quant(tensors: &[ferrox_gguf::TensorInfo]) -> Option<String> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for t in tensors {
+        if t.name == "output.weight" || t.name == "token_embd.weight" {
+            continue;
+        }
+        let kind = format!("{:?}", t.dtype);
+        if kind != "F32" && kind != "F16" && kind != "BF16" {
+            *counts.entry(kind).or_default() += 1;
+        }
+    }
+    counts.into_iter().max_by_key(|(_, n)| *n).map(|(k, _)| k)
+}
+
+/// Dtype of the logits projection: untied `output.weight`, else tied embed.
+pub(super) fn lm_head_quant(tensors: &[ferrox_gguf::TensorInfo]) -> Option<String> {
+    tensors
+        .iter()
+        .find(|t| t.name == "output.weight")
+        .or_else(|| tensors.iter().find(|t| t.name == "token_embd.weight"))
+        .map(|t| format!("{:?}", t.dtype))
+}
+
+/// WHICH QUANTIZATION'S ARITHMETIC DOMINATES THIS COMPARISON — the one
+/// value the DRIFT message and the WRONG line's fallback both read.
+///
+/// Until [#109](https://github.com/antonellof/ferrox/issues/109) they
+/// were two rules. The threshold keyed on the OUTPUT HEAD alone and the
+/// message keyed on `lm_head.or(body)`, so a `Q8_0` head over a K-quant
+/// body was judged against the line for a model containing no K-quant
+/// arithmetic at all, and told to go run a per-layer divergence for a
+/// difference §10 fully explains. They agreed on every checkpoint in
+/// `models/`, which is why it never fired there — so a checkpoint of
+/// that shape was BUILT to see what happens (`llama-quantize --pure
+/// --output-tensor-type q8_0 --token-embedding-type q8_0 … Q4_K_S`),
+/// against Homebrew libllama b7650:
+///
+/// | checkpoint | head | body | KL(llama‖ferrox) | verdict then |
+/// |---|---|---|---|---|
+/// | Qwen3-0.6B q8-head | Q8_0 | Q4_K | **1.297e-2** | **WRONG** |
+/// | Qwen3-0.6B `--pure` | Q4_K | Q4_K | 1.975e-2 | DRIFT |
+/// | Llama-3.2-1B q8-head | Q8_0 | Q4_K | 1.417e-3 | DRIFT |
+/// | Llama-3.2-1B `--pure` | Q4_K | Q4_K | 1.126e-3 | DRIFT |
+/// | Llama-3.2-1B q6-head | Q6_K | Q8_0 | **2.313e-4** | MATCH |
+///
+/// The first two rows are the same body arithmetic on the same
+/// architecture, and the row with the MORE precise head read WRONG at a
+/// SMALLER KL than the row with the K-quant head read DRIFT. `ferrox
+/// parity` exited non-zero on the more accurate of the two.
+///
+/// The last row is what settles which tensor to key on: a K-quant head
+/// over a Q8_0 body lands at 2.313e-4, three orders of magnitude below
+/// its K-quant-bodied siblings and inside the MATCH floor. **The body
+/// carries the divergence and the head barely contributes** — the body
+/// is every layer, the head is one matvec — so the body is what this
+/// answers with when it is Q8_K-dotted.
+///
+/// The head still gets to TRIGGER the relaxation when the body is not
+/// Q8_K-dotted, even though the row above says the effect is tiny. The
+/// alternative is a rule that can invent a WRONG for a checkpoint whose
+/// only Q8_K arithmetic is in the head, which is the defect being
+/// fixed, in the other direction; and the sensitivity given up sits at
+/// 2.3e-4, four orders below either line, so nothing that could be
+/// measured is being traded away.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DominantQuant(Option<String>);
+
+impl DominantQuant {
+    /// Reads the tensor table. An empty slice — the file could not be
+    /// opened — and a table with no quantized tensor both give `None`.
+    pub(super) fn of(tensors: &[ferrox_gguf::TensorInfo]) -> Self {
+        Self::weigh(
+            lm_head_quant(tensors).as_deref(),
+            body_quant(tensors).as_deref(),
+        )
+    }
+
+    /// The rule itself, taking the two halves directly so it can be
+    /// exercised on shapes no checkpoint on this disk has.
+    pub(super) fn weigh(lm_head: Option<&str>, body: Option<&str>) -> Self {
+        // A Q8_K-dotted BODY wins outright: it is every layer, and the
+        // measurement above says it is what carries the divergence.
+        // Otherwise the head, which still relaxes the line when it is
+        // itself a K-quant — that fallback is the `or`, not a third
+        // branch, because "the head when it is Q8_K-dotted" and "the
+        // head as the plain label" are the same expression and writing
+        // them separately gives one arm that can never be reached.
+        let picked = if body.is_some_and(llama_dots_this_against_q8k) {
+            body
+        } else {
+            lm_head.or(body)
+        };
+        Self(picked.map(str::to_owned))
+    }
+
+    /// What to call it in the report.
+    pub(super) fn label(&self) -> Option<&str> {
+        self.0.as_deref()
+    }
+
+    /// Whether llama.cpp dots this checkpoint's dominant arithmetic
+    /// against Q8_K-quantized activations. The DRIFT message and the
+    /// uncalibrated WRONG line both go through here, so they cannot
+    /// disagree.
+    pub(super) fn q8k_dotted(&self) -> bool {
+        self.0.as_deref().is_some_and(llama_dots_this_against_q8k)
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+
+    /// Every K-quant / IQ spelling that llama.cpp dots against Q8_K
+    /// activations. Shared with [`super::super::calibration`]'s tests,
+    /// which walk the same list against the WRONG line.
+    pub(in crate::parity) const Q8K_DOTTED: &[&str] = &[
+        "Q2K", "Q3K", "Q4K", "Q5K", "Q6K", "IQ2XXS", "IQ2XS", "IQ2S", "IQ3XXS", "IQ3S", "IQ1S",
+        "IQ1M", "IQ4XS",
+    ];
+
+    /// Quantizations llama.cpp dots against Q8_0 activations instead.
+    pub(in crate::parity) const Q8_0_DOTTED: &[&str] = &["Q8_0", "Q4_0", "Q5_0", "IQ4NL"];
+
+    pub(super) fn tensor(name: &str, dtype: ferrox_gguf::GgmlType) -> ferrox_gguf::TensorInfo {
+        ferrox_gguf::TensorInfo {
+            name: name.to_string(),
+            shape: vec![1],
+            dtype,
+            offset: 0,
+        }
+    }
+
+    /// A `Q8_0` OUTPUT HEAD OVER A K-QUANT BODY IS A K-QUANT
+    /// COMPARISON — the shape #109 is about.
+    ///
+    /// It shipped judged as a Q8_0 one, because the threshold read the
+    /// head and never asked what the layers were. No checkpoint in
+    /// `models/` has the shape, so one was built:
+    /// `llama-quantize --pure --output-tensor-type q8_0
+    /// --token-embedding-type q8_0 Qwen3-0.6B-BF16.gguf out.gguf
+    /// Q4_K_S`. Against Homebrew libllama b7650 it measured KL
+    /// **1.297e-2** and read **WRONG** — while the same model quantized
+    /// `--pure` (K-quant head as well) measured a LARGER 1.975e-2 and
+    /// read DRIFT.
+    #[test]
+    fn a_q8_0_head_over_a_kquant_body_is_judged_as_the_kquant_it_is() {
+        for body in Q8K_DOTTED {
+            let q = DominantQuant::weigh(Some("Q8_0"), Some(body));
+            assert!(
+                q.q8k_dotted(),
+                "a {body} body dots against Q8_K activations whatever the output head is"
+            );
+            assert_eq!(q.label(), Some(*body), "the body is what the report names");
+        }
+        // When BOTH halves are Q8_K-dotted only the label distinguishes
+        // the rules — and the body is the honest label, because it is
+        // the layers that carry the drift (2.313e-4 for a K-quant head
+        // alone). Keying the label on the head, as the message did
+        // before #109, must be visible here rather than only in the
+        // shape that changes the verdict.
+        assert_eq!(
+            DominantQuant::weigh(Some("Q6K"), Some("Q4K")).label(),
+            Some("Q4K"),
+            "with a K-quant on both ends the report names the body"
+        );
+    }
+
+    /// The head can still TRIGGER the allowance, so no row can move
+    /// DRIFT → WRONG because of #109's fix.
+    ///
+    /// Measured cost of keeping it: a Q6_K head over a Q8_0 body
+    /// (`--pure Q8_0 --output-tensor-type q6_K`) lands at KL 2.313e-4,
+    /// four orders below either line, so the sensitivity being conceded
+    /// is not sensitivity anything could use.
+    #[test]
+    fn a_kquant_head_over_a_q8_0_body_still_relaxes_rather_than_inventing_a_wrong() {
+        let q = DominantQuant::weigh(Some("Q6K"), Some("Q8_0"));
+        assert!(q.q8k_dotted());
+        assert_eq!(q.label(), Some("Q6K"));
+    }
+
+    /// The body is read off the LAYERS, and the output head cannot vote
+    /// in it.
+    ///
+    /// `body_quant` counts tensors, so on a checkpoint with few layers
+    /// and a head at a different precision the head could otherwise
+    /// join the tally it is being weighed against — two roles for one
+    /// tensor, which is how the head came to decide the threshold in
+    /// the first place.
+    #[test]
+    fn the_body_is_read_off_the_layers_and_the_output_head_does_not_vote_in_it() {
+        use ferrox_gguf::GgmlType;
+        // One layer, so the head would outvote it if it were counted.
+        let table = vec![
+            tensor("token_embd.weight", GgmlType::Q8_0),
+            tensor("output.weight", GgmlType::Q8_0),
+            tensor("blk.0.attn_q.weight", GgmlType::Q4K),
+            tensor("blk.0.attn_norm.weight", GgmlType::F32),
+        ];
+        assert_eq!(body_quant(&table).as_deref(), Some("Q4K"));
+        assert_eq!(lm_head_quant(&table).as_deref(), Some("Q8_0"));
+        let q = DominantQuant::of(&table);
+        assert_eq!(
+            q.label(),
+            Some("Q4K"),
+            "a Q8_0 head does not hide a Q4_K body"
+        );
+        assert!(q.q8k_dotted());
+
+        // A tied-embedding model: no `output.weight`, and the embedding
+        // is the head. It still must not count as the body.
+        let tied = vec![
+            tensor("token_embd.weight", GgmlType::Q8_0),
+            tensor("blk.0.ffn_up.weight", GgmlType::Q4K),
+        ];
+        assert_eq!(body_quant(&tied).as_deref(), Some("Q4K"));
+        assert!(DominantQuant::of(&tied).q8k_dotted());
+
+        // An unreadable file relaxes nothing.
+        assert_eq!(DominantQuant::of(&[]).label(), None);
+        assert!(!DominantQuant::of(&[]).q8k_dotted());
+    }
+
+    /// The Q8_K predicate is spelled in `GgmlType`'s variant names, not
+    /// ggml's.
+    ///
+    /// `format!("{:?}", dtype)` yields `Q4K`, and ggml calls the same
+    /// thing `Q4_K`. Writing the ggml spelling here matches NOTHING
+    /// while looking exactly right, and the symptom is the generic
+    /// "go run a per-layer divergence" message on every K-quant — which
+    /// is the message this predicate exists to suppress. That mistake
+    /// was made once already; this is what catches it.
+    #[test]
+    fn the_q8k_predicate_uses_the_dtype_debug_spelling() {
+        for kind in Q8K_DOTTED {
+            assert!(
+                llama_dots_this_against_q8k(kind),
+                "{kind} declares vec_dot_type = Q8_K in ggml-cpu.c"
+            );
+        }
+        // The ggml spelling must NOT match, or the underscore bug is
+        // back and invisible.
+        for wrong in ["Q4_K", "Q6_K", "IQ4_XS"] {
+            assert!(
+                !llama_dots_this_against_q8k(wrong),
+                "{wrong} is ggml's spelling, not GgmlType's -- if this now matches, the \
+                 predicate is accepting both and the next reader cannot tell which is real"
+            );
+        }
+        // Q8_0-dotted quants must stay out: these are the ones that
+        // MATCH, and claiming the divergence is expected for them would
+        // excuse a real bug.
+        for q8_0_dotted in Q8_0_DOTTED {
+            assert!(!llama_dots_this_against_q8k(q8_0_dotted));
+        }
+    }
+}

--- a/tools/build_llama_logits.sh
+++ b/tools/build_llama_logits.sh
@@ -8,6 +8,23 @@
 # Homebrew install (a source build works too — point at the directory
 # holding include/llama.h and lib/libllama.*, OR a cmake build dir whose
 # libllama lives under bin/ with headers in LLAMA_CPP_SOURCE).
+#
+# BUILD IT TWICE. `ferrox parity` takes `--dumper` more than once, and
+# the second one is not a nicety: with a single reference it cannot
+# render a WRONG verdict on any K-quant checkpoint at all, because two
+# builds of llama.cpp have been measured 3.5e-2 apart in KL from an
+# identical graph and no constant can sit above that and still mean
+# anything (issue #111). Two dumpers give the run a line it measured
+# for itself. LLAMA_LOGITS_OUT names the binary so the second build does
+# not overwrite the first:
+#
+#   bash tools/build_llama_logits.sh                      # target/llama_logits
+#   LLAMA_CPP_PREFIX=/tmp/llamabuild \
+#     LLAMA_LOGITS_OUT=target/llama_logits_scratch \
+#     bash tools/build_llama_logits.sh
+#
+#   ferrox parity -m model.gguf \
+#     --dumper target/llama_logits --dumper target/llama_logits_scratch
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,11 +45,14 @@ if [[ -z "$PREFIX" ]]; then
 #   * the same bottle cannot LOAD a gemma-4 checkpoint at all, so
 #     `ferrox parity` skipped that model entirely and its tokenizer went
 #     unchecked.
-#   * Qwen2.5-1.5B Q4_K_M parity is reference-dependent: DRIFT against
-#     Homebrew (KL ~7.7e-3) but WRONG against a fresh scratch build
-#     (KL ~2.7e-2, same top-1). Default to Homebrew for CI; rebuild from
-#     scratch only when chasing llama.cpp vintage drift, not as proof of a
-#     ferrox graph bug.
+#   * Qwen2.5-1.5B Q4_K_M parity used to be reference-dependent: DRIFT
+#     against Homebrew (KL ~7.7e-3) but WRONG against a fresh scratch
+#     build (KL ~2.7e-2, same top-1). The verdict no longer moves with
+#     the bottle -- `parity` measures the two builds against EACH OTHER
+#     and judges ferrox against that, which is why you want both
+#     dumpers. But every printed KL still belongs to the reference the
+#     report names, so a NUMBER quoted without its libllama is still
+#     half an experiment.
 #
 # Building llama.cpp from `.scratch/llama.cpp` and pointing this script
 # at it fixed both: BGE went DIVERGES to MATCH, and gemma-4 joined the
@@ -54,8 +74,14 @@ if [[ -z "$PREFIX" ]]; then
   fi
 fi
 
-mkdir -p "$ROOT/target"
-OUT="$ROOT/target/llama_logits"
+# A relative LLAMA_LOGITS_OUT is taken against the repo root, so the
+# same command works from anywhere; an absolute one is used as given.
+OUT="${LLAMA_LOGITS_OUT:-target/llama_logits}"
+case "$OUT" in
+  /*) ;;
+  *) OUT="$ROOT/$OUT" ;;
+esac
+mkdir -p "$(dirname "$OUT")"
 
 # Homebrew-style layout: PREFIX/include + PREFIX/lib
 if [[ -f "$PREFIX/include/llama.h" ]]; then
@@ -81,3 +107,6 @@ fi
 echo
 echo "It writes into target/, so 'cargo clean' removes it — rebuild with this"
 echo "script rather than assuming ferrox parity lost its reference."
+echo "Build it a second time against another libllama (LLAMA_CPP_PREFIX=… "
+echo "LLAMA_LOGITS_OUT=…) and pass both to 'ferrox parity --dumper': with one"
+echo "reference no K-quant checkpoint can be called WRONG (issue #111)."


### PR DESCRIPTION
Closes #111.

## What was wrong

`ferrox parity` called a checkpoint WRONG above an absolute KL, with a looser absolute KL for checkpoints llama.cpp dots against Q8_K activations. #108 derived that second number as `KL_REFERENCE_BUILD_SPREAD_KQUANT * 1.1` = **3.008e-2**, from the largest reference-against-reference KL then known, and named what would invalidate it: *"the spread is the largest of nine checkpoints, so a tenth could exceed it."*

A tenth did. #111 measured **3.514e-2** between two builds of llama.cpp on Qwen3-0.6B `--pure` Q4_K_S — two binaries whose graph is IDENTICAL, crossing the line that is supposed to mean the graphs disagree. The same file reads DRIFT against Homebrew b7650 and WRONG against `.scratch/llama.cpp`, from the same ferrox, and `parity` exits non-zero on the second.

**Raising the constant does not fix it**, and this PR does not raise it. The new largest measurement puts the line at 3.865e-2 and the newer reference reads 3.889e-2, still over.

## The shape, and why this one

The reference spread is not a constant of the engine. Across the 21 checkpoints measured here it ranges over **five orders of magnitude**, from exactly 0 to 3.514e-2, so 3.008e-2 was simultaneously *too tight* for Qwen3-0.6B and *14x too loose* for Llama-3.2-1B Q4_K_M, whose two references agree to 2.1e-3. One number cannot do this job in either direction.

So the run measures its own line:

> ferrox is WRONG only when it is further from **every** reference than the references are from **each other** — and never below the absolute `KL_WRONG`.

`line = max(KL_WRONG, spread)` tested against `min_i KL(ref_i || ferrox)`, where `spread` is the largest KL over ordered pairs of the references this run was given. `--dumper` is now **repeatable**; the first is the reference every printed number is about, the rest exist to measure the spread. `tools/build_llama_logits.sh` gained `LLAMA_LOGITS_OUT` so the second build has somewhere to go.

**No number moves, and three constants are deleted:** `KL_REFERENCE_BUILD_SPREAD_KQUANT` (2.735e-2), `KL_WRONG_Q8K_DOTTED` (3.008e-2) and its 1.1 margin. `KL_WRONG` stays 1e-2 — now as the floor under a calibrated line — and `KL_NOISE` stays 1e-3. **There is no margin constant and nothing fitted.** The worst-observed ratio is 0.58, so a margin would have been headroom the data does not ask for, and #112's precedent is that a rule can change without a number moving.

**Why the nearest reference and not the primary.** The claim a WRONG makes is "ferrox's forward pass computes something different from llama.cpp's". If ferrox reproduces build A as closely as build B reproduces A, then ferrox's graph agrees with A's as well as B's does, and convicting it would convict B. MATCH/DRIFT/TIE-FLIP still describe the reference the report *names* — they are statements about a comparison and are allowed to move with it — so **those rungs are byte-identical to before.** Only the WRONG rung is calibrated, and it now goes through one predicate (`Band::ferrox_is_outside`) read by both the same-top-1 and flipped-top-1 branches; they were two spellings of `kl < kl_wrong`.

## The measurement

Three references — Homebrew libllama b7650, `.scratch/llama.cpp` (ggml 0.18.0), and the same source built with FMA contraction disabled — CPU only, fixed parity prompt, 2026-09-04. `spread` is the larger of the two KL directions between b7650 and scratch; `nearest` is `min(KL(b7650||ferrox), KL(scratch||ferrox))`.

| checkpoint | spread | nearest | line | nearest/line |
|---|---|---|---|---|
| Llama-3.2-1B Q8_0 | **0.0** | 6.912e-4 | 1.000e-2 | 0.07 |
| tinyllama-1.1B Q8_0 | **0.0** | 2.445e-4 | 1.000e-2 | 0.02 |
| Llama-3.2-1B q6khead-q8body | 1.140e-13 | 2.313e-4 | 1.000e-2 | 0.02 |
| Llama-3.2-1B IQ4_XS | 2.981e-4 | 9.208e-4 | 1.000e-2 | 0.09 |
| olmoe-1b-7b Q4_0 | 4.570e-4 | 4.259e-4 | 1.000e-2 | 0.04 |
| Llama-3.2-3B Q4_K_M | 7.518e-4 | 6.463e-4 | 1.000e-2 | 0.06 |
| Llama-3.1-8B Q4_K_M | 7.579e-4 | 1.072e-3 | 1.000e-2 | 0.11 |
| Llama-3.2-1B pure-q4ks | 1.163e-3 | 1.126e-3 | 1.000e-2 | 0.11 |
| Llama-3.2-1B Q6_K | 1.280e-3 | 3.560e-3 | 1.000e-2 | 0.36 |
| Mistral-7B Q4_K_M | 1.436e-3 | 4.684e-4 | 1.000e-2 | 0.05 |
| Llama-3.2-1B q8head-q4ksbody | 1.857e-3 | 8.650e-4 | 1.000e-2 | 0.09 |
| Llama-3.2-1B Q4_K_M | 2.118e-3 | 1.077e-3 | 1.000e-2 | 0.11 |
| Llama-3.2-1B Q5_K_M | 2.174e-3 | 1.382e-3 | 1.000e-2 | 0.14 |
| Phi-4-mini Q4_K_M | 5.585e-3 | 3.800e-3 | 1.000e-2 | 0.38 |
| Qwen1.5-MoE-A2.7B Q4_K_M | 5.698e-3 | 4.826e-3 | 1.000e-2 | 0.48 |
| Yi-1.5-6B Q4_K_M | 7.318e-3 | 2.177e-3 | 1.000e-2 | 0.22 |
| DeepSeek-R1-Distill-1.5B Q4_K_M | 1.570e-2 | 9.157e-3 | 1.570e-2 | **0.58** |
| gemma-2-2b Q4_K_M | 1.674e-2 | 6.511e-3 | 1.674e-2 | 0.39 |
| Qwen2.5-1.5B Q4_K_M | 2.735e-2 | 7.679e-3 | 2.735e-2 | 0.28 |
| **Qwen3-0.6B q8head-q4ksbody** | 2.746e-2 | 1.297e-2 | 2.746e-2 | 0.47 |
| **Qwen3-0.6B pure-q4ks** | **3.514e-2** | 1.975e-2 | 3.514e-2 | 0.56 |

Every row inside its line, the worst at 58%. The constructed rows are `.scratch/mixed`, the exact artifacts #111 and #112 measured — re-quantizing with a different `llama-quantize` gives a different file and different numbers, which I checked; from the originals the harness reproduces #108/#111/#112's figures to the digit (2.735e-2, 3.514e-2, 2.651e-2, 1.297e-2, 1.975e-2, 3.889e-2, 2.313e-4, 1.417e-3, 1.126e-3).

This also **corrects a claim #108 made from a smaller sample.** "The reference's spread on Q8_0 is exactly zero" holds for VINTAGE — b7650 and ggml 0.18.0 are bit-identical on both Q8_0 checkpoints — but not for COMPILER FLAGS: the no-FMA build differs from b7650 by 4.11e-4 on tinyllama Q8_0, and Q4_0 (olmoe) already moves 4.57e-4 between vintages. All two orders under 1e-2, which is why that line does not move.

## What happens with only one reference

Stated rather than hoped, because it is a deliberate loss of a gate.

* **Q8_K-dotted checkpoints get NO WRONG line.** `WrongLine::Uncalibrated` carries no number, so nothing downstream can put one back. The report says so on the row and tells you to pass `--dumper` twice. This is the honest answer: every constant tried has been crossed by two builds with an identical graph.
* **The top-1 half of the verdict is unaffected** — it rests on no threshold — so a single-reference run still fails on a genuine argmax disagreement.
* **Q8_0 / Q4_0 / IQ4_NL keep the unchanged 1e-2**, because their measured spread is 0 to 4.6e-4.
* Practically it costs nothing today: no K-quant row in `models/` has ever been near 3.008e-2 on either reference (the largest is DeepSeek at 1.99e-2), and the one time the old gate fired it was a false alarm.

## The real risk, with a written answer

**A genuine ferrox bug inside a wide band is excused.** True, and it is the price. What makes it acceptable is that the band is only wide where the reference is: **16 of the 21 rows get the 1e-2 floor, three times TIGHTER than the 3.008e-2 they used to be judged against.** Per-checkpoint calibration raises sensitivity on most checkpoints and lowers it only where a WRONG could not have been believed anyway — on Qwen3-0.6B `--pure`, no "the graphs disagree" verdict is available at any threshold, because llama.cpp reproduces that difference against llama.cpp.

**Two builds are two points, not a distribution.** The spread is a lower bound on how much implementation choice moves this checkpoint, from the two implementations to hand. It is not an estimate of dispersion and the module does not pretend it is; the report prints the number and the pair it came from so a reader can judge. Adding a third reference *widens* the band (it is the max over pairs), so the references passed should be builds you would accept as correct.

**A future false WRONG is possible and here is its shape.** Ratios above 1 do occur — Llama-3.2-1B Q6_K sits at 1.80x its own spread — but only where the references agree closely and everything is far under the floor. If a checkpoint ever appears with a large absolute KL and a *small* reference spread, this rule will call it WRONG; check the printed spread before believing it. That is a trade taken deliberately: it is the direction where the instrument can be checked.

## Blast radius

Baseline binary built from `origin/main` (86162e2) and re-swept against the same references, 24 checkpoints (19 in `models/` + 5 constructed), in every single-reference configuration, plus the new two-reference one.

**46 of 48 (checkpoint, reference) pairs are unchanged — same verdict, same exit code. Two moved, and they are exactly the two #111 named:**

| row | reference | before | after |
|---|---|---|---|
| `Qwen3-0.6B-pure-q4ks` | `.scratch/llama.cpp` | **WRONG (rc 1)** | DRIFT (rc 0) |
| `Qwen3-0.6B-q8head-q4ksbody` | `.scratch/llama.cpp` | **WRONG (rc 1)** | DRIFT (rc 0) |

Every row in `models/` is byte-identical on both references. Adding the second reference changed no verdict anywhere, which is the expected one-directional radius: calibration can only relax. `bge-small` / `ms-marco` produce no verdict before and after (BERT, not covered), and `gemma-4-E2B` produces none when the Homebrew bottle is primary because that bottle cannot load it — the primary reference's failure is still fatal, by design, and the report names it.

## What a report looks like now

```
parity Qwen3-0.6B-pure-q4ks: DRIFT (5-token prompt, first-token distribution, ferrox cpu vs llama.cpp cpu)
  reference [0]     /opt/homebrew/Cellar/llama.cpp/7650/lib/libllama.0.0.7650.dylib   KL(llama||ferrox) 1.975e-2
  reference [1]     .../.scratch/llama.cpp/build-ppl/bin/libllama.0.0.1.dylib         KL(llama||ferrox) 3.889e-2
  WRONG line        3.514e-2  measured: references [0] and [1] disagree with EACH OTHER by 3.514e-2 on this checkpoint
                    ferrox's nearest reference is 1.975e-2, 56% of the line
```

and with one:

```
  WRONG line        NONE - Q4K is dotted against Q8_K activations, and two builds of llama.cpp disagree
                    with EACH OTHER by up to 3.5e-2 there (#111), so no constant can mean `the graphs disagree`.
                    Pass --dumper a second time, built against another libllama, to measure this checkpoint's own line.
```

## Files

`parity.rs` was 1217 lines and would have grown, so it is split first: `quant` (which quantization a verdict is about, moved intact), `metrics` (softmax / KL / ulps — two callers needed them and only one existed), `calibration` (the band and the argument for it). `parity.rs` shrinks.

## Tests, each sabotaged once

**Three tests did not go red on the first attempt, which is the finding.** `the_spread_is_the_larger_of_the_two_kl_directions` passed with the pair loop narrowed to `i < j`, because its fixture put the larger direction on a pair such a loop still visits. `softmax_is_shift_invariant` could not fail at all — shift invariance is algebraically free, and its shift was small enough that a softmax with no max-subtraction still agreed. And **nothing caught the WRONG rung being decided by the primary's KL instead of the nearest**, which is the entire change: the geometry that separates them needs the printed KL to be over the line while ferrox is not the outlier, and no fixture had it. All three are fixed and re-sabotaged.

| sabotage | red |
|---|---|
| `nearest()` takes the furthest reference | 3 tests |
| an `Uncalibrated` line becomes the old 3.008e-2 | 3 tests |
| the calibrated line loses its `KL_WRONG` floor | 2 tests |
| the spread walks `i < j` instead of ordered pairs | `the_spread_is_the_larger_of_the_two_kl_directions` |
| a zero spread is allowed to calibrate | `a_pair_of_references_that_cannot_disagree_...` |
| every reference dump lands in the primary's file | `no_two_dumped_vectors_share_a_file_name` |
| a missing `--dumper` falls back to the tree default | `every_dumper_is_resolved_and_a_missing_one_...` |
| `kl()` drops its zero-mass guard and clamp | `kl_is_zero_..._and_asymmetric_otherwise` |
| `kl()` is symmetrized | 2 tests |
| `softmax` stops subtracting the max | `softmax_is_shift_invariant_even_where_exp_would_overflow` |
| the WRONG rung reads the primary's KL | `the_wrong_rung_is_decided_by_the_nearest_reference_...` |
| `q8k_dotted` spelled the ggml way again | 3 tests |
| the body no longer outranks a Q8_0 head | 3 tests |

`no_measured_checkpoint_is_wrong_when_the_references_are_calibrated` carries all 21 measured rows as a table and asserts both that none is WRONG and that none sits above 60% of its line, so the sweep moving is a red test rather than a stale doc comment.

Gates: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, the same `--release`, `cargo fmt --all --check`. All pass.

## Doc delta (not applied; `docs/` is another agent's)

* `docs/plans/llama-cpp-parity-update-2026-09-03.md:80` names `KL_WRONG_LM_HEAD_KQUANT`; #112 renamed it to `KL_WRONG_Q8K_DOTTED` and this PR deletes it. It is a dated write-up, so it reads correctly as history — but a reader chasing the constant now finds nothing.
* `docs/plans/llama-cpp-gap-inventory.md` §10: the K-quant activation difference is measurable llama.cpp-against-llama.cpp, and it is not only a vintage effect — the no-FMA build shows 4.11e-4 on a **Q8_0** checkpoint where the two vintages are bit-identical. §10 is currently a ferrox-vs-llama.cpp story.
* `CLAUDE.md`'s "the logit half MATCHES on Q8_0/IQ4_NL while DRIFTING on K-quants" is still true, and could add that the K-quant DRIFT is now judged against a per-checkpoint measured band rather than a constant, and that a single reference cannot render a K-quant WRONG.
* `docs/CLI.md` should record `--dumper` as repeatable and `LLAMA_LOGITS_OUT`.

## What would have to be true for this to be wrong

That the reference's own build-to-build spread is not a usable proxy for how far a *correct* third implementation may legitimately sit. The check is the ratio column: if ferrox's f32-activation path were systematically further from llama.cpp than llama.cpp builds are from each other, ratios would cluster above 1. They cluster at 0.28-0.58 wherever the spread binds, and the two rows above 1 (Q6_K at 1.80, Q8_0 at infinity) are both far under the 1e-2 floor. If a future checkpoint puts a ratio above 1 *and* an absolute KL above 1e-2, this rule is wrong and the floor is what would have to be re-argued.

## What I did NOT do

* No benchmarks (agents may not, and none were needed — KL is deterministic).
* Did not touch `crates/ferrox-core`, `ferrox-models`, `ferrox-quant`, `ferrox-server`, or `docs/`.
* Did not add a third reference to any default. The no-FMA build was used to widen the evidence, not to change the tool's behaviour.
* Did not make the calibrated path CI's default; that needs a second libllama in CI, which is a decision about the workflow, not about this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
