### PR TITLE
fix(bench): --n-gpu-layers 0 now forces CPU, and a receipt cannot lie about which backend ran

### DIFF
--- a/crates/ferrox-cli/src/bench_model.rs
+++ b/crates/ferrox-cli/src/bench_model.rs
@@ -69,7 +69,20 @@ impl Row {
 ///
 /// # Safety
 /// Must be called while the process is still single-threaded.
-pub fn apply_env(threads: usize, n_gpu_layers: usize) {
+/// Applies the backend/threading env, then CHECKS that it took.
+///
+/// The check is the point. Setting `FERROX_METAL=0` is not the same as
+/// running on the CPU: the backend decision is cached in a `OnceLock`
+/// the first time anything reads it, so a caller that ran too late set
+/// a variable nobody would ever consult again. That is exactly what
+/// happened to every `cpu` row in `benchmarks/RESULTS.md` (#126) --
+/// each receipt recorded `backend: "cpu"` beside `backend_active:
+/// "Metal"`, and nothing compared them.
+///
+/// So this asks `active_backend()` immediately, which both forces the
+/// cache while the env is still fresh and reveals a disagreement, and
+/// it fails loudly rather than measuring the wrong device.
+pub fn apply_env(threads: usize, n_gpu_layers: usize) -> anyhow::Result<()> {
     // SAFETY: called from `main` before rayon/Metal workers spawn.
     unsafe {
         if threads > 0 {
@@ -90,6 +103,20 @@ pub fn apply_env(threads: usize, n_gpu_layers: usize) {
         ferrox_core::weight_matrix::default_cpu_int_dot_on();
     }
     ferrox_core::threads::init_cpu_pool();
+
+    // Reads (and therefore fixes) the cached backend while the env
+    // above is still the most recent word on it.
+    let active = active_backend();
+    let wanted_cpu = n_gpu_layers == 0;
+    if wanted_cpu && active != "CPU" {
+        anyhow::bail!(
+            "--n-gpu-layers 0 asks for CPU but this process resolved to {active}. \
+             The backend is decided once per process and something fixed it before \
+             this call, so the run would measure {active} and label the receipt `cpu`. \
+             Refusing rather than publishing a mislabelled row (#126)."
+        );
+    }
+    Ok(())
 }
 
 pub struct BenchArgs {
@@ -614,6 +641,16 @@ fn decode_tokens(vocab: usize, n_gen: usize) -> Vec<usize> {
     (0..n_gen).map(|i| (i + 1) % vocab).collect()
 }
 
+/// Whether a receipt's `backend` label describes the backend that ran.
+///
+/// The label is lowercase and comes from the suite (`cpu`, `metal`,
+/// `cuda`); the active backend is what [`active_backend`] resolved.
+/// Compared case-insensitively and nothing else: a mismatch is always
+/// a defect, never a naming convention.
+fn backend_label_agrees(label: &str, active: &str) -> bool {
+    label.eq_ignore_ascii_case(active)
+}
+
 pub fn active_backend() -> &'static str {
     #[cfg(feature = "metal")]
     {
@@ -840,6 +877,19 @@ fn write_receipt(
             "os": spec.os,
         })
     };
+    // A receipt may not claim one backend and record another. Every
+    // `cpu` row in the ledger did exactly that (#126), and the
+    // contradiction sat in the file: `backend: "cpu"` beside
+    // `backend_active: "Metal"`. Two fields that must agree, with
+    // nothing comparing them, which is this repo's oldest bug shape.
+    if !backend_label_agrees(&args.backend, backend) {
+        anyhow::bail!(
+            "refusing to write a receipt labelled `{}` for a run that executed on {}. \
+             The label is what the ledger publishes; the active backend is what ran (#126).",
+            args.backend,
+            backend
+        );
+    }
     let receipt = serde_json::json!({
         "schema": 2,
         "kind": "engine",
@@ -885,6 +935,22 @@ fn write_receipt(
 
 #[cfg(test)]
 mod tests {
+    use super::backend_label_agrees;
+
+    /// The receipt guard that #126 needed and did not have.
+    #[test]
+    fn a_cpu_label_does_not_describe_a_metal_run() {
+        assert!(backend_label_agrees("cpu", "CPU"));
+        assert!(backend_label_agrees("metal", "Metal"));
+        assert!(backend_label_agrees("cuda", "CUDA"));
+        assert!(
+            !backend_label_agrees("cpu", "Metal"),
+            "this exact pair is what all 13 published cpu receipts recorded"
+        );
+        assert!(!backend_label_agrees("metal", "CPU"));
+        assert!(!backend_label_agrees("cuda", "Metal"));
+    }
+
     use super::*;
 
     fn row(samples: &[f64]) -> Row {

--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -710,6 +710,34 @@ fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let cli = Cli::parse_from(rewrite_llama_style_argv(std::env::args().collect()));
 
+    // BEFORE `claim_instance`, and that ordering is the whole point.
+    //
+    // The backend decision is cached in a `OnceLock` the first time
+    // anything asks for it, and `claim_instance` asks: it records which
+    // backend this process holds. So the old ordering froze the answer
+    // while `FERROX_METAL` was still unset, and the `--n-gpu-layers 0`
+    // that `bench` applies later could not change it. Every `cpu` row
+    // in `benchmarks/RESULTS.md` was measured on Metal because of this,
+    // and every one of those receipts recorded `backend_active:
+    // "Metal"` next to `backend: "cpu"` without anything comparing the
+    // two (#126).
+    if let Commands::Bench {
+        threads,
+        n_gpu_layers,
+        suite,
+        render,
+        ..
+    } = &cli.command
+    {
+        // `--suite` and `--render` do not benchmark in THIS process:
+        // the suite spawns a child per entry and render only reads
+        // receipts, so applying a backend here would pin the parent to
+        // one backend for children that each want their own.
+        if !suite && !render {
+            bench_model::apply_env(*threads, *n_gpu_layers)?;
+        }
+    }
+
     // Held for the whole run: dropping it deregisters this process.
     let _instance = claim_instance(&cli)?;
     // Read before `cli.command` is moved into the match. Subcommands
@@ -1080,7 +1108,11 @@ fn main() -> anyhow::Result<()> {
                 });
             }
             if let Some(model) = model {
-                bench_model::apply_env(threads, n_gpu_layers);
+                // Already applied above, before `claim_instance` could
+                // freeze the backend. Kept as a no-op call rather than
+                // deleted so a future caller of this arm cannot get an
+                // unconfigured process.
+                bench_model::apply_env(threads, n_gpu_layers)?;
                 return bench_model::run(bench_model::BenchArgs {
                     model,
                     n_prompt,


### PR DESCRIPTION
Closes #126.

## The proof was already in the repo

All 13 `benchmarks/receipts/engine/*_cpu.json` record:

```json
"backend": "cpu",
"backend_active": "Metal",
```

Two fields that must agree, sitting in the same file, with nothing comparing them. **Every `cpu` row in the published ledger was measured on Metal.**

## The cause is an ordering

`apply_env` sets `FERROX_METAL=0` correctly. But the backend is decided **once per process** and cached in a `OnceLock`, and `claim_instance` reads it first (the single-instance registry records which backend the process holds, `main.rs` -> `instance.rs:165`). By the time `bench` applied its flag, the answer was frozen at whatever the bare environment implied.

## Measured, same file, `tg64`

| | backend column | tok/s |
|---|---|---|
| before, `--n-gpu-layers 0` | Metal | 64.13 |
| **after, `--n-gpu-layers 0`** | **CPU** | **46.55** |
| after, `--n-gpu-layers 99` | Metal | 350.91 |

So the published CPU rows are roughly **30% optimistic** at this size, and the real CPU gap against llama.cpp is wider than `RESULTS.md` claims.

## Two fixes, because ordering bugs come back

1. `apply_env` runs immediately after parsing, **before** `claim_instance`, and no longer trusts that setting the variable was enough: it calls `active_backend()` on the spot, which fixes the cache while the env is fresh and surfaces a disagreement. It returns `Result` and refuses when `--n-gpu-layers 0` resolves to anything but CPU.
2. `run` refuses to **write** a receipt whose `backend` label disagrees with `backend_active`. That is the check the last thirteen receipts needed, and it holds no matter which future call site freezes the cache early.

`--suite` and `--render` are excluded from the early call deliberately: the suite benchmarks in child processes, so pinning the parent would be wrong for children that each want their own backend.

## Sabotage

Making `backend_label_agrees` return `true` unconditionally turns the new test red on the `("cpu", "Metal")` pair, which is exactly the pair all thirteen published receipts recorded.

## Not done here

The committed CPU receipts are still the contaminated ones, so `RESULTS.md` still shows Metal numbers under a CPU heading. Regenerating them needs a quiet host, and this workspace's Mac has a daemon holding a core. That is the next step, along with the first CUDA and x86 rows the ledger has never had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN