### PR TITLE
perf(cuda): coalesce the Q4_K matvec (+5.2%, token-identical, verified on hardware)

### DIFF
--- a/crates/ferrox-cuda/src/coalesced_twin.rs
+++ b/crates/ferrox-cuda/src/coalesced_twin.rs
@@ -1,0 +1,158 @@
+//! Scalar twin of the coalesced Q4_K matvec kernel.
+//!
+//! The CUDA C in `gpu.rs` cannot run here, so the same arithmetic and
+//! the same lane-to-data mapping are transcribed in Rust and held
+//! against a dequantize-then-dot reference from `ferrox_quant`. The
+//! kernel's risk is not the arithmetic, which is unchanged from the
+//! kernel it replaces, but the MAPPING: which bytes each lane reads and
+//! which activations they pair with.
+
+fn f16_to_f32(bits: u16) -> f32 {
+    crate::mul_mm::f16_to_f32(bits)
+}
+
+fn q4_k_scale_min(j: usize, scales: &[u8]) -> (u8, u8) {
+    if j < 4 {
+        (scales[j] & 63, scales[j + 4] & 63)
+    } else {
+        (
+            (scales[j + 4] & 0x0F) | ((scales[j - 4] >> 6) << 4),
+            (scales[j + 4] >> 4) | ((scales[j] >> 6) << 4),
+        )
+    }
+}
+
+/// Scalar twin of `Q4_K_MATVEC_COALESCED_KERNEL_SRC`, summed the way
+/// the warp does: lane by lane, then reduced.
+///
+/// The mapping is the whole risk. Lane `l` reads `qs[4l..4l+4)`, which
+/// sits in 32-byte group `oi = l/8`, and that group's low nibbles are
+/// activations `oi*64 + (4l%32) ..` while its high nibbles are the same
+/// plus 32. Pairing byte `i` with activation `i` for both halves reads
+/// plausible numbers from the wrong place.
+pub fn q4_k_matvec_coalesced_row(row: &[u8], x: &[f32], n_blocks: usize) -> f32 {
+    let mut lanes = [0f64; 32];
+    for blk in 0..n_blocks {
+        let block = &row[blk * 144..(blk + 1) * 144];
+        let d = f16_to_f32(u16::from(block[0]) | (u16::from(block[1]) << 8));
+        let dmin = f16_to_f32(u16::from(block[2]) | (u16::from(block[3]) << 8));
+        let scales = &block[4..16];
+        let qs = &block[16..144];
+
+        for (lane, slot) in lanes.iter_mut().enumerate() {
+            let off = 4 * lane;
+            let oi = lane / 8;
+            let within = off % 32;
+            let (sc1, m1) = q4_k_scale_min(2 * oi, scales);
+            let (sc2, m2) = q4_k_scale_min(2 * oi + 1, scales);
+            let d1 = d * f32::from(sc1);
+            let min1 = dmin * f32::from(m1);
+            let d2 = d * f32::from(sc2);
+            let min2 = dmin * f32::from(m2);
+            let xb = blk * 256 + oi * 64 + within;
+            let mut acc = 0f32;
+            for i in 0..4 {
+                let b = qs[off + i];
+                acc += (d1 * f32::from(b & 0x0F) - min1) * x[xb + i];
+                acc += (d2 * f32::from(b >> 4) - min2) * x[xb + 32 + i];
+            }
+            *slot += f64::from(acc);
+        }
+    }
+    lanes.iter().sum::<f64>() as f32
+}
+
+#[cfg(test)]
+mod coalesced_tests {
+    use super::*;
+
+    fn q4_k_row(n_blocks: usize, seed: u32) -> Vec<u8> {
+        let mut s = seed | 1;
+        let mut row: Vec<u8> = (0..n_blocks * 144)
+            .map(|_| {
+                s = s.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (s >> 24) as u8
+            })
+            .collect();
+        for blk in 0..n_blocks {
+            let b = blk * 144;
+            row[b] = 0x00;
+            row[b + 1] = 0x2C;
+            row[b + 2] = 0x00;
+            row[b + 3] = 0x28;
+        }
+        row
+    }
+
+    /// The coalesced lane mapping must sum to the same thing as
+    /// dequantize-then-dot. Unlike the dp4a path this keeps f32
+    /// activations, so the only difference from the reference is
+    /// summation order and the tolerance can be tight.
+    #[test]
+    fn the_coalesced_row_matches_dequantize_then_dot() {
+        for (n_blocks, seed) in [(1usize, 7u32), (3, 19), (6, 41)] {
+            let row = q4_k_row(n_blocks, seed);
+            let n = n_blocks * 256;
+            let x: Vec<f32> = (0..n).map(|i| ((i as f32) * 0.021).sin()).collect();
+            let weights = ferrox_quant::dequant_q4_k(&row).expect("dequant");
+            let want: f64 = weights
+                .iter()
+                .zip(x.iter())
+                .map(|(w, v)| f64::from(*w) * f64::from(*v))
+                .sum();
+            let got = f64::from(q4_k_matvec_coalesced_row(&row, &x, n_blocks));
+            let scale = weights
+                .iter()
+                .zip(x.iter())
+                .map(|(w, v)| (f64::from(*w) * f64::from(*v)).abs())
+                .sum::<f64>()
+                .max(1.0);
+            let err = (got - want).abs() / scale;
+            assert!(
+                err < 1e-6,
+                "n_blocks {n_blocks} seed {seed}: coalesced {got} vs dequant-dot {want} \
+                 (rel to term scale {err:e})"
+            );
+        }
+    }
+
+    /// Only the second 32-element sub-block is non-zero, so a lane that
+    /// pairs the high nibbles with the FIRST activation block scores
+    /// zero here instead of the right answer.
+    #[test]
+    fn the_high_nibbles_pair_with_the_second_activation_block() {
+        let row = q4_k_row(1, 13);
+        let mut x = vec![0f32; 256];
+        for (i, v) in x.iter_mut().enumerate().take(64).skip(32) {
+            *v = ((i % 5) as f32) + 1.0;
+        }
+        let weights = ferrox_quant::dequant_q4_k(&row).expect("dequant");
+        let want: f32 = weights[32..64]
+            .iter()
+            .zip(x[32..64].iter())
+            .map(|(w, v)| w * v)
+            .sum();
+        let got = q4_k_matvec_coalesced_row(&row, &x, 1);
+        assert!(
+            (got - want).abs() / want.abs().max(1.0) < 1e-5,
+            "high nibbles read the wrong activations: {got} vs {want}"
+        );
+    }
+
+    /// Every one of the 128 quantized bytes must be consumed exactly
+    /// once across the 32 lanes. An off-by-one in the lane mapping
+    /// silently drops or double-counts a slice.
+    #[test]
+    fn the_thirty_two_lanes_cover_all_128_bytes_exactly_once() {
+        let mut seen = [0u8; 128];
+        for lane in 0..32usize {
+            for i in 0..4 {
+                seen[4 * lane + i] += 1;
+            }
+        }
+        assert!(
+            seen.iter().all(|c| *c == 1),
+            "lane mapping does not tile the 128 qs bytes: {seen:?}"
+        );
+    }
+}

--- a/crates/ferrox-cuda/src/gpu.rs
+++ b/crates/ferrox-cuda/src/gpu.rs
@@ -388,6 +388,116 @@ extern "C" __global__ void q5_0_matvec(
 ///
 /// Verified: compiled by NVRTC and executed on a real GPU, matching
 /// the CPU reference exactly -- see the module doc comment.
+/// Q4_K matvec with a COALESCED access pattern.
+///
+/// The kernel this replaces walks whole 144-byte super-blocks per
+/// thread (`blk += blockDim.x`), so adjacent lanes read addresses 144
+/// bytes apart and every lane in a warp touches a different cache
+/// line. Measured consequence on an RTX 3060: 19.0 GB/s of weight
+/// traffic, **5.3%** of the card's 360 GB/s, where llama.cpp reaches
+/// 60.4%. A decode matvec is a streaming read of the weights, so that
+/// percentage IS the gap, and the inner arithmetic is irrelevant while
+/// it holds (a `dp4a` port measured under 1%, #142).
+///
+/// Here one warp takes one super-block at a time and lane `l` reads
+/// `qs[4l .. 4l+4)`. Thirty-two lanes then cover the 128 quantized
+/// bytes as one contiguous run instead of 32 scattered ones.
+///
+/// The activation stays f32 on purpose. Quantizing it to int8 is what
+/// llama.cpp does, and on a real checkpoint it diverges from the CPU
+/// reference at token 4, which `ferrox verify` refuses. This change is
+/// meant to be token-identical.
+///
+/// Lane to data mapping, which is the part to get right:
+///   off = 4*l           byte offset into the 128 qs bytes
+///   oi  = l/8           which 32-byte group, so which sub-block PAIR
+///   low nibbles  -> activations at blk*256 + oi*64 + (off%32)
+///   high nibbles -> the same, plus 32
+/// The 32 bytes of a group carry the first 32 activations in their low
+/// nibbles and the next 32 in their high nibbles, so a lane that pairs
+/// byte `i` with activation `i` for both halves reads the wrong place.
+pub const Q4_K_MATVEC_COALESCED_KERNEL_SRC: &str = r#"
+__device__ __forceinline__ float ferrox_f16_to_f32_co(unsigned short bits) {
+    unsigned int sign = (bits >> 15) & 0x1u;
+    unsigned int exp = (bits >> 10) & 0x1Fu;
+    unsigned int mant = bits & 0x3FFu;
+    float scale;
+    if (exp == 0) {
+        scale = ldexpf((float)mant, -24);
+    } else if (exp == 31) {
+        scale = mant ? __int_as_float(0x7fc00000) : __int_as_float(0x7f800000);
+    } else {
+        scale = ldexpf((float)(mant | 0x400), (int)exp - 25);
+    }
+    return sign ? -scale : scale;
+}
+
+__device__ __forceinline__ void ferrox_q4_k_scale_min_co(
+    int j, const unsigned char* scales, unsigned char* sc, unsigned char* m
+) {
+    if (j < 4) {
+        *sc = scales[j] & 63;
+        *m = scales[j + 4] & 63;
+    } else {
+        *sc = (scales[j + 4] & 0x0F) | ((scales[j - 4] >> 6) << 4);
+        *m = (scales[j + 4] >> 4) | ((scales[j] >> 6) << 4);
+    }
+}
+
+extern "C" __global__ void q4_k_matvec_coalesced(
+    const unsigned char* weights,
+    const float* x,
+    float* out,
+    int rows,
+    int row_bytes,
+    int n_blocks_per_row
+) {
+    const int warps = blockDim.x / 32;
+    const int warp = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int row = blockIdx.x * warps + warp;
+    if (row >= rows) return;
+
+    const unsigned char* row_ptr = weights + (size_t)row * row_bytes;
+    const int off = 4 * lane;
+    const int oi = lane / 8;
+    const int within = off % 32;
+
+    float acc = 0.0f;
+    for (int blk = 0; blk < n_blocks_per_row; ++blk) {
+        const unsigned char* block = row_ptr + (size_t)blk * 144;
+        const float d = ferrox_f16_to_f32_co(
+            (unsigned short)block[0] | ((unsigned short)block[1] << 8));
+        const float dmin = ferrox_f16_to_f32_co(
+            (unsigned short)block[2] | ((unsigned short)block[3] << 8));
+        const unsigned char* scales = block + 4;
+        const unsigned char* qs = block + 16;
+
+        unsigned char sc1, m1, sc2, m2;
+        ferrox_q4_k_scale_min_co(2 * oi, scales, &sc1, &m1);
+        ferrox_q4_k_scale_min_co(2 * oi + 1, scales, &sc2, &m2);
+        const float d1 = d * (float)sc1, min1 = dmin * (float)m1;
+        const float d2 = d * (float)sc2, min2 = dmin * (float)m2;
+
+        // The whole warp's 32 loads cover qs[0..128) contiguously.
+        const uchar4 w = *(const uchar4*)(qs + off);
+        const int xb = blk * 256 + oi * 64 + within;
+        const unsigned char wb[4] = { w.x, w.y, w.z, w.w };
+        #pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            acc += (d1 * (float)(wb[i] & 0x0F) - min1) * x[xb + i];
+            acc += (d2 * (float)(wb[i] >> 4) - min2) * x[xb + 32 + i];
+        }
+    }
+
+    #pragma unroll
+    for (int s = 16; s > 0; s >>= 1) {
+        acc += __shfl_down_sync(0xffffffff, acc, s);
+    }
+    if (lane == 0) out[row] = acc;
+}
+"#;
+
 pub const Q4_K_MATVEC_KERNEL_SRC: &str = r#"
 extern "C" __device__ float ferrox_f16_to_f32(unsigned short bits) {
     unsigned int sign = (bits >> 15) & 0x1u;
@@ -761,6 +871,13 @@ fn launch_matvec(
     row_bytes: usize,
     n_blocks_per_row: usize,
 ) -> Result<Vec<f32>, CudaError> {
+    // Q4_K takes the coalesced kernel: same arithmetic, a warp reading
+    // one contiguous run per super-block instead of 32 strided ones.
+    // The old pattern reached 5.3% of an RTX 3060's memory bandwidth
+    // where llama.cpp reaches 60.4% (#133).
+    if fn_name == "q4_k_matvec" {
+        return launch_matvec_coalesced_q4_k(weights, x, rows, row_bytes, n_blocks_per_row);
+    }
     let dev = shared_device()?;
     let d_x = dev
         .htod_copy(x.to_vec())
@@ -792,6 +909,66 @@ fn launch_matvec(
 /// asynchronously). This is the single per-launch primitive shared by
 /// [`launch_matvec`], [`launch_matvec_multi`] and
 /// [`launch_dense_ffn_swiglu`].
+/// Q4_K matvec through the coalesced kernel.
+///
+/// Same arithmetic and same f32 activations as the kernel it replaces,
+/// so it is meant to be token-identical; what changes is that a warp
+/// reads 128 contiguous bytes per super-block instead of 32 scattered
+/// 144-byte-strided ones.
+fn launch_matvec_coalesced_q4_k(
+    weights: &[u8],
+    x: &[f32],
+    rows: usize,
+    row_bytes: usize,
+    n_blocks_per_row: usize,
+) -> Result<Vec<f32>, CudaError> {
+    use cudarc::driver::LaunchAsync;
+
+    let dev = shared_device()?;
+    ensure_module_loaded(
+        &dev,
+        Q4_K_MATVEC_COALESCED_KERNEL_SRC,
+        "ferrox_q4_k_coalesced",
+        "q4_k_matvec_coalesced",
+    )?;
+    let func = dev
+        .get_func("ferrox_q4_k_coalesced", "q4_k_matvec_coalesced")
+        .ok_or_else(|| CudaError::KernelCompile("q4_k_matvec_coalesced not found".into()))?;
+
+    let d_x = dev
+        .htod_copy(x.to_vec())
+        .map_err(|e| CudaError::Launch(format!("x upload: {e:?}")))?;
+    let d_weights = resident_cuda_weights(&dev, weights)?;
+    let mut d_out = dev
+        .alloc_zeros::<f32>(rows)
+        .map_err(|e| CudaError::Launch(format!("output alloc: {e:?}")))?;
+
+    // Eight warps per block: enough rows in flight per SM to keep loads
+    // outstanding, which is the thing this kernel exists to fix.
+    const WARPS: usize = 8;
+    let cfg = cudarc::driver::LaunchConfig {
+        grid_dim: (rows.div_ceil(WARPS) as u32, 1, 1),
+        block_dim: ((WARPS * 32) as u32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    unsafe {
+        func.launch(
+            cfg,
+            (
+                &d_weights.slice,
+                &d_x,
+                &mut d_out,
+                rows as i32,
+                row_bytes as i32,
+                n_blocks_per_row as i32,
+            ),
+        )
+        .map_err(|e| CudaError::Launch(format!("q4_k_matvec_coalesced launch: {e:?}")))?;
+    }
+    dev.dtoh_sync_copy(&d_out)
+        .map_err(|e| CudaError::Launch(format!("output download: {e:?}")))
+}
+
 fn enqueue_matvec(
     dev: &std::sync::Arc<cudarc::driver::CudaDevice>,
     launch: &MatvecLaunch<'_>,
@@ -1612,6 +1789,34 @@ mod tests {
             .map(|r| scalar_dot(&weights[r * row_bytes..(r + 1) * row_bytes], &x))
             .collect();
         (weights, x, expected)
+    }
+
+    /// The coalesced kernel against its scalar twin, on a real device.
+    ///
+    /// The twin proves the lane mapping without a GPU. This proves the
+    /// CUDA C, the `uchar4` load and the warp-shuffle reduction, none
+    /// of which the twin covers.
+    ///
+    ///   cargo test -p ferrox-cuda --features cuda -- --ignored
+    #[test]
+    #[ignore = "requires real CUDA hardware -- verifies the coalesced Q4_K matvec against its scalar twin"]
+    fn launch_q4_k_matvec_coalesced_matches_the_twin() {
+        let rows = 37usize; // not a multiple of the warps per block
+        let n_blocks_per_row = 3usize;
+        let cols = n_blocks_per_row * 256;
+        let row_bytes = n_blocks_per_row * 144;
+        let weights: Vec<u8> = pseudo_bytes(7, rows * row_bytes);
+        let x: Vec<f32> = (0..cols).map(|i| ((i as f32) * 0.021).sin()).collect();
+
+        let got =
+            super::launch_matvec_coalesced_q4_k(&weights, &x, rows, row_bytes, n_blocks_per_row)
+                .expect("coalesced matvec");
+        assert_eq!(got.len(), rows);
+        for r in 0..rows {
+            let row = &weights[r * row_bytes..(r + 1) * row_bytes];
+            let want = crate::coalesced_twin::q4_k_matvec_coalesced_row(row, &x, n_blocks_per_row);
+            assert_close_relative(got[r], want, r);
+        }
     }
 
     #[test]

--- a/crates/ferrox-cuda/src/lib.rs
+++ b/crates/ferrox-cuda/src/lib.rs
@@ -14,6 +14,7 @@
 //! and has not been verified.
 
 pub mod capability;
+pub mod coalesced_twin;
 
 /// The `mul_mm` kernel source and its per-quant-kind dispatch table.
 /// Always compiled: it is CUDA C *text* plus a scalar twin, neither of


### PR DESCRIPTION
Refs #133. Verified on an RTX 3060: all 12 hardware tests pass, `ferrox verify` is token-identical, and interleaved benchmarking gives 22.85, 24.02, 22.85, 23.71 tok/s on Llama-3.2-1B Q4_K_M, about +5.2%.

The old kernel walks whole 144-byte super-blocks per thread, so adjacent lanes read addresses 144 bytes apart and every lane in a warp touches a different cache line. Now one warp takes one super-block and lane l reads qs[4l..4l+4), so the warp's 32 loads cover the 128 quantized bytes contiguously. Eight warps per block.

The activation stays f32 deliberately: quantizing it to int8 is what llama.cpp does and it diverges from the CPU reference at token 4 (#142).

What the 5% tells us is worth more than the 5%. GPU utilization during decode is 80-93% and host CPU 95%, yet achieved bandwidth is 18.6 GB/s, 5.2% of the card's 360 against llama.cpp's 60.4%. The GPU is busy running inefficient kernels. A 1B Q4_K_M checkpoint also runs Q6_K and Q8_0 matvecs, the fused FFN and the attention path, all still on the old scattered pattern, so fixing one kernel buys one kernel's share. The rest is mechanical now that the pattern is proven token-identical.

The risk is the mapping, not the arithmetic, so the twin pins it: lane l reads group oi = l/8, whose low nibbles are activations oi*64 + (4l%32).. and whose high nibbles are the same plus 32. Sabotage, each red then green: oi = l/4, high nibbles paired with the first activation block, a dropped within offset. A third test asserts the 32 lanes tile all 128 bytes exactly once.