### PR TITLE
docs(plans): retract the 36% utilization figure, CUDA decode is kernel-bound

### DIFF
--- a/docs/plans/cpu-cuda-parity.md
+++ b/docs/plans/cpu-cuda-parity.md
@@ -148,13 +148,31 @@ now ruled out**:
 - **CUDA graphs are not it, yet.** `FERROX_CUDA_GRAPH=1` measures
   11.80 against 11.84 off, exactly as its own doc predicts: nothing
   enqueues into a captured stream, so it is groundwork.
-- **The GPU is idle.** `nvidia-smi` reports **36% utilization** during
-  decode. Two thirds of the time nothing is computing, so the cost is
-  host-side: launch overhead, per-token synchronisation, or per-launch
-  allocation. That is where to look next, and it is consistent with a
-  gap that is uniform across every quant kind.
+- **The GPU is NOT idle, and the claim that it was is retracted.** An
+  earlier version of this plan said `nvidia-smi` reported 36%
+  utilization during decode, and concluded the cost was host-side. That
+  number came from a single instantaneous sample taken AFTER a bench
+  run had finished, so it caught an idle moment. Sampled five times
+  DURING a `tg256` decode on a GTX 1080, `main` sits at **86% to 93%**.
+  Decode is **kernel-bound**, and the host-side theory this plan was
+  built on for a day was wrong.
 
-**The cause is identified, and the fix is already written.**
+  The correction cost a PR (#136, measured 22% SLOWER on hardware:
+  8.24 against 10.55 tok/s). The arithmetic that should have caught it
+  was available before the code was written: at 36% utilization,
+  removing every host round-trip buys at most 1/0.36 = 2.8x against a
+  9x to 17x gap. A lever that cannot reach the target is the wrong
+  lever even if the diagnosis is right, and here the diagnosis was also
+  wrong.
+
+**The cause is the kernels.** ferrox's CUDA matvec uses one 256-thread
+block per row with a shared-memory tree reduction; ggml-cuda uses
+warp-level `dp4a` with no shared-memory round trip. At ~90%
+utilization and 9x to 17x off, that is where essentially all of the
+difference is. Compare one kernel against its ggml-cuda equivalent for
+the same kind and shape, and close the arithmetic.
+
+**A dead API that should still go.** 
 `ferrox-cuda/src/gpu.rs` defines `DeviceAct` / `upload_act` /
 `matvec_into` / `download_act`, whose doc says they exist "so a
 matvec's output can be fed straight into the next matvec without a
@@ -165,8 +183,14 @@ that file.** The decode path takes `launch_matvec`, which returns
 uploads, allocates, launches, synchronises and downloads, on the order
 of a hundred times per token.
 
-**Exit:** wire the chaining, then before/after `tg128` on the same GPU
-plus `nvidia-smi` utilization, which should rise from 36%.
+Five DtoH points exist per dense decode layer and chaining can reach
+only three of them: norms, RoPE and the attention reduction sit between
+the matmuls on the host, so there is no consecutive-matmul pair left
+for `matvec_into` to serve. Measured, and the reason the narrow fix
+could never have worked even had the diagnosis been right.
+
+**Exit:** tok/s against llama.cpp on the same GPU and model, with
+utilization already high on both sides. Not a utilization target.
 
 **The hazard to design around first.** Metal's equivalent
 (`take_resident_activation_if_matches`) matches on LENGTH alone, which
@@ -268,7 +292,18 @@ all, which is honest and temporary.
   and loses at 135M on aarch64. A single-machine ledger would have
   published either as universal.
 - **Do not benchmark on a laptop with a UI.** Rent a box. The whole
-  investigation behind this plan cost $0.49.
+  investigation behind this plan cost under a dollar.
+- **One instantaneous sample is not a measurement.** The claim that
+  CUDA decode ran at 36% GPU utilization came from a single
+  `nvidia-smi` taken after a bench had finished. It sent a day of work
+  at a host-side cost that does not exist: the real figure, sampled
+  during the run, is 86% to 93%. Sample repeatedly, and sample WHILE
+  the thing is running.
+- **Check whether the lever can reach the target before pulling it.**
+  At the (wrong) 36% figure, removing every host round-trip was worth
+  at most 2.8x against a 9x to 17x gap. That arithmetic was in the
+  agent's PR body before the code was written, and reading past it cost
+  a merged-nothing PR.
 
 ## Status
 


### PR DESCRIPTION
Retracts a number this plan was built on for a day.

## What was wrong

The plan said CUDA decode ran with the GPU at **36% utilization**, and concluded the cost was host-side. That came from a single instantaneous `nvidia-smi` sample I took **after** a bench run had already finished, so it caught an idle moment.

Sampled five times **during** a `tg256` decode on a GTX 1080, `main` sits at **86% to 93%**.

Decode is **kernel-bound, not host-bound.**

## What it cost

PR #136, which wired device-resident activation chaining to remove host round-trips. Measured on hardware it is **22% slower** (8.24 against 10.55 tok/s) while raising utilization to 94%. Its 13 hardware tests all pass, including the aliasing-refusal one, so the code is correct. It is simply not the lever.

The mismatch was catchable before any code was written: at 36% utilization, removing **every** host round-trip buys at most 1/0.36 = 2.8x against a 9x to 17x gap. The agent put exactly that arithmetic in its PR body. Reading past it is the second trap added here.

## Where the gap actually is

ferrox's CUDA matvec uses one 256-thread block per row with a shared-memory tree reduction; ggml-cuda uses warp-level `dp4a` with no shared-memory round trip. At ~90% utilization and 9x-17x off, that is essentially all of it.

## Kept from #136

- The dead `DeviceAct`/`upload_act`/`matvec_into`/`download_act` API and the unwired thread-local `ResidentActivation` should still be deleted. That thread-local cached residency by **host pointer and length**, which is precisely the aliasing hazard the plan warns about, sitting unused in the tree. Landing separately.
- Five DtoH points per dense decode layer, of which chaining can reach three, because norms, RoPE and the attention reduction sit between the matmuls on the host.

## Two new traps

Both paid for today:

- **One instantaneous sample is not a measurement.** Sample repeatedly, and sample while the thing is running.
- **Check whether the lever can reach the target before pulling it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN