### PR TITLE
fix(cpu): the int-dot default cost x86 up to 8.8x of decode

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -18,7 +18,20 @@ faster than llama.cpp, the widest being Qwen2.5-0.5B at 0.62×. The
 remaining Metal gap is small enough that run-to-run spread explains
 most of it.
 
-**The CPU rows were withdrawn on 2026-09-04, not improved away.** All
+**x86 CPU has rows, and they exist because a default was wrong.**
+`FERROX_CPU_INT_DOT` defaults on, and the interleaved integer kernels it
+selects were written for aarch64 (i8mm, interleave-8 NEON, the Q8_K
+repack). On x86 it chose a scalar integer loop and simultaneously
+bypassed the AVX2 f32 dot that does exist, costing between **4x and
+8.8x of decode** on an idle Zen 4. Llama-3.2-1B Q4_K_M `tg64` went
+10.08 to 46.62 tok/s against llama.cpp's 66.24 once the default became
+architecture-aware, which is 6.8x off to 1.4x off (#127). The rows
+below are taken with the fix.
+
+Prefill on x86 is still 6x to 10x and is the honest remaining gap
+there.
+
+**The Apple CPU rows were withdrawn on 2026-09-04, not improved away.** All
 13 of them recorded `backend_active: "Metal"` inside their own
 receipts while being published under a CPU heading: `--n-gpu-layers 0`
 did not force CPU, and nothing compared the label to what ran
@@ -116,7 +129,7 @@ float4 elem, early Multi-CB. `FERROX_METAL_FA_VEC=0` → ~25.5 pred.
 
 ## Engine (`ferrox bench` vs `llama-bench`)
 
-Measured on **2 hosts**, one section each. Rows are never compared across machines.
+Measured on **3 hosts**, one section each. Rows are never compared across machines.
 
 No HTTP, no chat template, no tokenizer, no sampler. This is the engine
 alone. `pp512` is batched prefill, `tg128` is decode. **Neither engine's
@@ -138,6 +151,33 @@ gap first**. Regenerate with `ferrox bench --suite` / `--render`.
 - `Llama-3.2-1B-Instruct Q5_K_M` / cuda / pp512: 🔴 **11.89×**
 - `Gemma-2-2B-IT Q4_K_M` / cuda / pp512: 🔴 **11.61×**
 - `Llama-3.2-1B-Instruct Q4_K_M` / cuda / pp512: 🔴 **11.22×**
+
+### AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic
+
+#### CPU
+
+| Model | Test | ferrox tok/s | llama.cpp tok/s | Gap |
+|---|---|---|---|---|
+| Llama-3.2-1B-Instruct Q4_K_M | pp512 | **89.61** | **908.72** | 🔴 **10.14×** |
+| Llama-3.2-3B-Instruct Q4_K_M | pp512 | **31.54** | **316.49** | 🔴 **10.04×** |
+| Meta-Llama-3.1-8B-Instruct Q4_K_M | pp512 | **13.29** | **132.01** | 🔴 **9.93×** |
+| Gemma-2-2B-IT Q4_K_M | pp512 | **42.72** | **420.94** | 🔴 **9.85×** |
+| Llama-3.2-1B-Instruct Q6_K | pp512 | **64.50** | **513.30** | 🔴 **7.96×** |
+| Qwen3-0.6B Q8_0 | pp512 | **204.07** | **1413.34** | 🔴 **6.93×** |
+| Qwen2.5-0.5B-Instruct Q8_0 | pp512 | **272.33** | **1860.01** | 🔴 **6.83×** |
+| SmolLM2-135M-Instruct Q8_0 | pp512 | **574.98** | **3891.58** | 🔴 **6.77×** |
+| TinyLlama-1.1B-Chat-v1.0 Q8_0 | pp512 | **112.39** | **734.28** | 🔴 **6.53×** |
+| Gemma-3-1B-IT Q8_0 | pp512 | **146.65** | **917.50** | 🔴 **6.26×** |
+| SmolLM2-135M-Instruct Q8_0 | tg128 | **206.83** | **397.71** | 🔴 **1.92×** |
+| Llama-3.2-1B-Instruct Q6_K | tg128 | **37.28** | **53.84** | 🔴 **1.44×** |
+| Llama-3.2-1B-Instruct Q4_K_M | tg128 | **46.53** | **67.10** | 🔴 **1.44×** |
+| Llama-3.2-3B-Instruct Q4_K_M | tg128 | **18.91** | **27.02** | 🔴 **1.43×** |
+| Meta-Llama-3.1-8B-Instruct Q4_K_M | tg128 | **9.06** | **12.07** | 🔴 **1.33×** |
+| Gemma-2-2B-IT Q4_K_M | tg128 | **22.23** | **29.47** | 🔴 **1.33×** |
+| Qwen3-0.6B Q8_0 | tg128 | **63.64** | **82.39** | 🔴 **1.29×** |
+| Qwen2.5-0.5B-Instruct Q8_0 | tg128 | **85.86** | **99.03** | 🔴 **1.15×** |
+| TinyLlama-1.1B-Chat-v1.0 Q8_0 | tg128 | **43.56** | **49.98** | 🔴 **1.15×** |
+| Gemma-3-1B-IT Q8_0 | tg128 | **46.47** | **49.46** | 🔴 **1.06×** |
 
 ### Apple M2 Pro (10c/6p) macOS 26.6.1
 

--- a/benchmarks/receipts/engine/gemma2_2b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/gemma2_2b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 3387949056,
+  "arch": "gemma2",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 10.48,
+  "host_load_1min_start": 1.85,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "gemma2_2b_q4km",
+  "kind": "engine",
+  "load_s": 0.036846367,
+  "model_path": "models/gemma-2-2b-it-Q4_K_M.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 1708582752,
+  "tests": [
+    {
+      "ferrox_samples": [
+        42.64344987392455,
+        43.17168379634493,
+        42.716461370275674
+      ],
+      "ferrox_stddev": 0.23371141097787557,
+      "ferrox_tps": 42.716461370275674,
+      "gap": 9.854280680021681,
+      "llama_tps": 420.94,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        21.80279544916587,
+        22.23418145959551,
+        22.350457686054664
+      ],
+      "ferrox_stddev": 0.23559569335528557,
+      "ferrox_tps": 22.23418145959551,
+      "gap": 1.325436695457109,
+      "llama_tps": 29.47,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/gemma3_1b_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/gemma3_1b_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 1363083264,
+  "arch": "gemma3",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 6.38,
+  "host_load_1min_start": 1.93,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "gemma3_1b_q8",
+  "kind": "engine",
+  "load_s": 0.038948978,
+  "model_path": "models/hf_test/gemma-3-1b-it-Q8_0.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 1069306624,
+  "tests": [
+    {
+      "ferrox_samples": [
+        146.65271421145638,
+        147.8533218648517,
+        145.53952726625636
+      ],
+      "ferrox_stddev": 0.9448274008659592,
+      "ferrox_tps": 146.65271421145638,
+      "gap": 6.256276980166015,
+      "llama_tps": 917.5,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        46.259836022932724,
+        46.46982355576812,
+        46.55686990056943
+      ],
+      "ferrox_stddev": 0.12467778673821764,
+      "ferrox_tps": 46.46982355576812,
+      "gap": 1.064346627885156,
+      "llama_tps": 49.46,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/llama31_8b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/llama31_8b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 8835301376,
+  "arch": "llama",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 14.75,
+  "host_load_1min_start": 1.88,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "llama31_8b_q4km",
+  "kind": "engine",
+  "load_s": 0.042021183,
+  "model_path": "models/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 4920739232,
+  "tests": [
+    {
+      "ferrox_samples": [
+        13.32623379303825,
+        13.175551622621771,
+        13.29257880561053
+      ],
+      "ferrox_stddev": 0.06457823525552826,
+      "ferrox_tps": 13.29257880561053,
+      "gap": 9.931105313009784,
+      "llama_tps": 132.01,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        8.97882774817076,
+        9.059558276516375,
+        9.125721832334248
+      ],
+      "ferrox_stddev": 0.060067467889270566,
+      "ferrox_tps": 9.059558276516375,
+      "gap": 1.3322945370622656,
+      "llama_tps": 12.07,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/llama32_1b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/llama32_1b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 1599078400,
+  "arch": "llama",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 8.12,
+  "host_load_1min_start": 1.85,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "llama32_1b_q4km",
+  "kind": "engine",
+  "load_s": 0.040720888,
+  "model_path": "models/Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 807694464,
+  "tests": [
+    {
+      "ferrox_samples": [
+        90.37729516214686,
+        89.61269261408377,
+        89.47357879670705
+      ],
+      "ferrox_stddev": 0.397306623802135,
+      "ferrox_tps": 89.61269261408377,
+      "gap": 10.140527792345157,
+      "llama_tps": 908.72,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        46.534573053186755,
+        47.38657800522417,
+        45.40279197928437
+      ],
+      "ferrox_stddev": 0.8125575421848895,
+      "ferrox_tps": 46.534573053186755,
+      "gap": 1.441938661891406,
+      "llama_tps": 67.1,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/llama32_1b_q6k_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/llama32_1b_q6k_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 1599078400,
+  "arch": "llama",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 8.06,
+  "host_load_1min_start": 1.9,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "llama32_1b_q6k",
+  "kind": "engine",
+  "load_s": 0.040767661,
+  "model_path": "models/Llama-3.2-1B-Instruct-Q6_K.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 1021800576,
+  "tests": [
+    {
+      "ferrox_samples": [
+        63.084830601968726,
+        64.86840053511591,
+        64.49644924435363
+      ],
+      "ferrox_stddev": 0.7682690978683454,
+      "ferrox_tps": 64.49644924435363,
+      "gap": 7.958577658365233,
+      "llama_tps": 513.3,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        37.27937264524242,
+        37.500553920535474,
+        35.83378562032999
+      ],
+      "ferrox_stddev": 0.7391255771897929,
+      "ferrox_tps": 37.27937264524242,
+      "gap": 1.4442303123593752,
+      "llama_tps": 53.84,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/llama32_3b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/llama32_3b_q4km_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 3958898688,
+  "arch": "llama",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 12.85,
+  "host_load_1min_start": 1.91,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "llama32_3b_q4km",
+  "kind": "engine",
+  "load_s": 0.048191828,
+  "model_path": "models/Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 2019377696,
+  "tests": [
+    {
+      "ferrox_samples": [
+        31.641235348716393,
+        31.465705763404173,
+        31.536090765079294
+      ],
+      "ferrox_stddev": 0.07212648400083564,
+      "ferrox_tps": 31.536090765079294,
+      "gap": 10.035803180477187,
+      "llama_tps": 316.49,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        19.021551811115923,
+        18.914549204359133,
+        18.885964627766853
+      ],
+      "ferrox_stddev": 0.05835763318656838,
+      "ferrox_tps": 18.914549204359133,
+      "gap": 1.4285299484575,
+      "llama_tps": 27.02,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/qwen25_05b_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/qwen25_05b_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 663126016,
+  "arch": "qwen2",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 4.07,
+  "host_load_1min_start": 1.9,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "qwen25_05b_q8",
+  "kind": "engine",
+  "load_s": 0.032845964,
+  "model_path": "models/hf_test/qwen2.5-0.5b-instruct-q8_0.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 531068480,
+  "tests": [
+    {
+      "ferrox_samples": [
+        278.6395848284553,
+        265.96465241253077,
+        272.3308880117034
+      ],
+      "ferrox_stddev": 5.174537263027315,
+      "ferrox_tps": 272.3308880117034,
+      "gap": 6.82996340804377,
+      "llama_tps": 1860.01,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        85.95906206787502,
+        85.86037672364522,
+        85.80863508585102
+      ],
+      "ferrox_stddev": 0.062400383873668114,
+      "ferrox_tps": 85.86037672364522,
+      "gap": 1.1533841776485938,
+      "llama_tps": 99.03,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/qwen3_06b_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/qwen3_06b_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 692846592,
+  "arch": "qwen3",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 4.74,
+  "host_load_1min_start": 1.91,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "qwen3_06b_q8",
+  "kind": "engine",
+  "load_s": 0.032641524,
+  "model_path": "models/hf_test/Qwen3-0.6B-Q8_0.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 804753824,
+  "tests": [
+    {
+      "ferrox_samples": [
+        206.40813544313824,
+        204.07022609701627,
+        203.82026330620238
+      ],
+      "ferrox_stddev": 1.165493872647264,
+      "ferrox_tps": 204.07022609701627,
+      "gap": 6.925753095055078,
+      "llama_tps": 1413.34,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        63.426117162046644,
+        63.78532385887925,
+        63.636357259169024
+      ],
+      "ferrox_stddev": 0.14735497477431392,
+      "ferrox_tps": 63.636357259169024,
+      "gap": 1.2947001297458594,
+      "llama_tps": 82.39,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/smollm2_135m_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/smollm2_135m_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 176062464,
+  "arch": "llama",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 2.98,
+  "host_load_1min_start": 1.85,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "smollm2_135m_q8",
+  "kind": "engine",
+  "load_s": 0.011405305,
+  "model_path": "models/hf_test/SmolLM2-135M-Instruct-Q8_0.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 144811360,
+  "tests": [
+    {
+      "ferrox_samples": [
+        578.7849409473185,
+        574.9847771937975,
+        569.8592515542048
+      ],
+      "ferrox_stddev": 3.6572635304136183,
+      "ferrox_tps": 574.9847771937975,
+      "gap": 6.768144400261836,
+      "llama_tps": 3891.58,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        206.8337977258404,
+        206.83478200980218,
+        206.51725841091994
+      ],
+      "ferrox_stddev": 0.1494506022263527,
+      "ferrox_tps": 206.8337977258404,
+      "gap": 1.9228482210009374,
+      "llama_tps": 397.71,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/benchmarks/receipts/engine/tinyllama_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
+++ b/benchmarks/receipts/engine/tinyllama_q8_cpu__amd-ryzen-9-7945hx-with-radeon-graphics-16c-linux-6-17-0-23-generic.json
@@ -1,0 +1,72 @@
+{
+  "approx_params": 1261436928,
+  "arch": "llama",
+  "backend": "cpu",
+  "backend_active": "CPU",
+  "engine_env": {},
+  "ferrox_version": "0.17.1",
+  "host_load_1min_end": 6.92,
+  "host_load_1min_start": 1.28,
+  "host_spec": {
+    "arch": "x86_64",
+    "cores": 16,
+    "cpu": "AMD Ryzen 9 7945HX with Radeon Graphics",
+    "label": "AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic",
+    "os": "Linux 6.17.0-23-generic",
+    "perf_cores": null,
+    "ram_gb": 30.1
+  },
+  "host_thermal_end": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "host_thermal_start": {
+    "cpu_speed_limit_percent": null,
+    "degraded": null,
+    "measured": false,
+    "pressure": null,
+    "source": null
+  },
+  "id": "tinyllama_q8",
+  "kind": "engine",
+  "load_s": 0.011172726,
+  "model_path": "models/tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+  "quant": "quantized",
+  "quiet_host": true,
+  "reps": 3,
+  "schema": 2,
+  "size_bytes": 1170781568,
+  "tests": [
+    {
+      "ferrox_samples": [
+        112.394795115843,
+        112.39430220026564,
+        109.36794625476273
+      ],
+      "ferrox_stddev": 1.4267540697397134,
+      "ferrox_tps": 112.39430220026564,
+      "gap": 6.533071389078516,
+      "llama_tps": 734.28,
+      "test": "pp512",
+      "workload_digest": "b8d417040110e751"
+    },
+    {
+      "ferrox_samples": [
+        43.522311554399934,
+        43.55987838041119,
+        43.668796014475625
+      ],
+      "ferrox_stddev": 0.06212175721062305,
+      "ferrox_tps": 43.55987838041119,
+      "gap": 1.1473861236140623,
+      "llama_tps": 49.98,
+      "test": "tg128",
+      "workload_digest": "044655d19aa3baa5"
+    }
+  ],
+  "threads": 16,
+  "warmup_reps": 1
+}

--- a/crates/ferrox-cli/src/bench_suite.rs
+++ b/crates/ferrox-cli/src/bench_suite.rs
@@ -726,3 +726,60 @@ mod tests {
         assert!(twice.contains("v2") && !twice.contains("v1"));
     }
 }
+
+#[cfg(test)]
+mod committed_receipt_tests {
+    /// No committed receipt may claim one backend and record another.
+    ///
+    /// `bench_model::run` refuses to WRITE such a receipt (#126), but
+    /// that only guards receipts this build produces. Receipts arrive
+    /// by other routes: copied off a rented box, restored from a branch
+    /// cut before the fix, or pulled with a glob that swept up
+    /// neighbours. All three happened on 2026-09-04, and the last one
+    /// silently reintroduced five Metal-measured rows under a `cpu`
+    /// heading AFTER they had been deleted.
+    ///
+    /// So the repository asserts it too, over what is actually
+    /// committed, which is the artifact readers trust.
+    #[test]
+    fn every_committed_receipt_ran_on_the_backend_it_claims() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../benchmarks/receipts/engine");
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return; // not a checkout with receipts; nothing to assert
+        };
+        let mut wrong = Vec::new();
+        let mut seen = 0usize;
+        for e in entries.flatten() {
+            let path = e.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+                continue;
+            };
+            let (Some(label), Some(active)) = (
+                v.get("backend").and_then(|x| x.as_str()),
+                v.get("backend_active").and_then(|x| x.as_str()),
+            ) else {
+                continue;
+            };
+            seen += 1;
+            if !label.eq_ignore_ascii_case(active) {
+                wrong.push(format!(
+                    "{}: labelled `{label}` but ran on {active}",
+                    path.file_name().unwrap_or_default().to_string_lossy()
+                ));
+            }
+        }
+        assert!(seen > 0, "no receipts found under {}", dir.display());
+        assert!(
+            wrong.is_empty(),
+            "receipts that misdescribe the backend they ran on:\n  {}",
+            wrong.join("\n  ")
+        );
+    }
+}

--- a/crates/ferrox-core/src/weight_matrix.rs
+++ b/crates/ferrox-core/src/weight_matrix.rs
@@ -586,9 +586,45 @@ static INT_DOT_TEST_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::A
 /// Must be called while the process is still single-threaded, since it
 /// mutates the process environment.
 pub unsafe fn default_cpu_int_dot_on() {
-    if std::env::var_os("FERROX_CPU_INT_DOT").is_none() {
+    if std::env::var_os("FERROX_CPU_INT_DOT").is_none() && int_dot_is_a_win_here() {
         unsafe { std::env::set_var("FERROX_CPU_INT_DOT", "1") };
     }
+}
+
+/// Whether the int-dot path is faster than the f32 one on THIS
+/// architecture.
+///
+/// It is not universally faster, and the default said it was. The
+/// interleaved int8 kernels this path selects were written for
+/// aarch64: `i8mm` SMMLA tiers, interleave-8 NEON GEMV, the Q8_K repack.
+/// x86_64 has none of that, so on x86 the switch selects a scalar
+/// integer loop AND bypasses the AVX2 f32 dot that does exist
+/// (`dot_q4_k_f32` and friends are gated on `avx2` + `fma`).
+///
+/// Measured 2026-09-04 on an idle 32-core Ryzen 9 7945HX (Zen 4, with
+/// `avx512_vnni` that nothing here uses), `tg64`, int-dot on against
+/// off:
+///
+/// | model | on (was the default) | off |
+/// |---|---|---|
+/// | Llama-3.2-1B Q4_K_M | 10.08 | **48.94** |
+/// | Llama-3.2-1B Q6_K | 4.11 | **36.23** |
+/// | Llama-3.2-3B Q4_K_M | 4.73 | **19.30** |
+///
+/// So the default cost x86 between 4x and 8.8x of decode, and it is
+/// most of why `benchmarks/RESULTS.md` had no x86 row worth showing
+/// (#127). Prefill is unaffected (95.3 against 89.4 on the 1B), which
+/// is consistent: prefill goes through the batched GEMM rather than
+/// this dot.
+///
+/// aarch64 keeps the default, where it is worth ~28% and the kernels it
+/// selects are the ones that were actually written.
+///
+/// This is a DEFAULT, not a gate: `FERROX_CPU_INT_DOT=1` still turns it
+/// on anywhere, which is what an x86 VNNI implementation would want in
+/// order to measure itself against the f32 path.
+fn int_dot_is_a_win_here() -> bool {
+    cfg!(target_arch = "aarch64")
 }
 
 /// A batch of activations quantized once for reuse across several
@@ -4958,5 +4994,33 @@ mod tests {
         let report = reg.seal();
         assert!(!report.misses.is_empty());
         assert!(report.violations.is_empty(), "{}", report.render());
+    }
+}
+
+#[cfg(test)]
+mod int_dot_default_tests {
+    /// The int-dot default follows the architecture that has the
+    /// kernels, not the wish that every architecture did.
+    ///
+    /// Turning it on where the interleaved kernels do not exist selects
+    /// a scalar integer loop and skips the AVX2 f32 dot that does, which
+    /// measured 4x to 8.8x of x86 decode (#127). A future x86 VNNI
+    /// implementation should flip this deliberately, with its own
+    /// before/after, rather than by inheriting a default nobody
+    /// measured.
+    #[test]
+    fn the_int_dot_default_is_on_only_where_its_kernels_are() {
+        let on_by_default = super::int_dot_is_a_win_here();
+        assert_eq!(
+            on_by_default,
+            cfg!(target_arch = "aarch64"),
+            "int-dot defaults on for aarch64 (i8mm, interleave-8 NEON) and off elsewhere"
+        );
+        // The env var still wins in both directions: this is a default,
+        // not a gate, so an x86 VNNI port can measure itself.
+        assert!(
+            !on_by_default || cfg!(target_arch = "aarch64"),
+            "no architecture may default on without the kernels"
+        );
     }
 }

--- a/docs/plans/cpu-cuda-parity.md
+++ b/docs/plans/cpu-cuda-parity.md
@@ -182,15 +182,28 @@ drafter and pays the constant on every draft token.
 **Exit:** the constant named and removed, and 135M decode within 2x of
 llama.cpp on a quiet host.
 
-### 5. Diagnose x86 CPU (#127)
+### 5. x86 CPU  [DONE for decode, 2026-09-04]
 
-3B Q4_K_M at 1.03 tok/s on 10 Broadwell cores. x86 SIMD arms exist in
-`ferrox-quant`; whether they are reached on a pre-AVX-512 part is
-unknown. Check `is_x86_feature_detected!` gating first, then whether
-the repack/interleave paths have an x86 equivalent or fall back to
-scalar.
+The answer was a **default**, not a missing kernel.
+`FERROX_CPU_INT_DOT` defaults on, its interleaved integer kernels are
+aarch64-only, and on x86 it selected a scalar loop while bypassing the
+AVX2 f32 dot that does exist. Cost: 4x to 8.8x of decode. Fixed
+architecture-aware; Llama-3.2-1B Q4_K_M went from 6.8x off llama.cpp to
+**1.4x**.
 
-**Exit:** an x86 row in the ledger with a gap, whatever it says.
+Note the shape of the error, because it recurs: the AVX2 arms were
+present and correct, and were being SKIPPED. Two of the three
+hypotheses in this issue (no x86 SIMD, slow x86 SIMD) were wrong, and
+the code read as if they were right.
+
+**What is left on x86:**
+
+- **Prefill is still 6x to 10x.** That is now the biggest CPU gap in
+  the ledger and has had no investigation at all.
+- **No x86 int8 path exists.** Zen 4 advertises `avx512_vnni` and
+  nothing here uses it. That is the natural successor to this fix, and
+  `FERROX_CPU_INT_DOT=1` stays available precisely so such a port can
+  measure itself against the f32 path.
 
 ### 6. Kernel coverage, by what people actually run
 
@@ -243,9 +256,10 @@ all, which is honest and temporary.
 | Step | Issue | State |
 |---|---|---|
 | 1 CUDA K-quant GEMM verified | #131 | **done**: verify token-identical, 325x to 10.9x |
-| 2 CUDA decode | #131 | GQA and graphs ruled out; GPU at 36% util, host-bound |
+| 2 CUDA decode | #133 | GQA and graphs ruled out; GPU at 36% util, host-bound |
 | 3 CPU pool rule | #27 | measured, needs the predicate |
 | 4 fixed per-token cost | #128 | not started |
-| 5 x86 diagnosis | #127 | not started |
-| 6 kernel coverage | | not started |
-| 7 ledger | #126 | mostly landed |
+| 5 x86 decode | #127 | **done**: default was wrong, 6.8x to 1.4x |
+| 5b x86 prefill | | not started, now the largest CPU gap (6x to 10x) |
+| 6 kernel coverage | | Q4_K/Q5_K/Q6_K landed on CUDA; 16 kinds still host-only |
+| 7 ledger | #126 | **done**: three hosts, and a committed-receipt check |


### PR DESCRIPTION
Closes #127.

## The bug was a default, not a missing kernel

`FERROX_CPU_INT_DOT` defaults **on** in `ferrox` and `ferrox-server`. The interleaved integer kernels it selects were written for aarch64: i8mm SMMLA tiers, interleave-8 NEON GEMV, the Q8_K repack. x86_64 has none of them, so on x86 the switch chose a **scalar** integer loop **and** bypassed the AVX2 f32 dot that does exist. `dot_q4_k_f32` and friends are gated on `avx2` + `fma` and were simply never reached.

Measured on an idle 32-core Ryzen 9 7945HX (Zen 4), `tg64`:

| model | on (the default) | off | ratio |
|---|---|---|---|
| Llama-3.2-1B Q4_K_M | 10.08 | **48.94** | 4.9x |
| Llama-3.2-1B Q6_K | 4.11 | **36.23** | **8.8x** |
| Llama-3.2-3B Q4_K_M | 4.73 | **19.30** | 4.1x |

## After

Architecture-aware default, no environment variable set, same box:

| model | ferrox | llama.cpp | gap |
|---|---|---|---|
| Llama-3.2-1B Q4_K_M | **46.62** | 66.24 | **1.42x** |
| Llama-3.2-1B Q6_K | **36.64** | 53.85 | **1.47x** |

x86 CPU decode goes from roughly **6.8x off to 1.4x**, the same band as aarch64, and it explains the 1.03 tok/s Broadwell spot check that opened #127. Prefill was never affected (95.3 vs 89.4), which fits: prefill goes through the batched GEMM rather than this dot.

**It stays a default, not a gate.** `FERROX_CPU_INT_DOT=1` still turns it on anywhere, which is precisely what an x86 VNNI implementation needs in order to measure itself against the f32 path. Zen 4 advertises `avx512_vnni` and nothing in this tree uses it.

## Ledger

Three machines now: Apple M2 Pro (Metal), a rented Xeon with a GTX 1080 (CUDA), and this Ryzen (x86 CPU). The x86 rows are taken with the fix. **x86 prefill is still 6x to 10x** and is stated as the remaining gap rather than glossed over.

## A guard, because I broke this while fixing it

The five Apple `cpu` receipts deleted in #132 came **back**. The rented box had cloned main before that merge, so its tree still held them, and copying results off it with `tar *_cpu.json` swept them up beside the real ones. They rendered as an "Apple M2 Pro / CPU" section built from Metal runs, which is exactly the #126 defect.

`bench_model::run` refuses to *write* a mislabelled receipt, but that only covers receipts this build produces. Receipts also arrive by copy, by branch, and by glob, and all three happened in one day. The repository now asserts it over what is **committed**, which is the artifact a reader trusts. Sabotage: restoring one fails with ``labelled `cpu` but ran on Metal``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN