### PR TITLE
fix(server): a character split across two tokens was destroyed by decoding per token

### DIFF
--- a/crates/ferrox-models/src/engine.rs
+++ b/crates/ferrox-models/src/engine.rs
@@ -318,6 +318,19 @@ impl Engine for DeepseekV4Engine {
 pub trait TextTokenizer {
     fn encode(&self, text: &str) -> Vec<usize>;
     fn decode(&self, ids: &[usize]) -> String;
+
+    /// The raw bytes, before any UTF-8 decision is made about them.
+    ///
+    /// A caller decoding ONE token at a time needs these: a character
+    /// split across two tokens is two invalid fragments, and `decode`
+    /// resolves each to U+FFFD separately, losing the bytes (#124).
+    ///
+    /// The default is correct for any tokenizer whose tokens are whole
+    /// text, and no worse than `decode` for one whose tokens are not --
+    /// but such a tokenizer should override this.
+    fn decode_bytes(&self, ids: &[usize]) -> Vec<u8> {
+        self.decode(ids).into_bytes()
+    }
 }
 
 impl TextTokenizer for KimiTokenizer {

--- a/crates/ferrox-models/src/tokenizer.rs
+++ b/crates/ferrox-models/src/tokenizer.rs
@@ -280,8 +280,17 @@ impl ByteTokenizer {
     /// dropped rather than silently corrupting output; invalid UTF-8
     /// byte sequences are replaced per Rust's standard lossy conversion.
     pub fn decode(ids: &[u32]) -> String {
-        let bytes: Vec<u8> = ids.iter().filter_map(|&id| u8::try_from(id).ok()).collect();
-        String::from_utf8_lossy(&bytes).into_owned()
+        String::from_utf8_lossy(&Self::decode_bytes(ids)).into_owned()
+    }
+
+    /// The raw bytes, before any UTF-8 decision is made about them.
+    ///
+    /// A caller decoding ONE token at a time must have these: a
+    /// multi-byte character split across two tokens is two invalid
+    /// fragments, and `decode` would turn each into U+FFFD and lose the
+    /// bytes for good. See `ferrox_server::utf8_stream`.
+    pub fn decode_bytes(ids: &[u32]) -> Vec<u8> {
+        ids.iter().filter_map(|&id| u8::try_from(id).ok()).collect()
     }
 
     pub const VOCAB_SIZE: usize = 256;
@@ -794,6 +803,12 @@ impl GgufBpeTokenizer {
     /// GPT-2: remapped unicode → bytes. Gemma-4: unescape `▁` → space and
     /// expand `<0xXX>` byte tokens (same shape as SPM decode).
     pub fn decode(&self, ids: &[u32]) -> String {
+        String::from_utf8_lossy(&self.decode_bytes(ids)).into_owned()
+    }
+
+    /// The raw bytes, before any UTF-8 decision is made about them.
+    /// See [`GgufBpeTokenizer::decode`] and `ferrox_server::utf8_stream`.
+    pub fn decode_bytes(&self, ids: &[u32]) -> Vec<u8> {
         match self.style {
             BpeEncodingStyle::Gpt2 => {
                 let bytes: Vec<u8> = ids
@@ -802,7 +817,7 @@ impl GgufBpeTokenizer {
                     .flat_map(|token| token.chars())
                     .filter_map(|c| self.unicode_to_byte.get(&c).copied())
                     .collect();
-                String::from_utf8_lossy(&bytes).into_owned()
+                bytes
             }
             BpeEncodingStyle::SpmWhitespace => {
                 let mut bytes: Vec<u8> = Vec::new();
@@ -816,7 +831,7 @@ impl GgufBpeTokenizer {
                         bytes.extend(token.replace(SPM_SPACE, " ").into_bytes());
                     }
                 }
-                String::from_utf8_lossy(&bytes).into_owned()
+                bytes
             }
         }
     }
@@ -1136,6 +1151,17 @@ impl GgufSpmTokenizer {
     }
 
     pub fn decode(&self, ids: &[u32]) -> String {
+        String::from_utf8_lossy(&self.decode_bytes(ids)).into_owned()
+    }
+
+    /// The raw bytes, before any UTF-8 decision is made about them.
+    ///
+    /// The comment below is about several `<0xXX>` tokens inside ONE
+    /// call. The same character can just as easily straddle the
+    /// boundary BETWEEN two calls, which is why this is public: a
+    /// per-token caller has to do its own buffering, and it cannot do
+    /// that from a `String` that has already been made lossy.
+    pub fn decode_bytes(&self, ids: &[u32]) -> Vec<u8> {
         // Byte-fallback tokens must be collected as raw bytes (not
         // pushed as their 6-character literal token string) and
         // UTF-8-decoded together with the rest -- a single real
@@ -1155,7 +1181,7 @@ impl GgufSpmTokenizer {
                 bytes.extend(token.replace('\u{2581}', " ").into_bytes());
             }
         }
-        String::from_utf8_lossy(&bytes).into_owned()
+        bytes
     }
 }
 
@@ -1397,6 +1423,14 @@ impl GgufUnigramTokenizer {
             }
         }
         out
+    }
+
+    /// The raw bytes. Unigram has no byte-fallback convention, so every
+    /// token is already whole text and this can never split a
+    /// character -- it exists so a per-token caller can treat every
+    /// tokenizer the same way.
+    pub fn decode_bytes(&self, ids: &[u32]) -> Vec<u8> {
+        self.decode(ids).into_bytes()
     }
 }
 

