### PR TITLE
perf(cuda): coalesce the Q6_K, Q5_K and Q8_0 matvecs, behind one launcher and one table

### DIFF
--- a/crates/ferrox-cuda/src/coalesced_twin.rs
+++ b/crates/ferrox-cuda/src/coalesced_twin.rs
@@ -252,3 +252,199 @@ mod q6_k_coalesced_tests {
         );
     }
 }
+
+/// Scalar twin of `Q5_K_MATVEC_COALESCED_KERNEL_SRC`.
+///
+/// Q5_K shares Q4_K's six-bit scale/min packing; what it adds is a
+/// fifth bit per weight, held in `qh` one BIT-PLANE per 32-element
+/// group. Lane `l` owns element `l` of each group, so it reads
+/// `qh[l]` once per block and picks bit `2*oi` for the low nibble and
+/// bit `2*oi + 1` for the high one. Reading the wrong bit-plane
+/// perturbs weights by exactly 16 and is easy to miss by eye.
+pub fn q5_k_matvec_coalesced_row(row: &[u8], x: &[f32], n_blocks: usize) -> f32 {
+    let mut lanes = [0f64; 32];
+    for blk in 0..n_blocks {
+        let block = &row[blk * 176..(blk + 1) * 176];
+        let d = f16_to_f32(u16::from(block[0]) | (u16::from(block[1]) << 8));
+        let dmin = f16_to_f32(u16::from(block[2]) | (u16::from(block[3]) << 8));
+        let scales = &block[4..16];
+        let qh = &block[16..48];
+        let qs = &block[48..176];
+        let x_base = blk * 256;
+
+        for (lane, slot) in lanes.iter_mut().enumerate() {
+            let mut acc = 0f32;
+            for oi in 0..4usize {
+                let (sc1, m1) = q4_k_scale_min(2 * oi, scales);
+                let (sc2, m2) = q4_k_scale_min(2 * oi + 1, scales);
+                let d1 = d * f32::from(sc1);
+                let min1 = dmin * f32::from(m1);
+                let d2 = d * f32::from(sc2);
+                let min2 = dmin * f32::from(m2);
+                let ql = qs[oi * 32 + lane];
+                let u1 = 1u8 << (2 * oi);
+                let u2 = 2u8 << (2 * oi);
+                let xb = x_base + oi * 64;
+                let hi1 = if qh[lane] & u1 != 0 { 16u8 } else { 0 };
+                let hi2 = if qh[lane] & u2 != 0 { 16u8 } else { 0 };
+                acc += (d1 * f32::from((ql & 0x0F) + hi1) - min1) * x[xb + lane];
+                acc += (d2 * f32::from((ql >> 4) + hi2) - min2) * x[xb + 32 + lane];
+            }
+            *slot += f64::from(acc);
+        }
+    }
+    lanes.iter().sum::<f64>() as f32
+}
+
+/// Scalar twin of `Q8_0_MATVEC_COALESCED_KERNEL_SRC`.
+///
+/// The simplest of the family: a Q8_0 block is exactly one warp wide,
+/// so lane `l` takes byte `l` of every block and the whole warp's load
+/// is 32 contiguous bytes. The scale is per block, so every lane reads
+/// the same two header bytes and the hardware broadcasts them.
+pub fn q8_0_matvec_coalesced_row(row: &[u8], x: &[f32], n_blocks: usize) -> f32 {
+    let mut lanes = [0f64; 32];
+    for blk in 0..n_blocks {
+        let block = &row[blk * 34..(blk + 1) * 34];
+        let d = f16_to_f32(u16::from(block[0]) | (u16::from(block[1]) << 8));
+        let base = blk * 32;
+        for (lane, slot) in lanes.iter_mut().enumerate() {
+            let q = block[2 + lane] as i8;
+            *slot += f64::from(d * f32::from(q) * x[base + lane]);
+        }
+    }
+    lanes.iter().sum::<f64>() as f32
+}
+
+#[cfg(test)]
+mod q5_k_and_q8_0_coalesced_tests {
+    use super::*;
+
+    fn pseudo(len: usize, seed: u32) -> Vec<u8> {
+        let mut s = seed | 1;
+        (0..len)
+            .map(|_| {
+                s = s.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (s >> 24) as u8
+            })
+            .collect()
+    }
+
+    fn q5_k_row(n_blocks: usize, seed: u32) -> Vec<u8> {
+        let mut row = pseudo(n_blocks * 176, seed);
+        for blk in 0..n_blocks {
+            let b = blk * 176;
+            row[b] = 0x00;
+            row[b + 1] = 0x2C; // finite d
+            row[b + 2] = 0x00;
+            row[b + 3] = 0x28; // finite dmin
+        }
+        row
+    }
+
+    fn q8_0_row(n_blocks: usize, seed: u32) -> Vec<u8> {
+        let mut row = pseudo(n_blocks * 34, seed);
+        for blk in 0..n_blocks {
+            let b = blk * 34;
+            row[b] = 0x00;
+            row[b + 1] = 0x2C; // finite d
+        }
+        row
+    }
+
+    fn close(got: f64, want: f64, weights: &[f32], x: &[f32], tol: f64, what: &str) {
+        let scale = weights
+            .iter()
+            .zip(x.iter())
+            .map(|(w, v)| (f64::from(*w) * f64::from(*v)).abs())
+            .sum::<f64>()
+            .max(1.0);
+        assert!(
+            (got - want).abs() / scale < tol,
+            "{what}: coalesced {got} vs dequant-dot {want}"
+        );
+    }
+
+    #[test]
+    fn the_coalesced_q5_k_row_matches_dequantize_then_dot() {
+        for (n_blocks, seed) in [(1usize, 7u32), (3, 31), (5, 53)] {
+            let row = q5_k_row(n_blocks, seed);
+            let x: Vec<f32> = (0..n_blocks * 256)
+                .map(|i| ((i as f32) * 0.023).sin())
+                .collect();
+            let weights = ferrox_quant::dequant_q5_k(&row).expect("dequant");
+            let want: f64 = weights
+                .iter()
+                .zip(x.iter())
+                .map(|(w, v)| f64::from(*w) * f64::from(*v))
+                .sum();
+            let got = f64::from(q5_k_matvec_coalesced_row(&row, &x, n_blocks));
+            close(
+                got,
+                want,
+                &weights,
+                &x,
+                1e-6,
+                &format!("q5_k {n_blocks}/{seed}"),
+            );
+        }
+    }
+
+    /// The fifth bit lives in a per-group BIT-PLANE, so the low nibble
+    /// of group `oi` takes bit `2*oi` and the high nibble bit
+    /// `2*oi + 1`. Both wrong readings shift weights by 16.
+    #[test]
+    fn the_fifth_bit_comes_from_the_right_bit_plane() {
+        let row = q5_k_row(1, 13);
+        let x: Vec<f32> = (0..256).map(|i| ((i % 9) as f32) - 4.0).collect();
+        let weights = ferrox_quant::dequant_q5_k(&row).expect("dequant");
+        let want: f64 = weights
+            .iter()
+            .zip(x.iter())
+            .map(|(w, v)| f64::from(*w) * f64::from(*v))
+            .sum();
+        let got = f64::from(q5_k_matvec_coalesced_row(&row, &x, 1));
+        close(got, want, &weights, &x, 1e-5, "q5_k bit-plane");
+    }
+
+    #[test]
+    fn the_coalesced_q8_0_row_matches_dequantize_then_dot() {
+        for (n_blocks, seed) in [(1usize, 3u32), (7, 29), (16, 61)] {
+            let row = q8_0_row(n_blocks, seed);
+            let x: Vec<f32> = (0..n_blocks * 32)
+                .map(|i| ((i as f32) * 0.031).cos())
+                .collect();
+            let weights = ferrox_quant::dequant_q8_0(&row).expect("dequant");
+            let want: f64 = weights
+                .iter()
+                .zip(x.iter())
+                .map(|(w, v)| f64::from(*w) * f64::from(*v))
+                .sum();
+            let got = f64::from(q8_0_matvec_coalesced_row(&row, &x, n_blocks));
+            close(
+                got,
+                want,
+                &weights,
+                &x,
+                1e-6,
+                &format!("q8_0 {n_blocks}/{seed}"),
+            );
+        }
+    }
+
+    /// Q8_0's quants are SIGNED. Reading them unsigned agrees with
+    /// itself and with nothing else.
+    #[test]
+    fn the_q8_0_quants_are_read_signed() {
+        let mut row = q8_0_row(1, 1);
+        for i in 0..32 {
+            row[2 + i] = 0xF0; // -16 signed, 240 unsigned
+        }
+        let x = vec![1.0f32; 32];
+        let got = q8_0_matvec_coalesced_row(&row, &x, 1);
+        assert!(
+            got < 0.0,
+            "signed quants must give a negative sum, got {got}"
+        );
+    }
+}

--- a/crates/ferrox-cuda/src/coalesced_twin.rs
+++ b/crates/ferrox-cuda/src/coalesced_twin.rs
@@ -156,3 +156,99 @@ mod coalesced_tests {
         );
     }
 }
+
+/// Scalar twin of `Q6_K_MATVEC_COALESCED_KERNEL_SRC`, lane by lane.
+pub fn q6_k_matvec_coalesced_row(row: &[u8], x: &[f32], n_blocks: usize) -> f32 {
+    let mut lanes = [0f64; 32];
+    for blk in 0..n_blocks {
+        let block = &row[blk * 210..(blk + 1) * 210];
+        let d = f16_to_f32(u16::from(block[208]) | (u16::from(block[209]) << 8));
+        let x_base = blk * 256;
+        for (lane, slot) in lanes.iter_mut().enumerate() {
+            let is = lane / 16;
+            let mut acc = 0f32;
+            for half in 0..2 {
+                let ql = &block[half * 64..];
+                let qh = &block[128 + half * 32..];
+                let sc = &block[192 + half * 8..192 + half * 8 + 8];
+                let xh = x_base + half * 128;
+                let q1 = i32::from((ql[lane] & 0x0F) | ((qh[lane] & 0x03) << 4)) - 32;
+                let q2 = i32::from((ql[lane + 32] & 0x0F) | (((qh[lane] >> 2) & 0x03) << 4)) - 32;
+                let q3 = i32::from((ql[lane] >> 4) | (((qh[lane] >> 4) & 0x03) << 4)) - 32;
+                let q4 = i32::from((ql[lane + 32] >> 4) | (((qh[lane] >> 6) & 0x03) << 4)) - 32;
+                acc += d * f32::from(sc[is] as i8) * q1 as f32 * x[xh + lane];
+                acc += d * f32::from(sc[is + 2] as i8) * q2 as f32 * x[xh + lane + 32];
+                acc += d * f32::from(sc[is + 4] as i8) * q3 as f32 * x[xh + lane + 64];
+                acc += d * f32::from(sc[is + 6] as i8) * q4 as f32 * x[xh + lane + 96];
+            }
+            *slot += f64::from(acc);
+        }
+    }
+    lanes.iter().sum::<f64>() as f32
+}
+
+#[cfg(test)]
+mod q6_k_coalesced_tests {
+    use super::*;
+
+    fn q6_k_row(n_blocks: usize, seed: u32) -> Vec<u8> {
+        let mut s = seed | 1;
+        let mut row: Vec<u8> = (0..n_blocks * 210)
+            .map(|_| {
+                s = s.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (s >> 24) as u8
+            })
+            .collect();
+        for blk in 0..n_blocks {
+            let b = blk * 210;
+            row[b + 208] = 0x00;
+            row[b + 209] = 0x2C; // finite d
+        }
+        row
+    }
+
+    #[test]
+    fn the_coalesced_q6_k_row_matches_dequantize_then_dot() {
+        for (n_blocks, seed) in [(1usize, 5u32), (3, 23), (5, 47)] {
+            let row = q6_k_row(n_blocks, seed);
+            let n = n_blocks * 256;
+            let x: Vec<f32> = (0..n).map(|i| ((i as f32) * 0.017).cos()).collect();
+            let weights = ferrox_quant::dequant_q6_k(&row).expect("dequant");
+            let want: f64 = weights
+                .iter()
+                .zip(x.iter())
+                .map(|(w, v)| f64::from(*w) * f64::from(*v))
+                .sum();
+            let got = f64::from(q6_k_matvec_coalesced_row(&row, &x, n_blocks));
+            let scale = weights
+                .iter()
+                .zip(x.iter())
+                .map(|(w, v)| (f64::from(*w) * f64::from(*v)).abs())
+                .sum::<f64>()
+                .max(1.0);
+            assert!(
+                (got - want).abs() / scale < 1e-6,
+                "n_blocks {n_blocks} seed {seed}: coalesced {got} vs dequant-dot {want}"
+            );
+        }
+    }
+
+    /// The four sub-scales are 2 apart, not adjacent. Getting that
+    /// wrong scales three of the four outputs by the wrong factor.
+    #[test]
+    fn the_four_scale_indices_are_two_apart() {
+        let row = q6_k_row(1, 9);
+        let x: Vec<f32> = (0..256).map(|i| ((i % 11) as f32) - 5.0).collect();
+        let weights = ferrox_quant::dequant_q6_k(&row).expect("dequant");
+        let want: f64 = weights
+            .iter()
+            .zip(x.iter())
+            .map(|(w, v)| f64::from(*w) * f64::from(*v))
+            .sum();
+        let got = f64::from(q6_k_matvec_coalesced_row(&row, &x, 1));
+        assert!(
+            (got - want).abs() / want.abs().max(1.0) < 1e-5,
+            "{got} vs {want}"
+        );
+    }
+}

--- a/crates/ferrox-cuda/src/gpu.rs
+++ b/crates/ferrox-cuda/src/gpu.rs
@@ -430,6 +430,153 @@ extern "C" __global__ void q5_0_matvec(
 ///
 /// Same arithmetic and same f32 activations as before, so it stays
 /// token-identical.
+/// CUDA C for the coalesced Q5_K matvec: one warp per row, lane `l`
+/// owning element `l` of each 32-element group, so the warp's loads of
+/// `qs`, `qh` and the activations are each contiguous.
+///
+/// Q5_K adds a fifth bit per weight over Q4_K, held in `qh` as one
+/// BIT-PLANE per group: bit `2*oi` for the group's low nibbles and bit
+/// `2*oi + 1` for its high ones. `q5_k_matvec_coalesced_row` in
+/// `coalesced_twin.rs` is the scalar twin that pins that down.
+pub const Q5_K_MATVEC_COALESCED_KERNEL_SRC: &str = r#"
+__device__ __forceinline__ float ferrox_f16_to_f32_q5co(unsigned short bits) {
+    unsigned int sign = (bits >> 15) & 0x1u;
+    unsigned int exp = (bits >> 10) & 0x1Fu;
+    unsigned int mant = bits & 0x3FFu;
+    float scale;
+    if (exp == 0) {
+        scale = ldexpf((float)mant, -24);
+    } else if (exp == 31) {
+        scale = mant ? __int_as_float(0x7fc00000) : __int_as_float(0x7f800000);
+    } else {
+        scale = ldexpf((float)(mant | 0x400), (int)exp - 25);
+    }
+    return sign ? -scale : scale;
+}
+
+__device__ __forceinline__ void ferrox_q4_k_scale_min_q5co(
+    int j, const unsigned char* scales, unsigned char* sc, unsigned char* m
+) {
+    if (j < 4) {
+        *sc = scales[j] & 63;
+        *m = scales[j + 4] & 63;
+    } else {
+        *sc = (scales[j + 4] & 0x0F) | ((scales[j - 4] >> 6) << 4);
+        *m = (scales[j + 4] >> 4) | ((scales[j] >> 6) << 4);
+    }
+}
+
+extern "C" __global__ void q5_k_matvec_coalesced(
+    const unsigned char* weights,
+    const float* x,
+    float* out,
+    int rows,
+    int row_bytes,
+    int n_blocks_per_row
+) {
+    const int warps = blockDim.x / 32;
+    const int warp = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int row = blockIdx.x * warps + warp;
+    if (row >= rows) return;
+
+    const unsigned char* row_ptr = weights + (size_t)row * row_bytes;
+    float acc = 0.0f;
+
+    for (int blk = 0; blk < n_blocks_per_row; ++blk) {
+        const unsigned char* block = row_ptr + (size_t)blk * 176;
+        const float d = ferrox_f16_to_f32_q5co(
+            (unsigned short)block[0] | ((unsigned short)block[1] << 8));
+        const float dmin = ferrox_f16_to_f32_q5co(
+            (unsigned short)block[2] | ((unsigned short)block[3] << 8));
+        const unsigned char* scales = block + 4;
+        const unsigned char* qh = block + 16;
+        const unsigned char* qs = block + 48;
+        const int x_base = blk * 256;
+        const unsigned char h = qh[lane];
+
+        #pragma unroll
+        for (int oi = 0; oi < 4; ++oi) {
+            unsigned char sc1, m1, sc2, m2;
+            ferrox_q4_k_scale_min_q5co(2 * oi, scales, &sc1, &m1);
+            ferrox_q4_k_scale_min_q5co(2 * oi + 1, scales, &sc2, &m2);
+            const float d1 = d * (float)sc1, min1 = dmin * (float)m1;
+            const float d2 = d * (float)sc2, min2 = dmin * (float)m2;
+            const unsigned char ql = qs[oi * 32 + lane];
+            const unsigned char u1 = (unsigned char)(1u << (2 * oi));
+            const unsigned char u2 = (unsigned char)(2u << (2 * oi));
+            const int xb = x_base + oi * 64;
+            const int hi1 = (h & u1) ? 16 : 0;
+            const int hi2 = (h & u2) ? 16 : 0;
+            acc += (d1 * (float)((ql & 0x0F) + hi1) - min1) * x[xb + lane];
+            acc += (d2 * (float)((ql >> 4) + hi2) - min2) * x[xb + 32 + lane];
+        }
+    }
+
+    #pragma unroll
+    for (int s = 16; s > 0; s >>= 1) {
+        acc += __shfl_down_sync(0xffffffff, acc, s);
+    }
+    if (lane == 0) out[row] = acc;
+}
+"#;
+
+/// CUDA C for the coalesced Q8_0 matvec. A Q8_0 block holds exactly 32
+/// quants, so a warp maps onto one block with no leftovers: lane `l`
+/// takes byte `l` and the warp's load is 32 contiguous bytes, against
+/// the 1088-byte stride the one-thread-per-block kernel used.
+///
+/// The quants are SIGNED; the twin has a test that fails on an
+/// unsigned read.
+pub const Q8_0_MATVEC_COALESCED_KERNEL_SRC: &str = r#"
+__device__ __forceinline__ float ferrox_f16_to_f32_q8co(unsigned short bits) {
+    unsigned int sign = (bits >> 15) & 0x1u;
+    unsigned int exp = (bits >> 10) & 0x1Fu;
+    unsigned int mant = bits & 0x3FFu;
+    float scale;
+    if (exp == 0) {
+        scale = ldexpf((float)mant, -24);
+    } else if (exp == 31) {
+        scale = mant ? __int_as_float(0x7fc00000) : __int_as_float(0x7f800000);
+    } else {
+        scale = ldexpf((float)(mant | 0x400), (int)exp - 25);
+    }
+    return sign ? -scale : scale;
+}
+
+extern "C" __global__ void q8_0_matvec_coalesced(
+    const unsigned char* weights,
+    const float* x,
+    float* out,
+    int rows,
+    int row_bytes,
+    int n_blocks_per_row
+) {
+    const int warps = blockDim.x / 32;
+    const int warp = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int row = blockIdx.x * warps + warp;
+    if (row >= rows) return;
+
+    const unsigned char* row_ptr = weights + (size_t)row * row_bytes;
+    float acc = 0.0f;
+
+    for (int blk = 0; blk < n_blocks_per_row; ++blk) {
+        const unsigned char* block = row_ptr + (size_t)blk * 34;
+        const float d = ferrox_f16_to_f32_q8co(
+            (unsigned short)block[0] | ((unsigned short)block[1] << 8));
+        const signed char q = (signed char)block[2 + lane];
+        acc += d * (float)q * x[blk * 32 + lane];
+    }
+
+    #pragma unroll
+    for (int s = 16; s > 0; s >>= 1) {
+        acc += __shfl_down_sync(0xffffffff, acc, s);
+    }
+    if (lane == 0) out[row] = acc;
+}
+"#;
+
 pub const Q6_K_MATVEC_COALESCED_KERNEL_SRC: &str = r#"
 __device__ __forceinline__ float ferrox_f16_to_f32_q6co(unsigned short bits) {
     unsigned int sign = (bits >> 15) & 0x1u;
@@ -952,15 +1099,12 @@ fn launch_matvec(
     row_bytes: usize,
     n_blocks_per_row: usize,
 ) -> Result<Vec<f32>, CudaError> {
-    // Q4_K takes the coalesced kernel: same arithmetic, a warp reading
-    // one contiguous run per super-block instead of 32 strided ones.
-    // The old pattern reached 5.3% of an RTX 3060's memory bandwidth
-    // where llama.cpp reaches 60.4% (#133).
-    if fn_name == "q4_k_matvec" {
-        return launch_matvec_coalesced_q4_k(weights, x, rows, row_bytes, n_blocks_per_row);
-    }
-    if fn_name == "q6_k_matvec" {
-        return launch_matvec_coalesced_q6_k(weights, x, rows, row_bytes, n_blocks_per_row);
+    // Kinds with a coalesced kernel take it: same arithmetic, a warp
+    // reading one contiguous run per super-block instead of 32 strided
+    // ones. The old pattern reached 5.3% of an RTX 3060's memory
+    // bandwidth where llama.cpp reaches 60.4% (#133).
+    if let Some(kernel) = coalesced_matvec_kernel(fn_name) {
+        return launch_matvec_coalesced(kernel, weights, x, rows, row_bytes, n_blocks_per_row);
     }
     let dev = shared_device()?;
     let d_x = dev
@@ -993,65 +1137,53 @@ fn launch_matvec(
 /// asynchronously). This is the single per-launch primitive shared by
 /// [`launch_matvec`], [`launch_matvec_multi`] and
 /// [`launch_dense_ffn_swiglu`].
-/// Q4_K matvec through the coalesced kernel.
+/// The coalesced matvec kernel for `fn_name`, or `None` if that quant
+/// kind still runs the old one-thread-per-super-block kernel.
 ///
-/// Same arithmetic and same f32 activations as the kernel it replaces,
-/// so it is meant to be token-identical; what changes is that a warp
-/// reads 128 contiguous bytes per super-block instead of 32 scattered
-/// 144-byte-strided ones.
-/// Q6_K matvec through the coalesced kernel. See
-/// [`launch_matvec_coalesced_q4_k`]; same shape, different unpack.
-fn launch_matvec_coalesced_q6_k(
-    weights: &[u8],
-    x: &[f32],
-    rows: usize,
-    row_bytes: usize,
-    n_blocks_per_row: usize,
-) -> Result<Vec<f32>, CudaError> {
-    use cudarc::driver::LaunchAsync;
-
-    let dev = shared_device()?;
-    ensure_module_loaded(
-        &dev,
-        Q6_K_MATVEC_COALESCED_KERNEL_SRC,
-        "ferrox_q6_k_coalesced",
-        "q6_k_matvec_coalesced",
-    )?;
-    let func = dev
-        .get_func("ferrox_q6_k_coalesced", "q6_k_matvec_coalesced")
-        .ok_or_else(|| CudaError::KernelCompile("q6_k_matvec_coalesced not found".into()))?;
-    let d_x = dev
-        .htod_copy(x.to_vec())
-        .map_err(|e| CudaError::Launch(format!("x upload: {e:?}")))?;
-    let d_weights = resident_cuda_weights(&dev, weights)?;
-    let mut d_out = dev
-        .alloc_zeros::<f32>(rows)
-        .map_err(|e| CudaError::Launch(format!("output alloc: {e:?}")))?;
-    const WARPS: usize = 8;
-    let cfg = cudarc::driver::LaunchConfig {
-        grid_dim: (rows.div_ceil(WARPS) as u32, 1, 1),
-        block_dim: ((WARPS * 32) as u32, 1, 1),
-        shared_mem_bytes: 0,
-    };
-    unsafe {
-        func.launch(
-            cfg,
-            (
-                &d_weights.slice,
-                &d_x,
-                &mut d_out,
-                rows as i32,
-                row_bytes as i32,
-                n_blocks_per_row as i32,
-            ),
-        )
-        .map_err(|e| CudaError::Launch(format!("q6_k_matvec_coalesced launch: {e:?}")))?;
+/// This is the ONLY place a coalesced kernel is named. Four launchers
+/// that each hard-coded one kind is exactly the shape this repo keeps
+/// getting bitten by: structures that must agree with nothing enforcing
+/// it. `every_coalesced_kernel_is_reachable_from_the_table` fails if a
+/// kernel const is added and this table is not updated, so a kernel
+/// cannot sit in the file unreachable.
+fn coalesced_matvec_kernel(fn_name: &str) -> Option<(&'static str, &'static str, &'static str)> {
+    match fn_name {
+        "q4_k_matvec" => Some((
+            Q4_K_MATVEC_COALESCED_KERNEL_SRC,
+            "ferrox_q4_k_coalesced",
+            "q4_k_matvec_coalesced",
+        )),
+        "q5_k_matvec" => Some((
+            Q5_K_MATVEC_COALESCED_KERNEL_SRC,
+            "ferrox_q5_k_coalesced",
+            "q5_k_matvec_coalesced",
+        )),
+        "q6_k_matvec" => Some((
+            Q6_K_MATVEC_COALESCED_KERNEL_SRC,
+            "ferrox_q6_k_coalesced",
+            "q6_k_matvec_coalesced",
+        )),
+        "q8_0_matvec" => Some((
+            Q8_0_MATVEC_COALESCED_KERNEL_SRC,
+            "ferrox_q8_0_coalesced",
+            "q8_0_matvec_coalesced",
+        )),
+        _ => None,
     }
-    dev.dtoh_sync_copy(&d_out)
-        .map_err(|e| CudaError::Launch(format!("output download: {e:?}")))
 }
 
-fn launch_matvec_coalesced_q4_k(
+/// Runs one matvec through a coalesced kernel: same arithmetic and the
+/// same f32 activations as the kernel it replaces, so it is meant to be
+/// token-identical. What changes is the access pattern -- a warp reads
+/// one contiguous run per super-block instead of 32 runs strided by the
+/// block size -- and therefore the achieved memory bandwidth, which is
+/// what decode is actually limited by (#133).
+///
+/// Every coalesced kernel takes the same six arguments and the same
+/// launch geometry, so they share this one launcher; the kind-specific
+/// part is entirely inside the CUDA C.
+fn launch_matvec_coalesced(
+    kernel: (&'static str, &'static str, &'static str),
     weights: &[u8],
     x: &[f32],
     rows: usize,
@@ -1060,16 +1192,12 @@ fn launch_matvec_coalesced_q4_k(
 ) -> Result<Vec<f32>, CudaError> {
     use cudarc::driver::LaunchAsync;
 
+    let (src, module, entry) = kernel;
     let dev = shared_device()?;
-    ensure_module_loaded(
-        &dev,
-        Q4_K_MATVEC_COALESCED_KERNEL_SRC,
-        "ferrox_q4_k_coalesced",
-        "q4_k_matvec_coalesced",
-    )?;
+    ensure_module_loaded(&dev, src, module, entry)?;
     let func = dev
-        .get_func("ferrox_q4_k_coalesced", "q4_k_matvec_coalesced")
-        .ok_or_else(|| CudaError::KernelCompile("q4_k_matvec_coalesced not found".into()))?;
+        .get_func(module, entry)
+        .ok_or_else(|| CudaError::KernelCompile(format!("{entry} not found")))?;
 
     let d_x = dev
         .htod_copy(x.to_vec())
@@ -1080,7 +1208,7 @@ fn launch_matvec_coalesced_q4_k(
         .map_err(|e| CudaError::Launch(format!("output alloc: {e:?}")))?;
 
     // Eight warps per block: enough rows in flight per SM to keep loads
-    // outstanding, which is the thing this kernel exists to fix.
+    // outstanding, which is the thing these kernels exist to fix.
     const WARPS: usize = 8;
     let cfg = cudarc::driver::LaunchConfig {
         grid_dim: (rows.div_ceil(WARPS) as u32, 1, 1),
@@ -1099,7 +1227,7 @@ fn launch_matvec_coalesced_q4_k(
                 n_blocks_per_row as i32,
             ),
         )
-        .map_err(|e| CudaError::Launch(format!("q4_k_matvec_coalesced launch: {e:?}")))?;
+        .map_err(|e| CudaError::Launch(format!("{entry} launch: {e:?}")))?;
     }
     dev.dtoh_sync_copy(&d_out)
         .map_err(|e| CudaError::Launch(format!("output download: {e:?}")))
@@ -1927,58 +2055,115 @@ mod tests {
         (weights, x, expected)
     }
 
-    /// The coalesced Q6_K kernel against its scalar twin, on a real
-    /// device. A `Q4_K_M` checkpoint runs this one too, for its output
-    /// tensor.
+    /// Every coalesced kernel against its scalar twin, on a real
+    /// device. The twins prove the lane mapping without a GPU; this
+    /// proves the CUDA C, the vector loads and the warp-shuffle
+    /// reduction, none of which a twin covers.
+    ///
+    /// One test over the table rather than one test per kind, so a new
+    /// kind cannot be added with its hardware check quietly left out.
     ///
     ///   cargo test -p ferrox-cuda --features cuda -- --ignored
     #[test]
-    #[ignore = "requires real CUDA hardware -- verifies the coalesced Q6_K matvec against its scalar twin"]
-    fn launch_q6_k_matvec_coalesced_matches_the_twin() {
-        let rows = 37usize;
+    #[ignore = "requires real CUDA hardware -- verifies every coalesced matvec against its scalar twin"]
+    fn every_coalesced_matvec_matches_its_twin() {
+        type Twin = fn(&[u8], &[f32], usize) -> f32;
+        let cases: &[(&str, usize, usize, u32, Twin)] = &[
+            (
+                "q4_k_matvec",
+                144,
+                256,
+                7,
+                crate::coalesced_twin::q4_k_matvec_coalesced_row,
+            ),
+            (
+                "q5_k_matvec",
+                176,
+                256,
+                17,
+                crate::coalesced_twin::q5_k_matvec_coalesced_row,
+            ),
+            (
+                "q6_k_matvec",
+                210,
+                256,
+                11,
+                crate::coalesced_twin::q6_k_matvec_coalesced_row,
+            ),
+            (
+                "q8_0_matvec",
+                34,
+                32,
+                23,
+                crate::coalesced_twin::q8_0_matvec_coalesced_row,
+            ),
+        ];
+        let rows = 37usize; // not a multiple of the warps per block
         let n_blocks_per_row = 3usize;
-        let cols = n_blocks_per_row * 256;
-        let row_bytes = n_blocks_per_row * 210;
-        let weights: Vec<u8> = pseudo_bytes(11, rows * row_bytes);
-        let x: Vec<f32> = (0..cols).map(|i| ((i as f32) * 0.017).cos()).collect();
-
-        let got =
-            super::launch_matvec_coalesced_q6_k(&weights, &x, rows, row_bytes, n_blocks_per_row)
-                .expect("coalesced q6_k matvec");
-        assert_eq!(got.len(), rows);
-        for r in 0..rows {
-            let row = &weights[r * row_bytes..(r + 1) * row_bytes];
-            let want = crate::coalesced_twin::q6_k_matvec_coalesced_row(row, &x, n_blocks_per_row);
-            assert_close_relative(got[r], want, r);
+        for (fn_name, block_bytes, per_block, seed, twin) in cases {
+            let row_bytes = n_blocks_per_row * block_bytes;
+            let cols = n_blocks_per_row * per_block;
+            let weights = pseudo_bytes(*seed, rows * row_bytes);
+            let x: Vec<f32> = (0..cols).map(|i| ((i as f32) * 0.021).sin()).collect();
+            let kernel = super::coalesced_matvec_kernel(fn_name)
+                .unwrap_or_else(|| panic!("{fn_name} has no coalesced kernel"));
+            let got = super::launch_matvec_coalesced(
+                kernel,
+                &weights,
+                &x,
+                rows,
+                row_bytes,
+                n_blocks_per_row,
+            )
+            .unwrap_or_else(|e| panic!("{fn_name}: {e:?}"));
+            assert_eq!(got.len(), rows, "{fn_name}");
+            for r in 0..rows {
+                let row = &weights[r * row_bytes..(r + 1) * row_bytes];
+                let want = twin(row, &x, n_blocks_per_row);
+                assert!(
+                    !(want.is_nan() ^ got[r].is_nan()),
+                    "{fn_name} row {r}: GPU={} twin={want}",
+                    got[r]
+                );
+                assert_close_relative(got[r], want, r);
+            }
         }
     }
 
-    /// The coalesced kernel against its scalar twin, on a real device.
-    ///
-    /// The twin proves the lane mapping without a GPU. This proves the
-    /// CUDA C, the `uchar4` load and the warp-shuffle reduction, none
-    /// of which the twin covers.
-    ///
-    ///   cargo test -p ferrox-cuda --features cuda -- --ignored
+    /// A coalesced kernel the table does not name is dead code that
+    /// reads as coverage. The entry points are derived from this file,
+    /// not restated, so adding a kernel without routing it fails here.
     #[test]
-    #[ignore = "requires real CUDA hardware -- verifies the coalesced Q4_K matvec against its scalar twin"]
-    fn launch_q4_k_matvec_coalesced_matches_the_twin() {
-        let rows = 37usize; // not a multiple of the warps per block
-        let n_blocks_per_row = 3usize;
-        let cols = n_blocks_per_row * 256;
-        let row_bytes = n_blocks_per_row * 144;
-        let weights: Vec<u8> = pseudo_bytes(7, rows * row_bytes);
-        let x: Vec<f32> = (0..cols).map(|i| ((i as f32) * 0.021).sin()).collect();
-
-        let got =
-            super::launch_matvec_coalesced_q4_k(&weights, &x, rows, row_bytes, n_blocks_per_row)
-                .expect("coalesced matvec");
-        assert_eq!(got.len(), rows);
-        for r in 0..rows {
-            let row = &weights[r * row_bytes..(r + 1) * row_bytes];
-            let want = crate::coalesced_twin::q4_k_matvec_coalesced_row(row, &x, n_blocks_per_row);
-            assert_close_relative(got[r], want, r);
+    fn every_coalesced_kernel_is_reachable_from_the_table() {
+        let src = include_str!("gpu.rs");
+        let mut found = 0usize;
+        for line in src.lines() {
+            let Some(rest) = line.strip_prefix(r#"extern "C" __global__ void "#) else {
+                continue;
+            };
+            let Some(entry) = rest.split('(').next() else {
+                continue;
+            };
+            let Some(base) = entry.strip_suffix("_coalesced") else {
+                continue;
+            };
+            found += 1;
+            let routed = super::coalesced_matvec_kernel(base).unwrap_or_else(|| {
+                panic!("kernel {entry} is not reachable: no table row for {base}")
+            });
+            assert_eq!(
+                routed.2, entry,
+                "table row for {base} names the wrong entry point"
+            );
+            assert!(
+                routed.0.contains(entry),
+                "table row for {base} points at a source that does not define {entry}"
+            );
         }
+        assert!(
+            found >= 4,
+            "expected at least four coalesced kernels, found {found}"
+        );
     }
 
     #[test]

--- a/crates/ferrox-cuda/src/gpu.rs
+++ b/crates/ferrox-cuda/src/gpu.rs
@@ -416,6 +416,87 @@ extern "C" __global__ void q5_0_matvec(
 /// The 32 bytes of a group carry the first 32 activations in their low
 /// nibbles and the next 32 in their high nibbles, so a lane that pairs
 /// byte `i` with activation `i` for both halves reads the wrong place.
+/// Q6_K matvec with a coalesced access pattern.
+///
+/// The kernel this replaces gives each thread a whole 210-byte
+/// super-block, so a warp's 32 loads land 210 bytes apart. Here the
+/// warp takes one super-block and lane `l` takes the index the old
+/// inner loop iterated, which makes `ql[l]`, `ql[l+32]` and `qh[l]`
+/// each contiguous across the warp.
+///
+/// Q6_K is worth doing right after Q4_K because a `Q4_K_M` checkpoint
+/// is not all Q4_K: its output tensor is usually Q6_K, so this kernel
+/// runs every token too.
+///
+/// Same arithmetic and same f32 activations as before, so it stays
+/// token-identical.
+pub const Q6_K_MATVEC_COALESCED_KERNEL_SRC: &str = r#"
+__device__ __forceinline__ float ferrox_f16_to_f32_q6co(unsigned short bits) {
+    unsigned int sign = (bits >> 15) & 0x1u;
+    unsigned int exp = (bits >> 10) & 0x1Fu;
+    unsigned int mant = bits & 0x3FFu;
+    float scale;
+    if (exp == 0) {
+        scale = ldexpf((float)mant, -24);
+    } else if (exp == 31) {
+        scale = mant ? __int_as_float(0x7fc00000) : __int_as_float(0x7f800000);
+    } else {
+        scale = ldexpf((float)(mant | 0x400), (int)exp - 25);
+    }
+    return sign ? -scale : scale;
+}
+
+extern "C" __global__ void q6_k_matvec_coalesced(
+    const unsigned char* weights,
+    const float* x,
+    float* out,
+    int rows,
+    int row_bytes,
+    int n_blocks_per_row
+) {
+    const int warps = blockDim.x / 32;
+    const int warp = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int row = blockIdx.x * warps + warp;
+    if (row >= rows) return;
+
+    const unsigned char* row_ptr = weights + (size_t)row * row_bytes;
+    const int is = lane / 16;
+    float acc = 0.0f;
+
+    for (int blk = 0; blk < n_blocks_per_row; ++blk) {
+        const unsigned char* block = row_ptr + (size_t)blk * 210;
+        const float d = ferrox_f16_to_f32_q6co(
+            (unsigned short)block[208] | ((unsigned short)block[209] << 8));
+        const int x_base = blk * 256;
+
+        #pragma unroll
+        for (int half = 0; half < 2; ++half) {
+            const unsigned char* ql = block + half * 64;
+            const unsigned char* qh = block + 128 + half * 32;
+            const signed char* sc = (const signed char*)(block + 192 + half * 8);
+            const int xh = x_base + half * 128;
+
+            const int q1 = (int)((ql[lane] & 0x0F) | ((qh[lane] & 0x03) << 4)) - 32;
+            const int q2 = (int)((ql[lane + 32] & 0x0F) | (((qh[lane] >> 2) & 0x03) << 4)) - 32;
+            const int q3 = (int)((ql[lane] >> 4) | (((qh[lane] >> 4) & 0x03) << 4)) - 32;
+            const int q4 = (int)((ql[lane + 32] >> 4) | (((qh[lane] >> 6) & 0x03) << 4)) - 32;
+
+            acc += d * (float)sc[is] * (float)q1 * x[xh + lane];
+            acc += d * (float)sc[is + 2] * (float)q2 * x[xh + lane + 32];
+            acc += d * (float)sc[is + 4] * (float)q3 * x[xh + lane + 64];
+            acc += d * (float)sc[is + 6] * (float)q4 * x[xh + lane + 96];
+        }
+    }
+
+    #pragma unroll
+    for (int s = 16; s > 0; s >>= 1) {
+        acc += __shfl_down_sync(0xffffffff, acc, s);
+    }
+    if (lane == 0) out[row] = acc;
+}
+"#;
+
 pub const Q4_K_MATVEC_COALESCED_KERNEL_SRC: &str = r#"
 __device__ __forceinline__ float ferrox_f16_to_f32_co(unsigned short bits) {
     unsigned int sign = (bits >> 15) & 0x1u;
@@ -878,6 +959,9 @@ fn launch_matvec(
     if fn_name == "q4_k_matvec" {
         return launch_matvec_coalesced_q4_k(weights, x, rows, row_bytes, n_blocks_per_row);
     }
+    if fn_name == "q6_k_matvec" {
+        return launch_matvec_coalesced_q6_k(weights, x, rows, row_bytes, n_blocks_per_row);
+    }
     let dev = shared_device()?;
     let d_x = dev
         .htod_copy(x.to_vec())
@@ -915,6 +999,58 @@ fn launch_matvec(
 /// so it is meant to be token-identical; what changes is that a warp
 /// reads 128 contiguous bytes per super-block instead of 32 scattered
 /// 144-byte-strided ones.
+/// Q6_K matvec through the coalesced kernel. See
+/// [`launch_matvec_coalesced_q4_k`]; same shape, different unpack.
+fn launch_matvec_coalesced_q6_k(
+    weights: &[u8],
+    x: &[f32],
+    rows: usize,
+    row_bytes: usize,
+    n_blocks_per_row: usize,
+) -> Result<Vec<f32>, CudaError> {
+    use cudarc::driver::LaunchAsync;
+
+    let dev = shared_device()?;
+    ensure_module_loaded(
+        &dev,
+        Q6_K_MATVEC_COALESCED_KERNEL_SRC,
+        "ferrox_q6_k_coalesced",
+        "q6_k_matvec_coalesced",
+    )?;
+    let func = dev
+        .get_func("ferrox_q6_k_coalesced", "q6_k_matvec_coalesced")
+        .ok_or_else(|| CudaError::KernelCompile("q6_k_matvec_coalesced not found".into()))?;
+    let d_x = dev
+        .htod_copy(x.to_vec())
+        .map_err(|e| CudaError::Launch(format!("x upload: {e:?}")))?;
+    let d_weights = resident_cuda_weights(&dev, weights)?;
+    let mut d_out = dev
+        .alloc_zeros::<f32>(rows)
+        .map_err(|e| CudaError::Launch(format!("output alloc: {e:?}")))?;
+    const WARPS: usize = 8;
+    let cfg = cudarc::driver::LaunchConfig {
+        grid_dim: (rows.div_ceil(WARPS) as u32, 1, 1),
+        block_dim: ((WARPS * 32) as u32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    unsafe {
+        func.launch(
+            cfg,
+            (
+                &d_weights.slice,
+                &d_x,
+                &mut d_out,
+                rows as i32,
+                row_bytes as i32,
+                n_blocks_per_row as i32,
+            ),
+        )
+        .map_err(|e| CudaError::Launch(format!("q6_k_matvec_coalesced launch: {e:?}")))?;
+    }
+    dev.dtoh_sync_copy(&d_out)
+        .map_err(|e| CudaError::Launch(format!("output download: {e:?}")))
+}
+
 fn launch_matvec_coalesced_q4_k(
     weights: &[u8],
     x: &[f32],
@@ -1789,6 +1925,32 @@ mod tests {
             .map(|r| scalar_dot(&weights[r * row_bytes..(r + 1) * row_bytes], &x))
             .collect();
         (weights, x, expected)
+    }
+
+    /// The coalesced Q6_K kernel against its scalar twin, on a real
+    /// device. A `Q4_K_M` checkpoint runs this one too, for its output
+    /// tensor.
+    ///
+    ///   cargo test -p ferrox-cuda --features cuda -- --ignored
+    #[test]
+    #[ignore = "requires real CUDA hardware -- verifies the coalesced Q6_K matvec against its scalar twin"]
+    fn launch_q6_k_matvec_coalesced_matches_the_twin() {
+        let rows = 37usize;
+        let n_blocks_per_row = 3usize;
+        let cols = n_blocks_per_row * 256;
+        let row_bytes = n_blocks_per_row * 210;
+        let weights: Vec<u8> = pseudo_bytes(11, rows * row_bytes);
+        let x: Vec<f32> = (0..cols).map(|i| ((i as f32) * 0.017).cos()).collect();
+
+        let got =
+            super::launch_matvec_coalesced_q6_k(&weights, &x, rows, row_bytes, n_blocks_per_row)
+                .expect("coalesced q6_k matvec");
+        assert_eq!(got.len(), rows);
+        for r in 0..rows {
+            let row = &weights[r * row_bytes..(r + 1) * row_bytes];
+            let want = crate::coalesced_twin::q6_k_matvec_coalesced_row(row, &x, n_blocks_per_row);
+            assert_close_relative(got[r], want, r);
+        }
     }
 
     /// The coalesced kernel against its scalar twin, on a real device.


### PR DESCRIPTION
Extends #144's Q4_K restructure to the rest of the decode matvecs, and collapses the per-kind launcher copies into one.

Refs #133.

## Measured, RTX 3080, interleaved `main, branch, main, branch`

`tg128`, `--n-gpu-layers 99`, 3 reps + discarded warmup per run, quiet host, every receipt carrying `backend_active: "CUDA"`.

| model | main | branch | gain |
|---|---:|---:|---:|
| Llama-3.2-1B-Instruct-Q5_K_M | 34.74 | **43.17** | **+24.3%** |
| Llama-3.2-3B-Instruct-Q4_K_M | 20.74 | **23.24** | **+12.1%** |
| Llama-3.2-1B-Instruct-Q8_0 | 51.73 | **56.98** | **+10.1%** |

Raw sequence, so drift is visible rather than averaged away:

```
Q5_K_M   main 34.76, 34.71   branch 43.26, 43.07
Q4_K_M   main 20.87, 20.61   branch 23.37, 23.12
Q8_0     main 51.84, 51.63   branch 56.99, 56.97
```

The 3B is a `Q4_K_M` file, whose Q4_K kernel #144 already fixed; its remaining +12.1% comes from the Q6_K output tensor, which every decoded token also runs. That is why Q6_K was worth doing first.

## What is still wrong, stated plainly

Converting these into the resource they are limited by — `weights_bytes × tok/s` against the 3080's 760 GB/s — the branch reaches **5.2%** (Q5_K), **6.2%** (Q4_K_M) and **9.9%** (Q8_0) of peak. That is better than main and it is nowhere near llama.cpp's 60.4%. Coalescing removed the wasted transactions per load instruction; it did not raise the number of loads in flight, and on a card with twice the bandwidth of the RTX 3060 the achieved fraction barely moved. The next lever is occupancy and per-thread work, not the access pattern, and the fused dense FFN plus the attention kernels are still on the old pattern entirely.

## Correctness

- **Token identity**, greedy, `--ngl 99` against `--ngl 0`, byte-identical output on all three checkpoints — so Q4_K, Q6_K, Q5_K and Q8_0 all produce the same tokens as the CPU reference.
- **12/12 hardware tests pass** on the 3080, including `every_coalesced_matvec_matches_its_twin`, which holds all four kernels against their scalar twins, and the four pre-existing `launch_q*_matvec_matches_cpu_reference` tests, which now exercise the coalesced path because `launch_matvec` routes to it.
- **Seven sabotages**, each confirmed to land in the file before the run and each turning a test red before being restored: Q6_K adjacent scales, wrong scale quartet, wrong high-bit shift; Q5_K wrong bit-plane, shifted lane offset; Q8_0 unsigned read of signed quants, shifted activation index.
- GPU utilization sampled five times **during** a decode run: 82–92%.

## The structural half

Q4_K and Q6_K each arrived with their own copy of the launcher. Four copies would have been four places to forget something — the dominant bug shape in this repo. There is now one `launch_matvec_coalesced` and one table, `coalesced_matvec_kernel`, that names the kernels.

`every_coalesced_kernel_is_reachable_from_the_table` derives the entry points by scanning `gpu.rs` for `__global__ void *_coalesced(` and requires each to be routed, so a kernel cannot sit in the file unreachable while reading as coverage. Deleting the Q8_0 row makes it fail with `kernel q8_0_matvec_coalesced is not reachable`. The hardware check is likewise one test over the table rather than one per kind, so a new kind cannot be added with its hardware check quietly left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
