### PR TITLE
feat: ferrox gguf-split, a port of llama.cpp's llama-gguf-split

### DIFF
--- a/crates/ferrox-cli/src/gguf_split.rs
+++ b/crates/ferrox-cli/src/gguf_split.rs
@@ -25,8 +25,12 @@ pub struct GgufSplitArgs {
     pub merge: bool,
 
     /// Max tensors per shard (llama.cpp's default: 128).
-    #[arg(long, default_value_t = DEFAULT_MAX_TENSORS, conflicts_with = "split_max_size")]
-    pub split_max_tensors: usize,
+    ///
+    /// `Option`, not a `default_value_t`: `--merge` refuses every split
+    /// option it was given, and a defaulted field cannot say whether
+    /// the user typed it.
+    #[arg(long, conflicts_with = "split_max_size")]
+    pub split_max_tensors: Option<usize>,
 
     /// Max tensor bytes per shard, as `N(M|G)`: decimal megabytes or
     /// gigabytes, the way llama.cpp reads them (`128M` is 128,000,000).
@@ -78,12 +82,44 @@ pub fn parse_split_size(s: &str) -> std::result::Result<u64, String> {
         .ok_or_else(|| format!("{s} does not fit in 64 bits"))
 }
 
-/// The one place the two size flags become a mode: `--split-max-size`
-/// wins when given, otherwise tensor mode with the (defaulted) count.
-pub fn split_mode(args: &GgufSplitArgs) -> SplitMode {
-    match args.split_max_size {
-        Some(bytes) => SplitMode::MaxBytes(bytes),
-        None => SplitMode::MaxTensors(args.split_max_tensors),
+impl GgufSplitArgs {
+    /// The one place the two size flags become a mode:
+    /// `--split-max-size` wins when given, otherwise tensor mode, and
+    /// tensor mode is the default with llama.cpp's 128
+    /// (`gguf-split.cpp:45`, `:161-164`).
+    pub fn mode(&self) -> SplitMode {
+        match self.split_max_size {
+            Some(bytes) => SplitMode::MaxBytes(bytes),
+            None => SplitMode::MaxTensors(self.split_max_tensors.unwrap_or(DEFAULT_MAX_TENSORS)),
+        }
+    }
+
+    /// Every option that only means something to `--split`, named,
+    /// with whether it was typed. `--merge` refuses the ones it was
+    /// given from THIS list, and the tests walk it, so a flag cannot be
+    /// added to one and forgotten by the other.
+    ///
+    /// The destructure is exhaustive with no `..` on purpose: a new
+    /// field on `GgufSplitArgs` stops compiling here until someone
+    /// decides which half of the tool it belongs to. The alternative
+    /// ships a split-only flag that `--merge` accepts and ignores,
+    /// which is this repo's dominant bug shape.
+    fn split_only_flags(&self) -> [(&'static str, bool); 3] {
+        let GgufSplitArgs {
+            split: _,
+            merge: _,
+            split_max_tensors,
+            split_max_size,
+            no_tensor_first_split,
+            dry_run: _,
+            input: _,
+            output: _,
+        } = self;
+        [
+            ("--split-max-tensors", split_max_tensors.is_some()),
+            ("--split-max-size", split_max_size.is_some()),
+            ("--no-tensor-first-split", *no_tensor_first_split),
+        ]
     }
 }
 
@@ -111,10 +147,10 @@ fn print_plan(plan: &SplitPlan) {
 }
 
 fn run_split(args: &GgufSplitArgs) -> Result<()> {
-    let source = GgufFile::open(&args.input)
-        .with_context(|| format!("opening {}", args.input.display()))?;
+    let source =
+        GgufFile::open(&args.input).with_context(|| format!("opening {}", args.input.display()))?;
     let opts = SplitOptions {
-        mode: split_mode(args),
+        mode: args.mode(),
         no_tensor_first_split: args.no_tensor_first_split,
     };
     let plan = plan_split(&source, &opts)
@@ -136,8 +172,21 @@ fn run_split(args: &GgufSplitArgs) -> Result<()> {
 }
 
 fn run_merge(args: &GgufSplitArgs) -> Result<()> {
-    if args.no_tensor_first_split || args.split_max_size.is_some() {
-        bail!("--merge takes no split options");
+    // llama.cpp parses the split options in merge mode and then never
+    // reads them, so `--merge --split-max-size 1G` silently does
+    // nothing there. Refusing names what was ignored instead.
+    let given: Vec<&str> = args
+        .split_only_flags()
+        .iter()
+        .filter(|(_, typed)| *typed)
+        .map(|(name, _)| *name)
+        .collect();
+    if !given.is_empty() {
+        bail!(
+            "--merge takes no split options, but {} was given; a merge writes one file, so \
+             there is no shard size to choose",
+            given.join(", ")
+        );
     }
     eprintln!(
         "gguf_merge: {} -> {}",
@@ -192,16 +241,17 @@ mod tests {
     }
 
     /// Without either flag the mode is tensor mode at llama.cpp's 128
-    /// (`gguf-split.cpp:45`, `:162-164`); a size flag switches mode.
+    /// (`gguf-split.cpp:45`, `:161-164`); a size flag switches mode.
     #[test]
     fn the_default_mode_is_128_tensors_and_a_size_flag_switches_it() {
         let args = parse(&["in.gguf", "out"]);
-        assert_eq!(split_mode(&args), SplitMode::MaxTensors(128));
+        assert_eq!(args.mode(), SplitMode::MaxTensors(DEFAULT_MAX_TENSORS));
+        assert_eq!(DEFAULT_MAX_TENSORS, 128);
         assert!(!args.merge && !args.dry_run && !args.no_tensor_first_split);
         let args = parse(&["--split-max-size", "2G", "in.gguf", "out"]);
-        assert_eq!(split_mode(&args), SplitMode::MaxBytes(2_000_000_000));
+        assert_eq!(args.mode(), SplitMode::MaxBytes(2_000_000_000));
         let args = parse(&["--split-max-tensors", "7", "in.gguf", "out"]);
-        assert_eq!(split_mode(&args), SplitMode::MaxTensors(7));
+        assert_eq!(args.mode(), SplitMode::MaxTensors(7));
     }
 
     /// `gguf-split.cpp:119` and `:135`: the two operations and the two
@@ -209,16 +259,56 @@ mod tests {
     #[test]
     fn conflicting_flags_are_refused_at_parse_time() {
         for argv in [
-            ["--split", "--merge", "in.gguf", "out"],
-            ["--split-max-tensors", "3", "--split-max-size", "1G", "in.gguf", "out"][..4]
-                .try_into()
-                .unwrap(),
+            vec!["--split", "--merge", "in.gguf", "out"],
+            vec![
+                "--split-max-tensors",
+                "3",
+                "--split-max-size",
+                "1G",
+                "in.gguf",
+                "out",
+            ],
         ] {
             let mut full = vec!["gguf-split"];
             full.extend_from_slice(&argv);
             assert!(
                 GgufSplitArgs::try_parse_from(&full).is_err(),
                 "{argv:?} parsed"
+            );
+        }
+    }
+
+    /// Every split-only option has to be REFUSED by `--merge`, not
+    /// parsed and dropped: llama.cpp accepts `--merge --split-max-size
+    /// 1G` and ignores it. The list is walked rather than restated, so
+    /// a new flag that `split_only_flags` classifies is covered here
+    /// the moment it is added; the exhaustive destructure there is what
+    /// stops a new flag from being classified as neither.
+    #[test]
+    fn every_split_only_flag_is_refused_by_merge_and_named_in_the_refusal() {
+        let value_of = |flag: &str| match flag {
+            "--split-max-tensors" => Some("4"),
+            "--split-max-size" => Some("1G"),
+            _ => None,
+        };
+        let flags = parse(&["in.gguf", "out"]).split_only_flags();
+        assert_eq!(flags.len(), 3, "a flag was added without a case here");
+        for (flag, typed) in flags {
+            assert!(!typed, "`{flag}` reads as typed when it was not");
+            let mut argv = vec!["--merge", flag];
+            argv.extend(value_of(flag));
+            argv.extend(["in.gguf", "out"]);
+            let args = parse(&argv);
+            assert!(
+                args.split_only_flags()
+                    .iter()
+                    .any(|(name, typed)| *name == flag && *typed),
+                "`{flag}` did not register as typed"
+            );
+            let err = run_merge(&args).unwrap_err().to_string();
+            assert!(
+                err.contains(flag),
+                "merge with `{flag}` must name it; got: {err}"
             );
         }
     }

--- a/crates/ferrox-cli/src/gguf_split.rs
+++ b/crates/ferrox-cli/src/gguf_split.rs
@@ -1,0 +1,225 @@
+//! `ferrox gguf-split`: llama.cpp's `llama-gguf-split`, same flags,
+//! same shard names, same `split.*` keys. The work is in
+//! `ferrox_gguf::split`; this module is argument parsing and the
+//! progress lines.
+
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use ferrox_gguf::split::{
+    plan_merge, plan_split, write_merge, write_split, SplitMode, SplitOptions, SplitPlan,
+    DEFAULT_MAX_TENSORS,
+};
+use ferrox_gguf::GgufFile;
+
+#[derive(Parser, Debug)]
+pub struct GgufSplitArgs {
+    /// Split GGUF_IN into `GGUF_OUT-NNNNN-of-MMMMM.gguf` shards. The
+    /// default when neither operation is given.
+    #[arg(long, conflicts_with = "merge")]
+    pub split: bool,
+
+    /// Merge the shard set whose FIRST shard is GGUF_IN into GGUF_OUT.
+    #[arg(long)]
+    pub merge: bool,
+
+    /// Max tensors per shard (llama.cpp's default: 128).
+    #[arg(long, default_value_t = DEFAULT_MAX_TENSORS, conflicts_with = "split_max_size")]
+    pub split_max_tensors: usize,
+
+    /// Max tensor bytes per shard, as `N(M|G)`: decimal megabytes or
+    /// gigabytes, the way llama.cpp reads them (`128M` is 128,000,000).
+    #[arg(long, value_parser = parse_split_size)]
+    pub split_max_size: Option<u64>,
+
+    /// Leave the first shard metadata-only, the layout most published
+    /// multi-file checkpoints use.
+    #[arg(long)]
+    pub no_tensor_first_split: bool,
+
+    /// Print the split plan (shard count, tensors and size per shard)
+    /// and write nothing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Source GGUF for `--split`; first shard (`...-00001-of-MMMMM.gguf`)
+    /// for `--merge`.
+    pub input: PathBuf,
+
+    /// Output prefix for `--split` (`out/model` writes
+    /// `out/model-00001-of-00003.gguf`, ...); output file for `--merge`.
+    pub output: PathBuf,
+}
+
+/// `split_str_to_n_bytes`, `gguf-split.cpp:72-88`: a positive integer
+/// followed by `M` (10^6) or `G` (10^9). Lower case is accepted too.
+pub fn parse_split_size(s: &str) -> std::result::Result<u64, String> {
+    let (digits, unit) = match s.char_indices().last() {
+        Some((i, c)) => (&s[..i], c.to_ascii_uppercase()),
+        None => return Err("expected N(M|G), for example 4G".into()),
+    };
+    let multiplier: u64 = match unit {
+        'M' => 1_000_000,
+        'G' => 1_000_000_000,
+        other => {
+            return Err(format!(
+                "supported units are M (megabytes) or G (gigabytes), got '{other}'"
+            ))
+        }
+    };
+    let n: u64 = digits
+        .parse()
+        .map_err(|_| format!("'{digits}' is not a whole number"))?;
+    if n == 0 {
+        return Err("size must be a positive value".into());
+    }
+    n.checked_mul(multiplier)
+        .ok_or_else(|| format!("{s} does not fit in 64 bits"))
+}
+
+/// The one place the two size flags become a mode: `--split-max-size`
+/// wins when given, otherwise tensor mode with the (defaulted) count.
+pub fn split_mode(args: &GgufSplitArgs) -> SplitMode {
+    match args.split_max_size {
+        Some(bytes) => SplitMode::MaxBytes(bytes),
+        None => SplitMode::MaxTensors(args.split_max_tensors),
+    }
+}
+
+pub fn run(args: GgufSplitArgs) -> Result<()> {
+    if args.merge {
+        run_merge(&args)
+    } else {
+        run_split(&args)
+    }
+}
+
+/// llama.cpp's `print_info` (`gguf-split.cpp:294-308`), plus the file
+/// size, since the tool's reason to exist is fitting a size limit.
+fn print_plan(plan: &SplitPlan) {
+    println!("n_split: {}", plan.shards.len());
+    for (i, shard) in plan.shards.iter().enumerate() {
+        println!(
+            "split {:05}: n_tensors = {}, total_size = {}M (file {} bytes)",
+            i + 1,
+            shard.tensors.len(),
+            (shard.header_bytes as u64 + shard.data_bytes) / 1_000_000,
+            shard.file_bytes
+        );
+    }
+}
+
+fn run_split(args: &GgufSplitArgs) -> Result<()> {
+    let source = GgufFile::open(&args.input)
+        .with_context(|| format!("opening {}", args.input.display()))?;
+    let opts = SplitOptions {
+        mode: split_mode(args),
+        no_tensor_first_split: args.no_tensor_first_split,
+    };
+    let plan = plan_split(&source, &opts)
+        .with_context(|| format!("planning a split of {}", args.input.display()))?;
+    print_plan(&plan);
+    if args.dry_run {
+        println!("dry run: nothing written");
+        return Ok(());
+    }
+    let paths = write_split(&source, &plan, &args.output, |path| {
+        println!("Writing file {} ...", path.display());
+    })?;
+    eprintln!(
+        "gguf_split: {} gguf split written with a total of {} tensors.",
+        paths.len(),
+        plan.n_tensors
+    );
+    Ok(())
+}
+
+fn run_merge(args: &GgufSplitArgs) -> Result<()> {
+    if args.no_tensor_first_split || args.split_max_size.is_some() {
+        bail!("--merge takes no split options");
+    }
+    eprintln!(
+        "gguf_merge: {} -> {}",
+        args.input.display(),
+        args.output.display()
+    );
+    let plan = plan_merge(&args.input)?;
+    for path in plan.shard_paths() {
+        eprintln!("gguf_merge: reading metadata {} ... done", path.display());
+    }
+    println!(
+        "n_split: {}, n_tensors: {}",
+        plan.shard_paths().len(),
+        plan.tensors.len()
+    );
+    if args.dry_run {
+        println!("dry run: nothing written");
+        return Ok(());
+    }
+    write_merge(&plan, &args.output)?;
+    eprintln!(
+        "gguf_merge: {} merged from {} split with {} tensors.",
+        args.output.display(),
+        plan.shard_paths().len(),
+        plan.tensors.len()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> GgufSplitArgs {
+        let mut full = vec!["gguf-split"];
+        full.extend_from_slice(argv);
+        GgufSplitArgs::try_parse_from(full)
+            .unwrap_or_else(|e| panic!("`{}` did not parse: {e}", argv.join(" ")))
+    }
+
+    /// llama.cpp's units are decimal (`gguf-split.cpp:77`, `:80`):
+    /// `4G` is 4,000,000,000, not 2^32. A binary reading would produce
+    /// shards 7% larger than the limit the user typed.
+    #[test]
+    fn split_size_units_are_decimal_like_llama_cpp() {
+        assert_eq!(parse_split_size("128M").unwrap(), 128_000_000);
+        assert_eq!(parse_split_size("4G").unwrap(), 4_000_000_000);
+        assert_eq!(parse_split_size("4g").unwrap(), 4_000_000_000);
+        for bad in ["4", "4K", "0G", "-1G", "G", "", "4.5G"] {
+            assert!(parse_split_size(bad).is_err(), "{bad:?} parsed");
+        }
+    }
+
+    /// Without either flag the mode is tensor mode at llama.cpp's 128
+    /// (`gguf-split.cpp:45`, `:162-164`); a size flag switches mode.
+    #[test]
+    fn the_default_mode_is_128_tensors_and_a_size_flag_switches_it() {
+        let args = parse(&["in.gguf", "out"]);
+        assert_eq!(split_mode(&args), SplitMode::MaxTensors(128));
+        assert!(!args.merge && !args.dry_run && !args.no_tensor_first_split);
+        let args = parse(&["--split-max-size", "2G", "in.gguf", "out"]);
+        assert_eq!(split_mode(&args), SplitMode::MaxBytes(2_000_000_000));
+        let args = parse(&["--split-max-tensors", "7", "in.gguf", "out"]);
+        assert_eq!(split_mode(&args), SplitMode::MaxTensors(7));
+    }
+
+    /// `gguf-split.cpp:119` and `:135`: the two operations and the two
+    /// limits are each mutually exclusive.
+    #[test]
+    fn conflicting_flags_are_refused_at_parse_time() {
+        for argv in [
+            ["--split", "--merge", "in.gguf", "out"],
+            ["--split-max-tensors", "3", "--split-max-size", "1G", "in.gguf", "out"][..4]
+                .try_into()
+                .unwrap(),
+        ] {
+            let mut full = vec!["gguf-split"];
+            full.extend_from_slice(&argv);
+            assert!(
+                GgufSplitArgs::try_parse_from(&full).is_err(),
+                "{argv:?} parsed"
+            );
+        }
+    }
+}

--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -8,6 +8,7 @@ mod bench_model;
 mod bench_suite;
 mod chat;
 mod download;
+mod gguf_split;
 mod hf;
 mod host_state;
 mod http;
@@ -104,6 +105,11 @@ enum Commands {
     /// measurably worse text. Use `llama-quantize` for those; ferrox
     /// reads what it writes.
     Quantize(quantize::QuantizeArgs),
+    /// Split a GGUF into shards, or merge a shard set back into one
+    /// file: llama.cpp's `llama-gguf-split`, same flags and same
+    /// `<prefix>-NNNNN-of-MMMMM.gguf` names.
+    #[command(name = "gguf-split")]
+    GgufSplit(gguf_split::GgufSplitArgs),
     /// Print GGUF header metadata and tensor list for a model file.
     Inspect { path: String },
     /// Dry-run residency plan for a GGUF checkpoint: what it would
@@ -540,6 +546,7 @@ const SUBCOMMANDS: &[&str] = &[
     "layer-divergence",
     "quant-sensitivity",
     "quantize",
+    "gguf-split",
     "parity",
     "perplexity",
     "speculative",
@@ -762,6 +769,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Pull(args) => pull::run_pull(args)?,
         Commands::Download(args) => download::run(args)?,
         Commands::Quantize(args) => quantize::run(args)?,
+        Commands::GgufSplit(args) => gguf_split::run(args)?,
         Commands::Inspect { path } => {
             let file = ShardedGguf::open(&path)?;
             if file.shard_count() > 1 {

--- a/crates/ferrox-gguf/src/lib.rs
+++ b/crates/ferrox-gguf/src/lib.rs
@@ -5,6 +5,7 @@
 //! See docs/THIRD_PARTY_NOTICES.md for design-credit details.
 
 pub mod sharded;
+pub mod split;
 pub mod writer;
 pub use sharded::{ShardError, ShardName, ShardedGguf};
 pub use writer::{GgufWriteError, GgufWriter, TensorPlan};

--- a/crates/ferrox-gguf/src/split.rs
+++ b/crates/ferrox-gguf/src/split.rs
@@ -11,22 +11,22 @@
 //! What llama.cpp's tool does, with the lines this port follows:
 //!
 //! * The first shard carries the whole source metadata
-//!   (`gguf-split.cpp:236`); every later shard carries ONLY `split.no`
+//!   (`gguf-split.cpp:234-236`); every later shard carries ONLY `split.no`
 //!   (u16, 0-based), `split.count` (u16) and `split.tensors.count`
 //!   (i32, the total across all shards) (`:238-240`, `:272`).
 //! * Tensor mode starts a new shard every N tensors (`:288`); size mode
 //!   starts one when the running sum of alignment-padded tensor bytes
 //!   would exceed the limit (`:256-258`, `:285`). A shard is never
 //!   left empty, which is only possible when the first tensor alone
-//!   exceeds the size limit (`:227`), except the first shard under
-//!   `--no-tensor-first-split` (`:247-249`).
+//!   exceeds the size limit (`:226-228`), except the first shard under
+//!   `--no-tensor-first-split` (`:246-248`).
 //! * Filenames are `<prefix>-NNNNN-of-MMMMM.gguf`, 1-based
 //!   (`src/llama.cpp:537`, `llama_split_path`).
 //! * Merge takes the FIRST shard by name (`:474`), requires
 //!   `split.count` (`:449`), keeps the first shard's metadata with
 //!   `split.count` rewritten to 0 so the output is not itself read as
 //!   a shard (`:486`), and refuses to overwrite an existing output
-//!   (`:410`).
+//!   (`:409-411`).
 //!
 //! Two deliberate differences, both from choices the rest of this crate
 //! already made: metadata keys are written in sorted order, because the
@@ -248,7 +248,9 @@ pub fn plan_split(source: &GgufFile, opts: &SplitOptions) -> Result<SplitPlan, S
                 // overflowed the previous one.
                 let max = match opts.mode {
                     SplitMode::MaxBytes(max) => max,
-                    SplitMode::MaxTensors(_) => unreachable!("tensor mode never closes an empty shard"),
+                    SplitMode::MaxTensors(_) => {
+                        unreachable!("tensor mode never closes an empty shard")
+                    }
                 };
                 return Err(SplitError::TensorExceedsShard {
                     name: t.name.clone(),
@@ -327,11 +329,8 @@ pub fn write_split(
         let path = shard_path(prefix, no, count)?;
         on_shard(&path);
         let file = File::create(&path).map_err(|e| io_err(&path, e))?;
-        let mut w = GgufWriter::create(
-            BufWriter::new(file),
-            &shard.metadata,
-            shard.tensors.clone(),
-        )?;
+        let mut w =
+            GgufWriter::create(BufWriter::new(file), &shard.metadata, shard.tensors.clone())?;
         for t in &shard.tensors {
             w.write_tensor(&t.name, source.tensor_bytes(&t.name)?)?;
         }
@@ -351,7 +350,14 @@ pub fn plan_merge(first: &Path) -> Result<MergePlan, SplitError> {
     let name = ShardName::parse(first)
         .filter(|n| n.no == 1)
         .ok_or_else(|| SplitError::NotFirstShard(display.clone()))?;
-    let first_file = GgufFile::open(first)?;
+    // `GgufError::Io` carries no path, and a merge that cannot find its
+    // FIRST shard would otherwise report a bare "No such file or
+    // directory" while `ShardError::MissingShard` names every later
+    // one. Both halves of the refusal name the file they wanted.
+    let first_file = GgufFile::open(first).map_err(|e| match e {
+        GgufError::Io(source) => io_err(first, source),
+        other => SplitError::Gguf(other),
+    })?;
     let count = first_file
         .metadata_u64(SPLIT_COUNT_KEY)
         .ok_or_else(|| SplitError::NotSplit(display.clone()))?;
@@ -373,7 +379,7 @@ pub fn plan_merge(first: &Path) -> Result<MergePlan, SplitError> {
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
-    // `gguf-split.cpp:486`: the merged file keeps split.no and
+    // `gguf-split.cpp:485-486`: the merged file keeps split.no and
     // split.tensors.count, and gets split.count = 0 so nothing reads it
     // as a shard again.
     metadata.insert(SPLIT_COUNT_KEY.to_string(), GgufValue::U16(0));
@@ -390,7 +396,7 @@ pub fn plan_merge(first: &Path) -> Result<MergePlan, SplitError> {
 }
 
 /// Writes the merged file. Refuses an existing `out` the way llama.cpp
-/// does (`gguf-split.cpp:410`).
+/// does (`gguf-split.cpp:409-411`).
 pub fn write_merge(plan: &MergePlan, out: &Path) -> Result<(), SplitError> {
     if out.exists() {
         return Err(SplitError::OutputExists(out.display().to_string()));
@@ -460,7 +466,7 @@ mod tests {
             mk("blk.0.attn_q.weight", vec![32, 3], GgmlType::Q8_0, 5), // 102
             mk("blk.0.attn_norm.weight", vec![5], GgmlType::F32, 7), // 20
             mk("blk.1.ffn_up.weight", vec![7, 3], GgmlType::F16, 11), // 42
-            mk("output_norm.weight", vec![9], GgmlType::F32, 13),   // 36
+            mk("output_norm.weight", vec![9], GgmlType::F32, 13),  // 36
         ]
     }
 
@@ -512,7 +518,11 @@ mod tests {
     }
 
     fn assert_same_values(a: &GgufValue, b: &GgufValue, key: &str) {
-        assert_eq!(format!("{a:?}"), format!("{b:?}"), "metadata '{key}' changed");
+        assert_eq!(
+            format!("{a:?}"),
+            format!("{b:?}"),
+            "metadata '{key}' changed"
+        );
     }
 
     /// The property the module exists for: the shards this writes are
@@ -589,7 +599,7 @@ mod tests {
     /// Where llama.cpp's own tool is byte-identical, so is this one: a
     /// source that already carries `split.no = 0`, `split.count = 0`
     /// and `split.tensors.count = N` (what a previous merge leaves
-    /// behind, `gguf-split.cpp:486`) survives split then merge without
+    /// behind, `gguf-split.cpp:485-486`) survives split then merge without
     /// a single byte changing.
     #[test]
     fn merging_the_shards_reproduces_a_merged_source_byte_for_byte() {
@@ -655,13 +665,26 @@ mod tests {
         std::fs::remove_file(&paths[1]).unwrap();
 
         let err = plan_merge(&paths[0]).unwrap_err();
-        match err {
+        match &err {
             SplitError::Shard(ShardError::MissingShard(path, 3)) => {
-                assert_eq!(path, paths[1].display().to_string());
+                assert_eq!(path, &paths[1].display().to_string());
             }
             other => panic!("expected MissingShard naming shard 2, got {other:?}"),
         }
+        assert!(
+            err.to_string().contains(&paths[1].display().to_string()),
+            "the refusal has to print the missing shard's path: {err}"
+        );
         assert!(!dir.path("merged.gguf").exists());
+
+        // The FIRST shard missing is the same refusal, by the other
+        // half: `GgufError::Io` carries no path of its own.
+        std::fs::remove_file(&paths[0]).unwrap();
+        let err = plan_merge(&paths[0]).unwrap_err();
+        assert!(
+            matches!(&err, SplitError::Io { path, .. } if path == &paths[0].display().to_string()),
+            "got {err:?}"
+        );
     }
 
     /// Size mode groups by alignment-PADDED bytes (`gguf-split.cpp:256`),
@@ -690,13 +713,32 @@ mod tests {
 
         // Unpadded 192+102+20 = 314 < 330 would have put three in the
         // first shard; the padded arithmetic is what decides.
-        let plan = plan_split(
-            &source,
-            &SplitMode::MaxBytes(314).with_no_first(false),
-        )
-        .unwrap();
+        let plan = plan_split(&source, &SplitMode::MaxBytes(314).with_no_first(false)).unwrap();
         let groups: Vec<usize> = plan.shards.iter().map(|s| s.tensors.len()).collect();
         assert_eq!(groups, vec![1, 4], "192 alone; 128+32+64+64 = 288");
+
+        // The boundary is `next > max`, not `>=` (`gguf-split.cpp:285`):
+        // a shard that comes out EXACTLY at the limit is full and
+        // legal. Every other limit in this test leaves the prefix sums
+        // off the boundary, so `>` and `>=` behave identically at them
+        // and a sabotage of the comparison survives. 320 is 192 + 128
+        // exactly, which is the only value that tells the two apart.
+        let plan = plan_split(&source, &SplitMode::MaxBytes(320).with_no_first(false)).unwrap();
+        let groups: Vec<usize> = plan.shards.iter().map(|s| s.tensors.len()).collect();
+        assert_eq!(
+            groups,
+            vec![2, 3],
+            "192 + 128 == 320 must FILL the first shard, not overflow it"
+        );
+        assert_eq!(
+            plan.shards[0]
+                .tensors
+                .iter()
+                .map(|t| (t.byte_len as u64).next_multiple_of(32))
+                .sum::<u64>(),
+            320,
+            "the shard that proves `>` from `>=` has to sit on the limit"
+        );
     }
 
     impl SplitMode {
@@ -710,7 +752,7 @@ mod tests {
 
     /// The only way a shard can end up empty in size mode is the first
     /// tensor alone exceeding the limit; llama.cpp exits with "one of
-    /// splits have 0 tensors" (`gguf-split.cpp:227`). This names the
+    /// splits have 0 tensors" (`gguf-split.cpp:226-228`). This names the
     /// tensor and the two numbers instead.
     #[test]
     fn a_first_tensor_larger_than_the_size_limit_is_refused_by_name() {
@@ -727,7 +769,10 @@ mod tests {
         // Same with a metadata-only first shard: the SECOND shard is the
         // one that would be empty.
         let err = plan_split(&source, &SplitMode::MaxBytes(100).with_no_first(true)).unwrap_err();
-        assert!(matches!(err, SplitError::TensorExceedsShard { .. }), "got {err:?}");
+        assert!(
+            matches!(err, SplitError::TensorExceedsShard { .. }),
+            "got {err:?}"
+        );
     }
 
     /// `--no-tensor-first-split` produces the metadata-only first shard
@@ -784,10 +829,7 @@ mod tests {
         let (_, paths) = split_to(&dir, &src, &by_tensors(2));
         let shard = GgufFile::open(&paths[1]).unwrap();
         let err = plan_split(&shard, &by_tensors(2)).unwrap_err();
-        assert!(
-            matches!(err, SplitError::InputIsSplit(3)),
-            "got {err:?}"
-        );
+        assert!(matches!(err, SplitError::InputIsSplit(3)), "got {err:?}");
     }
 
     #[test]
@@ -808,7 +850,7 @@ mod tests {
         let err = plan_merge(&plain).unwrap_err();
         assert!(matches!(err, SplitError::NotSplit(_)), "got {err:?}");
 
-        // gguf-split.cpp:410: never overwrite.
+        // gguf-split.cpp:409-411: never overwrite.
         let plan = plan_merge(&paths[0]).unwrap();
         let err = write_merge(&plan, &src).unwrap_err();
         assert!(matches!(err, SplitError::OutputExists(_)), "got {err:?}");

--- a/crates/ferrox-gguf/src/split.rs
+++ b/crates/ferrox-gguf/src/split.rs
@@ -1,0 +1,857 @@
+//! Splitting one GGUF into shards and merging shards back: the writing
+//! half of what [`crate::sharded`] reads, and the port of llama.cpp's
+//! `tools/gguf-split/gguf-split.cpp`.
+//!
+//! The shard convention is the one `ShardedGguf` already validates, so
+//! the two halves cannot drift about it: shard filenames come from
+//! [`ShardName::sibling`], the three `split.*` keys from the constants
+//! in `sharded`, and a written set is proven by opening it with
+//! `ShardedGguf::open` in the tests below.
+//!
+//! What llama.cpp's tool does, with the lines this port follows:
+//!
+//! * The first shard carries the whole source metadata
+//!   (`gguf-split.cpp:236`); every later shard carries ONLY `split.no`
+//!   (u16, 0-based), `split.count` (u16) and `split.tensors.count`
+//!   (i32, the total across all shards) (`:238-240`, `:272`).
+//! * Tensor mode starts a new shard every N tensors (`:288`); size mode
+//!   starts one when the running sum of alignment-padded tensor bytes
+//!   would exceed the limit (`:256-258`, `:285`). A shard is never
+//!   left empty, which is only possible when the first tensor alone
+//!   exceeds the size limit (`:227`), except the first shard under
+//!   `--no-tensor-first-split` (`:247-249`).
+//! * Filenames are `<prefix>-NNNNN-of-MMMMM.gguf`, 1-based
+//!   (`src/llama.cpp:537`, `llama_split_path`).
+//! * Merge takes the FIRST shard by name (`:474`), requires
+//!   `split.count` (`:449`), keeps the first shard's metadata with
+//!   `split.count` rewritten to 0 so the output is not itself read as
+//!   a shard (`:486`), and refuses to overwrite an existing output
+//!   (`:410`).
+//!
+//! Two deliberate differences, both from choices the rest of this crate
+//! already made: metadata keys are written in sorted order, because the
+//! reader keeps them in a `HashMap` and the writer sorts (see
+//! [`GgufWriter::create`]); and shards are padded with the alignment
+//! the source declares, where llama.cpp's tool pads with 32 whatever
+//! `general.alignment` says (`gguf_init_empty` fixes `ctx->alignment`
+//! at `GGUF_DEFAULT_ALIGNMENT`, `ggml/src/gguf.cpp:223`, and
+//! `gguf_set_kv` never updates it).
+//!
+//! Tensor bytes are never buffered: each one is written straight from
+//! the source file's mapping.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{self, BufWriter};
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::sharded::{ShardName, SPLIT_COUNT_KEY, SPLIT_NO_KEY, SPLIT_TENSORS_COUNT_KEY};
+use crate::writer::{declared_alignment, encode_header};
+use crate::{
+    GgufError, GgufFile, GgufValue, GgufWriteError, GgufWriter, ShardError, ShardedGguf,
+    TensorInfo, TensorPlan,
+};
+
+/// llama.cpp's default for `--split-max-tensors` (`gguf-split.cpp:45`).
+pub const DEFAULT_MAX_TENSORS: usize = 128;
+
+/// How shard boundaries are chosen. Mirrors `split_mode` in
+/// `gguf-split.cpp:35-39`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SplitMode {
+    /// At most this many tensors per shard.
+    MaxTensors(usize),
+    /// At most this many alignment-padded tensor bytes per shard. The
+    /// header is not counted, exactly as llama.cpp does not count it.
+    MaxBytes(u64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SplitOptions {
+    pub mode: SplitMode,
+    /// Leave the first shard metadata-only (`--no-tensor-first-split`).
+    pub no_tensor_first_split: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum SplitError {
+    #[error(transparent)]
+    Gguf(#[from] GgufError),
+    #[error(transparent)]
+    Write(#[from] GgufWriteError),
+    #[error(transparent)]
+    Shard(#[from] ShardError),
+    #[error("{path}: {source}")]
+    Io { path: String, source: io::Error },
+    #[error("--split-max-tensors must be at least 1")]
+    ZeroMaxTensors,
+    #[error("--split-max-size must be at least 1 byte")]
+    ZeroMaxBytes,
+    #[error(
+        "the input is itself one shard of a {0}-file split. Splitting one shard would produce \
+         a set whose split.tensors.count covers that shard alone; merge the set first (ferrox \
+         gguf-split --merge) and split the result"
+    )]
+    InputIsSplit(u64),
+    #[error(
+        "tensor '{name}' is {bytes} bytes after padding, more than the {max}-byte shard limit, \
+         so the shard it starts would have to stay empty (llama.cpp refuses this as 'one of \
+         splits have 0 tensors'); raise --split-max-size"
+    )]
+    TensorExceedsShard { name: String, bytes: u64, max: u64 },
+    #[error("{0} shards do not fit split.count, which GGUF stores as a u16")]
+    TooManyShards(usize),
+    #[error("{0} tensors do not fit split.tensors.count, which GGUF stores as an i32")]
+    TooManyTensors(usize),
+    #[error("output prefix '{0}' is not valid UTF-8, so no shard name can be built from it")]
+    NonUtf8Prefix(String),
+    #[error(
+        "'{0}' is not the first shard of a set: merge takes '<prefix>-00001-of-MMMMM.gguf' and \
+         finds the rest from it"
+    )]
+    NotFirstShard(String),
+    #[error("'{0}' carries no split.count metadata, so it is not a split GGUF")]
+    NotSplit(String),
+    #[error("'{0}' declares split.count = 0, which is not a valid shard count")]
+    ZeroSplitCount(String),
+    #[error("output '{0}' already exists; merge refuses to overwrite it")]
+    OutputExists(String),
+}
+
+/// One shard of a [`SplitPlan`]: what it will carry and how big it
+/// will be, computed before any file is opened for writing.
+#[derive(Debug, Clone)]
+pub struct ShardPlan {
+    /// The shard's metadata: everything the source had for the first
+    /// shard, the three `split.*` keys for the rest.
+    pub metadata: BTreeMap<String, GgufValue>,
+    /// The shard's tensors, in source order.
+    pub tensors: Vec<TensorPlan>,
+    /// Header bytes, padding to the data section included: what
+    /// llama.cpp reports as `gguf_get_meta_size`.
+    pub header_bytes: usize,
+    /// Tensor bytes, unpadded, the way llama.cpp's `print_info` sums
+    /// them (`gguf-split.cpp:302`).
+    pub data_bytes: u64,
+    /// The size the shard file will have on disk.
+    pub file_bytes: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SplitPlan {
+    pub shards: Vec<ShardPlan>,
+    /// Tensors across all shards.
+    pub n_tensors: usize,
+}
+
+/// A merge, planned before anything is written: the shard set held
+/// open and the output's metadata and tensor order.
+pub struct MergePlan {
+    set: ShardedGguf,
+    pub metadata: BTreeMap<String, GgufValue>,
+    pub tensors: Vec<TensorPlan>,
+}
+
+impl MergePlan {
+    pub fn shard_paths(&self) -> &[PathBuf] {
+        self.set.shard_paths()
+    }
+}
+
+impl std::fmt::Debug for MergePlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MergePlan")
+            .field("shard_paths", &self.set.shard_paths())
+            .field("metadata_keys", &self.metadata.len())
+            .field("tensors", &self.tensors.len())
+            .finish()
+    }
+}
+
+/// A source tensor's header entry for the output, sized from its
+/// dtype. `None` from `byte_len` is a dtype whose block layout this
+/// build does not know, and the source's own `tensor_bytes` would
+/// refuse it the same way.
+fn tensor_plan(t: &TensorInfo) -> Result<TensorPlan, GgufError> {
+    let byte_len = t
+        .byte_len()
+        .ok_or_else(|| GgufError::UnsizedTensor(t.name.clone(), t.dtype))?;
+    Ok(TensorPlan {
+        name: t.name.clone(),
+        shape: t.shape.clone(),
+        dtype: t.dtype,
+        byte_len,
+    })
+}
+
+fn split_keys(no: u16, count: u16, n_tensors: i32) -> [(&'static str, GgufValue); 3] {
+    // The types are llama.cpp's exactly: `gguf_set_val_u16` for
+    // split.no and split.count, `gguf_set_val_i32` for
+    // split.tensors.count (`gguf-split.cpp:238-240`, `:272`).
+    [
+        (SPLIT_NO_KEY, GgufValue::U16(no)),
+        (SPLIT_COUNT_KEY, GgufValue::U16(count)),
+        (SPLIT_TENSORS_COUNT_KEY, GgufValue::I32(n_tensors)),
+    ]
+}
+
+fn io_err(path: &Path, source: io::Error) -> SplitError {
+    SplitError::Io {
+        path: path.display().to_string(),
+        source,
+    }
+}
+
+/// Decides which tensors go in which shard and what each shard will
+/// look like. Pure: reads the source's header, opens nothing.
+pub fn plan_split(source: &GgufFile, opts: &SplitOptions) -> Result<SplitPlan, SplitError> {
+    if let Some(count) = source.metadata_u64(SPLIT_COUNT_KEY).filter(|&c| c > 1) {
+        return Err(SplitError::InputIsSplit(count));
+    }
+    match opts.mode {
+        SplitMode::MaxTensors(0) => return Err(SplitError::ZeroMaxTensors),
+        SplitMode::MaxBytes(0) => return Err(SplitError::ZeroMaxBytes),
+        SplitMode::MaxTensors(_) | SplitMode::MaxBytes(_) => {}
+    }
+    let alignment = declared_alignment(source.metadata.get("general.alignment"))? as u64;
+    let n_tensors = source.tensors.len();
+    let tensors_count =
+        i32::try_from(n_tensors).map_err(|_| SplitError::TooManyTensors(n_tensors))?;
+
+    let plans: Vec<TensorPlan> = source
+        .tensors
+        .iter()
+        .map(tensor_plan)
+        .collect::<Result<_, _>>()?;
+
+    // Group source indices. `gguf-split.cpp:243-268`.
+    let mut groups: Vec<Vec<usize>> = vec![Vec::new()];
+    if opts.no_tensor_first_split {
+        groups.push(Vec::new());
+    }
+    let mut current: u64 = 0;
+    for (i, t) in plans.iter().enumerate() {
+        let padded = (t.byte_len as u64).next_multiple_of(alignment);
+        let next = current.saturating_add(padded);
+        let boundary = match opts.mode {
+            SplitMode::MaxBytes(max) => next > max,
+            SplitMode::MaxTensors(n) => i > 0 && i % n == 0,
+        };
+        if boundary {
+            let last = groups.last().expect("groups starts non-empty");
+            if last.is_empty() {
+                // Only reachable in size mode at i == 0: tensor mode
+                // never closes a shard before it has N tensors, and a
+                // later shard always opens with the tensor that
+                // overflowed the previous one.
+                let max = match opts.mode {
+                    SplitMode::MaxBytes(max) => max,
+                    SplitMode::MaxTensors(_) => unreachable!("tensor mode never closes an empty shard"),
+                };
+                return Err(SplitError::TensorExceedsShard {
+                    name: t.name.clone(),
+                    bytes: padded,
+                    max,
+                });
+            }
+            groups.push(vec![i]);
+            current = padded;
+        } else {
+            groups.last_mut().expect("groups starts non-empty").push(i);
+            current = next;
+        }
+    }
+
+    let count = u16::try_from(groups.len()).map_err(|_| SplitError::TooManyShards(groups.len()))?;
+
+    let mut shards = Vec::with_capacity(groups.len());
+    for (no, group) in groups.iter().enumerate() {
+        let mut metadata: BTreeMap<String, GgufValue> = if no == 0 {
+            source
+                .metadata
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        } else {
+            BTreeMap::new()
+        };
+        for (key, value) in split_keys(no as u16, count, tensors_count) {
+            metadata.insert(key.to_string(), value);
+        }
+        let tensors: Vec<TensorPlan> = group.iter().map(|&i| plans[i].clone()).collect();
+        let header_bytes = encode_header(&metadata, &tensors)?.len();
+        let data_bytes: u64 = tensors.iter().map(|t| t.byte_len as u64).sum();
+        let padded_bytes: u64 = tensors
+            .iter()
+            .map(|t| (t.byte_len as u64).next_multiple_of(alignment))
+            .sum();
+        shards.push(ShardPlan {
+            metadata,
+            tensors,
+            header_bytes,
+            data_bytes,
+            file_bytes: header_bytes as u64 + padded_bytes,
+        });
+    }
+    Ok(SplitPlan { shards, n_tensors })
+}
+
+/// The shard path `plan` will write for 0-based shard `no`.
+pub fn shard_path(prefix: &Path, no: usize, count: usize) -> Result<PathBuf, SplitError> {
+    let prefix = prefix
+        .to_str()
+        .ok_or_else(|| SplitError::NonUtf8Prefix(prefix.display().to_string()))?;
+    let name = ShardName {
+        prefix: prefix.to_string(),
+        no: 0,
+        count: count as u64,
+    };
+    Ok(name.sibling(no as u64 + 1))
+}
+
+/// Writes every shard of `plan` as `<prefix>-NNNNN-of-MMMMM.gguf`,
+/// calling `on_shard` with each path as it is about to be written.
+/// Returns the paths written. Tensor bytes go from `source`'s mapping
+/// to the file with no intermediate buffer.
+pub fn write_split(
+    source: &GgufFile,
+    plan: &SplitPlan,
+    prefix: &Path,
+    mut on_shard: impl FnMut(&Path),
+) -> Result<Vec<PathBuf>, SplitError> {
+    let count = plan.shards.len();
+    let mut paths = Vec::with_capacity(count);
+    for (no, shard) in plan.shards.iter().enumerate() {
+        let path = shard_path(prefix, no, count)?;
+        on_shard(&path);
+        let file = File::create(&path).map_err(|e| io_err(&path, e))?;
+        let mut w = GgufWriter::create(
+            BufWriter::new(file),
+            &shard.metadata,
+            shard.tensors.clone(),
+        )?;
+        for t in &shard.tensors {
+            w.write_tensor(&t.name, source.tensor_bytes(&t.name)?)?;
+        }
+        w.finish()?;
+        paths.push(path);
+    }
+    Ok(paths)
+}
+
+/// Opens the shard set whose first file is `first` and lays out the
+/// merged file. Every shard is validated by `ShardedGguf::open`, so a
+/// missing sibling refuses here, by path, before anything is written.
+pub fn plan_merge(first: &Path) -> Result<MergePlan, SplitError> {
+    let display = first.display().to_string();
+    // `llama_split_prefix` with i_split = 0 (`gguf-split.cpp:474`):
+    // the name has to end in `-00001-of-MMMMM.gguf`.
+    let name = ShardName::parse(first)
+        .filter(|n| n.no == 1)
+        .ok_or_else(|| SplitError::NotFirstShard(display.clone()))?;
+    let first_file = GgufFile::open(first)?;
+    let count = first_file
+        .metadata_u64(SPLIT_COUNT_KEY)
+        .ok_or_else(|| SplitError::NotSplit(display.clone()))?;
+    if count == 0 {
+        return Err(SplitError::ZeroSplitCount(display));
+    }
+    if name.count != count {
+        return Err(ShardError::ShardCountMismatch {
+            path: display,
+            expected: name.count,
+            found: count,
+        }
+        .into());
+    }
+    let set = ShardedGguf::open(first)?;
+
+    let mut metadata: BTreeMap<String, GgufValue> = first_file
+        .metadata
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    // `gguf-split.cpp:486`: the merged file keeps split.no and
+    // split.tensors.count, and gets split.count = 0 so nothing reads it
+    // as a shard again.
+    metadata.insert(SPLIT_COUNT_KEY.to_string(), GgufValue::U16(0));
+
+    let tensors = set
+        .tensors()
+        .map(|(_, t)| tensor_plan(t))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(MergePlan {
+        set,
+        metadata,
+        tensors,
+    })
+}
+
+/// Writes the merged file. Refuses an existing `out` the way llama.cpp
+/// does (`gguf-split.cpp:410`).
+pub fn write_merge(plan: &MergePlan, out: &Path) -> Result<(), SplitError> {
+    if out.exists() {
+        return Err(SplitError::OutputExists(out.display().to_string()));
+    }
+    let file = File::create(out).map_err(|e| io_err(out, e))?;
+    let mut w = GgufWriter::create(BufWriter::new(file), &plan.metadata, plan.tensors.clone())?;
+    for t in &plan.tensors {
+        w.write_tensor(&t.name, plan.set.tensor_bytes(&t.name)?)?;
+    }
+    w.finish()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::GgmlType;
+
+    struct TempDir(PathBuf);
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let d = std::env::temp_dir().join(format!(
+                "ferrox_split_test_{tag}_{}_{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            std::fs::remove_dir_all(&d).ok();
+            std::fs::create_dir_all(&d).unwrap();
+            TempDir(d)
+        }
+        fn path(&self, name: &str) -> PathBuf {
+            self.0.join(name)
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).ok();
+        }
+    }
+
+    /// Five tensors of three dtypes, sized so no two are equal and so
+    /// several are not multiples of the 32-byte alignment (the padding
+    /// arithmetic has to be exercised, not skipped).
+    fn synthetic_tensors() -> Vec<(TensorPlan, Vec<u8>)> {
+        let mk = |name: &str, shape: Vec<u64>, dtype: GgmlType, seed: u8| {
+            let n = TensorInfo {
+                name: name.into(),
+                shape: shape.clone(),
+                dtype,
+                offset: 0,
+            }
+            .byte_len()
+            .unwrap();
+            let bytes: Vec<u8> = (0..n).map(|i| (i as u8).wrapping_mul(seed)).collect();
+            (
+                TensorPlan {
+                    name: name.into(),
+                    shape,
+                    dtype,
+                    byte_len: n,
+                },
+                bytes,
+            )
+        };
+        vec![
+            mk("token_embd.weight", vec![8, 6], GgmlType::F32, 3), // 192
+            mk("blk.0.attn_q.weight", vec![32, 3], GgmlType::Q8_0, 5), // 102
+            mk("blk.0.attn_norm.weight", vec![5], GgmlType::F32, 7), // 20
+            mk("blk.1.ffn_up.weight", vec![7, 3], GgmlType::F16, 11), // 42
+            mk("output_norm.weight", vec![9], GgmlType::F32, 13),   // 36
+        ]
+    }
+
+    fn base_metadata() -> BTreeMap<String, GgufValue> {
+        [
+            ("general.architecture", GgufValue::String("llama".into())),
+            ("general.name", GgufValue::String("synthetic".into())),
+            ("llama.block_count", GgufValue::U32(2)),
+            (
+                "tokenizer.ggml.tokens",
+                GgufValue::Array(vec![
+                    GgufValue::String("<s>".into()),
+                    GgufValue::String("hi".into()),
+                ]),
+            ),
+            ("llama.rope.freq_base", GgufValue::F32(10000.0)),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect()
+    }
+
+    fn write_source(
+        path: &Path,
+        metadata: &BTreeMap<String, GgufValue>,
+        tensors: &[(TensorPlan, Vec<u8>)],
+    ) {
+        let file = File::create(path).unwrap();
+        let plan: Vec<TensorPlan> = tensors.iter().map(|(p, _)| p.clone()).collect();
+        let mut w = GgufWriter::create(BufWriter::new(file), metadata, plan).unwrap();
+        for (p, bytes) in tensors {
+            w.write_tensor(&p.name, bytes).unwrap();
+        }
+        w.finish().unwrap();
+    }
+
+    fn by_tensors(n: usize) -> SplitOptions {
+        SplitOptions {
+            mode: SplitMode::MaxTensors(n),
+            no_tensor_first_split: false,
+        }
+    }
+
+    fn split_to(dir: &TempDir, src: &Path, opts: &SplitOptions) -> (SplitPlan, Vec<PathBuf>) {
+        let source = GgufFile::open(src).unwrap();
+        let plan = plan_split(&source, opts).unwrap();
+        let paths = write_split(&source, &plan, &dir.path("out"), |_| {}).unwrap();
+        (plan, paths)
+    }
+
+    fn assert_same_values(a: &GgufValue, b: &GgufValue, key: &str) {
+        assert_eq!(format!("{a:?}"), format!("{b:?}"), "metadata '{key}' changed");
+    }
+
+    /// The property the module exists for: the shards this writes are
+    /// what `ShardedGguf` reads back, tensor for tensor and key for
+    /// key, and each shard carries llama.cpp's three keys with
+    /// llama.cpp's types and values.
+    #[test]
+    fn a_split_set_reads_back_through_the_shard_loader_as_the_original() {
+        let dir = TempDir::new("roundtrip");
+        let tensors = synthetic_tensors();
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &tensors);
+        let (plan, paths) = split_to(&dir, &src, &by_tensors(2));
+
+        assert_eq!(plan.shards.len(), 3, "5 tensors at 2 per shard is 3 shards");
+        assert_eq!(
+            paths,
+            vec![
+                dir.path("out-00001-of-00003.gguf"),
+                dir.path("out-00002-of-00003.gguf"),
+                dir.path("out-00003-of-00003.gguf"),
+            ]
+        );
+
+        // Per-shard keys, exactly as gguf-split.cpp:238-240 writes them.
+        for (no, path) in paths.iter().enumerate() {
+            let shard = GgufFile::open(path).unwrap();
+            assert!(
+                matches!(shard.metadata.get(SPLIT_NO_KEY), Some(GgufValue::U16(n)) if *n as usize == no),
+                "shard {no} split.no: {:?}",
+                shard.metadata.get(SPLIT_NO_KEY)
+            );
+            assert!(
+                matches!(shard.metadata.get(SPLIT_COUNT_KEY), Some(GgufValue::U16(3))),
+                "shard {no} split.count: {:?}",
+                shard.metadata.get(SPLIT_COUNT_KEY)
+            );
+            assert!(
+                matches!(
+                    shard.metadata.get(SPLIT_TENSORS_COUNT_KEY),
+                    Some(GgufValue::I32(5))
+                ),
+                "shard {no} split.tensors.count: {:?}",
+                shard.metadata.get(SPLIT_TENSORS_COUNT_KEY)
+            );
+            if no == 0 {
+                assert_eq!(shard.metadata.len(), base_metadata().len() + 3);
+            } else {
+                // gguf-split.cpp:234: "Save all metadata in first split only".
+                assert_eq!(shard.metadata.len(), 3, "shard {no} carries only split.*");
+            }
+            assert_eq!(shard.tensors.len(), plan.shards[no].tensors.len());
+        }
+
+        let set = ShardedGguf::open(&paths[0]).unwrap();
+        assert_eq!(set.shard_count(), 3);
+        assert_eq!(set.tensor_count(), tensors.len());
+        let source = GgufFile::open(&src).unwrap();
+        for (p, bytes) in &tensors {
+            assert_eq!(set.tensor_bytes(&p.name).unwrap(), &bytes[..], "{}", p.name);
+            let info = set.find_tensor(&p.name).unwrap();
+            assert_eq!(info.shape, p.shape);
+            assert_eq!(info.dtype, p.dtype);
+        }
+        for (key, value) in &source.metadata {
+            assert_same_values(set.metadata(key).unwrap(), value, key);
+        }
+        // Order is preserved across shards: shard order, then table order.
+        let order: Vec<String> = set.tensors().map(|(_, t)| t.name.clone()).collect();
+        let want: Vec<String> = tensors.iter().map(|(p, _)| p.name.clone()).collect();
+        assert_eq!(order, want);
+    }
+
+    /// Where llama.cpp's own tool is byte-identical, so is this one: a
+    /// source that already carries `split.no = 0`, `split.count = 0`
+    /// and `split.tensors.count = N` (what a previous merge leaves
+    /// behind, `gguf-split.cpp:486`) survives split then merge without
+    /// a single byte changing.
+    #[test]
+    fn merging_the_shards_reproduces_a_merged_source_byte_for_byte() {
+        let dir = TempDir::new("identical");
+        let tensors = synthetic_tensors();
+        let mut meta = base_metadata();
+        for (key, value) in split_keys(0, 0, tensors.len() as i32) {
+            meta.insert(key.to_string(), value);
+        }
+        let src = dir.path("src.gguf");
+        write_source(&src, &meta, &tensors);
+        let (_, paths) = split_to(&dir, &src, &by_tensors(2));
+
+        let out = dir.path("merged.gguf");
+        let plan = plan_merge(&paths[0]).unwrap();
+        write_merge(&plan, &out).unwrap();
+        assert_eq!(
+            std::fs::read(&out).unwrap(),
+            std::fs::read(&src).unwrap(),
+            "merge output differs from the source"
+        );
+    }
+
+    /// A source WITHOUT the split keys is not byte-identical after a
+    /// merge, in llama.cpp either: the merged file gains exactly
+    /// `split.no = 0`, `split.count = 0`, `split.tensors.count = N`
+    /// and nothing else changes.
+    #[test]
+    fn merging_a_plain_source_adds_exactly_the_three_split_keys() {
+        let dir = TempDir::new("plain");
+        let tensors = synthetic_tensors();
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &tensors);
+        let (_, paths) = split_to(&dir, &src, &by_tensors(2));
+        let out = dir.path("merged.gguf");
+        write_merge(&plan_merge(&paths[0]).unwrap(), &out).unwrap();
+
+        let merged = GgufFile::open(&out).unwrap();
+        let source = GgufFile::open(&src).unwrap();
+        assert_eq!(merged.metadata.len(), source.metadata.len() + 3);
+        for (key, value) in &source.metadata {
+            assert_same_values(merged.metadata.get(key).unwrap(), value, key);
+        }
+        for (key, value) in split_keys(0, 0, tensors.len() as i32) {
+            assert_same_values(merged.metadata.get(key).unwrap(), &value, key);
+        }
+        for (p, bytes) in &tensors {
+            assert_eq!(merged.tensor_bytes(&p.name).unwrap(), &bytes[..]);
+        }
+        let order: Vec<&str> = merged.tensors.iter().map(|t| t.name.as_str()).collect();
+        let want: Vec<&str> = tensors.iter().map(|(p, _)| p.name.as_str()).collect();
+        assert_eq!(order, want);
+    }
+
+    /// The refusal the task asked for by name: a merge whose set is
+    /// missing a shard stops before writing and says which file.
+    #[test]
+    fn a_merge_with_a_missing_shard_refuses_naming_the_shard() {
+        let dir = TempDir::new("missing");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let (_, paths) = split_to(&dir, &src, &by_tensors(2));
+        std::fs::remove_file(&paths[1]).unwrap();
+
+        let err = plan_merge(&paths[0]).unwrap_err();
+        match err {
+            SplitError::Shard(ShardError::MissingShard(path, 3)) => {
+                assert_eq!(path, paths[1].display().to_string());
+            }
+            other => panic!("expected MissingShard naming shard 2, got {other:?}"),
+        }
+        assert!(!dir.path("merged.gguf").exists());
+    }
+
+    /// Size mode groups by alignment-PADDED bytes (`gguf-split.cpp:256`),
+    /// so a limit that the unpadded sizes fit and the padded ones do
+    /// not has to start a new shard. Tensor sizes: 192, 102 (pads to
+    /// 128), 20 (32), 42 (64), 36 (64).
+    #[test]
+    fn size_mode_groups_by_padded_bytes_like_llama_cpp() {
+        let dir = TempDir::new("size");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let source = GgufFile::open(&src).unwrap();
+
+        // 192 + 128 = 320 fits; + 32 = 352 does not.
+        let plan = plan_split(
+            &source,
+            &SplitOptions {
+                mode: SplitMode::MaxBytes(330),
+                no_tensor_first_split: false,
+            },
+        )
+        .unwrap();
+        let groups: Vec<usize> = plan.shards.iter().map(|s| s.tensors.len()).collect();
+        // [192+128] [32+64+64=160]
+        assert_eq!(groups, vec![2, 3]);
+
+        // Unpadded 192+102+20 = 314 < 330 would have put three in the
+        // first shard; the padded arithmetic is what decides.
+        let plan = plan_split(
+            &source,
+            &SplitMode::MaxBytes(314).with_no_first(false),
+        )
+        .unwrap();
+        let groups: Vec<usize> = plan.shards.iter().map(|s| s.tensors.len()).collect();
+        assert_eq!(groups, vec![1, 4], "192 alone; 128+32+64+64 = 288");
+    }
+
+    impl SplitMode {
+        fn with_no_first(self, no_tensor_first_split: bool) -> SplitOptions {
+            SplitOptions {
+                mode: self,
+                no_tensor_first_split,
+            }
+        }
+    }
+
+    /// The only way a shard can end up empty in size mode is the first
+    /// tensor alone exceeding the limit; llama.cpp exits with "one of
+    /// splits have 0 tensors" (`gguf-split.cpp:227`). This names the
+    /// tensor and the two numbers instead.
+    #[test]
+    fn a_first_tensor_larger_than_the_size_limit_is_refused_by_name() {
+        let dir = TempDir::new("toobig");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let source = GgufFile::open(&src).unwrap();
+        let err = plan_split(&source, &SplitMode::MaxBytes(100).with_no_first(false)).unwrap_err();
+        assert!(
+            matches!(&err, SplitError::TensorExceedsShard { name, bytes: 192, max: 100 }
+                if name == "token_embd.weight"),
+            "got {err:?}"
+        );
+        // Same with a metadata-only first shard: the SECOND shard is the
+        // one that would be empty.
+        let err = plan_split(&source, &SplitMode::MaxBytes(100).with_no_first(true)).unwrap_err();
+        assert!(matches!(err, SplitError::TensorExceedsShard { .. }), "got {err:?}");
+    }
+
+    /// `--no-tensor-first-split` produces the metadata-only first shard
+    /// real published checkpoints use, and the loader reads the set.
+    #[test]
+    fn no_tensor_first_split_leaves_the_first_shard_metadata_only() {
+        let dir = TempDir::new("nofirst");
+        let tensors = synthetic_tensors();
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &tensors);
+        let (plan, paths) = split_to(&dir, &src, &SplitMode::MaxTensors(3).with_no_first(true));
+        let groups: Vec<usize> = plan.shards.iter().map(|s| s.tensors.len()).collect();
+        assert_eq!(groups, vec![0, 3, 2]);
+        let first = GgufFile::open(&paths[0]).unwrap();
+        assert!(first.tensors.is_empty());
+        assert_eq!(first.metadata_str("general.architecture"), Some("llama"));
+        let set = ShardedGguf::open(&paths[0]).unwrap();
+        assert_eq!(set.tensor_count(), tensors.len());
+        for (p, bytes) in &tensors {
+            assert_eq!(set.tensor_bytes(&p.name).unwrap(), &bytes[..]);
+        }
+        // And it merges back.
+        let out = dir.path("merged.gguf");
+        write_merge(&plan_merge(&paths[0]).unwrap(), &out).unwrap();
+        assert_eq!(GgufFile::open(&out).unwrap().tensors.len(), tensors.len());
+    }
+
+    /// The dry run's numbers are the numbers the write produces: a plan
+    /// that reported one size and wrote another would make `--dry-run`
+    /// a guess. Ties `header_bytes` (the shared `encode_header`) and the
+    /// padded data sum to the file on disk.
+    #[test]
+    fn a_dry_run_plan_reports_the_sizes_the_write_produces() {
+        let dir = TempDir::new("dryrun");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let (plan, paths) = split_to(&dir, &src, &by_tensors(2));
+        for (shard, path) in plan.shards.iter().zip(&paths) {
+            let on_disk = std::fs::metadata(path).unwrap().len();
+            assert_eq!(shard.file_bytes, on_disk, "{}", path.display());
+            assert!(shard.header_bytes as u64 + shard.data_bytes <= on_disk);
+        }
+        assert_eq!(plan.n_tensors, 5);
+    }
+
+    /// A shard passed to `--split` would be split as if it were a whole
+    /// model, with a `split.tensors.count` covering only itself. The
+    /// gate is reachable: any file out of `write_split` trips it.
+    #[test]
+    fn an_input_that_is_already_a_shard_is_refused() {
+        let dir = TempDir::new("reshard");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let (_, paths) = split_to(&dir, &src, &by_tensors(2));
+        let shard = GgufFile::open(&paths[1]).unwrap();
+        let err = plan_split(&shard, &by_tensors(2)).unwrap_err();
+        assert!(
+            matches!(err, SplitError::InputIsSplit(3)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn merge_refuses_a_non_first_shard_a_non_split_file_and_an_existing_output() {
+        let dir = TempDir::new("mergerefuse");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let (_, paths) = split_to(&dir, &src, &by_tensors(2));
+
+        // gguf-split.cpp:474: the input must be shard 1 by name.
+        let err = plan_merge(&paths[1]).unwrap_err();
+        assert!(matches!(err, SplitError::NotFirstShard(_)), "got {err:?}");
+
+        // gguf-split.cpp:449: no split.count means not a split. The name
+        // has to pass the shape check first, so give the plain file one.
+        let plain = dir.path("plain-00001-of-00001.gguf");
+        std::fs::copy(&src, &plain).unwrap();
+        let err = plan_merge(&plain).unwrap_err();
+        assert!(matches!(err, SplitError::NotSplit(_)), "got {err:?}");
+
+        // gguf-split.cpp:410: never overwrite.
+        let plan = plan_merge(&paths[0]).unwrap();
+        let err = write_merge(&plan, &src).unwrap_err();
+        assert!(matches!(err, SplitError::OutputExists(_)), "got {err:?}");
+    }
+
+    /// `split.count` in the filename and in the metadata are two
+    /// statements of one number; a first shard whose two disagree is
+    /// refused before any sibling is opened.
+    #[test]
+    fn merge_refuses_a_first_shard_whose_name_and_metadata_disagree_on_count() {
+        let dir = TempDir::new("countmismatch");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let (_, paths) = split_to(&dir, &src, &by_tensors(2));
+        let renamed = dir.path("out-00001-of-00004.gguf");
+        std::fs::rename(&paths[0], &renamed).unwrap();
+        let err = plan_merge(&renamed).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SplitError::Shard(ShardError::ShardCountMismatch {
+                    expected: 4,
+                    found: 3,
+                    ..
+                })
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn zero_limits_are_refused() {
+        let dir = TempDir::new("zero");
+        let src = dir.path("src.gguf");
+        write_source(&src, &base_metadata(), &synthetic_tensors());
+        let source = GgufFile::open(&src).unwrap();
+        assert!(matches!(
+            plan_split(&source, &by_tensors(0)),
+            Err(SplitError::ZeroMaxTensors)
+        ));
+        assert!(matches!(
+            plan_split(&source, &SplitMode::MaxBytes(0).with_no_first(false)),
+            Err(SplitError::ZeroMaxBytes)
+        ));
+    }
+}

--- a/crates/ferrox-gguf/src/writer.rs
+++ b/crates/ferrox-gguf/src/writer.rs
@@ -133,74 +133,14 @@ impl<W: Write> GgufWriter<W> {
         metadata: &BTreeMap<String, GgufValue>,
         plan: Vec<TensorPlan>,
     ) -> Result<Self, GgufWriteError> {
-        let declared_alignment = metadata
-            .get("general.alignment")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(DEFAULT_ALIGNMENT as u64);
-        let alignment = usize::try_from(declared_alignment)
-            .ok()
-            .filter(|a| a.is_power_of_two())
-            .ok_or(GgufWriteError::BadAlignment(declared_alignment))?;
-
-        let mut seen = std::collections::HashSet::with_capacity(plan.len());
-        for t in &plan {
-            if t.shape.is_empty() {
-                return Err(GgufWriteError::NoDimensions(t.name.clone()));
-            }
-            if !seen.insert(t.name.as_str()) {
-                return Err(GgufWriteError::DuplicateTensor(t.name.clone()));
-            }
-        }
-
+        let alignment = declared_alignment(metadata.get("general.alignment"))?;
         // The header goes into a buffer first: the tensor-data offsets
         // are relative to the start of the data section, so they do not
         // depend on the header's own length, but writing to a buffer
         // keeps the whole header one `write_all` and lets `create` fail
         // before touching the file for a metadata value it cannot
         // encode.
-        let mut buf: Vec<u8> = Vec::new();
-        buf.write_u32::<LittleEndian>(GGUF_MAGIC)?;
-        buf.write_u32::<LittleEndian>(GGUF_WRITE_VERSION)?;
-        buf.write_u64::<LittleEndian>(plan.len() as u64)?;
-        buf.write_u64::<LittleEndian>(metadata.len() as u64)?;
-
-        for (key, value) in metadata {
-            write_string(&mut buf, key)?;
-            buf.write_u32::<LittleEndian>(value_tag(value))?;
-            write_value(&mut buf, key, value)?;
-        }
-
-        let mut offset: usize = 0;
-        for t in &plan {
-            write_string(&mut buf, &t.name)?;
-            buf.write_u32::<LittleEndian>(t.shape.len() as u32)?;
-            for &dim in &t.shape {
-                buf.write_u64::<LittleEndian>(dim)?;
-            }
-            buf.write_u32::<LittleEndian>(t.dtype.to_tag())?;
-            buf.write_u64::<LittleEndian>(offset as u64)?;
-            // Every tensor starts on an alignment boundary, so the
-            // offset advances by the padded length. `checked_*`
-            // throughout: `byte_len` may come from a file's own header.
-            offset = offset
-                .checked_add(t.byte_len)
-                .and_then(|o| o.checked_next_multiple_of(alignment))
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "tensor '{}' pushes the data section past the address space",
-                            t.name
-                        ),
-                    )
-                })?;
-        }
-
-        // Pad the header up to the data section, exactly as the reader
-        // computes `data_start`.
-        let pad = buf.len().next_multiple_of(alignment) - buf.len();
-        buf.extend(std::iter::repeat_n(0u8, pad));
-
+        let buf = encode_header(metadata, &plan)?;
         out.write_all(&buf)?;
         Ok(GgufWriter {
             out,
@@ -252,6 +192,88 @@ impl<W: Write> GgufWriter<W> {
         self.out.flush()?;
         Ok(self.out)
     }
+}
+
+/// The data-section alignment a `general.alignment` value declares, or
+/// [`DEFAULT_ALIGNMENT`] when the key is absent. One function for both
+/// the writer and `split`, which has to size shards with the alignment
+/// the writer will pad with: two readings of the key would be two
+/// structures that must agree about one number.
+pub fn declared_alignment(value: Option<&GgufValue>) -> Result<usize, GgufWriteError> {
+    let declared = value
+        .and_then(|v| v.as_u64())
+        .unwrap_or(DEFAULT_ALIGNMENT as u64);
+    usize::try_from(declared)
+        .ok()
+        .filter(|a| a.is_power_of_two())
+        .ok_or(GgufWriteError::BadAlignment(declared))
+}
+
+/// The complete header for `metadata` and `plan`: magic, counts, every
+/// key/value, every tensor descriptor, and the pad up to the data
+/// section. These are EXACTLY the bytes [`GgufWriter::create`] writes
+/// before the first tensor, and its length is what llama.cpp calls
+/// `gguf_get_meta_size`, so a dry run that reports a shard's size and
+/// the write that produces it cannot disagree.
+pub fn encode_header(
+    metadata: &BTreeMap<String, GgufValue>,
+    plan: &[TensorPlan],
+) -> Result<Vec<u8>, GgufWriteError> {
+    let alignment = declared_alignment(metadata.get("general.alignment"))?;
+
+    let mut seen = std::collections::HashSet::with_capacity(plan.len());
+    for t in plan {
+        if t.shape.is_empty() {
+            return Err(GgufWriteError::NoDimensions(t.name.clone()));
+        }
+        if !seen.insert(t.name.as_str()) {
+            return Err(GgufWriteError::DuplicateTensor(t.name.clone()));
+        }
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    buf.write_u32::<LittleEndian>(GGUF_MAGIC)?;
+    buf.write_u32::<LittleEndian>(GGUF_WRITE_VERSION)?;
+    buf.write_u64::<LittleEndian>(plan.len() as u64)?;
+    buf.write_u64::<LittleEndian>(metadata.len() as u64)?;
+
+    for (key, value) in metadata {
+        write_string(&mut buf, key)?;
+        buf.write_u32::<LittleEndian>(value_tag(value))?;
+        write_value(&mut buf, key, value)?;
+    }
+
+    let mut offset: usize = 0;
+    for t in plan {
+        write_string(&mut buf, &t.name)?;
+        buf.write_u32::<LittleEndian>(t.shape.len() as u32)?;
+        for &dim in &t.shape {
+            buf.write_u64::<LittleEndian>(dim)?;
+        }
+        buf.write_u32::<LittleEndian>(t.dtype.to_tag())?;
+        buf.write_u64::<LittleEndian>(offset as u64)?;
+        // Every tensor starts on an alignment boundary, so the
+        // offset advances by the padded length. `checked_*`
+        // throughout: `byte_len` may come from a file's own header.
+        offset = offset
+            .checked_add(t.byte_len)
+            .and_then(|o| o.checked_next_multiple_of(alignment))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "tensor '{}' pushes the data section past the address space",
+                        t.name
+                    ),
+                )
+            })?;
+    }
+
+    // Pad the header up to the data section, exactly as the reader
+    // computes `data_start`.
+    let pad = buf.len().next_multiple_of(alignment) - buf.len();
+    buf.extend(std::iter::repeat_n(0u8, pad));
+    Ok(buf)
 }
 
 fn write_string(buf: &mut Vec<u8>, s: &str) -> Result<(), GgufWriteError> {

--- a/crates/ferrox-models/tests/gguf_roundtrip.rs
+++ b/crates/ferrox-models/tests/gguf_roundtrip.rs
@@ -547,3 +547,84 @@ fn store_backed_experts_produce_bit_identical_logits_to_resident() {
         }
     }
 }
+
+/// `ferrox gguf-split --split` has to produce shards the loader people
+/// actually use can read, not only ones `ShardedGguf::open` accepts.
+///
+/// The checked-in `ferrox_real_test_split-*` fixtures were written by a
+/// Python script; this splits the SAME single-file fixture with the
+/// Rust tool, at a boundary that lands mid-layer, and runs a real
+/// forward pass over the result. Then it merges the shards back and
+/// runs the pass a third time. All three logit sequences must be
+/// bit-identical: `assert_eq!` on `Vec<f32>`, not a tolerance, because
+/// a split moves bytes and must not change one.
+///
+/// `--no-tensor-first-split` is used because the metadata-only first
+/// shard is the layout published checkpoints use, and it is the case
+/// where the loader has to find the hparams in a shard holding no
+/// tensors at all.
+#[test]
+fn tool_split_shards_and_their_merge_load_and_decode_identically_to_the_source() {
+    use ferrox_gguf::split::{
+        plan_merge, plan_split, write_merge, write_split, SplitMode, SplitOptions,
+    };
+
+    let single_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/ferrox_real_test.gguf"
+    );
+
+    let dir = std::env::temp_dir().join(format!("ferrox_tool_split_{}", std::process::id()));
+    std::fs::remove_dir_all(&dir).ok();
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let source = ferrox_gguf::GgufFile::open(single_path).unwrap();
+    let opts = SplitOptions {
+        mode: SplitMode::MaxTensors(4),
+        no_tensor_first_split: true,
+    };
+    let plan = plan_split(&source, &opts).expect("the real fixture must plan a split");
+    assert!(
+        plan.shards.len() > 2,
+        "4 tensors per shard over {} tensors has to make several shards",
+        plan.n_tensors
+    );
+    assert!(
+        plan.shards[0].tensors.is_empty(),
+        "--no-tensor-first-split must leave shard 1 metadata-only"
+    );
+    let paths = write_split(&source, &plan, &dir.join("m"), |_| {}).expect("shards must write");
+
+    let merged_path = dir.join("merged.gguf");
+    let merge = plan_merge(&paths[0]).expect("the tool's own shards must merge");
+    write_merge(&merge, &merged_path).expect("the merge must write");
+
+    let logits = |path: &str| {
+        let decoder = Decoder::from_gguf(path, test_dense_fixture())
+            .unwrap_or_else(|e| panic!("{path} must load: {e}"));
+        let mut caches: Vec<KvCache> = decoder
+            .layers
+            .iter()
+            .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
+            .collect();
+        [3usize, 7, 11]
+            .iter()
+            .enumerate()
+            .map(|(pos, tok)| decoder.forward_token(*tok, pos, &mut caches))
+            .collect::<Vec<_>>()
+    };
+
+    let want = logits(single_path);
+    assert_eq!(
+        logits(paths[0].to_str().unwrap()),
+        want,
+        "the tool's shards must decode bit-identically to the single file"
+    );
+    assert_eq!(
+        logits(merged_path.to_str().unwrap()),
+        want,
+        "merging the tool's shards must decode bit-identically to the single file"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -598,6 +598,70 @@ TYPE, to Q5_0 or F16, and ferrox has neither encoder; padding the row
 would shift every following row on decode. SmolLM2-135M cannot be Q4_K
 quantized here for that reason, its embedding being 576 wide.
 
+## Split and merge GGUF (`ferrox gguf-split`)
+
+llama.cpp's `llama-gguf-split`, same flags, same shard names, same
+metadata keys. Splitting is the default operation; `--merge` is the
+other direction.
+
+```bash
+# By tensor count (llama.cpp's default limit is 128)
+ferrox gguf-split --split-max-tensors 128 model.gguf out/model
+
+# By size. Units are DECIMAL, as in llama.cpp: 4G is 4,000,000,000
+ferrox gguf-split --split-max-size 4G model.gguf out/model
+
+# Metadata-only first shard, the layout most published checkpoints use
+ferrox gguf-split --split-max-size 4G --no-tensor-first-split model.gguf out/model
+
+# Plan only: shard count, tensors and bytes per shard, nothing written
+ferrox gguf-split --split-max-size 4G --dry-run model.gguf out/model
+
+# Back to one file. The input is the FIRST shard
+ferrox gguf-split --merge out/model-00001-of-00003.gguf model.gguf
+```
+
+Shards are named `<prefix>-NNNNN-of-MMMMM.gguf`, 1-based, and carry
+llama.cpp's three keys with llama.cpp's types: `split.no` (u16, 0-based),
+`split.count` (u16) and `split.tensors.count` (i32, the total across the
+whole set). The first shard holds the complete source metadata and the
+rest hold only those three, so a set written here is one `ferrox run -m
+out/model-00001-of-00003.gguf` away from running, and one llama.cpp
+reads too.
+
+Tensor bytes are copied straight from the source's mmap into the shard,
+never buffered, so a 400 GB checkpoint splits in the memory a header
+takes.
+
+Four things differ from llama.cpp's tool, all of them refusals it does
+not make:
+
+* Splitting a file that is **already a shard** stops. llama.cpp would
+  write a set whose `split.tensors.count` covered that one shard, which
+  no loader can reassemble.
+* A first tensor **larger than `--split-max-size`** is named, with both
+  numbers. llama.cpp prints "one of splits have 0 tensors" and exits.
+* `--merge` **refuses the `--split-*` options** instead of parsing and
+  ignoring them.
+* A missing shard names the file it wanted, at plan time, before the
+  output is opened.
+
+Two byte-level differences, both inherited from choices this crate
+already made: metadata keys are written sorted, and shards are padded
+with the alignment the source declares where llama.cpp's tool always
+pads with 32. A merge of a set this tool wrote reproduces the source
+byte for byte when the source itself carried the `split.*` keys a
+previous merge leaves behind; otherwise the merged file gains exactly
+those three keys and nothing else changes.
+
+Cross-checked against the installed `llama-gguf-split` (build 7650, 68b4d516c) on the
+21-tensor test fixture at `--split-max-tensors 4`. All **6 of 6** shards
+came out the identical SIZE, byte for byte, and differ only where the
+metadata keys are ordered: 54 bytes on each later shard (the three
+`split.*` keys) and 754 on the first (the whole header). Both directions
+work across the two tools: llama.cpp merges a set ferrox split, and
+ferrox merges a set llama.cpp split, each producing a 24,032-byte file.
+
 ## Hugging Face Hub (`download`, `pull`)
 
 Fetches a GGUF over HTTPS directly. No Python and no

--- a/docs/plans/llama-cpp-full-parity-audit-2026-09-02.md
+++ b/docs/plans/llama-cpp-full-parity-audit-2026-09-02.md
@@ -19,7 +19,7 @@
 | Source files (C++/CUDA/Metal) | **1,103** mapped | **308** Rust files, **~230k** lines | Structural: 140 per-arch graphs vs 1 decoder |
 | Architecture graphs | **140** hand-written | **16** audited + 4 dedicated engines | **P0** — 124 graphs unported |
 | Backends | CPU, CUDA, Metal, Vulkan, SYCL, HIP, OpenCL, … | CPU, Metal, CUDA (partial), Vulkan (beachhead) | **P0** Vulkan; **P1** CUDA GEMM |
-| CLI tools | 15+ binaries | 20+ subcommands; most core tools present | **P2** gguf-split, imatrix, batched-bench |
+| CLI tools | 15+ binaries | 21+ subcommands; most core tools present | **P2** imatrix, batched-bench (gguf-split ported 2026-09-09) |
 | Logit parity (local sweep) | reference | 19 models tested | **2 WRONG**, 8 DRIFT (expected K-quant), 6 MATCH, 1 TIE-FLIP, 2 encoder skip |
 
 ### Live parity sweep (2026-09-02)
@@ -122,7 +122,7 @@ ferrox: `decoder.rs` + `engine_factory.rs` + 4 dedicated engines:
 | `llama-quantize` | `ferrox quantize` | partial — Q8_0 byte-identical; K-quants missing |
 | `llama-perplexity` | `ferrox perplexity` | partial — corpus ppl; no HellaSwag |
 | `llama-tokenize` | via `ferrox parity` tokenizer sweep | partial |
-| `llama-gguf-split` | — | **missing** |
+| `llama-gguf-split` | `ferrox gguf-split` | **ported**: split by tensors or size, merge, `--no-tensor-first-split`, `--dry-run` |
 | `llama-imatrix` | — | **missing** |
 | `llama-batched-bench` | — | **missing** |
 | `llama-mtmd` (multimodal) | — | **missing** |
@@ -188,7 +188,7 @@ ferrox: `decoder.rs` + `engine_factory.rs` + 4 dedicated engines:
 | `-b` / `-ub` batch flags | yes | env only |
 | Partial `-ngl` | yes | all-or-nothing |
 | Streamed CB output | token stream | buffers full completion |
-| gguf-split merge/split | yes | read shards only |
+| gguf-split merge/split | yes | **`ferrox gguf-split`**, both directions |
 | imatrix | yes | **missing** |
 
 ### 2.5 Sampling (mostly closed)
@@ -234,7 +234,7 @@ Ranked per [`north-star.md`](north-star.md) and [`roadmap.md`](roadmap.md).
 | 7 | **CUDA mul_mm + mmvq** — port from Metal `mul_mm_sg_impl` | L | CUDA prefill |
 | 8 | **Server: `-np`, slot save/load, streamed CB** | M | Serving parity |
 | 9 | **Embedding model path** — WordPiece + BERT loader | L | BGE/E5/nomic-embed |
-| 10 | **gguf-split utility** | S | Shard management |
+| ~~10~~ | ~~**gguf-split utility**~~ | S | **done 2026-09-09**: `ferrox gguf-split` |
 
 ### P2 — Hardware reach (this quarter)
 


### PR DESCRIPTION
Ports llama.cpp's `tools/gguf-split/gguf-split.cpp` as `ferrox gguf-split`. Closes P1 item 10 of the full-parity audit.

```bash
ferrox gguf-split --split-max-tensors 128 model.gguf out/model
ferrox gguf-split --split-max-size 4G --no-tensor-first-split model.gguf out/model
ferrox gguf-split --split-max-size 4G --dry-run model.gguf out/model
ferrox gguf-split --merge out/model-00001-of-00003.gguf model.gguf
```

## What landed

**`crates/ferrox-gguf/src/split.rs`** (new, 899 lines) is the writing half of what `crate::sharded` already reads. Every rule cites the llama.cpp line that decides it, and all of those citations were checked against the source, not remembered: the first shard carries the whole source metadata (`gguf-split.cpp:234-236`), later shards carry only `split.no` (u16, 0-based), `split.count` (u16) and `split.tensors.count` (i32) (`:238-240`, `:272`); tensor mode starts a shard every N tensors (`:288`), size mode when the running sum of alignment-padded bytes would exceed the limit (`:256-258`, `:285`); names are `<prefix>-NNNNN-of-MMMMM.gguf`, 1-based (`src/llama.cpp:537`).

The two halves cannot drift about the shard convention, because the writer takes it from the reader: filenames from `ShardName::sibling`, keys from `sharded`'s constants, and every test proves a written set by opening it with `ShardedGguf::open`.

**Zero-copy.** Tensor bytes are never buffered. Each goes from the source's mmap straight into the shard, so the memory a split needs is a header's, whatever the checkpoint weighs.

**`crates/ferrox-gguf/src/writer.rs`** gains `encode_header` and `declared_alignment`, lifted out of `GgufWriter::create` rather than copied. `--dry-run` has to report the size the write will produce; a second copy of the header layout would have put two structures in the position of agreeing about every byte before the data section. `a_dry_run_plan_reports_the_sizes_the_write_produces` ties the reported `file_bytes` to `std::fs::metadata().len()`.

**`crates/ferrox-cli/src/gguf_split.rs`** is argument parsing and the progress lines. `split_max_tensors` is an `Option`, not a `default_value_t`, because a defaulted field cannot say whether the user typed it. Which options are split-only lives in one `split_only_flags` that the merge refusal and the tests both walk, and its destructure is exhaustive with no `..`, so a new field stops compiling until someone classifies it.

## What differs from llama.cpp's tool

Four refusals it does not make, each naming what is wrong instead of exiting on a message:

* Splitting a file that is **already a shard**. llama.cpp would write a set whose `split.tensors.count` covered that one shard, which no loader can reassemble.
* A first tensor **larger than `--split-max-size`**, named with both numbers. llama.cpp prints "one of splits have 0 tensors" and exits.
* `--merge` **refuses the `--split-*` options** rather than parsing and ignoring them, which is what upstream does.
* A **missing shard** named at plan time, before the output is opened. `GgufError::Io` carries no path, so the first shard's own absence is re-reported through `SplitError::Io` rather than as a bare "No such file or directory".

Two byte-level differences, both inherited choices rather than defects: metadata keys are written sorted (the reader keeps them in a `HashMap` and the writer sorts), and shards are padded with the alignment the source declares where llama.cpp's tool always pads with 32, because `gguf_init_empty` fixes `ctx->alignment` and `gguf_set_kv` never updates it.

## Cross-checked against the real tool

Against the installed `llama-gguf-split` (build 7650, 68b4d516c), on the 21-tensor test fixture at `--split-max-tensors 4`:

* All **6 of 6** shards came out the identical SIZE, byte for byte, differing only where the metadata keys are ordered: 54 bytes on each later shard (the three `split.*` keys) and 754 on the first (the whole header).
* llama.cpp merges a set ferrox split, and ferrox merges a set llama.cpp split, each producing a 24,032-byte file. `ferrox inspect` reads llama.cpp's shard set and reports all 21 tensors.

## Tests

17 new: 12 in `split.rs`, 4 in the CLI module, 1 integration test in `crates/ferrox-models/tests/gguf_roundtrip.rs` that splits the real Q8_0 fixture with the tool and runs a real forward pass over the shards and over their merge, asserting all three logit sequences are bit-identical with `assert_eq!` on `Vec<f32>` rather than a tolerance.

## Sabotage-verified

Five mutations, each grepped from the file to confirm it landed before the run was believed:

| Mutation | Result |
|---|---|
| size-mode boundary `next > max` becomes `>=` | **survived at first**, see below |
| `split.count` written as `U32` instead of `U16` | 3 tests red |
| merge stops resetting `split.count` to 0 | 2 tests red |
| `--no-tensor-first-split` stops registering as typed in the CLI flag table | 1 test red, by name |
| one bit flipped in every tensor written into a shard | the models integration test red |

The first mutation is the finding. `size_mode_groups_by_padded_bytes_like_llama_cpp` passed under it, because at the limits it used (330 and 314) the prefix sums never land exactly on the limit, so `>` and `>=` behave identically and the test could not tell the two apart. The fix is an assertion at 320, which is `192 + 128` exactly, the only value in that fixture that separates them; the sabotage then goes red with `left: [1, 4], right: [2, 3]`. All five mutations are reverted, `grep -rn SABOTAGE crates/` is clean, and the three mutated lines were re-grepped after `cargo fmt`.

## Gates

`cargo test --workspace` clean (0 failures), `cargo clippy --workspace --all-targets -- -D warnings` clean in **debug and release**, `cargo fmt --all` applied. Every one of the five commits builds standalone under `cargo check --workspace --all-targets`, so the branch bisects.

Docs: `docs/CLI.md` gains the command and the cross-check numbers; `docs/plans/llama-cpp-full-parity-audit-2026-09-02.md` moves the `llama-gguf-split` row off missing and marks P1 item 10 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