--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -1525,7 +1525,7 @@ pub fn generate(
         &tokens,
         stop_tokens,
         params,
-        |ids| tokenizer.decode(ids),
+        |ids| tokenizer.decode_bytes(ids),
         |next, pos| {
             if first_token_at.is_none() {
                 first_token_at = Some(std::time::Instant::now());
@@ -1661,12 +1661,18 @@ fn sample_until_stop(
     prompt_ids: &[usize],
     stop_tokens: &StopTokens,
     params: &GenerationParams,
-    mut decode_one: impl FnMut(&[usize]) -> String,
+    // Raw BYTES, not text. A character can straddle two tokens, and
+    // deciding UTF-8 per token destroys it -- see `crate::utf8_stream`.
+    mut decode_one: impl FnMut(&[usize]) -> Vec<u8>,
     mut step: impl FnMut(usize, usize) -> Vec<f32>,
     mut emit: impl FnMut(&str),
     decode_token: &dyn Fn(usize) -> String,
 ) -> Result<(FinishReason, Vec<usize>, Vec<f32>), DecodeError> {
     let mut matcher = crate::stop::StopMatcher::new(&params.stop, &params.stop_token_ids);
+    // Sits BEFORE the stop matcher: a stop string is text, so it can
+    // only be matched against whole characters, and half of one is not
+    // text yet.
+    let mut utf8 = crate::utf8_stream::Utf8Stream::default();
     let mut state = crate::sample_step::SampleState::new(params.seed);
     // NOT `with_capacity(params.max_tokens)`. That is a caller-supplied
     // number sizing an allocation, and it reached
@@ -1727,7 +1733,7 @@ fn sample_until_stop(
 
         // Layer 2: only text that can no longer become part of a stop
         // string leaves here.
-        match matcher.push(&decode_one(&[next])) {
+        match matcher.push(&utf8.push(&decode_one(&[next]))) {
             crate::stop::StopStep::Emit(text) => {
                 if !text.is_empty() {
                     emit(&text);
@@ -1740,6 +1746,18 @@ fn sample_until_stop(
                 finish = FinishReason::StopSequence(stop);
                 break;
             }
+        }
+    }
+
+    // A generation that stopped mid-character cannot complete it, so
+    // the held bytes surface as U+FFFD rather than vanishing -- that
+    // goes through the matcher like any other text.
+    let partial = utf8.flush();
+    if !partial.is_empty() {
+        let (crate::stop::StopStep::Emit(text) | crate::stop::StopStep::Matched { text, .. }) =
+            matcher.push(&partial);
+        if !text.is_empty() {
+            emit(&text);
         }
     }
 
@@ -1810,7 +1828,7 @@ pub fn generate_engine<E: Engine, T: TextTokenizer>(
         &tokens,
         stop_tokens,
         params,
-        |ids| tokenizer.decode(ids),
+        |ids| tokenizer.decode_bytes(ids),
         |next, pos| {
             if first_token_at.is_none() {
                 first_token_at = Some(std::time::Instant::now());
@@ -2374,12 +2392,76 @@ mod tests {
             &[],
             &stop_tokens,
             params,
-            |ids| ids.iter().copied().map(&render).collect::<String>(),
+            |ids| {
+                ids.iter()
+                    .copied()
+                    .map(&render)
+                    .collect::<String>()
+                    .into_bytes()
+            },
             |_tok, _pos| logits_for(take()),
             |chunk| chunks.push(chunk.to_string()),
             &render,
         )?;
         Ok((finish, ids, chunks))
+    }
+
+    /// The wiring #124 was about, end to end through the decode loop.
+    ///
+    /// The unit tests in `crate::utf8_stream` prove the buffer works.
+    /// They cannot prove `sample_until_stop` USES it, and that call is
+    /// the whole fix -- the same gap that let a batched row ship with
+    /// no timings. So this drives the real loop with a tokenizer whose
+    /// tokens are single bytes, which is exactly what a byte-fallback
+    /// vocabulary does to an emoji.
+    ///
+    /// It cannot go through `run_scripted`: that helper's `render`
+    /// returns `String`, and half a character has no `String`.
+    #[test]
+    fn a_character_split_across_tokens_is_emitted_whole_by_the_decode_loop() {
+        let smiley = "😊".as_bytes().to_vec();
+        assert_eq!(smiley.len(), 4, "the point of this test");
+        let vocab = smiley.len() + 2;
+        let logits_for = |id: usize| {
+            let mut v = vec![0.0f32; vocab];
+            v[id] = 10.0;
+            v
+        };
+        let len = smiley.len();
+        let mut next = 0usize;
+        let mut take = move || {
+            let id = next.min(len - 1);
+            next += 1;
+            id
+        };
+        let first = logits_for(take());
+        let bytes = smiley;
+        let mut chunks: Vec<String> = Vec::new();
+        let (_finish, ids, _) = sample_until_stop(
+            first,
+            0,
+            &[],
+            &StopTokens::default(),
+            &scripted_params(4),
+            // One byte per token: each of the middle ones is invalid
+            // UTF-8 on its own, which is the whole problem.
+            |ids| ids.iter().map(|&id| bytes[id]).collect(),
+            |_tok, _pos| logits_for(take()),
+            |chunk| chunks.push(chunk.to_string()),
+            &|_id| String::new(),
+        )
+        .expect("decode");
+
+        assert_eq!(ids.len(), 4, "four tokens, one per byte");
+        assert_eq!(
+            chunks.concat(),
+            "😊",
+            "a character split across tokens must not be decoded per token"
+        );
+        assert!(
+            !chunks.concat().contains(char::REPLACEMENT_CHARACTER),
+            "the bytes were valid UTF-8 together; only the split made them look invalid"
+        );
     }
 
     fn scripted_params(max_tokens: usize) -> GenerationParams {
@@ -2655,7 +2737,20 @@ mod tests {
             // generated: nothing meaningful to truncate, skip.
             return;
         };
-        let stop_str = baseline[cut..].to_string();
+        // This decoder emits arbitrary bytes through `ServerTokenizer::
+        // Byte`, so the tail can end in a U+FFFD that `Utf8Stream::flush`
+        // produced -- a character whose remaining bytes never arrived
+        // because generation hit `max_tokens` mid-sequence.
+        //
+        // That one is NOT matchable, and correctly so: while the loop is
+        // running, those bytes may still be completed by the next token,
+        // so the replacement does not exist yet. It is only knowable
+        // once generation has ended, which is after every stop decision
+        // has been made. Trimming it keeps this test about what it says
+        // it is about -- a stop sequence that DOES match.
+        let stop_str = baseline[cut..]
+            .trim_end_matches(char::REPLACEMENT_CHARACTER)
+            .to_string();
         if stop_str.is_empty() {
             return;
         }

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -71,6 +71,7 @@ mod stream_events;
 mod tasks;
 mod tool_grammar;
 mod unsupported_sampling;
+mod utf8_stream;
 
 use std::cell::RefCell;
 use std::convert::Infallible;
@@ -3905,7 +3906,7 @@ pub(crate) fn activate_loaded_model(
                      (stop sequences use the same pending-buffer trim as the private generate loop)"
                 );
                 let tok = Arc::clone(&tokenizer);
-                let decode = Arc::new(move |ids: &[usize]| tok.decode(ids));
+                let decode = Arc::new(move |ids: &[usize]| tok.decode_bytes(ids));
                 Some(serving::batch::ContinuousBatcher::spawn_with_ceiling(
                     Arc::clone(&decoder),
                     decode,

--- a/crates/ferrox-server/src/model.rs
+++ b/crates/ferrox-server/src/model.rs
@@ -181,6 +181,18 @@ impl ServerTokenizer {
         }
     }
 
+    /// The raw bytes, before any UTF-8 decision is made about them.
+    /// See `crate::utf8_stream` for why a per-token caller needs them.
+    pub fn decode_bytes(&self, ids: &[usize]) -> Vec<u8> {
+        let ids32: Vec<u32> = ids.iter().map(|&id| id as u32).collect();
+        match self {
+            ServerTokenizer::Bpe(t) => t.decode_bytes(&ids32),
+            ServerTokenizer::Spm(t) => t.decode_bytes(&ids32),
+            ServerTokenizer::Unigram(t) => t.decode_bytes(&ids32),
+            ServerTokenizer::Byte => ferrox_models::tokenizer::ByteTokenizer::decode_bytes(&ids32),
+        }
+    }
+
     pub fn kind(&self) -> &'static str {
         match self {
             ServerTokenizer::Bpe(_) => "gguf-bpe",
@@ -198,6 +210,10 @@ impl TextTokenizer for ServerTokenizer {
 
     fn decode(&self, ids: &[usize]) -> String {
         ServerTokenizer::decode(self, ids)
+    }
+
+    fn decode_bytes(&self, ids: &[usize]) -> Vec<u8> {
+        ServerTokenizer::decode_bytes(self, ids)
     }
 }
 

--- a/crates/ferrox-server/src/serving/batch/clock.rs
+++ b/crates/ferrox-server/src/serving/batch/clock.rs
@@ -92,9 +92,16 @@ mod tests {
     /// not just its token counts.
     #[test]
     fn a_finished_row_reports_both_rates() {
+        // Each phase is given a measurable duration on purpose.
+        // `with_timings` leaves a rate unset for a ZERO-length phase
+        // rather than dividing into infinity, so a test that finished
+        // both phases inside one clock tick would fail against correct
+        // code -- it did, once the machine was quiet enough.
         let mut clock = RowClock::start();
+        std::thread::sleep(std::time::Duration::from_millis(2));
         clock.prefill_finished();
         clock.token();
+        std::thread::sleep(std::time::Duration::from_millis(2));
         let usage = clock.usage(41, 32);
         assert!(
             usage.prompt_per_second.is_some(),

--- a/crates/ferrox-server/src/serving/batch/config.rs
+++ b/crates/ferrox-server/src/serving/batch/config.rs
@@ -11,7 +11,14 @@ use crate::generate::{DecodeError, FinishReason, Usage};
 
 use super::status::DEFAULT_DECODE_LOG_INTERVAL;
 
-pub(super) type DecodeFn = Arc<dyn Fn(&[usize]) -> String + Send + Sync>;
+/// Detokenize to RAW BYTES, not text.
+///
+/// Bytes because a character can straddle two tokens and a batched row
+/// is decoded one token at a time: resolving UTF-8 per token turns each
+/// half into U+FFFD and loses it (#124). Each row buffers its own tail
+/// through `crate::utf8_stream::Utf8Stream` -- per row, because rows
+/// interleave and one shared buffer would splice two answers together.
+pub(super) type DecodeFn = Arc<dyn Fn(&[usize]) -> Vec<u8> + Send + Sync>;
 
 /// Finish reason, generated token ids, detokenized text (stop-trimmed),
 /// and usage. Callers should prefer `text` for the response body when

--- a/crates/ferrox-server/src/serving/batch/prefill.rs
+++ b/crates/ferrox-server/src/serving/batch/prefill.rs
@@ -255,6 +255,7 @@ impl Prefill {
             abort,
             blocks,
             clock,
+            utf8: Default::default(),
         }
     }
 }

--- a/crates/ferrox-server/src/serving/batch/row.rs
+++ b/crates/ferrox-server/src/serving/batch/row.rs
@@ -20,6 +20,7 @@ use super::block_budget::BlockBudget;
 use super::clock::RowClock;
 use super::config::{send_finished, BatcherEvent};
 use super::queue::AbortId;
+use crate::utf8_stream::Utf8Stream;
 
 /// Where one batched row keeps its KV.
 ///
@@ -242,6 +243,10 @@ pub(super) struct Slot {
     /// The row's own clock, started at admission. Owns the only path
     /// from a finished row to its `Usage`.
     pub(super) clock: RowClock,
+    /// This row's half-finished character, if a token ended inside one.
+    /// Per row: rows interleave, and one shared buffer would splice one
+    /// answer's bytes into another's.
+    pub(super) utf8: Utf8Stream,
 }
 
 impl Slot {
@@ -275,6 +280,13 @@ pub(super) fn reply_finished(mut slot: Slot) {
     // Text withheld against a stop that never arrived is ordinary
     // output; dropping it would truncate every answer whose tail looks
     // like the start of a stop string.
+    // A row cut off mid-character cannot finish it, so the held bytes
+    // surface as U+FFFD instead of vanishing -- through the stop
+    // matcher, like any other text this row produced.
+    let partial = slot.utf8.flush();
+    if !partial.is_empty() {
+        slot.stops.push(&partial);
+    }
     let tail = slot.stops.flush();
     if !tail.is_empty() {
         slot.visible.push_str(&tail);

--- a/crates/ferrox-server/src/serving/batch/tests/batching.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/batching.rs
@@ -290,9 +290,9 @@ fn continuous_batch_honors_stop_sequence_in_decoded_text() {
     let decode: DecodeFn = Arc::new(|ids: &[usize]| {
         ids.iter()
             .map(|id| match id % 3 {
-                0 => 'X',
-                1 => 'Y',
-                _ => 'Z',
+                0 => b'X',
+                1 => b'Y',
+                _ => b'Z',
             })
             .collect()
     });
@@ -348,7 +348,7 @@ fn continuous_batch_honors_stop_sequence_in_decoded_text() {
 #[test]
 fn continuous_batch_stops_on_any_member_of_the_stop_set() {
     let decoder = tiny_decoder();
-    let decode: DecodeFn = Arc::new(|_: &[usize]| String::new());
+    let decode: DecodeFn = Arc::new(|_: &[usize]| Vec::new());
     let prompt = vec![1usize, 2, 3];
     let params = greedy_params(32, 3);
     let ids = sequential_ids(&decoder, &prompt, &params);
@@ -618,7 +618,7 @@ fn a_grammar_constrains_a_batched_row_as_it_does_a_private_one() {
     let decoder = tiny_decoder();
     let decode: DecodeFn = Arc::new(|ids: &[usize]| {
         ids.iter()
-            .map(|id| if id % 2 == 0 { 'b' } else { 'a' })
+            .map(|id| if id % 2 == 0 { b'b' } else { b'a' })
             .collect()
     });
     let batcher = ContinuousBatcher::spawn_with_config(
@@ -673,7 +673,7 @@ fn a_batched_row_whose_grammar_dead_ends_is_refused_by_itself() {
     let decoder = tiny_decoder();
     let decode: DecodeFn = Arc::new(|ids: &[usize]| {
         ids.iter()
-            .map(|id| if id % 2 == 0 { 'b' } else { 'a' })
+            .map(|id| if id % 2 == 0 { b'b' } else { b'a' })
             .collect()
     });
     let batcher = ContinuousBatcher::spawn_with_config(
@@ -734,7 +734,7 @@ fn json_object_mode_constrains_a_batched_row_as_it_does_a_private_one() {
     let decoder = tiny_decoder();
     let decode: DecodeFn = Arc::new(|ids: &[usize]| {
         ids.iter()
-            .map(|id| if id % 2 == 0 { '<' } else { 'a' })
+            .map(|id| if id % 2 == 0 { b'<' } else { b'a' })
             .collect()
     });
     let batcher = ContinuousBatcher::spawn_with_config(

--- a/crates/ferrox-server/src/serving/batch/tests/cancel.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/cancel.rs
@@ -330,8 +330,7 @@ fn a_multi_token_stop_string_truncates_a_batched_row() {
         },
     );
     let baseline = sequential_ids(&decoder, &[1, 2, 3], &greedy_params(8, 4));
-    let decode = identity_decode();
-    let full = decode(&baseline);
+    let full = identity_decode_text(&baseline);
     if full.chars().count() < 4 {
         return;
     }
@@ -375,7 +374,7 @@ fn a_batched_row_that_never_matches_loses_no_output() {
         },
     );
     let baseline = sequential_ids(&decoder, &[1, 2, 3], &greedy_params(8, 4));
-    let expected = identity_decode()(&baseline);
+    let expected = identity_decode_text(&baseline);
 
     let (finish, ids, text, _usage) = batcher
         .generate(

--- a/crates/ferrox-server/src/serving/batch/tests/mod.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/mod.rs
@@ -71,11 +71,14 @@ fn greedy_params(max_tokens: usize, seed: u64) -> GenerationParams {
 }
 
 fn identity_decode() -> DecodeFn {
-    Arc::new(|ids: &[usize]| {
-        ids.iter()
-            .map(|id| char::from_u32(65 + (*id as u32 % 26)).unwrap_or('?'))
-            .collect()
-    })
+    Arc::new(|ids: &[usize]| ids.iter().map(|id| b'A' + (*id as u8 % 26)).collect())
+}
+
+/// `identity_decode`'s output as text, for tests that need to reason
+/// about characters rather than bytes. ASCII by construction, so this
+/// cannot be the lossy step the code under test is about.
+fn identity_decode_text(ids: &[usize]) -> String {
+    String::from_utf8(identity_decode()(ids)).expect("identity_decode is ASCII")
 }
 
 fn sequential_ids(decoder: &Decoder, prompt: &[usize], params: &GenerationParams) -> Vec<usize> {
@@ -162,6 +165,7 @@ fn test_slot(max_tokens: usize, seed: u64) -> (Slot, mpsc::Receiver<BatcherEvent
             finish: None,
             error: None,
             clock: super::clock::RowClock::start(),
+            utf8: Default::default(),
         },
         rx,
     )

--- a/crates/ferrox-server/src/serving/batch/worker.rs
+++ b/crates/ferrox-server/src/serving/batch/worker.rs
@@ -348,7 +348,12 @@ pub(super) fn worker_loop(
                 &slot.prompt_ids,
                 &slot.generated_ids,
                 &slot.stop_tokens,
-                &|id| decode(&[id]),
+                // Text, for the grammar and single-token stop
+                // decisions. Lossy per token, which is what those
+                // callers have always had; the EMITTED text below is
+                // what #124 was about and it goes through the row's
+                // own UTF-8 buffer.
+                &|id| String::from_utf8_lossy(&decode(&[id])).into_owned(),
             ) {
                 Ok(crate::sample_step::Step::Token(next)) => next,
                 // A complete grammar with nothing legal after it: this
@@ -386,8 +391,11 @@ pub(super) fn worker_loop(
             }
             slot.generated_ids.push(next);
             slot.clock.token();
-            let piece = decode(&[next]);
-            if apply_stop_buffer(slot, &piece) {
+            let piece = slot.utf8.push(&decode(&[next]));
+            // An empty piece means the token was the middle of a
+            // character. Nothing to show, and nothing a stop string
+            // could match yet.
+            if !piece.is_empty() && apply_stop_buffer(slot, &piece) {
                 continue;
             }
             active.push(uid);

--- a/crates/ferrox-server/src/utf8_stream.rs
+++ b/crates/ferrox-server/src/utf8_stream.rs
@@ -1,0 +1,153 @@
+//! Holding the tail of a character that has not finished arriving.
+//!
+//! The generation loop decodes ONE token at a time, and every
+//! tokenizer's `decode` ends in `String::from_utf8_lossy`. A character
+//! whose UTF-8 encoding straddles a token boundary is therefore two
+//! separately-invalid fragments, each of which becomes U+FFFD before
+//! any caller sees a byte. A DeepSeek answer ending in an emoji printed
+//! as `Hello! How can I assist you today? \u{fffd}\u{fffd}` (#124), and
+//! the same thing happens to CJK text and to accented Latin coming
+//! through byte-fallback tokens.
+//!
+//! `GgufSpmTokenizer::decode_bytes` already carries a comment about a
+//! character split across several `<0xXX>` tokens WITHIN one call. This
+//! is the same defect one level up: between calls.
+//!
+//! # Incomplete is not the same as invalid
+//!
+//! Nothing here guesses. [`std::str::from_utf8`] distinguishes the two
+//! cases exactly, and the distinction is the whole design:
+//!
+//! - `error_len() == None` -- the input ended mid-character. The tail is
+//!   a valid PREFIX, so it is buffered and the next token completes it.
+//! - `error_len() == Some(n)` -- the bytes cannot begin a character at
+//!   all. That is genuinely broken output, so it becomes U+FFFD here,
+//!   where the replacement is a true statement about the model rather
+//!   than an artefact of where a token boundary fell.
+//!
+//! [`Utf8Stream::flush`] exists because a generation can END mid
+//! character (a truncated answer, a cancelled stream). What is still
+//! held then is never going to be completed, so it is emitted as U+FFFD
+//! rather than silently dropped: losing the bytes would make a
+//! truncated answer look like a shorter finished one.
+
+/// Accumulates decoded bytes and yields only whole characters.
+#[derive(Debug, Default)]
+pub(crate) struct Utf8Stream {
+    /// Bytes of a character whose remaining bytes have not arrived.
+    /// Never longer than 3: a UTF-8 sequence is at most 4 bytes, and a
+    /// 4th byte always completes one.
+    pending: Vec<u8>,
+}
+
+impl Utf8Stream {
+    /// Feeds one token's raw bytes, returning the text now complete.
+    ///
+    /// Returns an empty string when the token added nothing but the
+    /// middle of a character -- the caller emits nothing and asks again
+    /// with the next token.
+    pub(crate) fn push(&mut self, bytes: &[u8]) -> String {
+        self.pending.extend_from_slice(bytes);
+        let mut out = String::new();
+        loop {
+            match std::str::from_utf8(&self.pending) {
+                Ok(text) => {
+                    out.push_str(text);
+                    self.pending.clear();
+                    return out;
+                }
+                Err(error) => {
+                    let valid = error.valid_up_to();
+                    // SAFETY-equivalent: `valid_up_to` is exactly the
+                    // length `from_utf8`already validated, so this cannot panic
+                    // and cannot split a character.
+                    out.push_str(std::str::from_utf8(&self.pending[..valid]).expect("validated"));
+                    match error.error_len() {
+                        // Ended mid-character: keep the tail, wait.
+                        None => {
+                            self.pending.drain(..valid);
+                            return out;
+                        }
+                        // Genuinely not UTF-8: say so, and carry on with
+                        // whatever follows it.
+                        Some(bad) => {
+                            out.push(char::REPLACEMENT_CHARACTER);
+                            self.pending.drain(..valid + bad);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Whatever is still held when the generation ends.
+    ///
+    /// A character that was never completed cannot be recovered, so it
+    /// surfaces as U+FFFD. Dropping it instead would turn a truncated
+    /// answer into a shorter one that looks whole.
+    pub(crate) fn flush(&mut self) -> String {
+        if self.pending.is_empty() {
+            return String::new();
+        }
+        self.pending.clear();
+        char::REPLACEMENT_CHARACTER.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug in #124, as a test: a 4-byte emoji arriving as two
+    /// tokens must come out as the emoji.
+    #[test]
+    fn a_character_split_across_two_tokens_survives() {
+        let smiley = "😊".as_bytes();
+        let (first, second) = smiley.split_at(2);
+        let mut stream = Utf8Stream::default();
+        assert_eq!(stream.push(first), "", "half a character is not text yet");
+        assert_eq!(stream.push(second), "😊");
+        assert_eq!(stream.flush(), "", "nothing left over");
+    }
+
+    /// Byte-fallback tokenizers emit one byte per token, so a
+    /// three-byte CJK character arrives in three pieces.
+    #[test]
+    fn one_byte_at_a_time_still_assembles() {
+        let mut stream = Utf8Stream::default();
+        let mut out = String::new();
+        for byte in "世界".as_bytes() {
+            out.push_str(&stream.push(&[*byte]));
+        }
+        assert_eq!(out, "世界");
+    }
+
+    /// Text and a split character in the same token stream: the ASCII
+    /// must not be held back waiting for the character behind it.
+    #[test]
+    fn ascii_is_emitted_immediately_and_not_held() {
+        let mut stream = Utf8Stream::default();
+        assert_eq!(stream.push(b"today? "), "today? ");
+        assert_eq!(stream.push(&"😊".as_bytes()[..1]), "");
+        assert_eq!(stream.push(&"😊".as_bytes()[1..]), "😊");
+    }
+
+    /// Bytes that cannot start a character are NOT buffered forever:
+    /// they are reported as the replacement they are, and decoding
+    /// continues with what follows.
+    #[test]
+    fn genuinely_invalid_bytes_become_one_replacement_and_do_not_stall() {
+        let mut stream = Utf8Stream::default();
+        assert_eq!(stream.push(&[0xff, b'o', b'k']), "\u{fffd}ok");
+    }
+
+    /// A generation cut off mid-character says so, rather than dropping
+    /// the bytes and looking complete.
+    #[test]
+    fn a_truncated_character_surfaces_at_flush() {
+        let mut stream = Utf8Stream::default();
+        assert_eq!(stream.push(&"😊".as_bytes()[..3]), "");
+        assert_eq!(stream.flush(), "\u{fffd}");
+        assert_eq!(stream.flush(), "", "flush does not repeat itself");
+    }
+}


### PR DESCRIPTION
Closes #124.

You reported two strange characters at the end of a DeepSeek answer:

```
Hello! How can I assist you today? ��
```

It was the emoji. Reproduced against the server directly, on **both** the streamed and the buffered response, so the UI was never at fault.

## Cause

`generate.rs:1507` decoded one token at a time, and every `ServerTokenizer` arm ends in `String::from_utf8_lossy`. A character whose UTF-8 spans two tokens is two separately-invalid fragments: each resolved to U+FFFD and the bytes were gone before any caller saw them. A 4-byte emoji split across two tokens gives exactly two replacements.

Not emoji-specific -- it hits CJK text and **every byte-fallback token**, which are single bytes by construction.

The repo already knew both halves of this. `GgufSpmTokenizer::decode_bytes` carries a comment about a character split across several `<0xXX>` tokens *within* one call, and `grammar_sampler.rs` refers to "the bug llama.cpp's `partial_utf8` exists to avoid". This was the same defect one level up, between calls.

## Nothing is guessed

`std::str::from_utf8` separates the two cases exactly, and that distinction is the whole design:

| | meaning | action |
|---|---|---|
| `error_len() == None` | ended mid-character; the tail is a valid **prefix** | buffer it, the next token completes it |
| `error_len() == Some(n)` | cannot start a character at all | emit U+FFFD -- here it is a true statement about the model, not an artefact of a token boundary |

Each batcher row gets its **own** `Utf8Stream`: rows interleave, and one shared buffer would splice one answer's bytes into another's. A generation that ends mid-character flushes U+FFFD rather than dropping the bytes, since dropping would make a truncated answer look like a shorter finished one.

## Two behaviours changed, both correct, both caught by existing tests

- A stop string ending in a **flush-produced** replacement character no longer matches. It cannot: while the loop runs those bytes may still be completed, so that character does not exist yet, and it is only knowable after every stop decision is made. The test that found this now says so.
- `a_finished_row_reports_both_rates` was timing-dependent and failed once the machine went quiet -- `with_timings` correctly leaves a rate unset for a zero-length phase. Each phase now gets a measurable duration. My test, not the code.

## Sabotage

Restoring the per-token `from_utf8_lossy` at the emit site turns the new end-to-end test red with `"����"`, one per byte -- the original bug, reproduced.

That test drives the **real decode loop**, not the buffer. The unit tests in `utf8_stream` prove the buffer works; they cannot prove `sample_until_stop` uses it, and that call IS the fix. Same gap that let a batched row ship with no timings at all (#116).

## Verified

Live on `DeepSeek-R1-Distill-Qwen-1.5B`, both paths: `Hello! How can I assist you today? 😊`, zero replacement characters. 815 tests pass; clippy clean with `--all-targets --features metal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN