### PR TITLE
fix(server): a batched row reported token counts and no rates at all

### DIFF
--- a/crates/ferrox-server/src/serving/batch/clock.rs
+++ b/crates/ferrox-server/src/serving/batch/clock.rs
@@ -1,0 +1,142 @@
+//! The one clock a batched row is timed by.
+//!
+//! Continuous batching used to answer with a `Usage` carrying token
+//! counts and nothing else: no `prompt_per_second`, no
+//! `predicted_per_second`, no `time_to_first_token_ms`. The private
+//! `generate` loop set all three, so whether a client saw a rate
+//! depended on which decode path served it -- and on Metal, where
+//! batching is the default, it never did. Ferrox Studio reads every
+//! number under an answer out of `usage`, so the columns were simply
+//! blank.
+//!
+//! The durable half of that fix is this type. It owns both the
+//! timestamps AND the construction of the row's `Usage`, so a caller
+//! cannot build one and forget the rates: there is no path from a
+//! finished row to a `Usage` that does not go through
+//! [`RowClock::usage`].
+
+use std::time::Instant;
+
+use ferrox_api::Usage;
+
+/// Timestamps for one row, from the start of its prefill to the token
+/// that ended it.
+///
+/// A row is timed by wall clock, which under batching includes the
+/// steps taken for OTHER rows in the same batch. That is deliberate and
+/// matches llama-server: the rate a caller cares about is the rate its
+/// own request was served at, not a rate the row would have reached
+/// alone.
+pub(super) struct RowClock {
+    /// Start of this row's prefill, set when the job is admitted to the
+    /// worker rather than when it was enqueued: queue wait belongs to
+    /// the request's duration, not to the prefill rate.
+    started: Instant,
+    /// Set once, when the prompt is through and the row becomes a
+    /// decode slot.
+    prefill_done: Option<Instant>,
+    /// Set once, by the FIRST generated token. A later token must not
+    /// move it, which is the whole reason this is not a plain field
+    /// assignment at the push site.
+    first_token: Option<Instant>,
+}
+
+impl RowClock {
+    /// Starts the clock at the beginning of a row's prefill.
+    pub(super) fn start() -> Self {
+        Self {
+            started: Instant::now(),
+            prefill_done: None,
+            first_token: None,
+        }
+    }
+
+    /// Marks the end of prefill. Called once, on the handover from
+    /// `Prefill` to `Slot`.
+    pub(super) fn prefill_finished(&mut self) {
+        self.prefill_done = Some(Instant::now());
+    }
+
+    /// Records a generated token. Only the first one moves the clock;
+    /// every later call is a no-op, so the push site does not have to
+    /// know which token it is holding.
+    pub(super) fn token(&mut self) {
+        self.first_token.get_or_insert_with(Instant::now);
+    }
+
+    /// The row's `Usage`, rates included.
+    ///
+    /// A row that failed during prefill has no `prefill_done`, and its
+    /// decode phase is empty rather than negative: `Usage::with_timings`
+    /// leaves a rate unset for a zero-length phase, so an unfinished
+    /// row reports durations without inventing a throughput.
+    pub(super) fn usage(&self, prompt_tokens: usize, completion_tokens: usize) -> Usage {
+        let ended = Instant::now();
+        let prefill_end = self.prefill_done.unwrap_or(ended);
+        let prefill_secs = prefill_end.duration_since(self.started).as_secs_f64();
+        let decode_secs = ended.duration_since(prefill_end).as_secs_f64();
+        let usage =
+            Usage::new(prompt_tokens, completion_tokens).with_timings(prefill_secs, decode_secs);
+        match self.first_token {
+            Some(first) => usage.with_ttft(first.duration_since(self.started).as_secs_f64()),
+            None => usage,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shape the bug had: a finished row must report both rates,
+    /// not just its token counts.
+    #[test]
+    fn a_finished_row_reports_both_rates() {
+        let mut clock = RowClock::start();
+        clock.prefill_finished();
+        clock.token();
+        let usage = clock.usage(41, 32);
+        assert!(
+            usage.prompt_per_second.is_some(),
+            "prefill rate missing: {usage:?}"
+        );
+        assert!(
+            usage.predicted_per_second.is_some(),
+            "decode rate missing: {usage:?}"
+        );
+        assert!(
+            usage.time_to_first_token_ms.is_some(),
+            "ttft missing: {usage:?}"
+        );
+    }
+
+    /// The first token owns the TTFT. A row whose later tokens moved it
+    /// would report the time to its LAST token, which is not a
+    /// latency anybody asked for.
+    #[test]
+    fn only_the_first_token_sets_ttft() {
+        let mut clock = RowClock::start();
+        clock.prefill_finished();
+        clock.token();
+        let first = clock.first_token.expect("first token recorded");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        clock.token();
+        assert_eq!(
+            clock.first_token.expect("still recorded"),
+            first,
+            "a later token moved the TTFT"
+        );
+    }
+
+    /// A row that ended during prefill has no decode phase. It reports
+    /// durations, and no decode rate, rather than a negative duration
+    /// or a fabricated rate.
+    #[test]
+    fn a_row_that_never_decoded_has_no_decode_rate() {
+        let clock = RowClock::start();
+        let usage = clock.usage(41, 0);
+        assert_eq!(usage.predicted_per_second, None);
+        assert_eq!(usage.time_to_first_token_ms, None);
+        assert!(usage.generation_duration_ms.is_some_and(|ms| ms >= 0.0));
+    }
+}

--- a/crates/ferrox-server/src/serving/batch/mod.rs
+++ b/crates/ferrox-server/src/serving/batch/mod.rs
@@ -144,6 +144,7 @@
 
 mod batcher;
 mod block_budget;
+mod clock;
 mod config;
 mod counters;
 mod prefill;

--- a/crates/ferrox-server/src/serving/batch/prefill.rs
+++ b/crates/ferrox-server/src/serving/batch/prefill.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use crate::generate::{GenerationParams, PagedLease};
 
+use super::clock::RowClock;
 use super::config::BatcherEvent;
 use super::queue::AbortId;
 use super::row::{RowKv, Slot};
@@ -211,6 +212,11 @@ pub(super) struct Prefill {
     /// Blocks reserved at admission; carried into the `Slot` so the
     /// reservation survives the prefill-to-decode handover.
     pub(super) blocks: usize,
+    /// Started when this row was admitted, and carried into the `Slot`
+    /// so one clock spans prefill AND decode. Two clocks handed over at
+    /// this seam would be two things that must agree about when prefill
+    /// ended.
+    pub(super) clock: RowClock,
 }
 
 impl Prefill {
@@ -223,8 +229,13 @@ impl Prefill {
             reply,
             abort,
             blocks,
+            mut clock,
         } = self;
         let (kv, logits, pos, prompt_ids) = state.into_decode_start();
+        // The handover IS the end of prefill, so it is marked here
+        // rather than at the call site: every path from a prompt to a
+        // decode row goes through this function.
+        clock.prefill_finished();
         Slot {
             kv,
             pos,
@@ -243,6 +254,7 @@ impl Prefill {
             error: None,
             abort,
             blocks,
+            clock,
         }
     }
 }

--- a/crates/ferrox-server/src/serving/batch/row.rs
+++ b/crates/ferrox-server/src/serving/batch/row.rs
@@ -12,11 +12,12 @@ use std::sync::mpsc::Sender;
 use ferrox_core::cache::KvCache;
 use ferrox_models::tokenizer::StopTokens;
 
-use crate::generate::{DecodeError, FinishReason, GenerationParams, PagedLease, Usage};
+use crate::generate::{DecodeError, FinishReason, GenerationParams, PagedLease};
 use crate::sample_step::SampleState;
 use crate::stop::StopMatcher;
 
 use super::block_budget::BlockBudget;
+use super::clock::RowClock;
 use super::config::{send_finished, BatcherEvent};
 use super::queue::AbortId;
 
@@ -238,6 +239,9 @@ pub(super) struct Slot {
     pub(super) abort: AbortId,
     /// KV blocks this row reserved at admission, returned when it ends.
     pub(super) blocks: usize,
+    /// The row's own clock, started at admission. Owns the only path
+    /// from a finished row to its `Usage`.
+    pub(super) clock: RowClock,
 }
 
 impl Slot {
@@ -276,7 +280,9 @@ pub(super) fn reply_finished(mut slot: Slot) {
         slot.visible.push_str(&tail);
         let _ = slot.reply.send(BatcherEvent::Chunk(tail));
     }
-    let usage = Usage::new(slot.prompt_tokens, slot.generated_ids.len());
+    let usage = slot
+        .clock
+        .usage(slot.prompt_tokens, slot.generated_ids.len());
     send_finished(
         &slot.reply,
         Ok((finish, slot.generated_ids, slot.visible, usage)),

--- a/crates/ferrox-server/src/serving/batch/tests/mod.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/mod.rs
@@ -161,6 +161,7 @@ fn test_slot(max_tokens: usize, seed: u64) -> (Slot, mpsc::Receiver<BatcherEvent
             blocks: 1,
             finish: None,
             error: None,
+            clock: super::clock::RowClock::start(),
         },
         rx,
     )

--- a/crates/ferrox-server/src/serving/batch/tests/rows.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/rows.rs
@@ -95,6 +95,44 @@ fn flush_replies_on_each_rows_own_channel() {
     );
 }
 
+/// A batched row must report the same RATES the private `generate`
+/// loop reports, not just its token counts.
+///
+/// This is the regression the `RowClock` exists for: continuous
+/// batching built its `Usage` with `Usage::new` and never called
+/// `with_timings`, so every field Ferrox Studio puts under an answer
+/// came back null -- and because batching is the default on Metal,
+/// that was the common case rather than a corner. A unit test on the
+/// clock alone would not have caught it: what was missing was the CALL
+/// at the reply site, so the assertion has to run through
+/// `flush_finished`.
+#[test]
+fn a_finished_batched_row_reports_its_rates() {
+    let mut rows = Rows::default();
+    let (mut row, rx) = test_slot(4, 44);
+    row.prompt_tokens = 6;
+    row.clock.prefill_finished();
+    row.clock.token();
+    row.generated_ids.push(7);
+    row.finish = Some(FinishReason::Stop);
+    rows.insert(row);
+    rows.flush_finished(&no_budget());
+
+    let (_, _, _, usage) = finished_result(rx.try_recv().expect("replied")).expect("ok");
+    assert!(
+        usage.prompt_per_second.is_some(),
+        "batched row reported no prefill rate: {usage:?}"
+    );
+    assert!(
+        usage.predicted_per_second.is_some(),
+        "batched row reported no decode rate: {usage:?}"
+    );
+    assert!(
+        usage.time_to_first_token_ms.is_some(),
+        "batched row reported no TTFT: {usage:?}"
+    );
+}
+
 /// End to end, with the batch mutation that renumbers a positional
 /// table: three concurrent rows, one of which trips a stop sequence
 /// mid-batch and leaves while the other two keep decoding. In that

--- a/crates/ferrox-server/src/serving/batch/worker.rs
+++ b/crates/ferrox-server/src/serving/batch/worker.rs
@@ -14,6 +14,7 @@ use crate::generate::{acquire_paged_caches, DecodeError, FinishReason, PagedKvCo
 use crate::stop::StopStep;
 
 use super::block_budget::BlockBudget;
+use super::clock::RowClock;
 use super::config::{decode_log_interval_from_env, send_finished, BatcherConfig, DecodeFn};
 use super::counters::Counters;
 use super::prefill::{Prefill, PrefillState};
@@ -384,6 +385,7 @@ pub(super) fn worker_loop(
                 continue;
             }
             slot.generated_ids.push(next);
+            slot.clock.token();
             let piece = decode(&[next]);
             if apply_stop_buffer(slot, &piece) {
                 continue;
@@ -564,6 +566,7 @@ pub(super) fn accept(
     };
     Some(Prefill {
         state,
+        clock: RowClock::start(),
         prompt_tokens: job.prompt_tokens.len(),
         params: job.params,
         stop_tokens: job.stop_tokens,


### PR DESCRIPTION
Closes #116.

Continuous batching built its `Usage` with `Usage::new` and never called `with_timings`, so every rate and duration came back null. Batching is the default on Metal, so on a Mac that was the common case.

## Before / after

Measured on `Llama-3.2-3B-Instruct-Q4_K_M`, Metal, same server, cache miss both times:

| | usage keys |
|---|---|
| before | `completion_tokens`, `prompt_tokens`, `total_tokens` |
| after | the full set: **219.2 tok/s prefill, 19.1 tok/s decode, 210 ms TTFT** |

Ferrox Studio reads every number under an answer out of `usage` and runs no client stopwatch on purpose, so those columns were blank with nothing on screen to explain it.

## Not the missing call

The shape is the repo's usual one: two construction sites that had to agree about what a `Usage` carries, nothing enforcing it. Adding `with_timings` at the reply site would leave the next site free to forget.

`RowClock` (new `serving/batch/clock.rs`, 1 concept, ~90 lines) owns the timestamps **and** the construction, so there is no path from a finished row to a `Usage` that does not go through `RowClock::usage`. Adding the field to `Slot` immediately broke the test builder's compile, which is the enforcement working on day one.

One clock spans prefill and decode and is handed over inside `Prefill::into_slot`, because two clocks meeting at that seam would be two more things that must agree about when prefill ended.

A row is timed by wall clock, including steps taken for other rows in the batch. That is deliberate, matches llama-server, and is the rate the caller actually got.

## Sabotage

Each confirmed red, then green again:

- `reply_finished` rebuilt with `Usage::new` -> end-to-end test fails naming the missing prefill rate.
- `token()` assigning unconditionally instead of `get_or_insert_with` -> TTFT test fails, a later token had moved it.
- `prefill_finished()` deleted from the handover -> decode phase collapses to zero, end-to-end test fails.

**The first sabotage run proved nothing and looked like a pass.** `cargo fmt` had wrapped the target line across three lines, so the patch never matched and the file was never mutated. A mutation that does not land is indistinguishable from a test that holds. It was re-applied against the wrapped form and verified in the file before the run counted.

A unit test on the clock alone would not have caught the original bug -- what was missing was the CALL at the reply site -- so the regression test runs through `flush_finished`.

## Checks

`cargo clippy -p ferrox-server --all-targets --features metal -- -D warnings` clean; 64 batch tests + 3 clock tests pass; verified live against a running server.

## Noted, not fixed here

Decode on this checkpoint is **19.1 tok/s batched vs 31.5 tok/s** through the private loop on the same machine and model. That gap is real and is not this PR's subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN