### PR TITLE
feat(server): report reasoning tokens instead of a hardcoded zero

### DIFF
--- a/crates/ferrox-api/src/lib.rs
+++ b/crates/ferrox-api/src/lib.rs
@@ -40,4 +40,4 @@ pub use health::{Capability, HealthResponse, HealthState};
 pub use lifecycle::{ServerReady, READY_EVENT};
 pub use progress::{RateEstimator, RateReport};
 pub use request_id::next_request_id;
-pub use usage::Usage;
+pub use usage::{CompletionTokensDetails, Usage};

--- a/crates/ferrox-api/src/usage.rs
+++ b/crates/ferrox-api/src/usage.rs
@@ -20,11 +20,27 @@
 
 use serde::{Deserialize, Serialize};
 
+/// OpenAI's `usage.completion_tokens_details`.
+///
+/// Only the one field is carried: the others in OpenAI's object
+/// (`audio_tokens`, `accepted_prediction_tokens`) describe features
+/// this server does not implement, and inventing zeroes for them would
+/// be the same lie this type exists to stop telling.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CompletionTokensDetails {
+    pub reasoning_tokens: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
     pub total_tokens: usize,
+    /// OpenAI's nested completion breakdown. Absent unless the
+    /// reasoning split actually ran, because a zero here is a claim
+    /// about the model and not about this server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens_details: Option<CompletionTokensDetails>,
     /// Prefill throughput (prompt tokens / prefill seconds), when timed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_per_second: Option<f64>,
@@ -82,6 +98,7 @@ impl Usage {
             prompt_tokens,
             completion_tokens,
             total_tokens: prompt_tokens + completion_tokens,
+            completion_tokens_details: None,
             prompt_per_second: None,
             predicted_per_second: None,
             prompt_eval_duration_ms: None,
@@ -116,6 +133,27 @@ impl Usage {
         if self.completion_tokens > 0 {
             self.time_to_first_token_ms = Some(secs * 1000.0);
         }
+        self
+    }
+
+    /// How many of the completion's tokens were spent reasoning.
+    ///
+    /// OpenAI's own field, and the only part of a reasoning model's
+    /// accounting that IS in their spec -- `reasoning_content` is a
+    /// DeepSeek convention this server also speaks, but the token
+    /// count is standard, and it is how a caller prices or budgets a
+    /// thinking model.
+    ///
+    /// `None`, not zero, when this build cannot know: a checkpoint
+    /// whose family emits no reasoning at all, and any path that did
+    /// not run the split. `/v1/responses` used to report a hardcoded
+    /// `0` here, which reads as "this model did not think" rather than
+    /// "nobody counted" -- the exact confusion this module's header
+    /// rules out for timings.
+    pub fn with_reasoning_tokens(mut self, reasoning: usize) -> Self {
+        self.completion_tokens_details = Some(CompletionTokensDetails {
+            reasoning_tokens: reasoning,
+        });
         self
     }
 

--- a/crates/ferrox-server/src/completion/mod.rs
+++ b/crates/ferrox-server/src/completion/mod.rs
@@ -531,6 +531,10 @@ pub(crate) async fn completion(
 
     let prompt = req.prompt_text()?.to_string();
     let mut params = GenerationParams {
+        // This endpoint returns the text verbatim and never splits a
+        // reasoning block out of it, so counting one would describe a
+        // split that did not happen.
+        reasoning: None,
         max_tokens: 0,
         sampling: req.sampling_knobs()?.resolve(),
         seed: req.seed(),

--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -1048,6 +1048,17 @@ pub use ferrox_api::Usage;
 
 #[derive(Clone)]
 pub struct GenerationParams {
+    /// The reasoning split this request's checkpoint implies, resolved
+    /// once by whoever holds the model name
+    /// (`ReasoningFormat::infer`). `None` when the checkpoint has no
+    /// reasoning format at all, which is what makes
+    /// `usage.completion_tokens_details` ABSENT rather than a zero the
+    /// model did not earn.
+    ///
+    /// Whether the prompt already opened the block is not carried here:
+    /// it is a property of the rendered prompt, which `generate` has,
+    /// so deriving it there keeps one source instead of two.
+    pub reasoning: Option<crate::policy::parser::ReasoningFormat>,
     pub max_tokens: usize,
     pub sampling: SamplingParams,
     pub seed: u64,
@@ -1560,6 +1571,26 @@ pub fn generate(
     if let Some(cached) = cached_tokens {
         usage = usage.with_cached_tokens(cached);
     }
+    // How much of the answer was thinking. `None` when this checkpoint
+    // has no reasoning format, which leaves `completion_tokens_details`
+    // ABSENT -- a zero there reads as "this model did not think" rather
+    // than "nobody counted", and `/v1/responses` shipped exactly that
+    // confusion (#120).
+    //
+    // Whether the prompt already opened the block is read off the
+    // rendered prompt, not guessed from the family: a template asked to
+    // think opens it itself, and then the first generated token is
+    // already reasoning with no marker to find.
+    if let Some(reasoning) = crate::reasoning_tokens::count(
+        params.reasoning,
+        params
+            .reasoning
+            .is_some_and(|f| f.prompt_opens_reasoning(prompt)),
+        &generated_ids,
+        |ids| tokenizer.decode(ids),
+    ) {
+        usage = usage.with_reasoning_tokens(reasoning);
+    }
     // A paged request's reuse is the radix tree's, not the contiguous
     // prefix cache's, so it is counted here instead. Reported through
     // the same field because it means the same thing to a caller:
@@ -1915,6 +1946,7 @@ mod tests {
 
     fn greedy_params(max_tokens: usize) -> GenerationParams {
         GenerationParams {
+            reasoning: None,
             max_tokens,
             sampling: SamplingParams::default(),
             seed: 1,
@@ -2308,6 +2340,7 @@ mod tests {
             None,
             &prompt,
             &GenerationParams {
+                reasoning: None,
                 max_tokens: 20,
                 sampling: SamplingParams::default(),
                 seed: 1,
@@ -2466,6 +2499,7 @@ mod tests {
 
     fn scripted_params(max_tokens: usize) -> GenerationParams {
         GenerationParams {
+            reasoning: None,
             max_tokens,
             sampling: SamplingParams {
                 temperature: 0.0,
@@ -2763,6 +2797,7 @@ mod tests {
             None,
             &prompt,
             &GenerationParams {
+                reasoning: None,
                 max_tokens: 20,
                 sampling: SamplingParams::default(),
                 seed: 1,

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -56,6 +56,7 @@ mod openai_extra;
 mod output;
 mod policy;
 mod rerank;
+mod reasoning_tokens;
 mod response_cache;
 pub(crate) mod responses;
 mod resume;

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -55,8 +55,8 @@ mod model;
 mod openai_extra;
 mod output;
 mod policy;
-mod rerank;
 mod reasoning_tokens;
+mod rerank;
 mod response_cache;
 pub(crate) mod responses;
 mod resume;
@@ -1851,6 +1851,11 @@ impl ChatCompletionRequest {
     /// asked for.
     fn generation_params(&self) -> Result<GenerationParams, ApiError> {
         Ok(GenerationParams {
+            // Set by `generation_params_for_template`, which is the only
+            // caller that knows the SERVED model name. Left `None` here
+            // so a path that never resolves it reports the field absent
+            // rather than claiming the model did not think.
+            reasoning: None,
             max_tokens: self.max_tokens,
             sampling: self.sampling_params()?,
             seed: self.resolved_seed(),
@@ -1887,6 +1892,11 @@ impl ChatCompletionRequest {
         served_model: &str,
     ) -> Result<GenerationParams, ApiError> {
         let mut params = self.generation_params()?;
+        // The served model, not the request's `model` field -- see this
+        // function's doc. Same name `OutputPosture::resolve` reads the
+        // answer back with, so the count and the split cannot disagree
+        // about which family this checkpoint is.
+        params.reasoning = crate::policy::parser::ReasoningFormat::infer(served_model);
         if let Some(stop) = template.end_of_turn() {
             if !params.stop.iter().any(|s| s == stop) {
                 params.stop.push(stop.to_string());
@@ -5218,6 +5228,7 @@ mod tests {
 
     fn greedy_params(max_tokens: usize) -> GenerationParams {
         GenerationParams {
+            reasoning: None,
             max_tokens,
             sampling: SamplingParams::default(),
             seed: 1,
@@ -8233,6 +8244,40 @@ mod tests {
 
     fn chat_request(value: serde_json::Value) -> ChatCompletionRequest {
         serde_json::from_value(value).expect("request")
+    }
+
+    /// The reasoning split is resolved from the SERVED model, and it is
+    /// what decides whether `usage.completion_tokens_details` exists at
+    /// all. Resolved from the request's `model` field instead, a client
+    /// naming an alias would silently get no count -- and `None` here is
+    /// indistinguishable on the wire from "this model did not think",
+    /// which is the confusion #120 is about.
+    #[test]
+    fn the_reasoning_split_is_resolved_from_the_served_model_not_the_request() {
+        let req = chat_request(serde_json::json!({
+            // Deliberately a name that infers NOTHING, so a pass can only
+            // come from the served name below.
+            "model": "some-alias",
+            "messages": [{"role": "user", "content": "hi"}],
+        }));
+        let template = chat_template::PromptTemplate::plain();
+
+        let thinks = req
+            .generation_params_for_template(&template, "Qwen3-8B")
+            .expect("params");
+        assert!(
+            thinks.reasoning.is_some(),
+            "a thinking checkpoint must carry its format into generation"
+        );
+
+        let plain = req
+            .generation_params_for_template(&template, "Llama-3.2-1B-Instruct")
+            .expect("params");
+        assert!(
+            plain.reasoning.is_none(),
+            "a checkpoint with no reasoning format must carry none, so the \
+             usage field stays absent rather than becoming a zero"
+        );
     }
 
     /// The wire field reaches the sampler, compiled.

--- a/crates/ferrox-server/src/openai_extra.rs
+++ b/crates/ferrox-server/src/openai_extra.rs
@@ -479,6 +479,10 @@ pub async fn completions(
     let prompt = req.prompt_text()?.to_string();
     let active = state.require_active()?;
     let params = GenerationParams {
+        // This endpoint returns the text verbatim and never splits a
+        // reasoning block out of it, so counting one would describe a
+        // split that did not happen.
+        reasoning: None,
         max_tokens: req.max_tokens,
         sampling: req.sampling_knobs()?.resolve(),
         seed: req.seed.unwrap_or(0),

--- a/crates/ferrox-server/src/reasoning_tokens.rs
+++ b/crates/ferrox-server/src/reasoning_tokens.rs
@@ -1,0 +1,150 @@
+//! How many of a completion's tokens were spent thinking.
+//!
+//! `usage.completion_tokens_details.reasoning_tokens` is OpenAI's own
+//! field and the only part of a reasoning model's accounting that is in
+//! their spec (`reasoning_content`, which this server also speaks, is
+//! DeepSeek's convention). It is how a caller prices or budgets a
+//! thinking model, and `/v1/responses` reported a hardcoded `0` for it
+//! -- which says "this model did not think" rather than "nobody
+//! counted", the exact confusion `ferrox_api::usage`'s header rules out
+//! for timings.
+//!
+//! # Why this counts tokens instead of measuring text
+//!
+//! `usage`'s doc comment states the rule: counts come from the exact
+//! token ids the generation loop processed, because re-tokenizing
+//! decoded text is not guaranteed to round-trip to the same count. So
+//! the reasoning text is NOT re-encoded. The generated ids are replayed
+//! through the same parser the response body is split with, and the
+//! tokens are counted.
+//!
+//! # Why an offset, and not "which push emitted content"
+//!
+//! [`ReasoningParser`] buffers: a token may emit nothing while the
+//! parser holds text back against a partial marker, and a later token
+//! releases all of it at once. So the push that FIRST emits content is
+//! not the token content started at -- it is one or more tokens late,
+//! by however much was held. Counting that way was tried and is off by
+//! exactly the length of every buffered run.
+//!
+//! What buffering cannot move is where the answer begins in the raw
+//! output. In every format this server supports the chain of thought is
+//! a **prefix**: `<think>` blocks, DeepSeek's DSML variant, Gemma's
+//! channels, MiniMax-M3's namespaced pair and the gpt-oss harmony
+//! `analysis` channel all put reasoning first and never return to it.
+//! So the content the parser produces is a SUFFIX of the raw text, its
+//! start offset is `raw.len() - content.len()`, and the count is the
+//! number of tokens needed to reach that offset.
+//!
+//! A token that straddles the boundary (its piece closes the marker and
+//! opens the answer) counts as reasoning: the thinking ended inside it,
+//! and the alternative is to charge the answer for a token it did not
+//! begin.
+
+use crate::policy::parser::reasoning::{ReasoningFormat, ReasoningParser};
+
+/// Counts the tokens spent reasoning, replaying `ids` through the split.
+///
+/// `decode` turns one id into its piece, which is the same detokenizer
+/// the generation loop used. Returns `None` when the served checkpoint
+/// has no reasoning format at all, so a model that does not think
+/// reports the field as absent rather than as a zero it did not earn.
+pub(crate) fn count(
+    format: Option<ReasoningFormat>,
+    prompt_opened_reasoning: bool,
+    ids: &[usize],
+    mut decode: impl FnMut(&[usize]) -> String,
+) -> Option<usize> {
+    let format = format?;
+    let pieces: Vec<String> = ids
+        .iter()
+        .map(|id| decode(std::slice::from_ref(id)))
+        .collect();
+    let raw: String = pieces.concat();
+
+    // Untrimmed on purpose: `parse_complete` trims both sides, and a
+    // trimmed length cannot be subtracted from a raw one to get an
+    // offset into that raw text.
+    let mut parser = ReasoningParser::new(format, prompt_opened_reasoning, true);
+    let head = parser.push(&raw);
+    let tail = parser.flush();
+    let content_len = head.content.len() + tail.content.len();
+
+    // Where the answer starts. Saturating because a format that
+    // rewrites rather than merely strips (harmony channels) can emit
+    // more content than the raw text held, and a wrapped subtraction
+    // here would charge the whole generation to reasoning.
+    let boundary = raw.len().saturating_sub(content_len);
+
+    let mut consumed = 0usize;
+    for (index, piece) in pieces.iter().enumerate() {
+        if consumed >= boundary {
+            return Some(index);
+        }
+        consumed += piece.len();
+    }
+    Some(pieces.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pieces stand in for a tokenizer: each "id" indexes this table,
+    /// so a test can place a marker on its own token or bury it inside
+    /// one.
+    fn decoder(pieces: &'static [&'static str]) -> impl FnMut(&[usize]) -> String {
+        move |ids: &[usize]| ids.iter().map(|i| pieces[*i]).collect()
+    }
+
+    fn count_pieces(pieces: &'static [&'static str]) -> Option<usize> {
+        let ids: Vec<usize> = (0..pieces.len()).collect();
+        count(
+            Some(ReasoningFormat::Think),
+            false,
+            &ids,
+            decoder(pieces),
+        )
+    }
+
+    #[test]
+    fn thinking_is_charged_to_reasoning_and_the_answer_is_not() {
+        // <think> a b </think> answer  ->  the four tokens through the
+        // closing marker are reasoning, "answer" is not.
+        let n = count_pieces(&["<think>", "a", "b", "</think>", "answer"]);
+        assert_eq!(n, Some(4));
+    }
+
+    /// The regression the prefix rule exists for: a parser that buffers
+    /// against a partial marker emits nothing for several tokens, and
+    /// counting only the pushes that produced reasoning text would
+    /// score those as answer tokens.
+    #[test]
+    fn a_buffered_run_is_still_reasoning() {
+        let n = count_pieces(&["<think>", "a", "<", "/th", "ink>", "answer"]);
+        assert_eq!(n, Some(5), "the split marker's tokens are reasoning");
+    }
+
+    #[test]
+    fn a_model_that_never_thinks_spends_no_reasoning_tokens() {
+        assert_eq!(count_pieces(&["hello", " world"]), Some(0));
+    }
+
+    /// A checkpoint whose family emits no reasoning must report the
+    /// field as ABSENT. Zero is a claim about the model; `None` is the
+    /// truth about this build.
+    #[test]
+    fn no_format_means_no_number_rather_than_zero() {
+        let ids = [0usize, 1];
+        assert_eq!(count(None, false, &ids, decoder(&["a", "b"])), None);
+    }
+
+    /// A generation that is still inside its thinking when it runs out
+    /// of budget spent ALL of its tokens reasoning -- this is the case
+    /// that rendered as an empty message in #118.
+    #[test]
+    fn an_answer_that_never_stopped_thinking_is_all_reasoning() {
+        let n = count_pieces(&["<think>", "a", "b", "c"]);
+        assert_eq!(n, Some(4));
+    }
+}

--- a/crates/ferrox-server/src/reasoning_tokens.rs
+++ b/crates/ferrox-server/src/reasoning_tokens.rs
@@ -99,12 +99,7 @@ mod tests {
 
     fn count_pieces(pieces: &'static [&'static str]) -> Option<usize> {
         let ids: Vec<usize> = (0..pieces.len()).collect();
-        count(
-            Some(ReasoningFormat::Think),
-            false,
-            &ids,
-            decoder(pieces),
-        )
+        count(Some(ReasoningFormat::Think), false, &ids, decoder(pieces))
     }
 
     #[test]

--- a/crates/ferrox-server/src/response_cache.rs
+++ b/crates/ferrox-server/src/response_cache.rs
@@ -113,11 +113,19 @@ impl Hash for GrammarKey {
 /// The destructure below is exhaustive ON PURPOSE, for the same reason
 /// [`sampling_key`]'s is: a field added to `GenerationParams` stops this
 /// crate compiling, HERE, until someone decides whether it belongs in
-/// the cache key. Two of the nine fields are deliberately NOT keyed and
+/// the cache key. Three of the ten fields are deliberately NOT keyed and
 /// each says why at its `_` binding -- an exclusion on the record is a
 /// decision; a field nobody looked at is the bug in #35.
 pub fn generation_key(params: &GenerationParams) -> GenerationKey {
     let GenerationParams {
+        // NOT KEYED. `reasoning` is `ReasoningFormat::infer` of the
+        // SERVED model name, so it is a pure function of the checkpoint
+        // answering -- and the checkpoint is already keyed, by
+        // `CacheKey::model`. Two entries that agree on the model cannot
+        // disagree on this. Keying it as well would add a field that can
+        // never differ when the rest matches, which is a key that looks
+        // stricter than it is rather than a cache that is safer.
+        reasoning: _,
         max_tokens,
         sampling,
         // NOT KEYED. The resolved seed is a clock reading for any
@@ -434,6 +442,7 @@ mod tests {
     /// field at its do-nothing value.
     fn params() -> GenerationParams {
         GenerationParams {
+            reasoning: None,
             max_tokens: 16,
             sampling: SamplingParams::default(),
             seed: 0,

--- a/crates/ferrox-server/src/responses.rs
+++ b/crates/ferrox-server/src/responses.rs
@@ -705,7 +705,7 @@ fn failure_code(error: &DecodeError) -> &'static str {
 /// semantics); `cached_tokens` is 0 when no prefix cache is configured,
 /// which is the same thing `Usage::cached_tokens: None` means.
 fn usage_json(usage: &Usage) -> Value {
-    json!({
+    let mut v = json!({
         "input_tokens": usage.prompt_tokens,
         "output_tokens": usage.completion_tokens,
         "total_tokens": usage.prompt_tokens + usage.completion_tokens,
@@ -713,8 +713,14 @@ fn usage_json(usage: &Usage) -> Value {
             "cached_tokens": usage.cached_tokens.unwrap_or(0),
             "cache_write_tokens": 0,
         },
-        "output_tokens_details": {"reasoning_tokens": 0},
-    })
+    });
+    // Present only when the split actually ran. This used to be a
+    // hardcoded `0`, which told every caller that every model on every
+    // request thought for exactly no tokens (#120).
+    if let Some(d) = usage.completion_tokens_details.as_ref() {
+        v["output_tokens_details"] = json!({"reasoning_tokens": d.reasoning_tokens});
+    }
+    v
 }
 
 fn reasoning_item(id: &str, text: Option<&str>, status: &str) -> Value {
@@ -1714,6 +1720,40 @@ mod tests {
 
     fn usage(prompt: usize, completion: usize) -> Usage {
         Usage::new(prompt, completion)
+    }
+
+    /// `/v1/responses` reported `reasoning_tokens: 0` for every answer
+    /// from every model, which is a claim that the model did not think,
+    /// not an admission that nobody counted (#120).
+    #[test]
+    fn a_model_that_did_not_think_omits_the_reasoning_field_entirely() {
+        let v = usage_json(&usage(10, 20));
+        assert_eq!(v["input_tokens"], 10);
+        assert_eq!(v["output_tokens"], 20);
+        assert!(
+            v.get("output_tokens_details").is_none(),
+            "a checkpoint with no reasoning format must report NO details \
+             object, not a zero it did not earn: {v}"
+        );
+    }
+
+    #[test]
+    fn a_counted_reasoning_split_reaches_the_wire() {
+        let v = usage_json(&usage(10, 20).with_reasoning_tokens(7));
+        assert_eq!(
+            v["output_tokens_details"]["reasoning_tokens"], 7,
+            "the counted split must be what the wire carries: {v}"
+        );
+    }
+
+    /// Zero is a real answer when the split RAN and found no reasoning,
+    /// and it has to survive as a present zero rather than being folded
+    /// back into "absent".
+    #[test]
+    fn a_split_that_ran_and_found_nothing_reports_a_present_zero() {
+        let v = usage_json(&usage(10, 20).with_reasoning_tokens(0));
+        assert_eq!(v["output_tokens_details"]["reasoning_tokens"], 0);
+        assert!(v.get("output_tokens_details").is_some());
     }
 
     /// Drive the stream machine with a script of semantic events.

--- a/crates/ferrox-server/src/sample_step.rs
+++ b/crates/ferrox-server/src/sample_step.rs
@@ -215,6 +215,7 @@ mod tests {
 
     fn params(json_object: bool, temperature: f32) -> GenerationParams {
         GenerationParams {
+            reasoning: None,
             max_tokens: 8,
             sampling: SamplingParams {
                 temperature,

--- a/crates/ferrox-server/src/serving/batch/tests/batching.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/batching.rs
@@ -56,6 +56,7 @@ fn continuous_batching_composes_with_paged_kv() {
         let results = Arc::clone(&results);
         let prompt = prompts[i].clone();
         let par = GenerationParams {
+            reasoning: None,
             max_tokens: params[i].max_tokens,
             sampling: SamplingParams {
                 temperature: params[i].sampling.temperature,
@@ -245,6 +246,7 @@ fn continuous_batch_matches_sequential_generate_token_ids() {
         let results = Arc::clone(&results);
         let prompt = prompts[i].clone();
         let par = GenerationParams {
+            reasoning: None,
             max_tokens: params[i].max_tokens,
             sampling: SamplingParams {
                 temperature: params[i].sampling.temperature,

--- a/crates/ferrox-server/src/serving/batch/tests/mod.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/mod.rs
@@ -48,6 +48,7 @@ fn tiny_decoder() -> Arc<Decoder> {
 
 fn greedy_params(max_tokens: usize, seed: u64) -> GenerationParams {
     GenerationParams {
+        reasoning: None,
         max_tokens,
         sampling: SamplingParams {
             temperature: 0.0,


### PR DESCRIPTION
Closes #120.

`/v1/responses` sent `"reasoning_tokens": 0` for every answer from every model. That is not "nobody counted" — it is a claim that the model did not think.

## The counter already existed and was never called

`reasoning_tokens::count` was written, documented and covered by five tests on a WIP branch four days ago. The compiler said what was missing: `function count is never used`. Nothing carried the reasoning format down to where `Usage` is built. This threads it, and rebases the WIP commit onto current `main` (the branch had drifted far enough that merging it would have reverted this week's CUDA and Metal work).

## One field, and the decisions it forced

`GenerationParams` gains the format — not the "did the prompt already open the block" flag, because that is a property of the rendered prompt which `generate` already has. Deriving it there keeps one source instead of two that can disagree.

It is resolved in `generation_params_for_template`, from the **served** model name. That function's doc already argued this is the name that must be used: it is what `OutputPosture::resolve` reads the answer back with, and a count taken against a different name than the split describes a different model.

Adding the field broke four construction sites and `response_cache`'s exhaustive destructure — which is exactly what that destructure is for. Each got a decision:

| site | decision | why |
|---|---|---|
| `generation_params` (base) | `None` | a path that never resolves it reports the field absent, not "no thinking" |
| `/v1/completions`, `openai_extra` | `None` | returns text verbatim, never splits reasoning out — counting one would describe a split that did not happen |
| `response_cache` key | **not keyed** | pure function of the served model, and `CacheKey::model` already keys that; a field that cannot differ when the rest matches makes a key look stricter than it is |

## On the wire

`output_tokens_details` is now **absent** when the checkpoint has no reasoning format, and **present** — including a real `0` — when the split ran. A zero that was counted and a zero that was invented are different facts, and the object's presence is what distinguishes them.

## Tests

Three states, three tests: absent, counted, and a present zero. Plus one pinning that the format comes from the served model rather than the request's `model` field.

Both sabotages confirmed red, each mutation verified in the file first:
- restoring the hardcoded zero → two wire tests fail;
- resolving from `self.model` instead of `served_model` → the threading test fails.

`cargo clippy --workspace --all-targets -D warnings` and `cargo test --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
