### PR TITLE
fix(ui): a reasoning model streamed its thinking to a client that dropped it

### DIFF
--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -121,6 +121,37 @@ test("a resumable request asks the server for a replay buffer and names itself",
   assert.equal(calls.length, 1, "a completed stream needs no recovery");
 });
 
+test("a reasoning model's thinking arrives on its own channel, not as answer text", async () => {
+  // The bug this covers: the client typed the delta as `{ content }`
+  // only, so every `reasoning_content` frame was dropped. On an R1
+  // distill that is most of the answer's wall-clock, so the transcript
+  // sat empty and the stream looked dead until the answer landed whole.
+  const thinking = `id: chatcmpl-1:0\ndata: ${JSON.stringify({
+    id: "chatcmpl-1",
+    request_id: "chatcmpl-1",
+    choices: [{ index: 0, delta: { reasoning_content: "17 x 3 = 51" } }],
+  })}\n\n`;
+  responders = [async () => sse(thinking, chunk(1, "51"), finalChunk(2))];
+  const sink = collect();
+  let reasoning = "";
+  await streamChat(
+    { model: "m", messages: [{ role: "user", content: "hi" }] },
+    {
+      onToken: sink.onToken,
+      onReasoning: (t) => {
+        reasoning += t;
+      },
+    },
+  );
+
+  assert.equal(reasoning, "17 x 3 = 51");
+  assert.equal(
+    sink.text(),
+    "51",
+    "thinking must not be concatenated into the answer",
+  );
+});
+
 test("a stream that dies mid-answer resumes from the last id, repeating nothing", async () => {
   responders = [
     // The connection dies after two events: no finish reason, no [DONE].

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -346,7 +346,18 @@ type StreamChunk = {
   usage?: Usage;
   choices?: {
     finish_reason?: string | null;
-    delta?: { content?: string | null };
+    delta?: {
+      content?: string | null;
+      /**
+       * A reasoning model's thinking, which the server streams in its
+       * OWN field rather than inside `content` (llama.cpp and DeepSeek
+       * both do this). A client that reads only `content` shows
+       * nothing at all while a reasoning model thinks, which on an R1
+       * distill is most of the answer's wall-clock: the transcript sits
+       * empty, the stream looks dead, and then the answer lands whole.
+       */
+      reasoning_content?: string | null;
+    };
   }[];
 };
 
@@ -369,6 +380,15 @@ export type Transport = "stream" | "resumed" | "polling";
 export type StreamHandlers = {
   signal?: AbortSignal;
   onToken?: (text: string) => void;
+  /**
+   * A reasoning model's thinking, as it arrives.
+   *
+   * Kept separate from `onToken` rather than concatenated into it: the
+   * two are shown differently, and only one of them is the answer. A
+   * caller that does not set this simply does not render thinking,
+   * which is the old behaviour.
+   */
+  onReasoning?: (text: string) => void;
   onRequestId?: (id: string) => void;
   onStall?: (ms: number | null) => void;
   onTransport?: (transport: Transport) => void;
@@ -451,6 +471,11 @@ function applyEvent(
   if (chunk.usage) state.usage = chunk.usage;
   const choice = chunk.choices?.[0];
   if (choice?.finish_reason) state.finishReason = choice.finish_reason;
+  // Reasoning first, because that is the order the server sends it in
+  // and the order it has to be shown in: thinking, then the answer it
+  // led to.
+  const reasoning = choice?.delta?.reasoning_content;
+  if (reasoning) handlers.onReasoning?.(reasoning);
   const text = choice?.delta?.content;
   if (text) handlers.onToken?.(text);
 }

--- a/ui/src/screens/chat/reasoning.tsx
+++ b/ui/src/screens/chat/reasoning.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import type { ReasoningMessagePartComponent } from "@assistant-ui/react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A reasoning model's thinking, shown above the answer it led to.
+ *
+ * assistant-ui renders NOTHING for a reasoning part unless a component
+ * is supplied for it, which is how this went unnoticed: the server
+ * streamed `reasoning_content` correctly, the client dropped it, and an
+ * R1 distill therefore spent most of its wall-clock producing tokens
+ * that never reached the screen. The transcript looked frozen and the
+ * answer arrived whole, which reads as "streaming is broken" rather
+ * than "thinking is hidden".
+ *
+ * Collapsed by default, because it is working-out and not the answer.
+ * It is deliberately NOT markdown: thinking is where a model emits
+ * half-open code fences and unbalanced brackets, and a renderer that
+ * reflows them makes the text harder to read, not easier.
+ */
+export const ReasoningPart: ReasoningMessagePartComponent = ({ text }) => {
+  const [open, setOpen] = useState(false);
+  const trimmed = text.trim();
+  // A part that exists but has not been written to yet would otherwise
+  // render an empty, clickable box under every answer.
+  if (!trimmed) return null;
+  return (
+    <div className="mb-2 rounded-lg border border-line bg-inset">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-muted transition-colors hover:text-fg"
+      >
+        <ChevronRight
+          aria-hidden
+          className={cn(
+            "size-3.5 shrink-0 transition-transform",
+            open && "rotate-90",
+          )}
+        />
+        <span>Thinking</span>
+        <span className="text-muted/70">
+          {trimmed.length.toLocaleString()} chars
+        </span>
+      </button>
+      {open && (
+        <div className="max-h-80 overflow-y-auto whitespace-pre-wrap border-t border-line px-2.5 py-2 text-xs leading-relaxed text-muted">
+          {trimmed}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/src/screens/chat/runtime.ts
+++ b/ui/src/screens/chat/runtime.ts
@@ -155,7 +155,11 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
         wire.push({ role: "system", content: sampling.system.trim() });
       wire.push(...toWire(messages));
 
-      const tokens = pump<string>();
+      // ONE pump, carrying tagged chunks, rather than one per kind.
+      // Two queues drained in sequence would be two structures that
+      // have to agree about ordering, and they would disagree the first
+      // time a model interleaved thinking with its answer.
+      const tokens = pump<{ kind: "text" | "reasoning"; text: string }>();
       let requestId: string | null = null;
       let result: StreamResult | null = null;
       let failure: unknown = null;
@@ -185,7 +189,9 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
             requestId = id;
             live.add(id);
           },
-          onToken: (token) => tokens.push(token),
+          onToken: (token) => tokens.push({ kind: "text", text: token }),
+          onReasoning: (token) =>
+            tokens.push({ kind: "reasoning", text: token }),
           onStall: deps.onStall,
           onTransport: deps.onTransport,
         },
@@ -202,10 +208,20 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
         });
 
       let text = "";
+      let reasoning = "";
+      // Thinking is shown ABOVE the answer, which is also the order it
+      // arrives in. An empty part is never emitted: a model that does
+      // not think must not grow an empty block, and an answer that has
+      // not started must not be an empty bubble under one.
+      const parts = () => [
+        ...(reasoning ? [{ type: "reasoning" as const, text: reasoning }] : []),
+        ...(text ? [{ type: "text" as const, text }] : []),
+      ];
       try {
-        for await (const token of tokens.drain()) {
-          text += token;
-          yield { content: [{ type: "text", text }] };
+        for await (const chunk of tokens.drain()) {
+          if (chunk.kind === "reasoning") reasoning += chunk.text;
+          else text += chunk.text;
+          yield { content: parts() };
         }
         await task;
       } finally {
@@ -229,7 +245,10 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
           usage: finished?.usage ?? null,
         };
         yield {
-          content: [{ type: "text", text }],
+          // The reasoning is kept on the finished message too. Dropping
+          // it here would make the thinking vanish at the moment the
+          // answer completes, which reads as a rendering bug.
+          content: parts(),
           status: cancelled
             ? { type: "incomplete", reason: "cancelled" }
             : { type: "complete", reason: "stop" },
@@ -243,8 +262,11 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
         // arrive are kept, and the line says why there are no timings.
         yield {
           content: [
+            ...(reasoning
+              ? [{ type: "reasoning" as const, text: reasoning }]
+              : []),
             {
-              type: "text",
+              type: "text" as const,
               text: text || "_(stopped before any token arrived)_",
             },
           ],

--- a/ui/src/screens/chat/thread.tsx
+++ b/ui/src/screens/chat/thread.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { MarkdownText } from "@/screens/chat/markdown";
+import { ReasoningPart } from "@/screens/chat/reasoning";
 import type { AnswerStats } from "@/screens/chat/runtime";
 
 // The transcript, the composer, autoscroll, branching and the abort
@@ -145,7 +146,9 @@ const AssistantMessage: FC = () => (
       </span>
       <div className="min-w-0 flex-1">
         <div className="min-w-0">
-          <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+          <MessagePrimitive.Parts
+            components={{ Text: MarkdownText, Reasoning: ReasoningPart }}
+          />
         </div>
 
         <MessagePrimitive.Error>


### PR DESCRIPTION
Closes #118.

The server streams a reasoning model's thinking as `reasoning_content` on every delta. The client typed the delta as `{ content }` and read nothing else, so all of it was dropped.

On an R1 distill that is most of an answer's wall-clock: the transcript sat empty (a dead-looking stream), and an answer that spent its whole budget thinking rendered as an **empty message with a stat line saying 512 tokens were decoded**.

## Two halves

Either alone still shows nothing:

1. `reasoning_content` read off the delta, into its own `onReasoning` handler -- kept separate from `onToken` rather than concatenated, because the two are shown differently and only one is the answer.
2. A `Reasoning` component supplied to `MessagePrimitive.Parts`. assistant-ui renders a reasoning part with **nothing at all** by default, so a part emitted without a component is as invisible as a part never emitted. That is why the existing `{ type: "reasoning" }` handling in `conversations.ts` was not enough.

## Choices

- **Above the answer, collapsed, with its length.** It is working-out, not the answer.
- **Not markdown.** Thinking is where a model emits half-open fences and unbalanced brackets; reflowing those makes them harder to read.
- **One pump carrying tagged chunks**, not one queue per kind. Two queues drained in sequence would be two structures that must agree about ordering, and they would disagree the first time a model interleaved thinking with its answer.
- **Still not stored in the transcript.** Already true, already tested (`only text becomes transcript content`). Thinking is shown, not replayed as context -- which is also DeepSeek's own guidance.
- Empty parts are never emitted, so a non-reasoning model grows no empty block.

## Checks

`npm run check` (typecheck + eslint + 23 tests) clean.

Sabotage: dropping the `reasoning_content` read from the frame handler turns the new test red, naming the thinking that never arrived.

Verified live on `DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M` through the dev server: the Thinking block appears within a second, its char count grows as it streams, it expands, and the answer streams below it. Stat line: TTFT 81 ms, prefill 295.4 tok/s, decode 412 tok at 22.4 tok/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN