### PR TITLE
bench(cuda): the prefill gap widens with GPU generation

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -61,6 +61,35 @@ Correctness was checked before speed: `ferrox verify --backend cuda
 --prompt-tokens 512` is token-identical to the CPU reference for Q4_K,
 Q5_K and Q6_K.
 
+**The CUDA gap gets WORSE on newer hardware.** Re-measured on an
+RTX 3060 (Ampere, compute 8.6), ferrox and llama.cpp both built with
+CUDA on the same box, quiet host:
+
+| model | test | ferrox | llama.cpp | gap |
+|---|---|---|---|---|
+| Llama-3.2-1B Q4_K_M | pp512 | 185.33 | 10277.19 | **55.5×** |
+| Llama-3.2-1B Q4_K_M | tg128 | 24.50 | 282.17 | 11.5× |
+| Llama-3.2-3B Q4_K_M | pp512 | 75.58 | 4276.84 | **56.6×** |
+| Llama-3.2-3B Q4_K_M | tg128 | 10.38 | 127.03 | 12.2× |
+
+Against the Pascal rows above, prefill goes from ~11× to ~56×.
+**llama.cpp is 2.4× faster on Ampere than on Pascal (4318 to 10277
+tok/s on the 1B); ferrox does not scale at all.** Decode is roughly
+unchanged. So the remaining prefill gap is not a constant factor: it
+widens with GPU generation, which means the kernel leaves newer
+hardware unused.
+
+Thread count is not the explanation (`-t 4` against ferrox's chosen
+`-t 1` gives 232.73 against 186.83, still 44× off), and the GPU is
+about half idle during prefill (sampled 0%, 57%, 50%), a different
+signature from decode's ~90%.
+
+These four rows are **prose, not receipts.** They come from
+`ferrox bench -m --compare` rather than `--suite`, so nothing was
+written to `receipts/engine/` and they are absent from the generated
+table below. Stated here rather than omitted, and marked rather than
+mixed in.
+
 **What remains is one number, not a list.** Every CUDA row is now
 between 10.8× and 17.4× on prefill and 9.2× and 17.1× on decode,
 across every kind. A uniform band is a systemic per-token cost rather

--- a/docs/plans/cpu-cuda-parity.md
+++ b/docs/plans/cpu-cuda-parity.md
@@ -165,6 +165,20 @@ now ruled out**:
   lever even if the diagnosis is right, and here the diagnosis was also
   wrong.
 
+**And prefill is a second, larger problem that widens with hardware.**
+Re-measured on an RTX 3060 (Ampere): prefill is **55x to 57x** off
+llama.cpp, against ~11x on the GTX 1080. llama.cpp is 2.4x faster on
+Ampere than on Pascal; ferrox is not faster at all. Decode is roughly
+unchanged at 11.5x to 12.2x. The GPU sits about half idle during
+prefill (0%, 57%, 50%) where decode runs it at ~90%, so the two have
+different signatures and are probably different bugs. Thread count is
+not it: `-t 4` against ferrox's chosen `-t 1` is worth 25% and leaves
+44x.
+
+Treat the 50% as a lead needing repeated sampling, not a conclusion.
+One instantaneous utilization sample already cost this plan a day and a
+PR.
+
 **What llama.cpp's CUDA backend does**, read out of
 `.scratch/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu`. Kept because it
 is true and useful, with the caveat that it is NOT the explanation for


### PR DESCRIPTION
Adds the Ampere measurements to the ledger and the plan.

## The finding

Re-measured `main` on an **RTX 3060 (Ampere, compute 8.6)**, ferrox and llama.cpp both built with CUDA on the same box, quiet host with the `--max-load` guard on:

| model | test | ferrox | llama.cpp | gap |
|---|---|---|---|---|
| Llama-3.2-1B Q4_K_M | pp512 | 185.33 | 10277.19 | **55.5x** |
| Llama-3.2-1B Q4_K_M | tg128 | 24.50 | 282.17 | 11.5x |
| Llama-3.2-3B Q4_K_M | pp512 | 75.58 | 4276.84 | **56.6x** |
| Llama-3.2-3B Q4_K_M | tg128 | 10.38 | 127.03 | 12.2x |

**Prefill goes from ~11x on the GTX 1080 to ~56x here.** llama.cpp is 2.4x faster on Ampere than on Pascal (4318 to 10277 tok/s on the 1B); ferrox is not faster at all.

So the remaining prefill gap is **not a constant factor**. It widens with GPU generation, which means the kernel leaves newer hardware unused. The K-quant GEMM fixed the catastrophic case (325x, no kernel at all); this is what was underneath it.

## Two different problems, not one

Decode is roughly unchanged (11.5x-12.2x here against 15x-17x on Pascal), and the signatures differ: the GPU is **~90% busy during decode** and **about half idle during prefill** (sampled 0%, 57%, 50%). Probably different bugs.

The 50% is recorded as a **lead needing repeated sampling, not a conclusion**. One instantaneous utilization sample already cost this plan a day and a PR (#136), and that trap is now written into CLAUDE.md.

Thread count is excluded: this box has 4 cores and ferrox chose `threads=1`; forcing `-t 4` is worth 25% and still leaves 44x.

## Correctness on a second architecture

All 11 `--ignored` hardware tests pass on Ampere. Every CUDA kernel in the tree, including the K-quant GEMM and Q5_0, had previously only ever executed on Pascal.

## Marked, not mixed

The four rows are labelled in `RESULTS.md` as **prose, not receipts**: they come from `bench -m --compare` rather than `--suite`, so nothing was written to `receipts/engine/` and they do not appear in the generated table. Stated rather than omitted, and marked rather than blended into receipt-backed rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN