### PR TITLE
perf(metal): let Gemma-class models encode concurrently again (-8% to -13% decode GPU time)

### DIFF
--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -5883,31 +5883,28 @@ pub fn launch_decode_dense_stack(
         .collect::<Result<Vec<_>, MetalError>>()?;
 
     let cmd_buf = queue.commandBuffer().ok_or(MetalError::CommandFailed)?;
-    // Sandwich (Gemma post-norms): use the default serial encoder. Concurrent
-    // dispatch + in-place RMSNorm/deferred residuals was measured to diverge
-    // from CPU on Gemma-2 B=1 decode while the serial prefill-shaped residual
-    // path stays coherent. Non-sandwich (SmolLM2) keeps Concurrent for Q∥K∥V.
+    // Gemma-style post-norms ("sandwich"): these layers take the EAGER
+    // residual path below, which is what makes concurrent encode safe here.
     let sandwich = layers
         .iter()
         .any(|l| l.post_attn_norm.is_some() || l.post_ffn_norm.is_some());
-    // The encoder kind and the hazard tracker are chosen together, from one
-    // expression, so they can never disagree: a serial encoder means Metal
-    // already orders the dispatches and every barrier is dead weight (llama
-    // likewise skips them when it is not encoding concurrently), while a
-    // Concurrent encoder means every hazard has to be declared. `mrs` emits
-    // a barrier only where a dispatch actually reads or overwrites something
-    // still in flight, narrowed to those resources rather than every buffer.
-    let (encoder, mut mrs) = if sandwich {
-        (
-            cmd_buf
-                .computeCommandEncoder()
-                .ok_or(MetalError::CommandFailed)?,
-            MemRanges::serial(),
-        )
-    } else {
-        // llama.cpp concurrent encode: gate∥up and Q∥K∥V overlap
-        (compute_encoder_concurrent(&cmd_buf)?, MemRanges::new())
-    };
+    // Every model encodes concurrently: gate∥up and Q∥K∥V overlap, and the
+    // hazard tracker emits a barrier only where a dispatch reads or
+    // overwrites something still in flight, narrowed to those resources.
+    //
+    // Sandwich models (Gemma post-norms) used to be forced onto the serial
+    // encoder, because concurrent dispatch with in-place RMSNorm and
+    // DEFERRED residuals diverged from CPU on Gemma-2 B=1 decode. That fix
+    // landed two changes at once -- serial encode AND eager residuals -- and
+    // the eager residuals are the half that mattered: with them, every op in
+    // this function declares its own reads and writes (`encode_gqa_with_kv`
+    // self-tracks, including the f16 dequant scratch no caller can name), so
+    // concurrency is safe by construction rather than by scheduling luck.
+    //
+    // Measured on an M2 Pro, interleaved, GPU-clock: Gemma-2-2B Q4_K_M decode
+    // 13.23 -> 12.20 ms/token, and greedy output stays byte-identical to the
+    // serial encoder across Gemma-2 and Gemma-3 on every prompt tried.
+    let (encoder, mut mrs) = (compute_encoder_concurrent(&cmd_buf)?, MemRanges::new());
 
     let embd_resident = if let Some(e) = embd {
         let w = resident_weight_buffer(device, e.weights)?;

--- a/crates/ferrox-metal/src/mem_ranges.rs
+++ b/crates/ferrox-metal/src/mem_ranges.rs
@@ -60,11 +60,6 @@ pub(crate) struct MemRanges {
     bufs: Vec<*const ProtocolObject<dyn MTLBuffer>>,
     srcs: Vec<usize>,
     dsts: Vec<usize>,
-    /// Encoder was created `MTLDispatchTypeSerial`, so Metal already orders
-    /// dispatches and no barrier is needed. llama does the same: with a
-    /// null `mem_ranges`, `ggml_metal_op_concurrency_reset` returns before
-    /// `ggml_metal_encoder_memory_barrier`.
-    serial: bool,
 }
 
 #[inline]
@@ -75,17 +70,6 @@ fn buf_key(b: &ProtocolObject<dyn MTLBuffer>) -> usize {
 impl MemRanges {
     pub(crate) fn new() -> Self {
         Self::default()
-    }
-
-    /// Tracker for a `MTLDispatchTypeSerial` encoder: every `begin_op` is a
-    /// no-op, because Metal already orders one dispatch after the next and
-    /// `memoryBarrierWithScope:` is only meaningful under concurrent
-    /// dispatch. Keeps call sites identical between the two encoder kinds.
-    pub(crate) fn serial() -> Self {
-        Self {
-            serial: true,
-            ..Self::default()
-        }
     }
 
     pub(crate) fn reset(&mut self) {
@@ -149,9 +133,6 @@ impl MemRanges {
         srcs: &[&ProtocolObject<dyn MTLBuffer>],
         dsts: &[&ProtocolObject<dyn MTLBuffer>],
     ) {
-        if self.serial {
-            return;
-        }
         BEGIN_OP_COUNT.fetch_add(1, Ordering::Relaxed);
         if !self.check(srcs, dsts) {
             // SAFETY: pointers were taken from live encoder-bound scratch /
@@ -176,9 +157,67 @@ impl MemRanges {
         srcs: &[&ProtocolObject<dyn MTLBuffer>],
         dsts: &[&ProtocolObject<dyn MTLBuffer>],
     ) {
-        if self.serial {
-            return;
-        }
         self.add(srcs, dsts);
+    }
+}
+
+#[cfg(test)]
+mod declaration_tests {
+    /// Every dispatch encoded into the decode stack must declare what it
+    /// reads and writes, or the concurrent encoder is free to run it
+    /// against data still in flight.
+    ///
+    /// This is the failure that used to be papered over: Gemma's post-norm
+    /// layers diverged under concurrent dispatch, and the fix disabled
+    /// concurrency for that whole class of model rather than finding the
+    /// undeclared op. Concurrency is only safe by CONSTRUCTION -- every op
+    /// declared -- and nothing was checking that construction held.
+    ///
+    /// An op declares itself one of two ways: the call site wraps it in
+    /// `begin_op`/`end_op`, or the helper takes `&mut mrs` and tracks its
+    /// own hazards (`encode_gqa_with_kv` does, because with a quantized KV
+    /// cache it writes an f16 dequant scratch no caller can name).
+    #[test]
+    fn every_encode_in_the_decode_stack_declares_its_hazards() {
+        let src = include_str!("attn.rs");
+        let start = src
+            .find("pub fn launch_decode_dense_stack(")
+            .expect("decode stack function");
+        // Stop at the next top-level item.
+        let body = &src[start..];
+        let end = body[1..]
+            .find("\npub fn ")
+            .map(|i| i + 1)
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        let mut open = false;
+        let mut undeclared = Vec::new();
+        for (i, line) in body.lines().enumerate() {
+            let t = line.trim();
+            if t.starts_with("mrs.begin_op(") {
+                open = true;
+            }
+            if t.starts_with("mrs.end_op(") {
+                open = false;
+            }
+            let is_encode = t.starts_with("encode_") && t.contains('(');
+            if is_encode && !open {
+                // A self-tracking helper takes the tracker itself. The call
+                // spans several lines, so look at the next few.
+                let window: String = body.lines().skip(i).take(6).collect::<Vec<_>>().join(" ");
+                // The tracker is handed over either as `&mut mrs` or, where
+                // the caller already holds `&mut MemRanges`, as bare `mrs`.
+                let handed_over = window.contains("&mut mrs") || window.contains(" mrs,");
+                if !handed_over {
+                    undeclared.push(t.to_string());
+                }
+            }
+        }
+        assert!(
+            undeclared.is_empty(),
+            "these dispatches declare no reads/writes and are not self-tracking, \
+             so the concurrent encoder may run them against in-flight data: {undeclared:#?}"
+        );
     }
 }


### PR DESCRIPTION
Any model with post-norms — Gemma-2, Gemma-3 — was forced onto the **serial** encoder, so its entire decode ran with no dispatch overlap. Refs #149.

## Why it was there, and why it no longer needs to be

The comment said it plainly: concurrent dispatch with in-place RMSNorm and **deferred** residuals diverged from CPU on Gemma-2 B=1 decode. That fix landed two changes at once — serial encode **and** eager residuals — and the eager residuals are the half that mattered.

With eager residuals, every dispatch in `launch_decode_dense_stack` declares its own reads and writes. `encode_gqa_with_kv` and `encode_gqa_prefill_with_kv` self-track, including the f16 dequant scratch no caller can name. So concurrency here is safe **by construction**, not by scheduling luck. The serial encoder was a correct fix aimed one layer too high, and it outlived its cause.

## Measured, M2 Pro, interleaved `main, branch, main, branch`

`MTLCommandBuffer` GPU-clock timing (`FERROX_METAL_GPU_TIMING=1`), which is immune to host load — this machine was not quiet.

| model | main | branch | change |
|---|---:|---:|---:|
| Gemma-2-2B Q4_K_M | 13.09 | **12.00** ms/tok | **−8.3%** |
| Gemma-3-1B Q8_0 | 8.24 | **7.15** ms/tok | **−13.2%** |
| Llama-3.2-1B Q4_K_M | 4.93 | 4.95 | unchanged |

```
gemma-2   main 13.104, 13.070   branch 11.999, 12.008
gemma-3   main  8.285,  8.193   branch  7.144,  7.158
```

Llama-3.2-1B is unchanged, as it must be — it was already concurrent, and this only deletes the branch that excluded everything else.

Gemma-2-2B is the **worst Metal row in the ledger at 1.23×**; this is most of the way to parity on it.

## Correctness

- Greedy output **byte-identical to `main`** on both models across three prompts each.
- 54 Metal hardware tests pass.
- `gemma2_metal_quality_gate` passes (both CPU and Metal).

## The guard

`every_encode_in_the_decode_stack_declares_its_hazards` reads `attn.rs` and requires every `encode_*` in the decode stack to sit inside a `begin_op`/`end_op` pair, or to be handed the tracker itself.

That is the invariant concurrency rests on, and **nothing was checking it** — which is precisely why the response to one undeclared hazard could be to disable concurrency for a whole class of model instead of finding the op. Deleting the gate/up declaration turns it red (confirmed, with the mutation verified in the file first).

`MemRanges::serial()` and the `serial` field go too: one caller, now gone, and a tracker that skips every barrier is not something to leave sitting next to one that emits them.

## Note for #149

This is GPU-side. The larger Metal finding still stands: ferrox's kernels already beat llama.cpp's total token time, and the remaining gap is host-side encode overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
