### PR TITLE
feat(cuda): Q5_0 matvec and mul_mm GEMM (cpu-cuda-parity step 6), unverified on hardware

### DIFF
--- a/crates/ferrox-core/src/weight_matrix.rs
+++ b/crates/ferrox-core/src/weight_matrix.rs
@@ -2869,34 +2869,16 @@ impl WeightMatrix {
                 else {
                     return None;
                 };
-                let (kernel_src, module_name, fn_name) = match kind {
-                    QuantKind::Q8_0 => (
-                        ferrox_cuda::gpu::Q8_0_MATVEC_KERNEL_SRC,
-                        "ferrox_q8_0",
-                        "q8_0_matvec",
-                    ),
-                    QuantKind::Q4_0 => (
-                        ferrox_cuda::gpu::Q4_0_MATVEC_KERNEL_SRC,
-                        "ferrox_q4_0",
-                        "q4_0_matvec",
-                    ),
-                    QuantKind::Q4K => (
-                        ferrox_cuda::gpu::Q4_K_MATVEC_KERNEL_SRC,
-                        "ferrox_q4_k",
-                        "q4_k_matvec",
-                    ),
-                    QuantKind::Q5K => (
-                        ferrox_cuda::gpu::Q5_K_MATVEC_KERNEL_SRC,
-                        "ferrox_q5_k",
-                        "q5_k_matvec",
-                    ),
-                    QuantKind::Q6K => (
-                        ferrox_cuda::gpu::Q6_K_MATVEC_KERNEL_SRC,
-                        "ferrox_q6_k",
-                        "q6_k_matvec",
-                    ),
-                    _ => return None,
-                };
+                // One table, in `ferrox-cuda`, exactly as the Metal arm
+                // below asks `matvec_launch_meta`. This match was
+                // written out here and again in
+                // `apply_gpu_dense_ffn_swiglu`, three copies of one
+                // five-row list with nothing holding them together --
+                // and a kind added to the capability table but not to a
+                // copy loses its fused launch silently, which is the
+                // failure this file has paid for twice.
+                let (kernel_src, module_name, fn_name) =
+                    ferrox_cuda::gpu::matvec_launch_meta(kind.name())?;
                 let row_bytes = m.block_bytes_per_row(*kind, *cols);
                 let n_blocks_per_row = row_bytes / Self::block_bytes_for_kind(*kind);
                 launches.push(ferrox_cuda::gpu::MatvecLaunch {
@@ -2997,34 +2979,10 @@ impl WeightMatrix {
                     else {
                         return None;
                     };
-                    let (kernel_src, module_name, fn_name) = match kind {
-                        QuantKind::Q8_0 => (
-                            ferrox_cuda::gpu::Q8_0_MATVEC_KERNEL_SRC,
-                            "ferrox_q8_0",
-                            "q8_0_matvec",
-                        ),
-                        QuantKind::Q4_0 => (
-                            ferrox_cuda::gpu::Q4_0_MATVEC_KERNEL_SRC,
-                            "ferrox_q4_0",
-                            "q4_0_matvec",
-                        ),
-                        QuantKind::Q4K => (
-                            ferrox_cuda::gpu::Q4_K_MATVEC_KERNEL_SRC,
-                            "ferrox_q4_k",
-                            "q4_k_matvec",
-                        ),
-                        QuantKind::Q5K => (
-                            ferrox_cuda::gpu::Q5_K_MATVEC_KERNEL_SRC,
-                            "ferrox_q5_k",
-                            "q5_k_matvec",
-                        ),
-                        QuantKind::Q6K => (
-                            ferrox_cuda::gpu::Q6_K_MATVEC_KERNEL_SRC,
-                            "ferrox_q6_k",
-                            "q6_k_matvec",
-                        ),
-                        _ => return None,
-                    };
+                    // The second of the two copies this used to hold.
+                    // See the note in `apply_gpu_multi`.
+                    let (kernel_src, module_name, fn_name) =
+                        ferrox_cuda::gpu::matvec_launch_meta(kind.name())?;
                     let row_bytes = m.block_bytes_per_row(*kind, *cols);
                     let n_blocks_per_row = row_bytes / WeightMatrix::block_bytes_for_kind(*kind);
                     Some(ferrox_cuda::gpu::MatvecLaunch {
@@ -3494,18 +3452,28 @@ impl WeightMatrix {
     }
 
     /// The block size (in bytes) for exactly the quant kinds
-    /// `apply_gpu` dispatches to a real kernel for -- a small,
-    /// deliberately partial mirror of `block_bytes_per_row`'s per-kind
-    /// match (only these five formats have a real GPU kernel today).
+    /// `apply_gpu` dispatches to a real CUDA or Vulkan kernel for -- a
+    /// small, deliberately partial mirror of `block_bytes_per_row`'s
+    /// per-kind match.
+    ///
+    /// Partial means this `unreachable!()` is reachable by a mistake:
+    /// widening `Cuda::matvec_kernel` without adding the row here
+    /// turns a decode into a panic in a rayon worker rather than a
+    /// fallback. `every_cuda_or_vulkan_matvec_kind_has_a_block_size`
+    /// calls it for every claimed kind so that lands as a red test
+    /// instead.
     #[cfg(any(feature = "cuda", feature = "vulkan"))]
     pub(crate) fn block_bytes_for_kind(kind: QuantKind) -> usize {
         match kind {
             QuantKind::Q8_0 => ferrox_quant::Q8_0_BLOCK_BYTES,
             QuantKind::Q4_0 => ferrox_quant::Q4_0_BLOCK_BYTES,
+            QuantKind::Q5_0 => ferrox_quant::Q5_0_BLOCK_BYTES,
             QuantKind::Q4K => ferrox_quant::Q4_K_BLOCK_BYTES,
             QuantKind::Q5K => ferrox_quant::Q5_K_BLOCK_BYTES,
             QuantKind::Q6K => ferrox_quant::Q6_K_BLOCK_BYTES,
-            _ => unreachable!("apply_gpu only calls this for the five GPU-dispatchable kinds"),
+            _ => unreachable!(
+                "apply_gpu only calls this for the CUDA/Vulkan-dispatchable kinds, not {kind:?}"
+            ),
         }
     }
 }
@@ -3599,6 +3567,54 @@ mod tests {
                 cuda_mul_mm_kind_supported(kind),
                 ferrox_cuda::mul_mm::kind_by_name(kind.name()).is_some(),
                 "{kind:?}: the predicate and the kernel table disagree"
+            );
+        }
+    }
+
+    /// The CUDA matvec capability table and the launch-meta table must
+    /// name the same set, for every kind.
+    ///
+    /// `Cuda::matvec_kernel` is compiled unconditionally and
+    /// `ferrox_cuda::gpu::matvec_launch_meta` only under `cuda`, so the
+    /// set is written out twice and this is the only thing making the
+    /// two agree. Over-claiming here sends a decode to an NVRTC module
+    /// that does not exist; under-claiming leaves a kernel nothing ever
+    /// calls. The GEMM half has had this check since 2026-09-04; the
+    /// matvec half did not, and `apply_gpu_multi` carried its own third
+    /// copy of the table until Q5_0 landed.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn the_cuda_matvec_kinds_match_the_launch_meta_table() {
+        for &kind in QuantKind::ALL {
+            assert_eq!(
+                cuda_matvec_kind_supported(kind),
+                ferrox_cuda::gpu::matvec_launch_meta(kind.name()).is_some(),
+                "{kind:?}: the capability table and the launch-meta table disagree"
+            );
+        }
+    }
+
+    /// `block_bytes_for_kind` is deliberately partial, so every kind
+    /// CUDA or Vulkan claims a matvec for has to be one of its arms.
+    ///
+    /// Calling it IS the assertion: the arm it lacks is an
+    /// `unreachable!()`, and reaching that in a rayon worker is a panic
+    /// rather than the fallback the seam promises. `Metal` is
+    /// deliberately not checked -- it claims IQ4_XS, asks
+    /// `ferrox_metal::gpu::matvec_launch_meta` for its block size, and
+    /// never touches this function.
+    #[cfg(any(feature = "cuda", feature = "vulkan"))]
+    #[test]
+    fn every_cuda_or_vulkan_matvec_kind_has_a_block_size() {
+        use super::gpu_backend::{BackendCaps, Cuda, Vulkan};
+        for &kind in QuantKind::ALL {
+            if Cuda::matvec_kernel(kind).is_none() && Vulkan::matvec_kernel(kind).is_none() {
+                continue;
+            }
+            let block_bytes = WeightMatrix::block_bytes_for_kind(kind);
+            assert!(
+                block_bytes > 0,
+                "{kind:?}: a claimed matvec kind needs a real block size"
             );
         }
     }
@@ -4932,17 +4948,24 @@ mod tests {
     /// llama.cpp's 1586.80, and the invariant below now forbids the
     /// combination from coming back.
     ///
-    /// So the probe moved to `Q5_0`, which has neither kernel, and the
+    /// So the probe moved to a kind with neither kernel, and the
     /// expected fallback moved with it: with no matvec to loop over
     /// there is no per-position loop, and the whole matmul leaves for
     /// the host.
+    ///
+    /// It moved twice. `Q5_0` was that kind until 2026-09-05, when it
+    /// gained both; `Q2_K` has neither on any GPU backend and is the
+    /// next row of the coverage table in
+    /// `docs/plans/cpu-cuda-parity.md` §6. When Q2_K lands, this probe
+    /// moves again -- which is the point: the test names a real hole
+    /// and stops compiling a comment.
     #[test]
     fn a_kind_cuda_cannot_run_is_recorded_as_leaving_the_gpu() {
         use crate::kernel_registry::{op, Backend, Outcome};
 
         let reg = crate::kernel_registry::Registry::new();
         let loc = std::panic::Location::caller();
-        shaped(QuantKind::Q5_0, 64, 256).probe_kernels_for(&reg, Backend::Cuda, "ffn_down", loc);
+        shaped(QuantKind::Q2K, 64, 256).probe_kernels_for(&reg, Backend::Cuda, "ffn_down", loc);
         let report = reg.seal();
         assert!(
             report.entries.iter().any(|e| e.key.backend == Backend::Cuda

--- a/crates/ferrox-core/src/weight_matrix/gpu_backend.rs
+++ b/crates/ferrox-core/src/weight_matrix/gpu_backend.rs
@@ -233,6 +233,7 @@ fn cuda_matvec_launch(kind: QuantKind) -> Option<CudaMatvecLaunchFn> {
     match kind {
         QuantKind::Q8_0 => Some(ferrox_cuda::gpu::launch_q8_0_matvec),
         QuantKind::Q4_0 => Some(ferrox_cuda::gpu::launch_q4_0_matvec),
+        QuantKind::Q5_0 => Some(ferrox_cuda::gpu::launch_q5_0_matvec),
         QuantKind::Q4K => Some(ferrox_cuda::gpu::launch_q4_k_matvec),
         QuantKind::Q5K => Some(ferrox_cuda::gpu::launch_q5_k_matvec),
         QuantKind::Q6K => Some(ferrox_cuda::gpu::launch_q6_k_matvec),
@@ -368,6 +369,7 @@ impl BackendCaps for Cuda {
         match kind {
             QuantKind::Q8_0
             | QuantKind::Q4_0
+            | QuantKind::Q5_0
             | QuantKind::Q4K
             | QuantKind::Q5K
             | QuantKind::Q6K => Some(kind.name()),
@@ -387,6 +389,12 @@ impl BackendCaps for Cuda {
     /// circulation (#131). IQ4_XS is still absent: it is a codebook
     /// lookup rather than an affine dequant.
     ///
+    /// Q5_0 joined on 2026-09-05, matvec and GEMM together, because
+    /// `a_cuda_kind_with_a_matvec_also_has_a_gemm` makes half of it
+    /// fail the suite -- and because half of it is the shape that cost
+    /// Metal a Q5_0 decode path: GPU prefill with every decode step on
+    /// the host.
+    ///
     /// Stated here rather than delegating to
     /// `ferrox_cuda::mul_mm::kind_by_name`, because `ferrox-cuda` is
     /// only a dependency under the `cuda` feature and this predicate is
@@ -405,7 +413,12 @@ impl BackendCaps for Cuda {
     fn gemm_supported(kind: QuantKind) -> bool {
         matches!(
             kind,
-            QuantKind::Q8_0 | QuantKind::Q4_0 | QuantKind::Q4K | QuantKind::Q5K | QuantKind::Q6K
+            QuantKind::Q8_0
+                | QuantKind::Q4_0
+                | QuantKind::Q5_0
+                | QuantKind::Q4K
+                | QuantKind::Q5K
+                | QuantKind::Q6K
         )
     }
 }

--- a/crates/ferrox-cuda/examples/mul_mm_host_check.rs
+++ b/crates/ferrox-cuda/examples/mul_mm_host_check.rs
@@ -26,6 +26,15 @@ fn main() {
     for k in KINDS {
         std::fs::write(format!("{dir}/{}.cu", k.name), kernel_src(k)).unwrap();
         for &(n_rows, n_cols, batch) in SHAPES {
+            // `n_cols` is rounded UP to a whole super-block for this
+            // kind rather than taken literally. `validate_shape`
+            // refuses anything else, and it was right to: a 128-column
+            // Q4_K row is not a Q4_K row. Without this the whole tool
+            // panicked on the first K-quant in `KINDS` and checked
+            // nothing at all, which is what it did between the
+            // K-quants landing and 2026-09-05. The 32-element kinds
+            // (Q8_0, Q4_0, Q5_0) keep the exact shapes they had.
+            let n_cols = n_cols.next_multiple_of(k.block_elems);
             let row_bytes = (n_cols / k.block_elems) * k.block_bytes;
             // Deliberately arbitrary bytes, not a well-formed
             // quantization: it exercises degenerate f16 scales (NaN/Inf)

--- a/crates/ferrox-cuda/src/gpu.rs
+++ b/crates/ferrox-cuda/src/gpu.rs
@@ -6,8 +6,9 @@
 //!
 //! # Verified on real GPU hardware
 //!
-//! All five matvec kernels (`launch_q8_0_matvec`, `launch_q4_0_matvec`,
-//! `launch_q4_k_matvec`, `launch_q5_k_matvec`, `launch_q6_k_matvec`) have
+//! Five of the six matvec kernels (`launch_q8_0_matvec`,
+//! `launch_q4_0_matvec`, `launch_q4_k_matvec`, `launch_q5_k_matvec`,
+//! `launch_q6_k_matvec`) have
 //! been compiled by NVRTC and executed on real NVIDIA GPUs (RTX 3060s,
 //! rented on vast.ai), with their output cross-checked against
 //! `ferrox_quant`'s scalar reference for real, non-trivial quantized test
@@ -41,6 +42,16 @@
 //! Q8_0/Q4_0/Q4_K/Q5_K all pass on real hardware as of 2026-07-31; Q6_K's
 //! NaN-comparison fix has not yet been re-run on hardware (see that
 //! test's own `#[ignore]` message).
+//!
+//! **`launch_q5_0_matvec` is the sixth, and NO GPU HAS RUN IT.** It
+//! landed 2026-09-05 (`docs/plans/cpu-cuda-parity.md` §6) and is a
+//! transcription of `ferrox-metal`'s Q5_0 matvec, which is itself
+//! `ggml`'s `dequantize_row_q5_0`. Nothing above applies to it: the
+//! only checks it has are that the CUDA C names the entry point its
+//! table row claims and strides by `Q5_0_BLOCK_BYTES`. Until
+//! `cargo test -p ferrox-cuda --features cuda -- --ignored` has run
+//! `launch_q5_0_matvec_matches_cpu_reference` on a device and the
+//! result is written down, CUDA Q5_0 is a claim, not a capability.
 //!
 //! The device-probe path (`probe()`) was already verified earlier
 //! (tested to degrade correctly with no GPU present -- including a real
@@ -251,6 +262,103 @@ extern "C" __global__ void q4_0_matvec(
             int hi = (int)((byte >> 4) & 0x0F) - 8;
             block_acc += (float)lo * x[base + i];
             block_acc += (float)hi * x[base + i + 16];
+        }
+        acc += block_acc * scale;
+    }
+
+    partial[threadIdx.x] = acc;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            partial[threadIdx.x] += partial[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+        out[row] = partial[0];
+    }
+}
+"#;
+
+/// CUDA C source for a fused Q5_0 dequant+dot kernel, the same
+/// one-block-per-lane / block-level-reduction structure as
+/// `Q4_0_MATVEC_KERNEL_SRC` above, but unpacking Q5_0's 22-byte blocks:
+/// 2-byte f16 scale, a 4-byte `qh` bitplane, then 16 bytes of packed
+/// 4-bit nibbles. Element `j` takes the low nibble of `qs[j]` with bit
+/// `j` of `qh` as its fifth bit; element `j + 16` takes the high nibble
+/// with bit `j + 16`. Both are biased by -16. This mirrors
+/// `ferrox_quant::dot_q5_0_f32_scalar`'s exact math, and is `ggml`'s
+/// `dequantize_row_q5_0` reference form rather than the nibble-packed
+/// `ushort` trick `Q4_0_MATVEC_KERNEL_SRC` uses -- the same choice
+/// `ferrox-metal`'s `Q5_0_MATVEC_KERNEL_SRC` made and for the same
+/// reason: the fifth bit is indexed differently in the two halves, so
+/// folding it into the activation scaling needs two more shift chains
+/// and is much easier to get subtly wrong.
+///
+/// **UNVERIFIED ON HARDWARE.** No GPU has run this. Unlike the GEMM in
+/// `mul_mm.rs`, whose emitted C is executed on the host by
+/// `tools/mul_mm_host_check/run.sh` and compared bit for bit against a
+/// Rust twin, there is no host harness for the matvec kernels: the only
+/// check on this text is `launch_q5_0_matvec_matches_cpu_reference`,
+/// which is `#[ignore]`d and needs a device. Run it with
+/// `cargo test -p ferrox-cuda --features cuda -- --ignored` before any
+/// doc calls Q5_0 a measured CUDA capability.
+pub const Q5_0_MATVEC_KERNEL_SRC: &str = r#"
+extern "C" __global__ void q5_0_matvec(
+    const unsigned char* weights, // [rows * row_bytes]
+    const float* x,               // [cols]
+    float* out,                   // [rows]
+    int rows,
+    int row_bytes,
+    int n_blocks_per_row
+) {
+    int row = blockIdx.x;
+    if (row >= rows) return;
+
+    const unsigned char* row_ptr = weights + (size_t)row * row_bytes;
+
+    __shared__ float partial[256];
+    float acc = 0.0f;
+
+    for (int b = threadIdx.x; b < n_blocks_per_row; b += blockDim.x) {
+        const unsigned char* block = row_ptr + (size_t)b * 22;
+        unsigned short bits = (unsigned short)block[0] | ((unsigned short)block[1] << 8);
+        unsigned int sign = (bits >> 15) & 0x1u;
+        unsigned int exp = (bits >> 10) & 0x1Fu;
+        unsigned int mant = bits & 0x3FFu;
+        float scale;
+        if (exp == 0) {
+            scale = ldexpf((float)mant, -24);
+        } else if (exp == 31) {
+            scale = mant ? __int_as_float(0x7fc00000) : __int_as_float(0x7f800000);
+        } else {
+            scale = ldexpf((float)(mant | 0x400), (int)exp - 25);
+        }
+        if (sign) scale = -scale;
+
+        const unsigned int qh = (unsigned int)block[2]
+            | ((unsigned int)block[3] << 8)
+            | ((unsigned int)block[4] << 16)
+            | ((unsigned int)block[5] << 24);
+        const unsigned char* qs = block + 6;
+
+        int base = b * 32;
+        float block_acc = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < 16; j++) {
+            // ggml `dequantize_row_q5_0`: the low half takes bit `j` of
+            // qh shifted UP into position 4, the high half takes bit
+            // `j + 16` shifted DOWN into it -- hence `j + 12`, not
+            // `j + 16`, because the bit is left in place rather than
+            // moved to position 0.
+            unsigned int xh_0 = ((qh >> j) << 4) & 0x10u;
+            unsigned int xh_1 = (qh >> (j + 12)) & 0x10u;
+            int x0 = (int)(((unsigned int)qs[j] & 0x0Fu) | xh_0) - 16;
+            int x1 = (int)(((unsigned int)qs[j] >> 4) | xh_1) - 16;
+            block_acc += (float)x0 * x[base + j];
+            block_acc += (float)x1 * x[base + j + 16];
         }
         acc += block_acc * scale;
     }
@@ -787,6 +895,57 @@ pub(crate) fn resident_cuda_weights(
     Ok(cached)
 }
 
+/// The per-kind matvec table, keyed by GGUF quant name: source, NVRTC
+/// module cache key, entry point. `None` means CUDA has no matvec for
+/// that format and the caller must fall back and say so.
+///
+/// This is the SINGLE holder of those three strings. It was not: the
+/// same five-row table was written out twice more, inline in
+/// `ferrox-core`'s `apply_gpu_multi` and `apply_gpu_dense_ffn_swiglu`,
+/// and a kind added to one and not the others silently lost the fused
+/// launch while the capability report kept saying GPU. That is the
+/// shape `ferrox-metal`'s `matvec_launch_meta` already exists to
+/// prevent, and this is its CUDA counterpart -- keyed the same way, by
+/// `QuantKind::name()`, so `ferrox-core` can ask for a kind without
+/// depending on a CUDA type.
+pub fn matvec_launch_meta(kind_name: &str) -> Option<(&'static str, &'static str, &'static str)> {
+    match kind_name {
+        "Q8_0" => Some((Q8_0_MATVEC_KERNEL_SRC, "ferrox_q8_0", "q8_0_matvec")),
+        "Q4_0" => Some((Q4_0_MATVEC_KERNEL_SRC, "ferrox_q4_0", "q4_0_matvec")),
+        "Q5_0" => Some((Q5_0_MATVEC_KERNEL_SRC, "ferrox_q5_0", "q5_0_matvec")),
+        "Q4_K" => Some((Q4_K_MATVEC_KERNEL_SRC, "ferrox_q4_k", "q4_k_matvec")),
+        "Q5_K" => Some((Q5_K_MATVEC_KERNEL_SRC, "ferrox_q5_k", "q5_k_matvec")),
+        "Q6_K" => Some((Q6_K_MATVEC_KERNEL_SRC, "ferrox_q6_k", "q6_k_matvec")),
+        _ => None,
+    }
+}
+
+/// Looks a kind up in [`matvec_launch_meta`] and launches it. Every
+/// `launch_q*_matvec` below is this call with its name filled in, so
+/// the launchers cannot name a module or entry point the table does
+/// not.
+fn launch_matvec_by_kind(
+    kind_name: &str,
+    weights: &[u8],
+    x: &[f32],
+    rows: usize,
+    row_bytes: usize,
+    n_blocks_per_row: usize,
+) -> Result<Vec<f32>, CudaError> {
+    let (kernel_src, module_name, fn_name) = matvec_launch_meta(kind_name)
+        .ok_or_else(|| CudaError::Unsupported(format!("no CUDA matvec kernel for {kind_name}")))?;
+    launch_matvec(
+        kernel_src,
+        module_name,
+        fn_name,
+        weights,
+        x,
+        rows,
+        row_bytes,
+        n_blocks_per_row,
+    )
+}
+
 /// Launches the Q8_0 matvec kernel. Verified on real GPU hardware -- see module docs.
 pub fn launch_q8_0_matvec(
     weights: &[u8],
@@ -795,16 +954,7 @@ pub fn launch_q8_0_matvec(
     row_bytes: usize,
     n_blocks_per_row: usize,
 ) -> Result<Vec<f32>, CudaError> {
-    launch_matvec(
-        Q8_0_MATVEC_KERNEL_SRC,
-        "ferrox_q8_0",
-        "q8_0_matvec",
-        weights,
-        x,
-        rows,
-        row_bytes,
-        n_blocks_per_row,
-    )
+    launch_matvec_by_kind("Q8_0", weights, x, rows, row_bytes, n_blocks_per_row)
 }
 
 /// Launches the Q4_0 matvec kernel. Verified on real GPU hardware -- see module docs.
@@ -815,16 +965,20 @@ pub fn launch_q4_0_matvec(
     row_bytes: usize,
     n_blocks_per_row: usize,
 ) -> Result<Vec<f32>, CudaError> {
-    launch_matvec(
-        Q4_0_MATVEC_KERNEL_SRC,
-        "ferrox_q4_0",
-        "q4_0_matvec",
-        weights,
-        x,
-        rows,
-        row_bytes,
-        n_blocks_per_row,
-    )
+    launch_matvec_by_kind("Q4_0", weights, x, rows, row_bytes, n_blocks_per_row)
+}
+
+/// Launches the Q5_0 matvec kernel. **NEVER RUN ON A GPU** -- see
+/// `Q5_0_MATVEC_KERNEL_SRC`'s doc comment for what is and is not
+/// established about it.
+pub fn launch_q5_0_matvec(
+    weights: &[u8],
+    x: &[f32],
+    rows: usize,
+    row_bytes: usize,
+    n_blocks_per_row: usize,
+) -> Result<Vec<f32>, CudaError> {
+    launch_matvec_by_kind("Q5_0", weights, x, rows, row_bytes, n_blocks_per_row)
 }
 
 /// Launches the Q4_K matvec kernel. Verified on real GPU hardware -- see module docs.
@@ -835,16 +989,7 @@ pub fn launch_q4_k_matvec(
     row_bytes: usize,
     n_blocks_per_row: usize,
 ) -> Result<Vec<f32>, CudaError> {
-    launch_matvec(
-        Q4_K_MATVEC_KERNEL_SRC,
-        "ferrox_q4_k",
-        "q4_k_matvec",
-        weights,
-        x,
-        rows,
-        row_bytes,
-        n_blocks_per_row,
-    )
+    launch_matvec_by_kind("Q4_K", weights, x, rows, row_bytes, n_blocks_per_row)
 }
 
 /// Launches the Q5_K matvec kernel. Verified on real GPU hardware -- see module docs.
@@ -855,16 +1000,7 @@ pub fn launch_q5_k_matvec(
     row_bytes: usize,
     n_blocks_per_row: usize,
 ) -> Result<Vec<f32>, CudaError> {
-    launch_matvec(
-        Q5_K_MATVEC_KERNEL_SRC,
-        "ferrox_q5_k",
-        "q5_k_matvec",
-        weights,
-        x,
-        rows,
-        row_bytes,
-        n_blocks_per_row,
-    )
+    launch_matvec_by_kind("Q5_K", weights, x, rows, row_bytes, n_blocks_per_row)
 }
 
 /// Launches the Q6_K matvec kernel. NOT yet re-verified on real GPU
@@ -877,16 +1013,7 @@ pub fn launch_q6_k_matvec(
     row_bytes: usize,
     n_blocks_per_row: usize,
 ) -> Result<Vec<f32>, CudaError> {
-    launch_matvec(
-        Q6_K_MATVEC_KERNEL_SRC,
-        "ferrox_q6_k",
-        "q6_k_matvec",
-        weights,
-        x,
-        rows,
-        row_bytes,
-        n_blocks_per_row,
-    )
+    launch_matvec_by_kind("Q6_K", weights, x, rows, row_bytes, n_blocks_per_row)
 }
 
 /// Metadata for a single matvec launch in a multi-matvec batch (shared
@@ -1413,6 +1540,116 @@ mod tests {
         .expect("kernel launch must succeed on real CUDA hardware");
         assert_eq!(result.len(), expected.len());
         for (i, (got, want)) in result.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-2,
+                "row {i}: GPU={got} CPU reference={want}"
+            );
+        }
+    }
+
+    /// The three strings a matvec launch needs live in exactly one
+    /// table, and each source has to define the entry point its row
+    /// names. Runnable without a device, because the failure this
+    /// guards against -- a row whose `fn_name` and source disagree --
+    /// is a `KernelCompile` error at a user's first token, not
+    /// something a GPU is needed to see.
+    #[test]
+    fn matvec_launch_meta_defines_every_entry_point_it_names() {
+        let mut modules = std::collections::HashSet::new();
+        for name in ["Q8_0", "Q4_0", "Q5_0", "Q4_K", "Q5_K", "Q6_K"] {
+            let (src, module, func) = matvec_launch_meta(name)
+                .unwrap_or_else(|| panic!("{name} must have a CUDA matvec"));
+            assert!(
+                src.contains(&format!("void {func}(")),
+                "{name}: the source in {module} does not define {func}"
+            );
+            assert!(
+                modules.insert(module),
+                "{name}: module cache key {module} collides with another kind"
+            );
+        }
+        // A kind with no kernel must not resolve to one. Resolving
+        // would send a matmul to a module that cannot compile, and the
+        // caller would have no way to fall back honestly.
+        for name in ["Q2_K", "Q3_K", "Q5_1", "IQ4_XS", "MXFP4"] {
+            assert!(
+                matvec_launch_meta(name).is_none(),
+                "{name} resolved to a CUDA matvec that does not exist"
+            );
+        }
+    }
+
+    /// The Q5_0 kernel's block stride and element stride are literals in
+    /// CUDA C, so nothing but this holds them to the format's real
+    /// geometry. A wrong stride walks the row past the first block and
+    /// every value after it is garbage -- and `nl` is 2 here, not the
+    /// K-quants' 16, which is the assumption easiest to carry over by
+    /// mistake.
+    #[test]
+    fn the_q5_0_matvec_strides_by_the_real_block_geometry() {
+        assert_eq!(ferrox_quant::Q5_0_BLOCK_BYTES, 22);
+        assert_eq!(ferrox_quant::Q5_0_BLOCK_ELEMS, 32);
+        assert!(
+            Q5_0_MATVEC_KERNEL_SRC.contains("(size_t)b * 22"),
+            "the Q5_0 matvec does not stride by Q5_0_BLOCK_BYTES"
+        );
+        assert!(
+            Q5_0_MATVEC_KERNEL_SRC.contains("int base = b * 32;"),
+            "the Q5_0 matvec does not step the activation by Q5_0_BLOCK_ELEMS"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires real CUDA hardware -- NEVER RUN: the Q5_0 matvec has never executed on a GPU. Run with --ignored on a CUDA-capable machine and record the result before any doc claims CUDA Q5_0 works"]
+    fn launch_q5_0_matvec_matches_cpu_reference() {
+        // Run manually on a machine with an actual CUDA device:
+        //   cargo test -p ferrox-cuda --features cuda -- --ignored
+        let rows = 4;
+        let cols = 64;
+        let blocks_per_row = cols / ferrox_quant::Q5_0_BLOCK_ELEMS;
+        let row_bytes = blocks_per_row * ferrox_quant::Q5_0_BLOCK_BYTES;
+
+        // `ferrox_quant` has no Q5_0 quantizer (the format is load-only
+        // here), so the fixture is built byte by byte. The scale is
+        // pinned finite -- a random f16 is NaN or Inf often enough to
+        // be the usual outcome -- while `qh` is deliberately varied, so
+        // both the low half's fifth bit (`qh` bit j) and the high
+        // half's (`qh` bit j + 16) are set on some elements and clear
+        // on others. A kernel that dropped `qh` entirely would still
+        // produce plausible numbers against a fixture where it is zero.
+        let mut weights = Vec::with_capacity(rows * row_bytes);
+        for r in 0..rows {
+            for b in 0..blocks_per_row {
+                let idx = (r * blocks_per_row + b) as u32;
+                weights.extend_from_slice(
+                    &half::f16::from_f32(0.05 + idx as f32 * 0.01).to_le_bytes(),
+                );
+                let qh = 0x9E3D_7A51u32.wrapping_mul(idx + 1);
+                weights.extend_from_slice(&qh.to_le_bytes());
+                for i in 0..16u8 {
+                    let lo = (i + r as u8 + b as u8) % 16;
+                    let hi = (15 - i + r as u8 + b as u8) % 16;
+                    weights.push(lo | (hi << 4));
+                }
+            }
+        }
+        assert_eq!(weights.len(), rows * row_bytes);
+
+        let x: Vec<f32> = (0..cols).map(|i| ((i as f32) * 0.09).sin()).collect();
+        let expected: Vec<f32> = (0..rows)
+            .map(|r| {
+                ferrox_quant::dot_q5_0_f32_scalar(&weights[r * row_bytes..(r + 1) * row_bytes], &x)
+            })
+            .collect();
+
+        let result = launch_q5_0_matvec(&weights, &x, rows, row_bytes, blocks_per_row)
+            .expect("kernel launch must succeed on real CUDA hardware");
+        assert_eq!(result.len(), expected.len());
+        for (i, (got, want)) in result.iter().zip(expected.iter()).enumerate() {
+            // Absolute, like the Q8_0/Q4_0 tests and unlike the K-quant
+            // ones: Q5_0 accumulates an exact integer dot per block and
+            // applies the scale once, so there is no per-element
+            // scale multiply for an FMA to reassociate.
             assert!(
                 (got - want).abs() < 1e-2,
                 "row {i}: GPU={got} CPU reference={want}"

--- a/crates/ferrox-cuda/src/mul_mm.rs
+++ b/crates/ferrox-cuda/src/mul_mm.rs
@@ -18,8 +18,10 @@
 //!    `ferrox-metal`'s `mul_mm_sg_impl` (`crates/ferrox-metal/src/gpu.rs`),
 //!    which is at parity with llama.cpp on Metal and has goldens. The
 //!    per-kind unpack functions below are line-for-line transcriptions of
-//!    that file's `Q8_0Dequant` / `Q4_0Dequant` functors, which are
-//!    themselves llama's `dequantize_q8_0` / `dequantize_q4_0`.
+//!    that file's `Q8_0Dequant` / `Q4_0Dequant` / `Q5_0Dequant` /
+//!    `Q5KDequant` / `Q6KDequant` functors, which are themselves
+//!    llama's `dequantize_q8_0` / `dequantize_q4_0` /
+//!    `dequantize_q5_0` / `dequantize_q5_K` / `dequantize_q6_K`.
 //! 2. **It has a scalar twin.** [`crate::mul_mm_ref`] emulates this
 //!    kernel on the CPU -- same tiling, same clamping, same index
 //!    arithmetic, same accumulation order -- and its tests, which run in
@@ -38,11 +40,20 @@
 //!    one real thread per CUDA thread, a counting barrier for
 //!    `__syncthreads()`, one block at a time so `__shared__` behaves --
 //!    then compares it to the twin. Result on 2026-09-01, macOS/clang,
-//!    both kinds, three shapes (exact tiles, partial on both axes,
-//!    narrow batch): **zero mismatches, bit for bit**, including 1,458
-//!    positions where a degenerate f16 scale made both sides NaN
-//!    together. Deleting one term of the CUDA-only index arithmetic
-//!    makes it fail, so it is a check and not a formality.
+//!    both kinds then in the table, three shapes (exact tiles, partial
+//!    on both axes, narrow batch): **zero mismatches, bit for bit**,
+//!    including 1,458 positions where a degenerate f16 scale made both
+//!    sides NaN together. Deleting one term of the CUDA-only index
+//!    arithmetic makes it fail, so it is a check and not a formality.
+//!
+//!    Re-run on 2026-09-05 over all six kinds: **zero mismatches**
+//!    again, 40,932 compared positions. That run was the first for the
+//!    K-quants and for Q5_0 -- the tool took `n_cols` from a fixed list
+//!    that is not a whole Q4_K super-block, so from the day the
+//!    K-quants landed it panicked on the first one and checked
+//!    NOTHING. A tool that cannot fire is worse than no tool; `n_cols`
+//!    is now rounded up per kind. Sabotaging Q5_0's `qh` shift
+//!    (`12` for `16`) makes it report 6,096 mismatches.
 //!
 //! What none of that covers, and what only hardware can settle: that
 //! NVRTC accepts the source (clang and NVRTC are different front ends),
@@ -230,6 +241,93 @@ fn dequant_sub_q4_0(xb: &[u8], il: usize, reg: &mut [f32; SUB]) {
         let w = u16::from(qs[2 * i]) | (u16::from(qs[2 * i + 1]) << 8);
         reg[2 * i] = d1 * f32::from(w & mask0) + md;
         reg[2 * i + 1] = d2 * f32::from(w & mask1) + md;
+    }
+}
+
+/// Q5_0: `half d`, `uint32 qh`, then 16 bytes holding 32 nibbles. The
+/// fifth bit of each quant lives in `qh`, and each value is biased by
+/// -16. Transcribed from `ferrox-metal`'s `Q5_0Dequant::get`, which is
+/// llama's `dequantize_q5_0`.
+///
+/// **`nl` is 2, not 16.** This is a 32-element legacy block like Q4_0,
+/// so `il` selects the LOW half (elements 0..16) or the HIGH half
+/// (elements 16..32) -- it does not index one of sixteen sub-blocks the
+/// way the K-quants' `il` does. Every derived quantity below flips on
+/// that one bit, and the four that do are easy to confuse:
+///
+/// - `mask` picks the low or high nibble of each `qs` byte,
+/// - `x_mv` shifts the high nibble back down to 0..15,
+/// - `gh_mv` selects `qh` bit `j` (low half) or bit `j + 16` (high),
+/// - `gh_bk` puts that bit into position 4.
+///
+/// `gh_mv`/`gh_bk` are llama's two spellings of the same fifth bit:
+/// `((qh >> j) << 4) & 0x10` for the low half and
+/// `(qh >> (j + 12)) & 0x10` for the high one, which is `12`, not `16`,
+/// precisely because the bit is left in place rather than shifted to 0.
+pub const Q5_0: MulMmKind = MulMmKind {
+    name: "Q5_0",
+    module_name: "ferrox_mul_mm_q5_0",
+    fn_name: "q5_0_mul_mm",
+    block_bytes: 22,
+    block_elems: 32,
+    dequant_src: r#"
+__device__ __forceinline__ void ferrox_dequant_sub(
+    const unsigned char* xb, int il, float* reg
+) {
+    const float d = ferrox_f16_to_f32(
+        (unsigned short)xb[0] | ((unsigned short)xb[1] << 8));
+    const float md = -16.0f * d;
+    const unsigned int qh = (unsigned int)xb[2]
+        | ((unsigned int)xb[3] << 8)
+        | ((unsigned int)xb[4] << 16)
+        | ((unsigned int)xb[5] << 24);
+    const unsigned char* qs = xb + 6;
+    const unsigned short mask = il ? 0x00F0 : 0x000F;
+    const int x_mv = il ? 4 : 0;
+    const int gh_mv = il ? 12 : 0;
+    const int gh_bk = il ? 0 : 4;
+#pragma unroll
+    for (int i = 0; i < 8; i++) {
+        const unsigned short w =
+            (unsigned short)qs[2 * i] | ((unsigned short)qs[2 * i + 1] << 8);
+        const unsigned char xh_0 =
+            (unsigned char)(((qh >> (gh_mv + 2 * i)) << gh_bk) & 0x10u);
+        const unsigned char xh_1 =
+            (unsigned char)(((qh >> (gh_mv + 2 * i + 1)) << gh_bk) & 0x10u);
+        const int x0 = (int)((((w) & mask) >> x_mv) | xh_0);
+        const int x1 = (int)((((w >> 8) & mask) >> x_mv) | xh_1);
+        reg[2 * i + 0] = d * (float)x0 + md;
+        reg[2 * i + 1] = d * (float)x1 + md;
+    }
+}
+"#,
+    dequant_twin: dequant_sub_q5_0,
+};
+
+/// Scalar twin of [`Q5_0`]'s `dequant_src`.
+///
+/// Note the bias, as in [`Q4_0`]: `d * q + (-16 * d)`, not
+/// `d * (q - 16)`. That is llama's order and the twin mirrors it.
+fn dequant_sub_q5_0(xb: &[u8], il: usize, reg: &mut [f32; SUB]) {
+    let d = f16_to_f32(u16::from(xb[0]) | (u16::from(xb[1]) << 8));
+    let md = -16.0 * d;
+    let qh = u32::from(xb[2])
+        | (u32::from(xb[3]) << 8)
+        | (u32::from(xb[4]) << 16)
+        | (u32::from(xb[5]) << 24);
+    let qs = &xb[6..6 + 16];
+    let mask: u16 = if il != 0 { 0x00F0 } else { 0x000F };
+    let x_mv = if il != 0 { 4 } else { 0 };
+    let gh_mv = if il != 0 { 12 } else { 0 };
+    let gh_bk = if il != 0 { 0 } else { 4 };
+    for i in 0..8 {
+        let w = u16::from(qs[2 * i]) | (u16::from(qs[2 * i + 1]) << 8);
+        let xh_0 = (((qh >> (gh_mv + 2 * i)) << gh_bk) & 0x10) as u8;
+        let xh_1 = (((qh >> (gh_mv + 2 * i + 1)) << gh_bk) & 0x10) as u8;
+        let x0 = i32::from((((w & mask) >> x_mv) as u8) | xh_0);
+        let x1 = i32::from(((((w >> 8) & mask) >> x_mv) as u8) | xh_1);
+        reg[2 * i] = d * x0 as f32 + md;
+        reg[2 * i + 1] = d * x1 as f32 + md;
     }
 }
 
@@ -550,7 +648,7 @@ pub fn f16_to_f32(bits: u16) -> f32 {
 
 /// The dispatch table. A caller looks up by GGUF quant name; a new
 /// format is one row here.
-pub const KINDS: &[MulMmKind] = &[Q8_0, Q4_0, Q4_K, Q5_K, Q6_K];
+pub const KINDS: &[MulMmKind] = &[Q8_0, Q4_0, Q5_0, Q4_K, Q5_K, Q6_K];
 
 /// Looks up a kind by its GGUF quant name (`"Q4_0"`, `"Q8_0"`).
 /// `None` means this GEMM does not implement that format -- the caller
@@ -873,7 +971,7 @@ pub fn grid_dims(n_rows: usize, batch: usize) -> (usize, usize) {
 }
 
 #[cfg(test)]
-mod kquant_twin_tests {
+mod dequant_twin_tests {
     use super::*;
 
     /// Deterministic pseudo-random bytes: a block's contents only have
@@ -898,12 +996,16 @@ mod kquant_twin_tests {
     /// different uses of `il` produces plausible numbers from the wrong
     /// offsets, and that is exactly what this catches.
     #[test]
-    fn every_kquant_twin_matches_the_cpu_dequant() {
+    fn every_dequant_twin_matches_the_cpu_dequant() {
         struct Case {
             kind: &'static MulMmKind,
             dequant: fn(&[u8]) -> Result<Vec<f32>, ferrox_quant::QuantError>,
         }
         let cases = [
+            Case {
+                kind: &Q5_0,
+                dequant: ferrox_quant::dequant_q5_0,
+            },
             Case {
                 kind: &Q4_K,
                 dequant: ferrox_quant::dequant_q4_k,
@@ -926,9 +1028,16 @@ mod kquant_twin_tests {
                 // is Inf or NaN often enough to be the usual outcome.
                 // The scales get finite values so the comparison is
                 // about the UNPACK: 0x2C00 is 0.0625, 0x2800 is
-                // 0.03125. Everything else stays random.
+                // 0.03125. Everything else stays random -- for Q5_0
+                // that deliberately includes the four `qh` bytes at
+                // 2..6, which carry the fifth bit of all 32 quants and
+                // are the half of the format a transcription gets
+                // wrong.
                 let (d_at, dmin_at) = match k.name {
                     "Q6_K" => (208, None),
+                    // Q5_0 has no `dmin`; bytes 2..6 are `qh`, and
+                    // pinning them would blind the fifth-bit check.
+                    "Q5_0" => (0, None),
                     _ => (0, Some(2)),
                 };
                 block[d_at] = 0x00;
@@ -962,12 +1071,29 @@ mod kquant_twin_tests {
     /// The block geometry each kind declares has to be the geometry the
     /// format actually has, or the GEMM walks the row with the wrong
     /// stride and every number after the first block is garbage.
+    ///
+    /// `nl` is part of that geometry and is NOT the same for every row:
+    /// the K-quants are 256-element super-blocks (`nl` 16) and Q5_0 is a
+    /// 32-element legacy block (`nl` 2). A Q5_0 row that inherited the
+    /// K-quant assumption would ask the kernel for sub-blocks 2..16 of a
+    /// block that has two, so the expectation is per row rather than one
+    /// shared constant.
     #[test]
-    fn kquant_block_geometry_is_the_gguf_geometry() {
-        for (k, bytes_, elems) in [(&Q4_K, 144, 256), (&Q5_K, 176, 256), (&Q6_K, 210, 256)] {
+    fn declared_block_geometry_is_the_gguf_geometry() {
+        for (k, bytes_, elems, nl) in [
+            (
+                &Q5_0,
+                ferrox_quant::Q5_0_BLOCK_BYTES,
+                ferrox_quant::Q5_0_BLOCK_ELEMS,
+                2,
+            ),
+            (&Q4_K, 144, 256, 16),
+            (&Q5_K, 176, 256, 16),
+            (&Q6_K, 210, 256, 16),
+        ] {
             assert_eq!(k.block_bytes, bytes_, "{} block_bytes", k.name);
             assert_eq!(k.block_elems, elems, "{} block_elems", k.name);
-            assert_eq!(k.nl(), 16, "{} sub-blocks per super-block", k.name);
+            assert_eq!(k.nl(), nl, "{} sub-blocks per super-block", k.name);
         }
     }
 }

--- a/crates/ferrox-cuda/src/mul_mm_launch.rs
+++ b/crates/ferrox-cuda/src/mul_mm_launch.rs
@@ -124,7 +124,7 @@ pub fn launch_mul_mm(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mul_mm::{BM, Q4_0, Q8_0};
+    use crate::mul_mm::{BM, Q4_0, Q5_0, Q8_0};
     use crate::mul_mm_ref::mul_mm_reference;
 
     #[test]
@@ -146,20 +146,23 @@ mod tests {
     ///
     /// It compares the kernel against [`mul_mm_reference`] -- the same
     /// scalar twin the host-side tests already hold to `ferrox_quant` --
-    /// on both an exact-tile and a partial-tile shape, for both quant
-    /// kinds in the table.
+    /// on both an exact-tile and a partial-tile shape, for the three
+    /// 32-element kinds in the table. (The K-quants are covered by
+    /// `tools/mul_mm_host_check/run.sh`, which executes the same
+    /// emitted C on the host for every kind in `KINDS`.)
     ///
     /// Run it on a machine with a real device:
     ///   cargo test -p ferrox-cuda --features cuda -- --ignored
     #[test]
     #[ignore = "requires real CUDA hardware -- NEVER RUN: this kernel has never executed on a GPU. Run with --ignored on a CUDA-capable machine and record the result before any doc claims CUDA mul_mm works"]
     fn launch_mul_mm_matches_the_scalar_twin() {
-        for (kind, weights_of) in [(&Q8_0, 0usize), (&Q4_0, 1usize)] {
+        for (kind, weights_of) in [(&Q8_0, 0usize), (&Q4_0, 1usize), (&Q5_0, 2usize)] {
             for (n_rows, n_cols, batch) in [(BM * 2, 128, 32), (BM + 7, 96, 37), (33, 64, 3)] {
                 let row_bytes = (n_cols / kind.block_elems) * kind.block_bytes;
                 let weights = match weights_of {
                     0 => q8_0_weights(n_rows, n_cols),
-                    _ => q4_0_weights(n_rows, n_cols),
+                    1 => q4_0_weights(n_rows, n_cols),
+                    _ => q5_0_weights(n_rows, n_cols),
                 };
                 let x: Vec<f32> = (0..batch * n_cols)
                     .map(|i| ((i as f32) * 0.019).cos())
@@ -206,6 +209,27 @@ mod tests {
                 .map(|i| (((r * n_cols + i) as f32) * 0.037).sin())
                 .collect();
             out.extend(ferrox_quant::quantize_q8_0(&row));
+        }
+        out
+    }
+
+    /// Q5_0 blocks: `half d`, a 4-byte `qh` bitplane, 16 packed
+    /// nibbles. `qh` is deliberately varied rather than zero -- a
+    /// kernel that dropped the fifth bit entirely would agree with the
+    /// twin on an all-zero `qh` fixture.
+    fn q5_0_weights(n_rows: usize, n_cols: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        let blocks = n_cols / 32;
+        let mut state = 6789u32;
+        for r in 0..n_rows {
+            for b in 0..blocks {
+                let scale = half::f16::from_f32(0.05 + ((r * blocks + b) % 13) as f32 * 0.01);
+                out.extend_from_slice(&scale.to_le_bytes());
+                for _ in 0..20 {
+                    state = state.wrapping_mul(1103515245).wrapping_add(12345);
+                    out.push((state >> 16) as u8);
+                }
+            }
         }
         out
     }

--- a/crates/ferrox-cuda/src/mul_mm_ref.rs
+++ b/crates/ferrox-cuda/src/mul_mm_ref.rs
@@ -489,7 +489,9 @@ mod tests {
         assert_eq!(Q8_0.block_elems, ferrox_quant::Q8_0_BLOCK_ELEMS);
         assert_eq!(Q4_0.block_bytes, ferrox_quant::Q4_0_BLOCK_BYTES);
         assert_eq!(Q4_0.block_elems, ferrox_quant::Q4_0_BLOCK_ELEMS);
-        use crate::mul_mm::{Q4_K, Q5_K, Q6_K};
+        use crate::mul_mm::{Q4_K, Q5_0, Q5_K, Q6_K};
+        assert_eq!(Q5_0.block_bytes, ferrox_quant::Q5_0_BLOCK_BYTES);
+        assert_eq!(Q5_0.block_elems, ferrox_quant::Q5_0_BLOCK_ELEMS);
         assert_eq!(Q4_K.block_bytes, ferrox_quant::Q4_K_BLOCK_BYTES);
         assert_eq!(Q4_K.block_elems, ferrox_quant::Q4_K_BLOCK_ELEMS);
         assert_eq!(Q5_K.block_bytes, ferrox_quant::Q5_K_BLOCK_BYTES);
@@ -509,7 +511,8 @@ mod tests {
             );
             assert_eq!(kind_by_name(k.name).map(|f| f.name), Some(k.name));
         }
-        // Q4_K, Q5_K and Q6_K resolve as of 2026-09-04. IQ4_XS does
+        // Q4_K, Q5_K and Q6_K resolve as of 2026-09-04, Q5_0 as of
+        // 2026-09-05. IQ4_XS does
         // not, and the distinction is not an oversight: it is a
         // codebook lookup rather than an affine dequant, so it does
         // not fit `dequant_src`'s shape and needs its own row. A kind

--- a/docs/plans/cpu-cuda-parity.md
+++ b/docs/plans/cpu-cuda-parity.md
@@ -85,7 +85,7 @@ tok/s column cannot show.
 | Q4_K | yes | yes | **new** | yes |
 | Q5_K | yes | yes | **new** | yes |
 | Q6_K | yes | yes | **new** | yes |
-| Q5_0 | no | **no** | **no** | yes |
+| Q5_0 | no | **new** | **new** | yes |
 | IQ4_XS / IQ4_NL | no | **no** | **no** | matvec+GEMM |
 | Q2_K, Q3_K | no | **no** | **no** | **no** |
 | Q4_1, Q5_1, Q8_1 | no | **no** | **no** | **no** |
@@ -229,9 +229,21 @@ the code read as if they were right.
 Not alphabetically, and not all 21. In order of how often a checkpoint
 in the wild uses it:
 
-- **CUDA Q5_0 and IQ4_XS.** Metal has both; CUDA has neither. IQ4_XS is
-  a codebook lookup, so it needs its own `MulMmKind` shape rather than
-  an `affine dequant_src`.
+- **CUDA Q5_0, landed 2026-09-05, UNVERIFIED ON HARDWARE.** Matvec and
+  GEMM together, because `a_cuda_kind_with_a_matvec_also_has_a_gemm`
+  forbids half of it. The GEMM's emitted C is executed on the host by
+  `crates/ferrox-cuda/tools/mul_mm_host_check/run.sh` and matches the
+  Rust twin bit for bit; the matvec's C has no such harness and no GPU
+  has run either. `cargo test -p ferrox-cuda --features cuda --
+  --ignored` is the exit criterion, plus a Q5_0 bench row.
+- **CUDA IQ4_XS.** Metal has it; CUDA does not. It is a codebook
+  lookup, so it needs its own `MulMmKind` shape rather than an affine
+  `dequant_src`: the kernel needs the 16-entry `KVALUES_IQ4NL` table
+  visible to every thread (a `__constant__` array, not a per-block
+  scale) and its `dequant_src` contract would have to become "given
+  the block and `il`, index the codebook" rather than "multiply by a
+  scale and add a bias". The `dequant_twin` seam survives unchanged;
+  only the emitted helper's shape differs.
 - **Q2_K and Q3_K everywhere.** Common in small-memory builds, and
   absent on all three GPU backends.
 - **MXFP4 on GPU.** gpt-oss ships it. CPU has it; no GPU does.
@@ -280,5 +292,5 @@ all, which is honest and temporary.
 | 4 fixed per-token cost | #128 | not started |
 | 5 x86 decode | #127 | **done**: default was wrong, 6.8x to 1.4x |
 | 5b x86 prefill | | not started, now the largest CPU gap (6x to 10x) |
-| 6 kernel coverage | | Q4_K/Q5_K/Q6_K landed on CUDA; 16 kinds still host-only |
+| 6 kernel coverage | | Q4_K/Q5_K/Q6_K landed on CUDA, Q5_0 2026-09-05 (unverified); 15 kinds still host-only |
 | 7 ledger | #126 | **done**: three hosts, and a committed-receipt check |


### PR DESCRIPTION
Closes one row of the coverage table in `docs/plans/cpu-cuda-parity.md`
**step 6** ("Kernel coverage, by what people actually run"). Q5_0 was
the first entry on that list: Metal has both a matvec and a GEMM for
it, CUDA had neither, so every matmul of a Q5_0 checkpoint left the
GPU. Per that plan's own trap list, that never showed up as a bug,
because "a fallback is not a failure, which is what makes it
dangerous."

## What landed

**Both halves, together.** `a_cuda_kind_with_a_matvec_also_has_a_gemm`
forbids adding one without the other, and half of it is the exact
shape that cost Metal its Q5_0 decode path: GPU prefill with every
single-token decode falling to the host.

- `mul_mm::Q5_0` - a `MulMmKind` row transcribed from `ferrox-metal`'s
  `Q5_0Dequant` (llama's `dequantize_q5_0`), plus the Rust
  `dequant_twin` written statement for statement beside it.
- `gpu::Q5_0_MATVEC_KERNEL_SRC` + `launch_q5_0_matvec`, mirroring
  `ferrox_quant::dot_q5_0_f32_scalar`.
- `Cuda::matvec_kernel`, `Cuda::gemm_supported`, `cuda_matvec_launch`
  and `WeightMatrix::block_bytes_for_kind` widened. The last of those
  is an `unreachable!()` outside its arms, so widening the first
  without it is a panic in a rayon worker rather than a fallback.

`nl` is **2**, not the K-quants' 16: Q5_0 is a 32-element legacy block
(`half d`, `uint32 qh`, 16 `qs` bytes), so `il` selects the low or the
high half rather than one of sixteen sub-blocks. Every derived
quantity flips on that one bit, and
`declared_block_geometry_is_the_gguf_geometry` holds
`block_bytes`/`block_elems` to `ferrox_quant::Q5_0_BLOCK_BYTES` and
`Q5_0_BLOCK_ELEMS` rather than to a literal.

## Two restated tables collapsed rather than grown

The three strings a CUDA matvec launch needs (source, NVRTC module
key, entry point) lived in `launch_q*_matvec` and again, **twice**,
inline in `ferrox-core`'s `apply_gpu_multi` and
`apply_gpu_dense_ffn_swiglu`. Adding Q5_0 to one and not the others
would have lost its fused launch silently while the capability report
said GPU, which is the dominant bug shape in this repo. They now all
come from one `ferrox_cuda::gpu::matvec_launch_meta`, keyed by
`QuantKind::name()` exactly as Metal's already was, and
`the_cuda_matvec_kinds_match_the_launch_meta_table` holds it to the
capability table for all 21 kinds.

## A gate that could not fire, found on the way

`crates/ferrox-cuda/tools/mul_mm_host_check/run.sh` says "every kind
in `ferrox_cuda::mul_mm::KINDS` is covered automatically - adding a
quant kind needs no edit here." It has covered **nothing** since the
K-quants landed: its fixed `n_cols` list is not a whole Q4_K
super-block, so `validate_shape` refused the first K-quant and the
tool panicked before checking anything. `n_cols` is now rounded up per
kind; the 32-element kinds keep the exact shapes they had.

That fix makes this the strongest evidence in the PR: **the emitted
CUDA C for all six kinds, compiled by clang and executed on the host,
matches the Rust scalar twin bit for bit over 40,932 positions**,
including the positions where a degenerate f16 scale makes both sides
NaN together.

## UNVERIFIED ON HARDWARE

**No GPU has run any of this.** There is no NVIDIA hardware in the
environment it was written in.

- The **GEMM's** CUDA C is host-executed and bit-exact against the
  twin, which the twin in turn holds to `ferrox_quant::dequant_q5_0`
  sub-block by sub-block. What that cannot see: that NVRTC (a
  different front end from clang) accepts the source, that the
  barriers survive a real warp scheduler, that the launch config is
  valid, or what any of it costs.
- The **matvec's** CUDA C has no host harness at all. Its only checks
  are that it defines the entry point its table row names and strides
  by `Q5_0_BLOCK_BYTES`. It is a second transcription of arithmetic
  that is right elsewhere, and transcription errors are exactly the
  failure mode.

Verify on a CUDA box with:

```
cargo test -p ferrox-cuda --features cuda -- --ignored
```

The two that matter are
`gpu::tests::launch_q5_0_matvec_matches_cpu_reference` and
`mul_mm_launch::tests::launch_mul_mm_matches_the_scalar_twin` (now
covering Q5_0 alongside Q8_0 and Q4_0). Per step 6's exit criterion a
Q5_0 bench row is still owed: `benchmarks/suite.json` has no Q5_0
checkpoint, so this path is correct-by-construction and unmeasured.
Nothing in `docs/FEATURES.md` or `docs/MODELS.md` claims otherwise.

## Sabotage receipts

Every test added was broken deliberately, confirmed red, restored,
confirmed green:

| sabotage | result |
|---|---|
| `gh_mv` 12 -> 16 in the Rust twin | red at Q5_0 sub-block 1, element 2 |
| `xh_0` forced to 0 in the Rust twin | red at Q5_0 sub-block 0, element 0 |
| `block_bytes` 22 -> 24 | red against `Q5_0_BLOCK_BYTES`, both geometry tests |
| entry point renamed `q5_0_matvecX` | red: "the source in ferrox_q5_0 does not define q5_0_matvecX" |
| matvec stride 22 -> 18 | red: "does not stride by Q5_0_BLOCK_BYTES" |
| Q5_0 dropped from `Cuda::matvec_kernel` | red twice: launch-meta mismatch **and** "CUDA has a launch for [Q5_0] that its capability table does not claim" |
| Q5_0 arm dropped from `block_bytes_for_kind` | red on the `unreachable!()` |
| `gh_mv` 12 -> 16 in the **emitted CUDA C** | host check reports 6,096 mismatches instead of 0 |

## Also

`a_kind_cuda_cannot_run_is_recorded_as_leaving_the_gpu` probed Q5_0 as
its example of a kind with no CUDA kernel. It now probes `Q2_K`, which
is the next row of the same coverage table, and its doc says so.

## Not attempted: IQ4_XS

Deliberately out of scope, and the plan now says why in more detail
than "it is a codebook lookup". It does not fit `dequant_src`'s shape:
that contract is "given a block and `il`, write 16 floats by an affine
`scale * q + bias`", and IQ4_XS needs the 16-entry `KVALUES_IQ4NL`
codebook visible to every thread (a `__constant__` array emitted once
per translation unit, not a per-block scale) with the unpack becoming
an index into it. The `dequant_twin` seam survives unchanged; only the
emitted helper's shape and the preamble differ.

## Gates

`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D
warnings`, the same `--release`, `cargo test --workspace`, and `cargo
build -p ferrox-cli --features cuda` all pass. `cargo test -p
ferrox-cuda -p ferrox-core --features cuda` also passes: 476 tests,
14 ignored hardware tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
