### PR TITLE
docs: check what the kernel is limited by, before optimising inside it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,17 @@ PR.
   read 4.88 tok/s against llama.cpp's 1586.80 and looked like a
   performance problem; there was no GEMM at all, and the fallback still
   answered correctly. Check coverage before profiling.
+- **Check what the kernel is actually limited BY, before optimising
+  anything in it.** Convert the measurement into the resource: for a
+  decode matvec, `weights_bytes * tok/s` is achieved memory bandwidth,
+  and that number is one line of arithmetic. ferrox reaches **5.3%** of
+  an RTX 3060's 360 GB/s where llama.cpp reaches **60.4%**, so decode
+  is limited by memory-request concurrency. A port of llama.cpp's
+  `dp4a` inner loop was written, verified correct on hardware, and
+  measured **under 1% faster**, because four MACs per instruction buys
+  nothing in a kernel that is waiting on loads. The source diff between
+  two kernels tells you what is different; it does not tell you which
+  difference is the limit.
 
 ## Working with agents
 


### PR DESCRIPTION
A day of work bought under 1%, and the lesson is one line of arithmetic that was available before any code was written.

## What happened

#142 ported llama.cpp's Q8_1 + `dp4a` matvec for Q4_K. It is correct: `launch_q4_k_matvec_dp4a_matches_cpu_reference` passes on an RTX 3060 alongside the other 11 hardware tests. The source differences it closed were real -- f32 activations against int8, one float MAC against four.

Measured against `main` on the same GPU, interleaved: **24.62/24.78 against 24.40/24.62 tok/s.** Under 1%.

## The number that settles it

`weights_bytes * tok/s` is achieved memory bandwidth. For Llama-3.2-1B Q4_K_M (771 MB read per token) on an RTX 3060 with 360 GB/s peak:

| | tok/s | bandwidth | % of peak |
|---|---|---|---|
| ferrox | 24.6 | 19.0 GB/s | **5.3%** |
| llama.cpp | 282.2 | 217.6 GB/s | **60.4%** |

A decode matvec is a streaming read of the weights. ferrox is limited by how many memory requests it keeps in flight, so four MACs per instruction buys nothing while the kernel waits on loads. And the activation, at ~8 KB, was never a bandwidth cost: re-reading it per row hits L2, not DRAM.

## Why this is a new trap and not "measure first"

CLAUDE.md already says measure before optimising, and I did measure -- that is how the 9x-19x gap was known at all. What was missing is the step between: **a source diff between two kernels tells you what is DIFFERENT, not which difference is the LIMIT.** Converting the measurement into the contended resource is what separates them, and it is usually one multiplication.

Added to the "Measuring, and not fooling yourself" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN