### PR TITLE
refactor(metal): one attn-residual path, not one per model class

### DIFF
--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -6086,37 +6086,26 @@ pub fn launch_decode_dense_stack(
             )?;
             mrs.end_op(&[o_buf], &[o_buf]);
         }
-        if sandwich {
-            // Eager residual + separate ffn_norm (prefill / CPU parity).
-            mrs.begin_op(&encoder, &[h_buf, o_buf], &[h_buf]);
-            encode_vec_add(&encoder, device, h_buf, o_buf, hidden_dim as u32)?;
-            mrs.end_op(&[h_buf, o_buf], &[h_buf]);
-            mrs.begin_op(&encoder, &[h_buf], &[x2_buf]);
-            encode_rms_norm(
-                &encoder,
-                device,
-                h_buf,
-                &ffn_nw.buffer,
-                x2_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[h_buf], &[x2_buf]);
-        } else {
-            // Fuse attn residual + ffn_norm into one dispatch.
-            mrs.begin_op(&encoder, &[h_buf, o_buf], &[h_buf, x2_buf]);
-            encode_add_rms_norm(
-                &encoder,
-                device,
-                h_buf,
-                o_buf,
-                &ffn_nw.buffer,
-                x2_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[h_buf, o_buf], &[h_buf, x2_buf]);
-        }
+        // Attn residual + ffn_norm in one dispatch, for every model.
+        //
+        // Sandwich layers used to split this into `vec_add` then `rms_norm`,
+        // which is the same arithmetic in two dispatches: `post_attn_norm`
+        // has already been applied to `o_buf` in place above, so both paths
+        // compute `h += o` then `x2 = rms_norm(h)`. The split was a leftover
+        // from the serial-encoder era -- `encode_add_rms_norm` writes `h`
+        // itself, so the residual is just as eager as the two-dispatch form.
+        mrs.begin_op(&encoder, &[h_buf, o_buf], &[h_buf, x2_buf]);
+        encode_add_rms_norm(
+            &encoder,
+            device,
+            h_buf,
+            o_buf,
+            &ffn_nw.buffer,
+            x2_buf,
+            hidden_dim as u32,
+            rms_eps,
+        )?;
+        mrs.end_op(&[h_buf, o_buf], &[h_buf, x2_buf]);
         // gate ∥ up (llama concurrent)
         mrs.begin_op(&encoder, &[x2_buf], &[gate_buf, up_buf]);
         encode_matvec(&encoder, device, &layer.gate, &gate_w, x2_buf, gate_buf)?;


### PR DESCRIPTION
Sandwich layers (Gemma post-norms) split `h += o` and `x2 = rms_norm(h)` into two dispatches where every other model used the fused `add_rms_norm`. The two branches computed the same thing — `post_attn_norm` has already been applied to `o_buf` in place above, and `encode_add_rms_norm` writes `h` itself, so the residual is exactly as eager as the two-dispatch form. The split was a leftover from the serial-encoder era removed in #150.

## No performance claim

Interleaved on this M2 Pro: **11.97 vs 11.95 ms/token GPU, 60.00 vs 59.98 tok/s** — no difference, which is what it should read. The change removes 26 of roughly 515 dispatches. Follow-up measurement on #149 puts a dispatch at ~5.16 µs of GPU time, so 26 of them is ~0.13 ms, about 1.1% — sitting exactly on the noise floor. The experiment could not resolve it in either direction, so this lands as a simplification.

What it buys is one path instead of two for the same arithmetic, which is the divergence shape this repo keeps paying for.

## Correctness

- Greedy output byte-identical on Gemma-2-2B and Gemma-3-1B across three prompts each.
- `gemma2_metal_quality_gate` passes; `cargo test -p ferrox-metal --features metal` clean.

Refs #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
