### PR TITLE
docs(readme): drop a quant preference the repo's own oracle contradicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,13 @@ curl -s -X POST http://127.0.0.1:8383/v1/chat/completions \
 ferrox bench -m models/Llama-3.2-3B-Instruct-Q4_K_M.gguf -p 512 -n 128 -r 3 --compare
 ```
 
-Prefer `Q4_K_M` day to day and `Q8_0` for small smoke tests.
+On `Q8_0` and `IQ4_NL`, ferrox's logits match llama.cpp's. On K-quants
+they drift, for a
+[known reason](docs/plans/llama-cpp-gap-inventory.md) that is not a
+ferrox bug: llama.cpp quantizes activations to `Q8_K` before the dot
+product and ferrox keeps them in f32. Use whichever quant you would
+use with llama.cpp; if you are comparing the two, `Q8_0` is the one
+that answers the question without that variable in it.
 [docs/MODELS.md](docs/MODELS.md) lists what runs today, and which
 checkpoints stop with an error instead.
 


### PR DESCRIPTION
"Prefer `Q4_K_M` day to day and `Q8_0` for small smoke tests" was advice with nothing behind it, and it pointed the **wrong way**.

`ferrox parity` -- this repo's own oracle -- finds the opposite: the logit half **matches** llama.cpp on `Q8_0`/`IQ4_NL` and **drifts** on K-quants. So the README's quick start was recommending, as the day-to-day default, the tier where the two engines agree least.

The drift is not a ferrox bug: llama.cpp quantizes activations to `Q8_K` before the dot product, ferrox keeps them in f32 (`docs/plans/llama-cpp-gap-inventory.md`). That is precisely why the reader deserves the fact instead of a preference -- someone picking a quant has their own reasons, and someone comparing the two engines needs to know which tier keeps that variable out of the measurement.

No number moved and nothing else in the quick start changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN