### PR TITLE
perf(metal): count the host's encode work per decode token, then remove 13% of it

### DIFF
--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -48,23 +48,24 @@
 //! environment variable.
 //!
 //! `FERROX_CTK` selects KV dtype ([`MetalKvDtype`]); see [`is_implemented`].
+pub use crate::decode_dense::{
+    launch_decode_dense_stack, AttnExtras, DenseLayerMetal, EmbdGatherMetal,
+};
+use crate::dispatch::dispatch_counted;
 use crate::elem::{
     encode_act_mul_f32_to_f16, encode_add_rms_norm, encode_add_rms_norm_batch,
-    encode_add_rms_norm_f32_to_f16_batch, encode_argmax, encode_f32_to_f16, encode_gelu_mul,
-    encode_rms_norm, encode_rms_norm_at, encode_rms_norm_batch, encode_rms_norm_f32_to_f16_batch,
+    encode_add_rms_norm_f32_to_f16_batch, encode_argmax, encode_f32_to_f16, encode_rms_norm,
+    encode_rms_norm_at, encode_rms_norm_batch, encode_rms_norm_f32_to_f16_batch,
     encode_rms_norm_per_head_batch, encode_silu_mul, encode_vec_add, encode_vec_add_at,
     warm_prefill_elem_pipelines,
 };
-use crate::embd::{encode_get_rows, EmbdKind};
+use crate::embd::encode_get_rows;
 use crate::gpu::{
     compute_encoder_concurrent, encode_matvec, encode_moe_topk_softmax_batch, encode_mul_mm_sg_f16,
     encode_q4_0_moe_gate_up_id, encode_q4_0_moe_id, encode_q4_0_moe_topk, ensure_pipeline,
     memory_barrier_resources, resident_f32_buffer, resident_weight_buffer, shared_metal,
     warm_mul_mm_sg_pipeline, MatvecLaunch, MetalError, MoeExpertLaunch, MoePackedQ4, MulMmSgLaunch,
     ResidentF32Buffer, ResidentWeightBuffer,
-};
-pub use crate::decode_dense::{
-    launch_decode_dense_stack, AttnExtras, DenseLayerMetal, EmbdGatherMetal,
 };
 use crate::mem_ranges::MemRanges;
 use crate::moe_ids::MoeIdsLog;
@@ -2914,7 +2915,11 @@ fn borrow_prefill_scratch(
 /// `n_rot/2` entries, which is narrower than `head_dim/2` under partial
 /// rotary. Checking it against the head width instead rejects every
 /// Phi-3/Phi-4 checkpoint at the door.
-pub(crate) fn assert_freq_factors_len(freq_factors: Option<&[f32]>, rope: MetalRope, head_dim: usize) {
+pub(crate) fn assert_freq_factors_len(
+    freq_factors: Option<&[f32]>,
+    rope: MetalRope,
+    head_dim: usize,
+) {
     if let Some(ff) = freq_factors {
         assert_eq!(ff.len(), rope.rot_dim.unwrap_or(head_dim) / 2);
     }
@@ -3000,7 +3005,8 @@ pub(crate) fn encode_rope(
             8,
         );
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_heads as usize,
             height: 1,
@@ -3104,7 +3110,8 @@ fn encode_rope_batch(
             9,
         );
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_heads as usize,
             height: n_tokens as usize,
@@ -3143,7 +3150,8 @@ fn encode_kv_append(
     }
     let tg = 256usize.min(n_elems as usize).max(1);
     let n_tg = (n_elems as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -3188,7 +3196,8 @@ fn encode_kv_append_q8_0(
     let n_blocks = (n_elems as usize) / ferrox_quant::Q8_0_BLOCK_ELEMS;
     let tg = 256usize.min(n_blocks).max(1);
     let n_tg = n_blocks.div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -3228,7 +3237,8 @@ fn encode_dequant_q8_0_to_f16(
     let n_blocks = (n_elems as usize) / ferrox_quant::Q8_0_BLOCK_ELEMS;
     let tg = 256usize.min(n_blocks).max(1);
     let n_tg = n_blocks.div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -3273,7 +3283,8 @@ fn encode_kv_append_turbo4(
     let n_blocks = (n_elems as usize) / ferrox_quant::TURBO4_KV_GROUP;
     let tg = 256usize.min(n_blocks).max(1);
     let n_tg = n_blocks.div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -3313,7 +3324,8 @@ fn encode_dequant_turbo4_to_f16(
     let n_blocks = (n_elems as usize) / ferrox_quant::TURBO4_KV_GROUP;
     let tg = 256usize.min(n_blocks).max(1);
     let n_tg = n_blocks.div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -3629,7 +3641,8 @@ fn encode_gqa_prefill_fa_ext(
         encoder.setBytes_length_atIndex(NonNull::new(&mut sc as *mut f32 as *mut _).unwrap(), 4, 9);
         encoder.setThreadgroupMemoryLength_atIndex(tg_mem, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_heads as usize,
             height: n_q.div_ceil(QN) as usize,
@@ -3749,7 +3762,8 @@ fn encode_gqa_prefill_fa_vec(
         encoder.setBytes_length_atIndex(NonNull::new(&mut sc as *mut f32 as *mut _).unwrap(), 4, 9);
         encoder.setThreadgroupMemoryLength_atIndex(tg_mem, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_heads as usize,
             height: n_q as usize,
@@ -3826,7 +3840,8 @@ fn encode_gqa_fa_vec(
         encoder.setBytes_length_atIndex(NonNull::new(&mut sc as *mut f32 as *mut _).unwrap(), 4, 9);
         encoder.setThreadgroupMemoryLength_atIndex(tg_mem, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_heads as usize,
             height: 1,
@@ -3897,7 +3912,8 @@ fn encode_gqa(
         encoder.setBytes_length_atIndex(NonNull::new(&mut sc as *mut f32 as *mut _).unwrap(), 4, 9);
         encoder.setThreadgroupMemoryLength_atIndex(tg_mem, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_heads as usize,
             height: 1,
@@ -3979,7 +3995,8 @@ fn encode_gqa_prefill(
         encoder.setBytes_length_atIndex(NonNull::new(&mut sc as *mut f32 as *mut _).unwrap(), 4, 9);
         encoder.setThreadgroupMemoryLength_atIndex(tg_mem, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_heads as usize,
             height: n_q as usize,

--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -63,6 +63,9 @@ use crate::gpu::{
     warm_mul_mm_sg_pipeline, MatvecLaunch, MetalError, MoeExpertLaunch, MoePackedQ4, MulMmSgLaunch,
     ResidentF32Buffer, ResidentWeightBuffer,
 };
+pub use crate::decode_dense::{
+    launch_decode_dense_stack, AttnExtras, DenseLayerMetal, EmbdGatherMetal,
+};
 use crate::mem_ranges::MemRanges;
 use crate::moe_ids::MoeIdsLog;
 use objc2::rc::Retained;
@@ -2147,12 +2150,12 @@ kernel void rope_neox_heads_batch(
 /// read f16 via a process-wide dequant scratch shared across layers.
 pub struct MetalKvBuffers {
     dtype: MetalKvDtype,
-    k: Retained<ProtocolObject<dyn MTLBuffer>>,
-    v: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) k: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) v: Retained<ProtocolObject<dyn MTLBuffer>>,
     pub n_kv_heads: usize,
     pub head_dim: usize,
     pub seq_len: usize,
-    capacity: usize,
+    pub(crate) capacity: usize,
 }
 
 // SAFETY: shared-mode MTLBuffers created once and mutated only from the
@@ -2393,7 +2396,7 @@ impl MetalKvBuffers {
 
 /// K or V plane when appending into [`MetalKvBuffers`].
 #[derive(Clone, Copy)]
-enum KvPlane {
+pub(crate) enum KvPlane {
     K,
     V,
 }
@@ -2492,7 +2495,7 @@ fn upload_f16_from_f32(
     .ok_or(MetalError::BufferAllocFailed)
 }
 
-fn copy_f32_into(buf: &ProtocolObject<dyn MTLBuffer>, data: &[f32]) {
+pub(crate) fn copy_f32_into(buf: &ProtocolObject<dyn MTLBuffer>, data: &[f32]) {
     let nbytes = data.len() * 4;
     debug_assert!(buf.length() >= nbytes);
     unsafe {
@@ -2506,22 +2509,22 @@ fn copy_f32_into(buf: &ProtocolObject<dyn MTLBuffer>, data: &[f32]) {
 
 /// Process-wide activation scratch for [`launch_decode_dense_stack`].
 /// Avoids allocating ~10 MTLBuffers every decode token.
-struct DecodeScratch {
-    h: Retained<ProtocolObject<dyn MTLBuffer>>,
-    x: Retained<ProtocolObject<dyn MTLBuffer>>,
-    x2: Retained<ProtocolObject<dyn MTLBuffer>>,
-    q: Retained<ProtocolObject<dyn MTLBuffer>>,
-    k: Retained<ProtocolObject<dyn MTLBuffer>>,
-    v: Retained<ProtocolObject<dyn MTLBuffer>>,
-    attn: Retained<ProtocolObject<dyn MTLBuffer>>,
-    o: Retained<ProtocolObject<dyn MTLBuffer>>,
-    gate: Retained<ProtocolObject<dyn MTLBuffer>>,
-    up: Retained<ProtocolObject<dyn MTLBuffer>>,
-    act: Retained<ProtocolObject<dyn MTLBuffer>>,
-    down: Retained<ProtocolObject<dyn MTLBuffer>>,
-    logits: Option<Retained<ProtocolObject<dyn MTLBuffer>>>,
+pub(crate) struct DecodeScratch {
+    pub(crate) h: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) x: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) x2: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) q: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) k: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) v: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) attn: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) o: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) gate: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) up: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) act: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) down: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) logits: Option<Retained<ProtocolObject<dyn MTLBuffer>>>,
     /// Single u32 slot for greedy argmax-in-stack (always resident; 4 bytes).
-    argmax_idx: Retained<ProtocolObject<dyn MTLBuffer>>,
+    pub(crate) argmax_idx: Retained<ProtocolObject<dyn MTLBuffer>>,
     hidden_cap: usize,
     max_q_cap: usize,
     max_kv_cap: usize,
@@ -2795,13 +2798,13 @@ pub fn metal_graph() -> std::sync::MutexGuard<'static, MetalGraph> {
         .unwrap()
 }
 
-struct ScratchCaps {
-    hidden: usize,
-    max_q: usize,
-    max_kv: usize,
-    attn: usize,
-    max_gate: usize,
-    logits: usize,
+pub(crate) struct ScratchCaps {
+    pub(crate) hidden: usize,
+    pub(crate) max_q: usize,
+    pub(crate) max_kv: usize,
+    pub(crate) attn: usize,
+    pub(crate) max_gate: usize,
+    pub(crate) logits: usize,
 }
 
 struct PrefillScratchCaps {
@@ -2812,7 +2815,7 @@ struct PrefillScratchCaps {
     max_gate: usize,
 }
 
-fn borrow_decode_scratch(
+pub(crate) fn borrow_decode_scratch(
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
     caps: ScratchCaps,
 ) -> Result<std::sync::MutexGuard<'static, Option<DecodeScratch>>, MetalError> {
@@ -2911,14 +2914,14 @@ fn borrow_prefill_scratch(
 /// `n_rot/2` entries, which is narrower than `head_dim/2` under partial
 /// rotary. Checking it against the head width instead rejects every
 /// Phi-3/Phi-4 checkpoint at the door.
-fn assert_freq_factors_len(freq_factors: Option<&[f32]>, rope: MetalRope, head_dim: usize) {
+pub(crate) fn assert_freq_factors_len(freq_factors: Option<&[f32]>, rope: MetalRope, head_dim: usize) {
     if let Some(ff) = freq_factors {
         assert_eq!(ff.len(), rope.rot_dim.unwrap_or(head_dim) / 2);
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn encode_rope(
+pub(crate) fn encode_rope(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
     rope: MetalRope,
@@ -3340,7 +3343,7 @@ fn encode_kv_dequant_to_f16(
     }
 }
 
-fn encode_kv_store_append(
+pub(crate) fn encode_kv_store_append(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
     src: &ProtocolObject<dyn MTLBuffer>,
@@ -3367,7 +3370,7 @@ fn encode_kv_store_append(
 /// Decode GQA against the layer's KV cache, hazard-tracked through `mrs`.
 /// Same shared-f16-scratch caveat as [`encode_gqa_prefill_with_kv`].
 #[allow(clippy::too_many_arguments)]
-fn encode_gqa_with_kv(
+pub(crate) fn encode_gqa_with_kv(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     mrs: &mut MemRanges,
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
@@ -3996,7 +3999,7 @@ fn encode_gqa_prefill(
 /// whole-vector (`weight.len() == q_rows` / `k_rows`, OLMoE). No-ops
 /// when `extras` is empty. Single-token path used by decode.
 #[allow(clippy::too_many_arguments)]
-fn encode_attn_extras(
+pub(crate) fn encode_attn_extras(
     encoder: &objc2::runtime::ProtocolObject<dyn objc2_metal::MTLComputeCommandEncoder>,
     device: &objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2_metal::MTLDevice>>,
     extras: &AttnExtras<'_>,
@@ -5710,556 +5713,6 @@ pub fn launch_decode_dense_layer(
 
     let out_ptr = h_buf.contents();
     Ok(unsafe { std::slice::from_raw_parts(out_ptr.as_ptr() as *const f32, hidden_dim).to_vec() })
-}
-
-/// Optional attention epilogue ops applied between the QKV matvecs and
-/// RoPE, in CPU-path order: bias add (Qwen2-family `qkv_bias`), then
-/// QK-RMSNorm — per-head (Qwen3 / Gemma-3, `weight.len() == head_dim`)
-/// or whole-vector (OLMoE, `weight.len() == n_heads|n_kv_heads * head_dim`).
-/// `attn_logit_softcap` is applied inside GQA after score scaling
-/// (Gemma-2); when set, FA-vec is skipped in favour of the legacy kernel
-/// unless the FA-vec softcap path is enabled.
-#[derive(Default)]
-pub struct AttnExtras<'a> {
-    pub q_bias: Option<&'a [f32]>,
-    pub k_bias: Option<&'a [f32]>,
-    pub v_bias: Option<&'a [f32]>,
-    pub q_norm: Option<&'a [f32]>,
-    pub k_norm: Option<&'a [f32]>,
-    pub attn_logit_softcap: Option<f32>,
-}
-
-impl AttnExtras<'_> {
-    pub fn is_empty(&self) -> bool {
-        self.q_bias.is_none()
-            && self.k_bias.is_none()
-            && self.v_bias.is_none()
-            && self.q_norm.is_none()
-            && self.k_norm.is_none()
-            && self.attn_logit_softcap.is_none()
-    }
-}
-
-/// Per-layer launches + norms for [`launch_decode_dense_stack`].
-pub struct DenseLayerMetal<'a> {
-    pub attn_norm_w: &'a [f32],
-    pub ffn_norm_w: &'a [f32],
-    pub q: MatvecLaunch<'a>,
-    pub k: MatvecLaunch<'a>,
-    pub v: MatvecLaunch<'a>,
-    pub o: MatvecLaunch<'a>,
-    pub gate: MatvecLaunch<'a>,
-    pub up: MatvecLaunch<'a>,
-    pub down: MatvecLaunch<'a>,
-    pub extras: AttnExtras<'a>,
-    /// This layer's RoPE base AND divisors. Both halves, always: a
-    /// Gemma-3 SWA layer differs from its full-attention neighbours in
-    /// both (`rope_theta_swa`, and no linear scale folded into the
-    /// divisors). See [`LayerRope`].
-    pub rope: LayerRope<'a>,
-    /// Sliding-window size for this layer (`None` = full causal).
-    pub window: Option<usize>,
-    /// Gemma post-attention / post-FFN sandwich norms, applied to the
-    /// block output *before* the residual add.
-    pub post_attn_norm: Option<&'a [f32]>,
-    pub post_ffn_norm: Option<&'a [f32]>,
-}
-
-/// Optional on-GPU embedding gather at the start of
-/// [`launch_decode_dense_stack`] (skips host `dequant_row` + upload).
-pub struct EmbdGatherMetal<'a> {
-    pub kind: EmbdKind,
-    pub weights: &'a [u8],
-    pub rows: usize,
-    pub row_bytes: usize,
-    pub n_cols: usize,
-    pub token_id: usize,
-}
-
-/// All dense layers in **one** command buffer (one wait). Hidden stays on
-/// GPU across layers — Crane-style residency for B=1 decode.
-/// When `embd` is `Some`, gathers that token row into scratch `h` on-GPU
-/// instead of copying a host-provided `hidden` slice.
-/// When `final_norm_w` + `output` are provided, also runs final RMSNorm +
-/// lm_head on-GPU. With `argmax_only`, runs argmax and returns a
-/// **1-element** `vec![token_id as f32]`; otherwise downloads vocab logits.
-///
-/// Chunked multi-CB early-commit (llama `n_main` style) was tried on Host B
-/// and regressed decode tok/s — see `…_multicb*` receipts; kept single CB.
-#[allow(clippy::too_many_arguments)]
-pub fn launch_decode_dense_stack(
-    hidden: &[f32],
-    layers: &[DenseLayerMetal<'_>],
-    kvs: &mut [MetalKvBuffers],
-    n_heads: usize,
-    rope_layout: MetalRope,
-    pos: usize,
-    rms_eps: f32,
-    final_norm_w: Option<&[f32]>,
-    output: Option<&MatvecLaunch<'_>>,
-    argmax_only: bool,
-    embd: Option<&EmbdGatherMetal<'_>>,
-    gelu_ffn: bool,
-) -> Result<Vec<f32>, MetalError> {
-    assert_eq!(layers.len(), kvs.len());
-    assert!(!layers.is_empty());
-    let hidden_dim = match embd {
-        Some(e) => e.n_cols,
-        None => hidden.len(),
-    };
-    assert!(hidden_dim > 0);
-    let head_dim = kvs[0].head_dim;
-    let n_kv_heads = kvs[0].n_kv_heads;
-    for kv in kvs.iter() {
-        assert_eq!(kv.head_dim, head_dim);
-        assert_eq!(kv.n_kv_heads, n_kv_heads);
-        assert_eq!(pos, kv.seq_len);
-        if kv.seq_len >= kv.capacity {
-            return Err(MetalError::CommandFailed);
-        }
-    }
-    for layer in layers.iter() {
-        assert_freq_factors_len(layer.rope.freq_factors, rope_layout, head_dim);
-    }
-
-    let max_q = layers.iter().map(|l| l.q.rows).max().unwrap();
-    let max_kv = layers.iter().map(|l| l.k.rows).max().unwrap();
-    let max_gate = layers.iter().map(|l| l.gate.rows).max().unwrap();
-    let attn_elems = n_heads * head_dim;
-    let logits_rows = output.map(|o| o.rows);
-
-    let shared = shared_metal()?;
-    let device = &shared.device;
-    let queue = &shared.queue;
-
-    let scratch_guard = borrow_decode_scratch(
-        device,
-        ScratchCaps {
-            hidden: hidden_dim,
-            max_q,
-            max_kv,
-            attn: attn_elems,
-            max_gate,
-            logits: logits_rows.unwrap_or(0),
-        },
-    )?;
-    let scratch = scratch_guard.as_ref().expect("scratch just ensured");
-    let h_buf = &scratch.h;
-    if let Some(e) = embd {
-        assert_eq!(e.n_cols, hidden_dim);
-        assert!(e.token_id < e.rows);
-        assert_eq!(e.weights.len(), e.rows * e.row_bytes);
-        // Gather runs in the same CB below (after encoder create).
-    } else {
-        assert_eq!(hidden.len(), hidden_dim);
-        copy_f32_into(h_buf, hidden);
-    }
-    let x_buf = &scratch.x;
-    let x2_buf = &scratch.x2;
-    let q_buf = &scratch.q;
-    let k_buf = &scratch.k;
-    let v_buf = &scratch.v;
-    let attn_buf = &scratch.attn;
-    let o_buf = &scratch.o;
-    let gate_buf = &scratch.gate;
-    let up_buf = &scratch.up;
-    let act_buf = &scratch.act;
-    let down_buf = &scratch.down;
-    let logits_buf = scratch.logits.as_ref();
-    let argmax_idx_buf = &scratch.argmax_idx;
-
-    // One resident buffer PER LAYER. `resident_f32_buffer` keys its
-    // cache on (pointer, len), so the at-most-two distinct divisor sets
-    // an alternating-SWA model has are uploaded once each and every
-    // layer past the first two is a cache hit -- no per-layer upload,
-    // and no table of "which set does layer i use" for a call site to
-    // get out of step with.
-    let ff_resident = layers
-        .iter()
-        .map(|l| match l.rope.freq_factors {
-            Some(ff) => resident_f32_buffer(device, ff).map(Some),
-            None => Ok(None),
-        })
-        .collect::<Result<Vec<_>, MetalError>>()?;
-
-    let cmd_buf = queue.commandBuffer().ok_or(MetalError::CommandFailed)?;
-    // Gemma-style post-norms ("sandwich"): these layers take the EAGER
-    // residual path below, which is what makes concurrent encode safe here.
-    let sandwich = layers
-        .iter()
-        .any(|l| l.post_attn_norm.is_some() || l.post_ffn_norm.is_some());
-    // Every model encodes concurrently: gate∥up and Q∥K∥V overlap, and the
-    // hazard tracker emits a barrier only where a dispatch reads or
-    // overwrites something still in flight, narrowed to those resources.
-    //
-    // Sandwich models (Gemma post-norms) used to be forced onto the serial
-    // encoder, because concurrent dispatch with in-place RMSNorm and
-    // DEFERRED residuals diverged from CPU on Gemma-2 B=1 decode. That fix
-    // landed two changes at once -- serial encode AND eager residuals -- and
-    // the eager residuals are the half that mattered: with them, every op in
-    // this function declares its own reads and writes (`encode_gqa_with_kv`
-    // self-tracks, including the f16 dequant scratch no caller can name), so
-    // concurrency is safe by construction rather than by scheduling luck.
-    //
-    // Measured on an M2 Pro, interleaved, GPU-clock: Gemma-2-2B Q4_K_M decode
-    // 13.23 -> 12.20 ms/token, and greedy output stays byte-identical to the
-    // serial encoder across Gemma-2 and Gemma-3 on every prompt tried.
-    let (encoder, mut mrs) = (compute_encoder_concurrent(&cmd_buf)?, MemRanges::new());
-
-    let embd_resident = if let Some(e) = embd {
-        let w = resident_weight_buffer(device, e.weights)?;
-        mrs.begin_op(&encoder, &[], &[h_buf]);
-        encode_get_rows(
-            &encoder,
-            device,
-            e.kind,
-            &w,
-            h_buf,
-            e.row_bytes as u32,
-            e.n_cols as u32,
-            e.token_id as u32,
-        )?;
-        mrs.end_op(&[], &[h_buf]);
-        Some(w)
-    } else {
-        None
-    };
-    let _embd_resident = embd_resident;
-
-    // Gemma sandwich (post_attn / post_ffn) must apply residuals eagerly —
-    // same shape as the working prefill stack / CPU path. Deferred
-    // `h += down` fused into the next layer's attn_norm matches SmolLM2
-    // (no post-norms) but diverges for Gemma-2 Metal greedy (BOS loops /
-    // `*` spam) even when GQA unit tests pass.
-    // `sandwich` was computed above (also selects serial encoder).
-
-    for (layer_idx, (layer, kv)) in layers.iter().zip(kvs.iter_mut()).enumerate() {
-        assert_eq!(layer.attn_norm_w.len(), hidden_dim);
-        assert_eq!(layer.ffn_norm_w.len(), hidden_dim);
-        assert_eq!(layer.o.rows, hidden_dim);
-        assert_eq!(layer.down.rows, hidden_dim);
-        assert_eq!(layer.gate.rows, layer.up.rows);
-
-        let attn_nw = resident_f32_buffer(device, layer.attn_norm_w)?;
-        let ffn_nw = resident_f32_buffer(device, layer.ffn_norm_w)?;
-        let q_w = resident_weight_buffer(device, layer.q.weights)?;
-        let k_w = resident_weight_buffer(device, layer.k.weights)?;
-        let v_w = resident_weight_buffer(device, layer.v.weights)?;
-        let o_w = resident_weight_buffer(device, layer.o.weights)?;
-        let gate_w = resident_weight_buffer(device, layer.gate.weights)?;
-        let up_w = resident_weight_buffer(device, layer.up.weights)?;
-        let down_w = resident_weight_buffer(device, layer.down.weights)?;
-        let kv_k = kv.k.as_ref();
-        let kv_v = kv.v.as_ref();
-
-        // Pre-LN: layer 0 norms raw hidden; later layers either fuse the
-        // previous FFN residual into attn_norm (non-sandwich) or just
-        // RMSNorm (sandwich already applied `h += down` eagerly).
-        if layer_idx == 0 || sandwich {
-            mrs.begin_op(&encoder, &[h_buf], &[x_buf]);
-            encode_rms_norm(
-                &encoder,
-                device,
-                h_buf,
-                &attn_nw.buffer,
-                x_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[h_buf], &[x_buf]);
-        } else {
-            mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf, x_buf]);
-            encode_add_rms_norm(
-                &encoder,
-                device,
-                h_buf,
-                down_buf,
-                &attn_nw.buffer,
-                x_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[h_buf, down_buf], &[h_buf, x_buf]);
-        }
-        // Q∥K∥V
-        mrs.begin_op(&encoder, &[x_buf], &[q_buf, k_buf, v_buf]);
-        encode_matvec(&encoder, device, &layer.q, &q_w, x_buf, q_buf)?;
-        encode_matvec(&encoder, device, &layer.k, &k_w, x_buf, k_buf)?;
-        encode_matvec(&encoder, device, &layer.v, &v_w, x_buf, v_buf)?;
-        mrs.end_op(&[x_buf], &[q_buf, k_buf, v_buf]);
-
-        mrs.begin_op(&encoder, &[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
-        encode_attn_extras(
-            &encoder,
-            device,
-            &layer.extras,
-            q_buf,
-            k_buf,
-            v_buf,
-            layer.q.rows,
-            layer.k.rows,
-            layer.v.rows,
-            n_heads,
-            n_kv_heads,
-            head_dim,
-            rms_eps,
-        )?;
-        mrs.end_op(&[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
-
-        let layer_theta = layer.rope.theta;
-        let ff_buf = ff_resident[layer_idx].as_ref().map(|b| b.buffer.as_ref());
-        mrs.begin_op(&encoder, &[q_buf, k_buf], &[q_buf, k_buf]);
-        encode_rope(
-            &encoder,
-            device,
-            rope_layout,
-            q_buf,
-            n_heads as u32,
-            head_dim as u32,
-            layer_theta,
-            pos as u32,
-            ff_buf,
-        )?;
-        encode_rope(
-            &encoder,
-            device,
-            rope_layout,
-            k_buf,
-            n_kv_heads as u32,
-            head_dim as u32,
-            layer_theta,
-            pos as u32,
-            ff_buf,
-        )?;
-        mrs.end_op(&[q_buf, k_buf], &[q_buf, k_buf]);
-
-        let token_elems = (n_kv_heads * head_dim) as u32;
-        let offset = (pos * n_kv_heads * head_dim) as u32;
-        mrs.begin_op(&encoder, &[k_buf, v_buf], &[kv_k, kv_v]);
-        encode_kv_store_append(&encoder, device, k_buf, kv, KvPlane::K, offset, token_elems)?;
-        encode_kv_store_append(&encoder, device, v_buf, kv, KvPlane::V, offset, token_elems)?;
-        mrs.end_op(&[k_buf, v_buf], &[kv_k, kv_v]);
-
-        let new_seq = (pos + 1) as u32;
-        // Sliding window: only the last `window` positions (incl. current)
-        // are visible, matching `causal_gqa_attention_windowed`.
-        let kv_start = match layer.window {
-            Some(w) => (pos + 1).saturating_sub(w) as u32,
-            None => 0,
-        };
-        // Self-tracking: with a quantized KV cache this also writes a shared
-        // f16 dequant scratch that no caller can name.
-        encode_gqa_with_kv(
-            &encoder,
-            &mut mrs,
-            device,
-            q_buf,
-            kv,
-            attn_buf,
-            n_heads as u32,
-            n_kv_heads as u32,
-            head_dim as u32,
-            new_seq,
-            kv_start,
-            layer.extras.attn_logit_softcap,
-        )?;
-
-        mrs.begin_op(&encoder, &[attn_buf], &[o_buf]);
-        encode_matvec(&encoder, device, &layer.o, &o_w, attn_buf, o_buf)?;
-        mrs.end_op(&[attn_buf], &[o_buf]);
-
-        // Gemma sandwich norm: normalize the attn block output *before*
-        // the residual add (in-place: each thread reads x[i] only after
-        // the barriered reduction, so out == x is safe).
-        if let Some(post) = layer.post_attn_norm {
-            assert_eq!(post.len(), hidden_dim);
-            let pw = resident_f32_buffer(device, post)?;
-            mrs.begin_op(&encoder, &[o_buf], &[o_buf]);
-            encode_rms_norm(
-                &encoder,
-                device,
-                o_buf,
-                &pw.buffer,
-                o_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[o_buf], &[o_buf]);
-        }
-        // Attn residual + ffn_norm in one dispatch, for every model.
-        //
-        // Sandwich layers used to split this into `vec_add` then `rms_norm`,
-        // which is the same arithmetic in two dispatches: `post_attn_norm`
-        // has already been applied to `o_buf` in place above, so both paths
-        // compute `h += o` then `x2 = rms_norm(h)`. The split was a leftover
-        // from the serial-encoder era -- `encode_add_rms_norm` writes `h`
-        // itself, so the residual is just as eager as the two-dispatch form.
-        mrs.begin_op(&encoder, &[h_buf, o_buf], &[h_buf, x2_buf]);
-        encode_add_rms_norm(
-            &encoder,
-            device,
-            h_buf,
-            o_buf,
-            &ffn_nw.buffer,
-            x2_buf,
-            hidden_dim as u32,
-            rms_eps,
-        )?;
-        mrs.end_op(&[h_buf, o_buf], &[h_buf, x2_buf]);
-        // gate ∥ up (llama concurrent)
-        mrs.begin_op(&encoder, &[x2_buf], &[gate_buf, up_buf]);
-        encode_matvec(&encoder, device, &layer.gate, &gate_w, x2_buf, gate_buf)?;
-        encode_matvec(&encoder, device, &layer.up, &up_w, x2_buf, up_buf)?;
-        mrs.end_op(&[x2_buf], &[gate_buf, up_buf]);
-
-        mrs.begin_op(&encoder, &[gate_buf, up_buf], &[act_buf]);
-        if gelu_ffn {
-            encode_gelu_mul(
-                &encoder,
-                device,
-                gate_buf,
-                up_buf,
-                act_buf,
-                layer.gate.rows as u32,
-            )?;
-        } else {
-            encode_silu_mul(
-                &encoder,
-                device,
-                gate_buf,
-                up_buf,
-                act_buf,
-                layer.gate.rows as u32,
-            )?;
-        }
-        mrs.end_op(&[gate_buf, up_buf], &[act_buf]);
-
-        mrs.begin_op(&encoder, &[act_buf], &[down_buf]);
-        encode_matvec(&encoder, device, &layer.down, &down_w, act_buf, down_buf)?;
-        mrs.end_op(&[act_buf], &[down_buf]);
-
-        if let Some(post) = layer.post_ffn_norm {
-            assert_eq!(post.len(), hidden_dim);
-            let pw = resident_f32_buffer(device, post)?;
-            mrs.begin_op(&encoder, &[down_buf], &[down_buf]);
-            encode_rms_norm(
-                &encoder,
-                device,
-                down_buf,
-                &pw.buffer,
-                down_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[down_buf], &[down_buf]);
-        }
-        if sandwich {
-            // Eager FFN residual — next layer attn_norm is plain RMSNorm.
-            mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf]);
-            encode_vec_add(&encoder, device, h_buf, down_buf, hidden_dim as u32)?;
-            mrs.end_op(&[h_buf, down_buf], &[h_buf]);
-        }
-        // Non-sandwich: defer `h += down` until the next layer's attn_norm
-        // (or final_norm) so it fuses with that RMSNorm. `down_buf` stays in
-        // the tracker's dst set, so the next layer's fused norm barriers
-        // against it exactly once. Last layer handled below.
-    }
-
-    // Final norm / lm_head. Sandwich already applied every FFN residual;
-    // non-sandwich still has a deferred last-layer `down` to fold in.
-    let (download_n, norm_resident) = if let Some(fnw) = final_norm_w {
-        assert_eq!(fnw.len(), hidden_dim);
-        let fn_buf = resident_f32_buffer(device, fnw)?;
-        if sandwich {
-            mrs.begin_op(&encoder, &[h_buf], &[x_buf]);
-            encode_rms_norm(
-                &encoder,
-                device,
-                h_buf,
-                &fn_buf.buffer,
-                x_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[h_buf], &[x_buf]);
-        } else {
-            mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf, x_buf]);
-            encode_add_rms_norm(
-                &encoder,
-                device,
-                h_buf,
-                down_buf,
-                &fn_buf.buffer,
-                x_buf,
-                hidden_dim as u32,
-                rms_eps,
-            )?;
-            mrs.end_op(&[h_buf, down_buf], &[h_buf, x_buf]);
-        }
-        if let (Some(out_l), Some(logits)) = (output, logits_buf) {
-            assert_eq!(out_l.rows, logits_rows.unwrap());
-            // RAW: lm_head reads `x_buf` written by the norm above. Without
-            // ordering here Metal may overlap the matvec with the norm on
-            // small hiddens (SmolLM2 h=576) and produce garbage logits /
-            // greedy tokens while host lm_head after wait looks fine — the
-            // tracker sees `x_buf` as src-after-dst and barriers.
-            mrs.begin_op(&encoder, &[x_buf], &[logits.as_ref()]);
-            let out_w = resident_weight_buffer(device, out_l.weights)?;
-            encode_matvec(&encoder, device, out_l, &out_w, x_buf, logits)?;
-            mrs.end_op(&[x_buf], &[logits.as_ref()]);
-            if argmax_only {
-                mrs.begin_op(&encoder, &[logits.as_ref()], &[argmax_idx_buf]);
-                encode_argmax(&encoder, device, logits, argmax_idx_buf, out_l.rows as u32)?;
-                mrs.end_op(&[logits.as_ref()], &[argmax_idx_buf]);
-                (1, false)
-            } else {
-                (out_l.rows, false)
-            }
-        } else {
-            // final_norm ran but no lm_head — download normalized hidden
-            // and mark x_buf resident for the next apply_gpu.
-            (hidden_dim, true)
-        }
-    } else if sandwich {
-        (hidden_dim, false)
-    } else {
-        // No final_norm: still apply the deferred last-layer FFN residual.
-        mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf]);
-        encode_vec_add(&encoder, device, h_buf, down_buf, hidden_dim as u32)?;
-        mrs.end_op(&[h_buf, down_buf], &[h_buf]);
-        (hidden_dim, false)
-    };
-
-    encoder.endEncoding();
-    cmd_buf.commit();
-    cmd_buf.waitUntilCompleted();
-    crate::gpu::gpu_timing_note(&cmd_buf, "dense-decode/tok", 32);
-
-    for kv in kvs.iter_mut() {
-        kv.seq_len = pos + 1;
-    }
-
-    // If final_norm ran but no lm_head, mark normalized hidden (x_buf)
-    // as resident so the next apply_gpu can skip re-upload.
-    if norm_resident {
-        crate::gpu::set_resident_activation(x_buf, hidden_dim);
-    }
-
-    if argmax_only && download_n == 1 && output.is_some() {
-        let ptr = argmax_idx_buf.contents();
-        let idx = unsafe { *(ptr.as_ptr() as *const u32) as usize };
-        return Ok(vec![idx as f32]);
-    }
-
-    let src: &ProtocolObject<dyn MTLBuffer> = if norm_resident {
-        x_buf
-    } else if download_n == hidden_dim {
-        h_buf
-    } else {
-        logits_buf.expect("logits buffer when downloading logits")
-    };
-    let out_ptr = src.contents();
-    Ok(unsafe { std::slice::from_raw_parts(out_ptr.as_ptr() as *const f32, download_n).to_vec() })
 }
 
 /// Per-layer `mul_mm_sg` launches for [`launch_prefill_dense_layer`] /

--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -203,6 +203,14 @@ pub fn metal_greedy_argmax_active() -> bool {
 // layout so `encode_rope` only swaps the entry point. Math mirrors
 // `ferrox_core::attention::{apply_rope_interleaved, apply_rope}` —
 // no Candle / third-party RoPE dependency.
+//
+// Both take TWO destinations (buffers 0/1 and 9/10) because every decode
+// call site ropes Q and then K with the same theta, position and freq
+// factors, and RoPE touches each head independently, so the two are one
+// dispatch. GitHub issue #149: 26-29% of Metal decode wall time is host
+// command encoding, and this pair was 16 of the 242 dispatches a
+// Llama-3.2-1B token encoded. A caller with one destination passes
+// `n_heads2 = 0`, which makes the second range empty.
 const ROPE_NORM_KERNEL_SRC: &str = r#"
 #include <metal_stdlib>
 using namespace metal;
@@ -217,10 +225,17 @@ kernel void rope_interleaved_heads(
     constant uint& use_freq_factors [[buffer(6)]],
     constant uint& rot_dim [[buffer(7)]],
     constant float& mscale [[buffer(8)]],
+    device float* vecs2 [[buffer(9)]],
+    constant uint& n_heads2 [[buffer(10)]],
     uint h [[thread_position_in_grid]]
 ) {
-    if (h >= n_heads) return;
-    device float* vec = vecs + h * head_dim;
+    if (h >= n_heads + n_heads2) return;
+    // Heads [0, n_heads) rotate `vecs`; [n_heads, n_heads + n_heads2)
+    // rotate `vecs2`. Distinct buffers, one head each, so the two
+    // ranges never alias.
+    device float* base = (h < n_heads) ? vecs : vecs2;
+    uint head = (h < n_heads) ? h : (h - n_heads);
+    device float* vec = base + head * head_dim;
     // ggml `n_dims`: the rotary width. `kernel_rope_norm` rotates
     // `[0, n_dims)` and copies `[n_dims, ne0)` straight through, and the
     // frequency exponent is `-i0/n_dims`, not `-i0/head_dim`.
@@ -259,10 +274,17 @@ kernel void rope_neox_heads(
     constant uint& use_freq_factors [[buffer(6)]],
     constant uint& rot_dim [[buffer(7)]],
     constant float& mscale [[buffer(8)]],
+    device float* vecs2 [[buffer(9)]],
+    constant uint& n_heads2 [[buffer(10)]],
     uint h [[thread_position_in_grid]]
 ) {
-    if (h >= n_heads) return;
-    device float* vec = vecs + h * head_dim;
+    if (h >= n_heads + n_heads2) return;
+    // Heads [0, n_heads) rotate `vecs`; [n_heads, n_heads + n_heads2)
+    // rotate `vecs2`. Distinct buffers, one head each, so the two
+    // ranges never alias.
+    device float* base = (h < n_heads) ? vecs : vecs2;
+    uint head = (h < n_heads) ? h : (h - n_heads);
+    device float* vec = base + head * head_dim;
     // `kernel_rope_neox` pairs `ic` with `ic + n_dims/2` — the split is
     // over the ROTARY width, not the head, so partial rotary changes
     // which channel each one is paired with, not just how many rotate.
@@ -291,16 +313,25 @@ const KV_APPEND_KERNEL_SRC: &str = r#"
 using namespace metal;
 
 // Append f32 K/V token into an f16-resident cache (llama.cpp default).
+//
+// K and V are one dispatch: the grid's HEIGHT is the plane count, so
+// `gid.y` picks the pair of buffers and no uniform has to carry it.
+// Every call site appends K and V at the same offset and length, and
+// GitHub issue #149 makes the second encode worth removing.
 kernel void kv_append(
     device const float* src [[buffer(0)]],
     device half* dst [[buffer(1)]],
     constant uint& offset_elems [[buffer(2)]],
     constant uint& n_elems [[buffer(3)]],
-    uint i [[thread_position_in_grid]]
+    device const float* src2 [[buffer(4)]],
+    device half* dst2 [[buffer(5)]],
+    uint2 gid [[thread_position_in_grid]]
 ) {
-    if (i < n_elems) {
-        dst[offset_elems + i] = half(src[i]);
-    }
+    uint i = gid.x;
+    if (i >= n_elems) return;
+    device const float* s = (gid.y == 0u) ? src : src2;
+    device half* d = (gid.y == 0u) ? dst : dst2;
+    d[offset_elems + i] = half(s[i]);
 }
 "#;
 
@@ -309,13 +340,20 @@ const KV_APPEND_Q8_0_KERNEL_SRC: &str = r#"
 #include <metal_stdlib>
 using namespace metal;
 
+// K and V in one dispatch; grid height is the plane count (see
+// `kv_append`).
 kernel void kv_append_q8_0(
-    device const float* src [[buffer(0)]],
-    device uchar* dst [[buffer(1)]],
+    device const float* src_in [[buffer(0)]],
+    device uchar* dst_in [[buffer(1)]],
     constant uint& offset_elems [[buffer(2)]],
     constant uint& n_elems [[buffer(3)]],
-    uint b [[thread_position_in_grid]]
+    device const float* src2 [[buffer(4)]],
+    device uchar* dst2 [[buffer(5)]],
+    uint2 gid [[thread_position_in_grid]]
 ) {
+    uint b = gid.x;
+    device const float* src = (gid.y == 0u) ? src_in : src2;
+    device uchar* dst = (gid.y == 0u) ? dst_in : dst2;
     const uint BLOCK = 32u;
     const uint BLOCK_BYTES = 34u;
     uint n_blocks = n_elems / BLOCK;
@@ -370,13 +408,20 @@ const KV_APPEND_TURBO4_KERNEL_SRC: &str = r#"
 #include <metal_stdlib>
 using namespace metal;
 
+// K and V in one dispatch; grid height is the plane count (see
+// `kv_append`).
 kernel void kv_append_turbo4(
-    device const float* src [[buffer(0)]],
-    device uchar* dst [[buffer(1)]],
+    device const float* src_in [[buffer(0)]],
+    device uchar* dst_in [[buffer(1)]],
     constant uint& offset_elems [[buffer(2)]],
     constant uint& n_elems [[buffer(3)]],
-    uint b [[thread_position_in_grid]]
+    device const float* src2 [[buffer(4)]],
+    device uchar* dst2 [[buffer(5)]],
+    uint2 gid [[thread_position_in_grid]]
 ) {
+    uint b = gid.x;
+    device const float* src = (gid.y == 0u) ? src_in : src2;
+    device uchar* dst = (gid.y == 0u) ? dst_in : dst2;
     const uint BLOCK = 32u;
     const uint BLOCK_BYTES = 18u;
     uint n_blocks = n_elems / BLOCK;
@@ -2395,13 +2440,6 @@ impl MetalKvBuffers {
     }
 }
 
-/// K or V plane when appending into [`MetalKvBuffers`].
-#[derive(Clone, Copy)]
-pub(crate) enum KvPlane {
-    K,
-    V,
-}
-
 /// Process-wide f16 view of Q8_0 KV for FA/GQA (one pair shared across layers).
 struct Q8AttnScratch {
     k: Retained<ProtocolObject<dyn MTLBuffer>>,
@@ -2926,17 +2964,42 @@ pub(crate) fn assert_freq_factors_len(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// One RoPE destination: `n_heads` contiguous `head_dim` f32 heads.
+pub(crate) struct RopeTarget<'a> {
+    pub(crate) vecs: &'a ProtocolObject<dyn MTLBuffer>,
+    pub(crate) n_heads: u32,
+}
+
+/// RoPE one or two destinations in a SINGLE dispatch.
+///
+/// Every call site rotates Q and then K with the same `theta`, `pos`,
+/// `head_dim` and `freq_factors`, into different buffers, and RoPE is
+/// independent per head -- so the pair is one dispatch, not two. Taking
+/// `second` as a parameter rather than adding a fused twin is what keeps
+/// the single- and two-destination paths from drifting: there is one
+/// kernel and one encoder, and `None` simply makes the second range
+/// empty.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn encode_rope(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
     rope: MetalRope,
-    vecs: &ProtocolObject<dyn MTLBuffer>,
-    n_heads: u32,
+    first: RopeTarget<'_>,
+    second: Option<RopeTarget<'_>>,
     head_dim: u32,
     theta: f32,
     pos: u32,
     freq_factors: Option<&ProtocolObject<dyn MTLBuffer>>,
 ) -> Result<(), MetalError> {
+    let vecs = first.vecs;
+    let n_heads = first.n_heads;
+    // With no second destination the kernel's `h < n_heads` branch is the
+    // only reachable one, so binding `vecs` again at index 9 is a valid
+    // buffer the kernel never reads.
+    let (vecs2, n_heads2) = match &second {
+        Some(t) => (t.vecs, t.n_heads),
+        None => (vecs, 0),
+    };
     let (src, name) = match rope.layout {
         MetalRopeLayout::Norm => (ROPE_NORM_KERNEL_SRC, "rope_interleaved_heads"),
         MetalRopeLayout::Neox => (ROPE_NEOX_KERNEL_SRC, "rope_neox_heads"),
@@ -3004,11 +3067,18 @@ pub(crate) fn encode_rope(
             4,
             8,
         );
+        encoder.setBuffer_offset_atIndex(Some(vecs2), 0, 9);
+        let mut n_heads2_u = n_heads2;
+        encoder.setBytes_length_atIndex(
+            NonNull::new(&mut n_heads2_u as *mut u32 as *mut _).unwrap(),
+            4,
+            10,
+        );
     }
     dispatch_counted(
         encoder,
         MTLSize {
-            width: n_heads as usize,
+            width: (n_heads + n_heads2) as usize,
             height: 1,
             depth: 1,
         },
@@ -3126,90 +3196,41 @@ fn encode_rope_batch(
     Ok(())
 }
 
-fn encode_kv_append(
-    encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
-    device: &Retained<ProtocolObject<dyn MTLDevice>>,
-    src: &ProtocolObject<dyn MTLBuffer>,
-    dst: &ProtocolObject<dyn MTLBuffer>,
-    offset_elems: u32,
-    n_elems: u32,
-) -> Result<(), MetalError> {
-    let pipe = ensure_pipeline(device, KV_APPEND_KERNEL_SRC, "kv_append")?;
-    encoder.setComputePipelineState(&pipe.0);
-    unsafe {
-        encoder.setBuffer_offset_atIndex(Some(src), 0, 0);
-        encoder.setBuffer_offset_atIndex(Some(dst), 0, 1);
-        let mut off = offset_elems;
-        encoder.setBytes_length_atIndex(
-            NonNull::new(&mut off as *mut u32 as *mut _).unwrap(),
-            4,
-            2,
-        );
-        let mut n = n_elems;
-        encoder.setBytes_length_atIndex(NonNull::new(&mut n as *mut u32 as *mut _).unwrap(), 4, 3);
-    }
-    let tg = 256usize.min(n_elems as usize).max(1);
-    let n_tg = (n_elems as usize).div_ceil(tg);
-    dispatch_counted(
-        encoder,
-        MTLSize {
-            width: n_tg,
-            height: 1,
-            depth: 1,
-        },
-        MTLSize {
-            width: tg,
-            height: 1,
-            depth: 1,
-        },
-    );
-    Ok(())
+/// Kernel + block geometry for one KV wire format.
+///
+/// One table rather than three near-identical encoders: the f16, Q8_0
+/// and Turbo4 appends previously restated the same threadgroup sizing,
+/// the same alignment check and the same buffer bindings, which is the
+/// shape that loses a fix in two of three copies.
+struct KvAppendKernel {
+    src: &'static str,
+    name: &'static str,
+    /// f32 elements one dispatched unit handles: 1 for the f16 copy, the
+    /// block size for a quantized wire, which is also the alignment
+    /// `offset_elems` and `n_elems` must satisfy.
+    elems_per_unit: u32,
 }
 
-fn encode_kv_append_q8_0(
-    encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
-    device: &Retained<ProtocolObject<dyn MTLDevice>>,
-    src: &ProtocolObject<dyn MTLBuffer>,
-    dst: &ProtocolObject<dyn MTLBuffer>,
-    offset_elems: u32,
-    n_elems: u32,
-) -> Result<(), MetalError> {
-    if !offset_elems.is_multiple_of(ferrox_quant::Q8_0_BLOCK_ELEMS as u32)
-        || !n_elems.is_multiple_of(ferrox_quant::Q8_0_BLOCK_ELEMS as u32)
-    {
-        return Err(MetalError::CommandFailed);
+fn kv_append_kernel(dtype: MetalKvDtype) -> KvAppendKernel {
+    if dtype.is_q8_wire() {
+        return KvAppendKernel {
+            src: KV_APPEND_Q8_0_KERNEL_SRC,
+            name: "kv_append_q8_0",
+            elems_per_unit: ferrox_quant::Q8_0_BLOCK_ELEMS as u32,
+        };
     }
-    let pipe = ensure_pipeline(device, KV_APPEND_Q8_0_KERNEL_SRC, "kv_append_q8_0")?;
-    encoder.setComputePipelineState(&pipe.0);
-    unsafe {
-        encoder.setBuffer_offset_atIndex(Some(src), 0, 0);
-        encoder.setBuffer_offset_atIndex(Some(dst), 0, 1);
-        let mut off = offset_elems;
-        encoder.setBytes_length_atIndex(
-            NonNull::new(&mut off as *mut u32 as *mut _).unwrap(),
-            4,
-            2,
-        );
-        let mut n = n_elems;
-        encoder.setBytes_length_atIndex(NonNull::new(&mut n as *mut u32 as *mut _).unwrap(), 4, 3);
+    match dtype {
+        MetalKvDtype::Turbo4 => KvAppendKernel {
+            src: KV_APPEND_TURBO4_KERNEL_SRC,
+            name: "kv_append_turbo4",
+            elems_per_unit: ferrox_quant::TURBO4_KV_GROUP as u32,
+        },
+        _ => KvAppendKernel {
+            src: KV_APPEND_KERNEL_SRC,
+            name: "kv_append",
+            elems_per_unit: 1,
+        },
     }
-    let n_blocks = (n_elems as usize) / ferrox_quant::Q8_0_BLOCK_ELEMS;
-    let tg = 256usize.min(n_blocks).max(1);
-    let n_tg = n_blocks.div_ceil(tg);
-    dispatch_counted(
-        encoder,
-        MTLSize {
-            width: n_tg,
-            height: 1,
-            depth: 1,
-        },
-        MTLSize {
-            width: tg,
-            height: 1,
-            depth: 1,
-        },
-    );
-    Ok(())
 }
 
 fn encode_dequant_q8_0_to_f16(
@@ -3235,52 +3256,6 @@ fn encode_dequant_q8_0_to_f16(
         encoder.setBytes_length_atIndex(NonNull::new(&mut n as *mut u32 as *mut _).unwrap(), 4, 2);
     }
     let n_blocks = (n_elems as usize) / ferrox_quant::Q8_0_BLOCK_ELEMS;
-    let tg = 256usize.min(n_blocks).max(1);
-    let n_tg = n_blocks.div_ceil(tg);
-    dispatch_counted(
-        encoder,
-        MTLSize {
-            width: n_tg,
-            height: 1,
-            depth: 1,
-        },
-        MTLSize {
-            width: tg,
-            height: 1,
-            depth: 1,
-        },
-    );
-    Ok(())
-}
-
-fn encode_kv_append_turbo4(
-    encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
-    device: &Retained<ProtocolObject<dyn MTLDevice>>,
-    src: &ProtocolObject<dyn MTLBuffer>,
-    dst: &ProtocolObject<dyn MTLBuffer>,
-    offset_elems: u32,
-    n_elems: u32,
-) -> Result<(), MetalError> {
-    if !offset_elems.is_multiple_of(ferrox_quant::TURBO4_KV_GROUP as u32)
-        || !n_elems.is_multiple_of(ferrox_quant::TURBO4_KV_GROUP as u32)
-    {
-        return Err(MetalError::CommandFailed);
-    }
-    let pipe = ensure_pipeline(device, KV_APPEND_TURBO4_KERNEL_SRC, "kv_append_turbo4")?;
-    encoder.setComputePipelineState(&pipe.0);
-    unsafe {
-        encoder.setBuffer_offset_atIndex(Some(src), 0, 0);
-        encoder.setBuffer_offset_atIndex(Some(dst), 0, 1);
-        let mut off = offset_elems;
-        encoder.setBytes_length_atIndex(
-            NonNull::new(&mut off as *mut u32 as *mut _).unwrap(),
-            4,
-            2,
-        );
-        let mut n = n_elems;
-        encoder.setBytes_length_atIndex(NonNull::new(&mut n as *mut u32 as *mut _).unwrap(), 4, 3);
-    }
-    let n_blocks = (n_elems as usize) / ferrox_quant::TURBO4_KV_GROUP;
     let tg = 256usize.min(n_blocks).max(1);
     let n_tg = n_blocks.div_ceil(tg);
     dispatch_counted(
@@ -3355,28 +3330,68 @@ fn encode_kv_dequant_to_f16(
     }
 }
 
+/// Append this token's K and V into the layer's cache in ONE dispatch.
+///
+/// Both planes always land at the same `offset_elems` with the same
+/// `n_elems` -- there is no caller that appends one without the other --
+/// so the kernel takes the second pair of buffers and the grid's height
+/// selects between them. That halves this step's encode cost, which is
+/// the whole point of GitHub issue #149: the K and V appends were 32 of
+/// the 242 dispatches a Llama-3.2-1B decode token encoded.
+///
+/// Taking both planes as parameters is also why there is no `KvPlane`
+/// enum any more: a single-plane entry point would be a second code path
+/// to keep in step with this one.
 pub(crate) fn encode_kv_store_append(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
-    src: &ProtocolObject<dyn MTLBuffer>,
+    k_src: &ProtocolObject<dyn MTLBuffer>,
+    v_src: &ProtocolObject<dyn MTLBuffer>,
     kv: &MetalKvBuffers,
-    plane: KvPlane,
     offset_elems: u32,
     n_elems: u32,
 ) -> Result<(), MetalError> {
-    let dst: &ProtocolObject<dyn MTLBuffer> = match plane {
-        KvPlane::K => &kv.k,
-        KvPlane::V => &kv.v,
-    };
-    match kv.dtype {
-        d if d.is_q8_wire() => {
-            encode_kv_append_q8_0(encoder, device, src, dst, offset_elems, n_elems)
-        }
-        MetalKvDtype::Turbo4 => {
-            encode_kv_append_turbo4(encoder, device, src, dst, offset_elems, n_elems)
-        }
-        _ => encode_kv_append(encoder, device, src, dst, offset_elems, n_elems),
+    let kernel = kv_append_kernel(kv.dtype);
+    let unit = kernel.elems_per_unit;
+    // A quantized wire writes whole blocks, so a token that does not sit
+    // on a block boundary would corrupt its neighbour. Refuse instead.
+    if !offset_elems.is_multiple_of(unit) || !n_elems.is_multiple_of(unit) {
+        return Err(MetalError::CommandFailed);
     }
+    let units = (n_elems / unit) as usize;
+    let pipe = ensure_pipeline(device, kernel.src, kernel.name)?;
+    encoder.setComputePipelineState(&pipe.0);
+    unsafe {
+        encoder.setBuffer_offset_atIndex(Some(k_src), 0, 0);
+        encoder.setBuffer_offset_atIndex(Some(&kv.k), 0, 1);
+        let mut off = offset_elems;
+        encoder.setBytes_length_atIndex(
+            NonNull::new(&mut off as *mut u32 as *mut _).unwrap(),
+            4,
+            2,
+        );
+        let mut n = n_elems;
+        encoder.setBytes_length_atIndex(NonNull::new(&mut n as *mut u32 as *mut _).unwrap(), 4, 3);
+        encoder.setBuffer_offset_atIndex(Some(v_src), 0, 4);
+        encoder.setBuffer_offset_atIndex(Some(&kv.v), 0, 5);
+    }
+    let tg = 256usize.min(units).max(1);
+    let n_tg = units.div_ceil(tg);
+    dispatch_counted(
+        encoder,
+        MTLSize {
+            width: n_tg,
+            // Plane 0 is K, plane 1 is V.
+            height: 2,
+            depth: 1,
+        },
+        MTLSize {
+            width: tg,
+            height: 1,
+            depth: 1,
+        },
+    );
+    Ok(())
 }
 
 /// Decode GQA against the layer's KV cache, hazard-tracked through `mrs`.
@@ -4289,19 +4304,14 @@ pub fn launch_decode_attn_block(
         &encoder,
         device,
         rope_layout,
-        &q_buf,
-        n_heads as u32,
-        head_dim as u32,
-        rope_theta,
-        pos as u32,
-        ff_buf.as_deref(),
-    )?;
-    encode_rope(
-        &encoder,
-        device,
-        rope_layout,
-        &k_buf,
-        n_kv_heads as u32,
+        RopeTarget {
+            vecs: &q_buf,
+            n_heads: n_heads as u32,
+        },
+        Some(RopeTarget {
+            vecs: &k_buf,
+            n_heads: n_kv_heads as u32,
+        }),
         head_dim as u32,
         rope_theta,
         pos as u32,
@@ -4310,24 +4320,7 @@ pub fn launch_decode_attn_block(
 
     let token_elems = (n_kv_heads * head_dim) as u32;
     let offset = (kv.seq_len * n_kv_heads * head_dim) as u32;
-    encode_kv_store_append(
-        &encoder,
-        device,
-        &k_buf,
-        kv,
-        KvPlane::K,
-        offset,
-        token_elems,
-    )?;
-    encode_kv_store_append(
-        &encoder,
-        device,
-        &v_buf,
-        kv,
-        KvPlane::V,
-        offset,
-        token_elems,
-    )?;
+    encode_kv_store_append(&encoder, device, &k_buf, &v_buf, kv, offset, token_elems)?;
 
     let new_seq = (kv.seq_len + 1) as u32;
     encode_gqa_with_kv(
@@ -4651,19 +4644,14 @@ pub fn launch_moe_decode_pre(
             &encoder,
             device,
             rope_layout,
-            &scratch.q,
-            n_heads as u32,
-            head_dim as u32,
-            rope_theta,
-            pos as u32,
-            ff_buf.as_deref(),
-        )?;
-        encode_rope(
-            &encoder,
-            device,
-            rope_layout,
-            &scratch.k,
-            n_kv_heads as u32,
+            RopeTarget {
+                vecs: &scratch.q,
+                n_heads: n_heads as u32,
+            },
+            Some(RopeTarget {
+                vecs: &scratch.k,
+                n_heads: n_kv_heads as u32,
+            }),
             head_dim as u32,
             rope_theta,
             pos as u32,
@@ -4675,17 +4663,8 @@ pub fn launch_moe_decode_pre(
             &encoder,
             device,
             &scratch.k,
-            kv,
-            KvPlane::K,
-            offset,
-            token_elems,
-        )?;
-        encode_kv_store_append(
-            &encoder,
-            device,
             &scratch.v,
             kv,
-            KvPlane::V,
             offset,
             token_elems,
         )?;
@@ -5001,19 +4980,14 @@ fn encode_moe_layer_fused(
             encoder,
             device,
             rope_layout,
-            &scratch.q,
-            n_heads as u32,
-            head_dim as u32,
-            rope_theta,
-            pos as u32,
-            ff_buf,
-        )?;
-        encode_rope(
-            encoder,
-            device,
-            rope_layout,
-            &scratch.k,
-            n_kv_heads as u32,
+            RopeTarget {
+                vecs: &scratch.q,
+                n_heads: n_heads as u32,
+            },
+            Some(RopeTarget {
+                vecs: &scratch.k,
+                n_heads: n_kv_heads as u32,
+            }),
             head_dim as u32,
             rope_theta,
             pos as u32,
@@ -5032,17 +5006,8 @@ fn encode_moe_layer_fused(
             encoder,
             device,
             &scratch.k,
-            kv,
-            KvPlane::K,
-            offset,
-            token_elems,
-        )?;
-        encode_kv_store_append(
-            encoder,
-            device,
             &scratch.v,
             kv,
-            KvPlane::V,
             offset,
             token_elems,
         )?;
@@ -5643,19 +5608,14 @@ pub fn launch_decode_dense_layer(
         &encoder,
         device,
         rope_layout,
-        &q_buf,
-        n_heads as u32,
-        head_dim as u32,
-        rope_theta,
-        pos as u32,
-        ff_buf.as_deref(),
-    )?;
-    encode_rope(
-        &encoder,
-        device,
-        rope_layout,
-        &k_buf,
-        n_kv_heads as u32,
+        RopeTarget {
+            vecs: &q_buf,
+            n_heads: n_heads as u32,
+        },
+        Some(RopeTarget {
+            vecs: &k_buf,
+            n_heads: n_kv_heads as u32,
+        }),
         head_dim as u32,
         rope_theta,
         pos as u32,
@@ -5664,24 +5624,7 @@ pub fn launch_decode_dense_layer(
 
     let token_elems = (n_kv_heads * head_dim) as u32;
     let offset = (kv.seq_len * n_kv_heads * head_dim) as u32;
-    encode_kv_store_append(
-        &encoder,
-        device,
-        &k_buf,
-        kv,
-        KvPlane::K,
-        offset,
-        token_elems,
-    )?;
-    encode_kv_store_append(
-        &encoder,
-        device,
-        &v_buf,
-        kv,
-        KvPlane::V,
-        offset,
-        token_elems,
-    )?;
+    encode_kv_store_append(&encoder, device, &k_buf, &v_buf, kv, offset, token_elems)?;
 
     let new_seq = (kv.seq_len + 1) as u32;
     encode_gqa_with_kv(
@@ -6008,8 +5951,7 @@ fn encode_prefill_dense_layer(
     let token_elems = (batch * kv_width) as u32;
     let offset = (kv.seq_len * kv_width) as u32;
     mrs.begin_op(encoder, &[k_buf, v_buf], &[kv_k, kv_v]);
-    encode_kv_store_append(encoder, device, k_buf, kv, KvPlane::K, offset, token_elems)?;
-    encode_kv_store_append(encoder, device, v_buf, kv, KvPlane::V, offset, token_elems)?;
+    encode_kv_store_append(encoder, device, k_buf, v_buf, kv, offset, token_elems)?;
     mrs.end_op(&[k_buf, v_buf], &[kv_k, kv_v]);
 
     encode_gqa_prefill_with_kv(
@@ -6466,8 +6408,11 @@ pub fn launch_rope_heads_host(
         &encoder,
         device,
         layout,
-        &buf,
-        n_heads as u32,
+        RopeTarget {
+            vecs: &buf,
+            n_heads: n_heads as u32,
+        },
+        None,
         head_dim as u32,
         theta,
         pos as u32,
@@ -6639,24 +6584,7 @@ pub fn launch_prefill_attn_block(
 
     let token_elems = (n_q * kv_width) as u32;
     let offset = (kv.seq_len * kv_width) as u32;
-    encode_kv_store_append(
-        &encoder,
-        device,
-        &k_buf,
-        kv,
-        KvPlane::K,
-        offset,
-        token_elems,
-    )?;
-    encode_kv_store_append(
-        &encoder,
-        device,
-        &v_buf,
-        kv,
-        KvPlane::V,
-        offset,
-        token_elems,
-    )?;
+    encode_kv_store_append(&encoder, device, &k_buf, &v_buf, kv, offset, token_elems)?;
 
     let prefill_result = encode_gqa_prefill_with_kv(
         &encoder,

--- a/crates/ferrox-metal/src/decode_dense.rs
+++ b/crates/ferrox-metal/src/decode_dense.rs
@@ -9,8 +9,8 @@
 
 use crate::attn::{
     assert_freq_factors_len, borrow_decode_scratch, copy_f32_into, encode_attn_extras,
-    encode_gqa_with_kv, encode_kv_store_append, encode_rope, KvPlane, LayerRope, MetalKvBuffers,
-    MetalRope, ScratchCaps,
+    encode_gqa_with_kv, encode_kv_store_append, encode_rope, LayerRope, MetalKvBuffers, MetalRope,
+    RopeTarget, ScratchCaps,
 };
 use crate::elem::{
     encode_add_rms_norm, encode_argmax, encode_gelu_mul, encode_rms_norm, encode_silu_mul,
@@ -43,13 +43,28 @@ pub struct AttnExtras<'a> {
 }
 
 impl AttnExtras<'_> {
-    pub fn is_empty(&self) -> bool {
-        self.q_bias.is_none()
-            && self.k_bias.is_none()
-            && self.v_bias.is_none()
-            && self.q_norm.is_none()
-            && self.k_norm.is_none()
-            && self.attn_logit_softcap.is_none()
+    /// True when `encode_attn_extras` would encode at least one dispatch.
+    ///
+    /// `attn_logit_softcap` is deliberately NOT part of this: it is a
+    /// scalar consumed inside the GQA kernel, so a Gemma-2 layer that
+    /// sets only the softcap encodes nothing here.
+    ///
+    /// The caller uses this to skip the hazard check entirely. That
+    /// matters more than it looks: a `begin_op` around zero dispatches
+    /// still emits a full `memoryBarrierWithResources`, and on
+    /// Llama-3.2-1B -- no biases, no QK-norm -- that was 16 of the 176
+    /// barriers a decode token encoded, ordering nothing against
+    /// nothing (GitHub issue #149).
+    ///
+    /// `attn_extras_predicate_lists_every_field_that_encodes` destructures
+    /// the struct exhaustively, so a new field cannot be added without
+    /// deciding which side of this predicate it falls on.
+    pub fn encodes_anything(&self) -> bool {
+        self.q_bias.is_some()
+            || self.k_bias.is_some()
+            || self.v_bias.is_some()
+            || self.q_norm.is_some()
+            || self.k_norm.is_some()
     }
 }
 
@@ -301,44 +316,46 @@ pub fn launch_decode_dense_stack(
         encode_matvec(&encoder, device, &layer.v, &v_w, x_buf, v_buf)?;
         mrs.end_op(&[x_buf], &[q_buf, k_buf, v_buf]);
 
-        mrs.begin_op(&encoder, &[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
-        encode_attn_extras(
-            &encoder,
-            device,
-            &layer.extras,
-            q_buf,
-            k_buf,
-            v_buf,
-            layer.q.rows,
-            layer.k.rows,
-            layer.v.rows,
-            n_heads,
-            n_kv_heads,
-            head_dim,
-            rms_eps,
-        )?;
-        mrs.end_op(&[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
+        // Skipped entirely when the layer has no biases and no QK-norm:
+        // the hazard check around zero dispatches is still a real
+        // barrier. See `AttnExtras::encodes_anything`.
+        if layer.extras.encodes_anything() {
+            mrs.begin_op(&encoder, &[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
+            encode_attn_extras(
+                &encoder,
+                device,
+                &layer.extras,
+                q_buf,
+                k_buf,
+                v_buf,
+                layer.q.rows,
+                layer.k.rows,
+                layer.v.rows,
+                n_heads,
+                n_kv_heads,
+                head_dim,
+                rms_eps,
+            )?;
+            mrs.end_op(&[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
+        }
 
         let layer_theta = layer.rope.theta;
         let ff_buf = ff_resident[layer_idx].as_ref().map(|b| b.buffer.as_ref());
+        // Q and K in one dispatch: same theta, position and freq
+        // factors, different buffers, and RoPE is per-head independent.
         mrs.begin_op(&encoder, &[q_buf, k_buf], &[q_buf, k_buf]);
         encode_rope(
             &encoder,
             device,
             rope_layout,
-            q_buf,
-            n_heads as u32,
-            head_dim as u32,
-            layer_theta,
-            pos as u32,
-            ff_buf,
-        )?;
-        encode_rope(
-            &encoder,
-            device,
-            rope_layout,
-            k_buf,
-            n_kv_heads as u32,
+            RopeTarget {
+                vecs: q_buf,
+                n_heads: n_heads as u32,
+            },
+            Some(RopeTarget {
+                vecs: k_buf,
+                n_heads: n_kv_heads as u32,
+            }),
             head_dim as u32,
             layer_theta,
             pos as u32,
@@ -349,8 +366,9 @@ pub fn launch_decode_dense_stack(
         let token_elems = (n_kv_heads * head_dim) as u32;
         let offset = (pos * n_kv_heads * head_dim) as u32;
         mrs.begin_op(&encoder, &[k_buf, v_buf], &[kv_k, kv_v]);
-        encode_kv_store_append(&encoder, device, k_buf, kv, KvPlane::K, offset, token_elems)?;
-        encode_kv_store_append(&encoder, device, v_buf, kv, KvPlane::V, offset, token_elems)?;
+        // K and V in one dispatch: same offset, same length, disjoint
+        // destinations.
+        encode_kv_store_append(&encoder, device, k_buf, v_buf, kv, offset, token_elems)?;
         mrs.end_op(&[k_buf, v_buf], &[kv_k, kv_v]);
 
         let new_seq = (pos + 1) as u32;
@@ -573,4 +591,80 @@ pub fn launch_decode_dense_stack(
     };
     let out_ptr = src.contents();
     Ok(unsafe { std::slice::from_raw_parts(out_ptr.as_ptr() as *const f32, download_n).to_vec() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AttnExtras;
+
+    /// `encodes_anything` decides whether the decode stack pays a barrier
+    /// for this layer's attention epilogue, so a field it forgets is a
+    /// silently skipped dispatch -- the repo's dominant defect shape,
+    /// two structures that must agree with nothing enforcing it.
+    ///
+    /// The exhaustive destructure below has no `..`, so adding a field to
+    /// `AttnExtras` fails to COMPILE here until somebody decides whether
+    /// it encodes a dispatch.
+    #[test]
+    fn attn_extras_predicate_lists_every_field_that_encodes() {
+        let w = [1.0f32];
+        let base = AttnExtras::default();
+        let AttnExtras {
+            q_bias,
+            k_bias,
+            v_bias,
+            q_norm,
+            k_norm,
+            attn_logit_softcap,
+        } = &base;
+        assert!(q_bias.is_none());
+        assert!(k_bias.is_none());
+        assert!(v_bias.is_none());
+        assert!(q_norm.is_none());
+        assert!(k_norm.is_none());
+        assert!(attn_logit_softcap.is_none());
+        assert!(
+            !base.encodes_anything(),
+            "an empty epilogue encodes nothing, so it must not take a barrier"
+        );
+
+        // Every field that DOES encode a dispatch, one at a time.
+        let encoders: [AttnExtras<'_>; 5] = [
+            AttnExtras {
+                q_bias: Some(&w),
+                ..AttnExtras::default()
+            },
+            AttnExtras {
+                k_bias: Some(&w),
+                ..AttnExtras::default()
+            },
+            AttnExtras {
+                v_bias: Some(&w),
+                ..AttnExtras::default()
+            },
+            AttnExtras {
+                q_norm: Some(&w),
+                ..AttnExtras::default()
+            },
+            AttnExtras {
+                k_norm: Some(&w),
+                ..AttnExtras::default()
+            },
+        ];
+        for (i, e) in encoders.iter().enumerate() {
+            assert!(e.encodes_anything(), "field {i} encodes but is not listed");
+        }
+
+        // And the one that does not: the softcap is read inside the GQA
+        // kernel, never encoded by `encode_attn_extras`.
+        let softcap_only = AttnExtras {
+            attn_logit_softcap: Some(30.0),
+            ..AttnExtras::default()
+        };
+        assert!(
+            !softcap_only.encodes_anything(),
+            "attn_logit_softcap encodes no dispatch of its own, so it must \
+             not force a barrier around zero work"
+        );
+    }
 }

--- a/crates/ferrox-metal/src/decode_dense.rs
+++ b/crates/ferrox-metal/src/decode_dense.rs
@@ -1,0 +1,576 @@
+//! The dense B=1 decode stack: every layer of a dense model in one
+//! command buffer, hidden state resident on the GPU across layers.
+//!
+//! Split out of `attn.rs` along the seam GitHub issue #149 touches: the
+//! host-side cost of encoding this stack is the whole remaining Metal
+//! decode gap, so the encode loop needs to live somewhere it can be read
+//! and changed in full. Per-token GPU/host accounting is in
+//! `crate::gpu::gpu_timing_note` and `crate::mem_ranges`.
+
+use crate::attn::{
+    assert_freq_factors_len, borrow_decode_scratch, copy_f32_into, encode_attn_extras,
+    encode_gqa_with_kv, encode_kv_store_append, encode_rope, KvPlane, LayerRope, MetalKvBuffers,
+    MetalRope, ScratchCaps,
+};
+use crate::elem::{
+    encode_add_rms_norm, encode_argmax, encode_gelu_mul, encode_rms_norm, encode_silu_mul,
+    encode_vec_add,
+};
+use crate::embd::{encode_get_rows, EmbdKind};
+use crate::gpu::{
+    compute_encoder_concurrent, encode_matvec, resident_f32_buffer, resident_weight_buffer,
+    shared_metal, MatvecLaunch, MetalError,
+};
+use crate::mem_ranges::MemRanges;
+use objc2::runtime::ProtocolObject;
+use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue};
+
+/// Optional attention epilogue ops applied between the QKV matvecs and
+/// RoPE, in CPU-path order: bias add (Qwen2-family `qkv_bias`), then
+/// QK-RMSNorm — per-head (Qwen3 / Gemma-3, `weight.len() == head_dim`)
+/// or whole-vector (OLMoE, `weight.len() == n_heads|n_kv_heads * head_dim`).
+/// `attn_logit_softcap` is applied inside GQA after score scaling
+/// (Gemma-2); when set, FA-vec is skipped in favour of the legacy kernel
+/// unless the FA-vec softcap path is enabled.
+#[derive(Default)]
+pub struct AttnExtras<'a> {
+    pub q_bias: Option<&'a [f32]>,
+    pub k_bias: Option<&'a [f32]>,
+    pub v_bias: Option<&'a [f32]>,
+    pub q_norm: Option<&'a [f32]>,
+    pub k_norm: Option<&'a [f32]>,
+    pub attn_logit_softcap: Option<f32>,
+}
+
+impl AttnExtras<'_> {
+    pub fn is_empty(&self) -> bool {
+        self.q_bias.is_none()
+            && self.k_bias.is_none()
+            && self.v_bias.is_none()
+            && self.q_norm.is_none()
+            && self.k_norm.is_none()
+            && self.attn_logit_softcap.is_none()
+    }
+}
+
+/// Per-layer launches + norms for [`launch_decode_dense_stack`].
+pub struct DenseLayerMetal<'a> {
+    pub attn_norm_w: &'a [f32],
+    pub ffn_norm_w: &'a [f32],
+    pub q: MatvecLaunch<'a>,
+    pub k: MatvecLaunch<'a>,
+    pub v: MatvecLaunch<'a>,
+    pub o: MatvecLaunch<'a>,
+    pub gate: MatvecLaunch<'a>,
+    pub up: MatvecLaunch<'a>,
+    pub down: MatvecLaunch<'a>,
+    pub extras: AttnExtras<'a>,
+    /// This layer's RoPE base AND divisors. Both halves, always: a
+    /// Gemma-3 SWA layer differs from its full-attention neighbours in
+    /// both (`rope_theta_swa`, and no linear scale folded into the
+    /// divisors). See [`LayerRope`].
+    pub rope: LayerRope<'a>,
+    /// Sliding-window size for this layer (`None` = full causal).
+    pub window: Option<usize>,
+    /// Gemma post-attention / post-FFN sandwich norms, applied to the
+    /// block output *before* the residual add.
+    pub post_attn_norm: Option<&'a [f32]>,
+    pub post_ffn_norm: Option<&'a [f32]>,
+}
+
+/// Optional on-GPU embedding gather at the start of
+/// [`launch_decode_dense_stack`] (skips host `dequant_row` + upload).
+pub struct EmbdGatherMetal<'a> {
+    pub kind: EmbdKind,
+    pub weights: &'a [u8],
+    pub rows: usize,
+    pub row_bytes: usize,
+    pub n_cols: usize,
+    pub token_id: usize,
+}
+
+/// All dense layers in **one** command buffer (one wait). Hidden stays on
+/// GPU across layers — Crane-style residency for B=1 decode.
+/// When `embd` is `Some`, gathers that token row into scratch `h` on-GPU
+/// instead of copying a host-provided `hidden` slice.
+/// When `final_norm_w` + `output` are provided, also runs final RMSNorm +
+/// lm_head on-GPU. With `argmax_only`, runs argmax and returns a
+/// **1-element** `vec![token_id as f32]`; otherwise downloads vocab logits.
+///
+/// Chunked multi-CB early-commit (llama `n_main` style) was tried on Host B
+/// and regressed decode tok/s — see `…_multicb*` receipts; kept single CB.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_decode_dense_stack(
+    hidden: &[f32],
+    layers: &[DenseLayerMetal<'_>],
+    kvs: &mut [MetalKvBuffers],
+    n_heads: usize,
+    rope_layout: MetalRope,
+    pos: usize,
+    rms_eps: f32,
+    final_norm_w: Option<&[f32]>,
+    output: Option<&MatvecLaunch<'_>>,
+    argmax_only: bool,
+    embd: Option<&EmbdGatherMetal<'_>>,
+    gelu_ffn: bool,
+) -> Result<Vec<f32>, MetalError> {
+    assert_eq!(layers.len(), kvs.len());
+    assert!(!layers.is_empty());
+    let hidden_dim = match embd {
+        Some(e) => e.n_cols,
+        None => hidden.len(),
+    };
+    assert!(hidden_dim > 0);
+    let head_dim = kvs[0].head_dim;
+    let n_kv_heads = kvs[0].n_kv_heads;
+    for kv in kvs.iter() {
+        assert_eq!(kv.head_dim, head_dim);
+        assert_eq!(kv.n_kv_heads, n_kv_heads);
+        assert_eq!(pos, kv.seq_len);
+        if kv.seq_len >= kv.capacity {
+            return Err(MetalError::CommandFailed);
+        }
+    }
+    for layer in layers.iter() {
+        assert_freq_factors_len(layer.rope.freq_factors, rope_layout, head_dim);
+    }
+
+    let max_q = layers.iter().map(|l| l.q.rows).max().unwrap();
+    let max_kv = layers.iter().map(|l| l.k.rows).max().unwrap();
+    let max_gate = layers.iter().map(|l| l.gate.rows).max().unwrap();
+    let attn_elems = n_heads * head_dim;
+    let logits_rows = output.map(|o| o.rows);
+
+    let shared = shared_metal()?;
+    let device = &shared.device;
+    let queue = &shared.queue;
+
+    let scratch_guard = borrow_decode_scratch(
+        device,
+        ScratchCaps {
+            hidden: hidden_dim,
+            max_q,
+            max_kv,
+            attn: attn_elems,
+            max_gate,
+            logits: logits_rows.unwrap_or(0),
+        },
+    )?;
+    let scratch = scratch_guard.as_ref().expect("scratch just ensured");
+    let h_buf = &scratch.h;
+    if let Some(e) = embd {
+        assert_eq!(e.n_cols, hidden_dim);
+        assert!(e.token_id < e.rows);
+        assert_eq!(e.weights.len(), e.rows * e.row_bytes);
+        // Gather runs in the same CB below (after encoder create).
+    } else {
+        assert_eq!(hidden.len(), hidden_dim);
+        copy_f32_into(h_buf, hidden);
+    }
+    let x_buf = &scratch.x;
+    let x2_buf = &scratch.x2;
+    let q_buf = &scratch.q;
+    let k_buf = &scratch.k;
+    let v_buf = &scratch.v;
+    let attn_buf = &scratch.attn;
+    let o_buf = &scratch.o;
+    let gate_buf = &scratch.gate;
+    let up_buf = &scratch.up;
+    let act_buf = &scratch.act;
+    let down_buf = &scratch.down;
+    let logits_buf = scratch.logits.as_ref();
+    let argmax_idx_buf = &scratch.argmax_idx;
+
+    // One resident buffer PER LAYER. `resident_f32_buffer` keys its
+    // cache on (pointer, len), so the at-most-two distinct divisor sets
+    // an alternating-SWA model has are uploaded once each and every
+    // layer past the first two is a cache hit -- no per-layer upload,
+    // and no table of "which set does layer i use" for a call site to
+    // get out of step with.
+    let ff_resident = layers
+        .iter()
+        .map(|l| match l.rope.freq_factors {
+            Some(ff) => resident_f32_buffer(device, ff).map(Some),
+            None => Ok(None),
+        })
+        .collect::<Result<Vec<_>, MetalError>>()?;
+
+    let cmd_buf = queue.commandBuffer().ok_or(MetalError::CommandFailed)?;
+    // Gemma-style post-norms ("sandwich"): these layers take the EAGER
+    // residual path below, which is what makes concurrent encode safe here.
+    let sandwich = layers
+        .iter()
+        .any(|l| l.post_attn_norm.is_some() || l.post_ffn_norm.is_some());
+    // Every model encodes concurrently: gate∥up and Q∥K∥V overlap, and the
+    // hazard tracker emits a barrier only where a dispatch reads or
+    // overwrites something still in flight, narrowed to those resources.
+    //
+    // Sandwich models (Gemma post-norms) used to be forced onto the serial
+    // encoder, because concurrent dispatch with in-place RMSNorm and
+    // DEFERRED residuals diverged from CPU on Gemma-2 B=1 decode. That fix
+    // landed two changes at once -- serial encode AND eager residuals -- and
+    // the eager residuals are the half that mattered: with them, every op in
+    // this function declares its own reads and writes (`encode_gqa_with_kv`
+    // self-tracks, including the f16 dequant scratch no caller can name), so
+    // concurrency is safe by construction rather than by scheduling luck.
+    //
+    // Measured on an M2 Pro, interleaved, GPU-clock: Gemma-2-2B Q4_K_M decode
+    // 13.23 -> 12.20 ms/token, and greedy output stays byte-identical to the
+    // serial encoder across Gemma-2 and Gemma-3 on every prompt tried.
+    let (encoder, mut mrs) = (compute_encoder_concurrent(&cmd_buf)?, MemRanges::new());
+
+    let embd_resident = if let Some(e) = embd {
+        let w = resident_weight_buffer(device, e.weights)?;
+        mrs.begin_op(&encoder, &[], &[h_buf]);
+        encode_get_rows(
+            &encoder,
+            device,
+            e.kind,
+            &w,
+            h_buf,
+            e.row_bytes as u32,
+            e.n_cols as u32,
+            e.token_id as u32,
+        )?;
+        mrs.end_op(&[], &[h_buf]);
+        Some(w)
+    } else {
+        None
+    };
+    let _embd_resident = embd_resident;
+
+    // Gemma sandwich (post_attn / post_ffn) must apply residuals eagerly —
+    // same shape as the working prefill stack / CPU path. Deferred
+    // `h += down` fused into the next layer's attn_norm matches SmolLM2
+    // (no post-norms) but diverges for Gemma-2 Metal greedy (BOS loops /
+    // `*` spam) even when GQA unit tests pass.
+    // `sandwich` was computed above (also selects serial encoder).
+
+    for (layer_idx, (layer, kv)) in layers.iter().zip(kvs.iter_mut()).enumerate() {
+        assert_eq!(layer.attn_norm_w.len(), hidden_dim);
+        assert_eq!(layer.ffn_norm_w.len(), hidden_dim);
+        assert_eq!(layer.o.rows, hidden_dim);
+        assert_eq!(layer.down.rows, hidden_dim);
+        assert_eq!(layer.gate.rows, layer.up.rows);
+
+        let attn_nw = resident_f32_buffer(device, layer.attn_norm_w)?;
+        let ffn_nw = resident_f32_buffer(device, layer.ffn_norm_w)?;
+        let q_w = resident_weight_buffer(device, layer.q.weights)?;
+        let k_w = resident_weight_buffer(device, layer.k.weights)?;
+        let v_w = resident_weight_buffer(device, layer.v.weights)?;
+        let o_w = resident_weight_buffer(device, layer.o.weights)?;
+        let gate_w = resident_weight_buffer(device, layer.gate.weights)?;
+        let up_w = resident_weight_buffer(device, layer.up.weights)?;
+        let down_w = resident_weight_buffer(device, layer.down.weights)?;
+        let kv_k = kv.k.as_ref();
+        let kv_v = kv.v.as_ref();
+
+        // Pre-LN: layer 0 norms raw hidden; later layers either fuse the
+        // previous FFN residual into attn_norm (non-sandwich) or just
+        // RMSNorm (sandwich already applied `h += down` eagerly).
+        if layer_idx == 0 || sandwich {
+            mrs.begin_op(&encoder, &[h_buf], &[x_buf]);
+            encode_rms_norm(
+                &encoder,
+                device,
+                h_buf,
+                &attn_nw.buffer,
+                x_buf,
+                hidden_dim as u32,
+                rms_eps,
+            )?;
+            mrs.end_op(&[h_buf], &[x_buf]);
+        } else {
+            mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf, x_buf]);
+            encode_add_rms_norm(
+                &encoder,
+                device,
+                h_buf,
+                down_buf,
+                &attn_nw.buffer,
+                x_buf,
+                hidden_dim as u32,
+                rms_eps,
+            )?;
+            mrs.end_op(&[h_buf, down_buf], &[h_buf, x_buf]);
+        }
+        // Q∥K∥V
+        mrs.begin_op(&encoder, &[x_buf], &[q_buf, k_buf, v_buf]);
+        encode_matvec(&encoder, device, &layer.q, &q_w, x_buf, q_buf)?;
+        encode_matvec(&encoder, device, &layer.k, &k_w, x_buf, k_buf)?;
+        encode_matvec(&encoder, device, &layer.v, &v_w, x_buf, v_buf)?;
+        mrs.end_op(&[x_buf], &[q_buf, k_buf, v_buf]);
+
+        mrs.begin_op(&encoder, &[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
+        encode_attn_extras(
+            &encoder,
+            device,
+            &layer.extras,
+            q_buf,
+            k_buf,
+            v_buf,
+            layer.q.rows,
+            layer.k.rows,
+            layer.v.rows,
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            rms_eps,
+        )?;
+        mrs.end_op(&[q_buf, k_buf, v_buf], &[q_buf, k_buf, v_buf]);
+
+        let layer_theta = layer.rope.theta;
+        let ff_buf = ff_resident[layer_idx].as_ref().map(|b| b.buffer.as_ref());
+        mrs.begin_op(&encoder, &[q_buf, k_buf], &[q_buf, k_buf]);
+        encode_rope(
+            &encoder,
+            device,
+            rope_layout,
+            q_buf,
+            n_heads as u32,
+            head_dim as u32,
+            layer_theta,
+            pos as u32,
+            ff_buf,
+        )?;
+        encode_rope(
+            &encoder,
+            device,
+            rope_layout,
+            k_buf,
+            n_kv_heads as u32,
+            head_dim as u32,
+            layer_theta,
+            pos as u32,
+            ff_buf,
+        )?;
+        mrs.end_op(&[q_buf, k_buf], &[q_buf, k_buf]);
+
+        let token_elems = (n_kv_heads * head_dim) as u32;
+        let offset = (pos * n_kv_heads * head_dim) as u32;
+        mrs.begin_op(&encoder, &[k_buf, v_buf], &[kv_k, kv_v]);
+        encode_kv_store_append(&encoder, device, k_buf, kv, KvPlane::K, offset, token_elems)?;
+        encode_kv_store_append(&encoder, device, v_buf, kv, KvPlane::V, offset, token_elems)?;
+        mrs.end_op(&[k_buf, v_buf], &[kv_k, kv_v]);
+
+        let new_seq = (pos + 1) as u32;
+        // Sliding window: only the last `window` positions (incl. current)
+        // are visible, matching `causal_gqa_attention_windowed`.
+        let kv_start = match layer.window {
+            Some(w) => (pos + 1).saturating_sub(w) as u32,
+            None => 0,
+        };
+        // Self-tracking: with a quantized KV cache this also writes a shared
+        // f16 dequant scratch that no caller can name.
+        encode_gqa_with_kv(
+            &encoder,
+            &mut mrs,
+            device,
+            q_buf,
+            kv,
+            attn_buf,
+            n_heads as u32,
+            n_kv_heads as u32,
+            head_dim as u32,
+            new_seq,
+            kv_start,
+            layer.extras.attn_logit_softcap,
+        )?;
+
+        mrs.begin_op(&encoder, &[attn_buf], &[o_buf]);
+        encode_matvec(&encoder, device, &layer.o, &o_w, attn_buf, o_buf)?;
+        mrs.end_op(&[attn_buf], &[o_buf]);
+
+        // Gemma sandwich norm: normalize the attn block output *before*
+        // the residual add (in-place: each thread reads x[i] only after
+        // the barriered reduction, so out == x is safe).
+        if let Some(post) = layer.post_attn_norm {
+            assert_eq!(post.len(), hidden_dim);
+            let pw = resident_f32_buffer(device, post)?;
+            mrs.begin_op(&encoder, &[o_buf], &[o_buf]);
+            encode_rms_norm(
+                &encoder,
+                device,
+                o_buf,
+                &pw.buffer,
+                o_buf,
+                hidden_dim as u32,
+                rms_eps,
+            )?;
+            mrs.end_op(&[o_buf], &[o_buf]);
+        }
+        // Attn residual + ffn_norm in one dispatch, for every model.
+        //
+        // Sandwich layers used to split this into `vec_add` then `rms_norm`,
+        // which is the same arithmetic in two dispatches: `post_attn_norm`
+        // has already been applied to `o_buf` in place above, so both paths
+        // compute `h += o` then `x2 = rms_norm(h)`. The split was a leftover
+        // from the serial-encoder era -- `encode_add_rms_norm` writes `h`
+        // itself, so the residual is just as eager as the two-dispatch form.
+        mrs.begin_op(&encoder, &[h_buf, o_buf], &[h_buf, x2_buf]);
+        encode_add_rms_norm(
+            &encoder,
+            device,
+            h_buf,
+            o_buf,
+            &ffn_nw.buffer,
+            x2_buf,
+            hidden_dim as u32,
+            rms_eps,
+        )?;
+        mrs.end_op(&[h_buf, o_buf], &[h_buf, x2_buf]);
+        // gate ∥ up (llama concurrent)
+        mrs.begin_op(&encoder, &[x2_buf], &[gate_buf, up_buf]);
+        encode_matvec(&encoder, device, &layer.gate, &gate_w, x2_buf, gate_buf)?;
+        encode_matvec(&encoder, device, &layer.up, &up_w, x2_buf, up_buf)?;
+        mrs.end_op(&[x2_buf], &[gate_buf, up_buf]);
+
+        mrs.begin_op(&encoder, &[gate_buf, up_buf], &[act_buf]);
+        if gelu_ffn {
+            encode_gelu_mul(
+                &encoder,
+                device,
+                gate_buf,
+                up_buf,
+                act_buf,
+                layer.gate.rows as u32,
+            )?;
+        } else {
+            encode_silu_mul(
+                &encoder,
+                device,
+                gate_buf,
+                up_buf,
+                act_buf,
+                layer.gate.rows as u32,
+            )?;
+        }
+        mrs.end_op(&[gate_buf, up_buf], &[act_buf]);
+
+        mrs.begin_op(&encoder, &[act_buf], &[down_buf]);
+        encode_matvec(&encoder, device, &layer.down, &down_w, act_buf, down_buf)?;
+        mrs.end_op(&[act_buf], &[down_buf]);
+
+        if let Some(post) = layer.post_ffn_norm {
+            assert_eq!(post.len(), hidden_dim);
+            let pw = resident_f32_buffer(device, post)?;
+            mrs.begin_op(&encoder, &[down_buf], &[down_buf]);
+            encode_rms_norm(
+                &encoder,
+                device,
+                down_buf,
+                &pw.buffer,
+                down_buf,
+                hidden_dim as u32,
+                rms_eps,
+            )?;
+            mrs.end_op(&[down_buf], &[down_buf]);
+        }
+        if sandwich {
+            // Eager FFN residual — next layer attn_norm is plain RMSNorm.
+            mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf]);
+            encode_vec_add(&encoder, device, h_buf, down_buf, hidden_dim as u32)?;
+            mrs.end_op(&[h_buf, down_buf], &[h_buf]);
+        }
+        // Non-sandwich: defer `h += down` until the next layer's attn_norm
+        // (or final_norm) so it fuses with that RMSNorm. `down_buf` stays in
+        // the tracker's dst set, so the next layer's fused norm barriers
+        // against it exactly once. Last layer handled below.
+    }
+
+    // Final norm / lm_head. Sandwich already applied every FFN residual;
+    // non-sandwich still has a deferred last-layer `down` to fold in.
+    let (download_n, norm_resident) = if let Some(fnw) = final_norm_w {
+        assert_eq!(fnw.len(), hidden_dim);
+        let fn_buf = resident_f32_buffer(device, fnw)?;
+        if sandwich {
+            mrs.begin_op(&encoder, &[h_buf], &[x_buf]);
+            encode_rms_norm(
+                &encoder,
+                device,
+                h_buf,
+                &fn_buf.buffer,
+                x_buf,
+                hidden_dim as u32,
+                rms_eps,
+            )?;
+            mrs.end_op(&[h_buf], &[x_buf]);
+        } else {
+            mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf, x_buf]);
+            encode_add_rms_norm(
+                &encoder,
+                device,
+                h_buf,
+                down_buf,
+                &fn_buf.buffer,
+                x_buf,
+                hidden_dim as u32,
+                rms_eps,
+            )?;
+            mrs.end_op(&[h_buf, down_buf], &[h_buf, x_buf]);
+        }
+        if let (Some(out_l), Some(logits)) = (output, logits_buf) {
+            assert_eq!(out_l.rows, logits_rows.unwrap());
+            // RAW: lm_head reads `x_buf` written by the norm above. Without
+            // ordering here Metal may overlap the matvec with the norm on
+            // small hiddens (SmolLM2 h=576) and produce garbage logits /
+            // greedy tokens while host lm_head after wait looks fine — the
+            // tracker sees `x_buf` as src-after-dst and barriers.
+            mrs.begin_op(&encoder, &[x_buf], &[logits.as_ref()]);
+            let out_w = resident_weight_buffer(device, out_l.weights)?;
+            encode_matvec(&encoder, device, out_l, &out_w, x_buf, logits)?;
+            mrs.end_op(&[x_buf], &[logits.as_ref()]);
+            if argmax_only {
+                mrs.begin_op(&encoder, &[logits.as_ref()], &[argmax_idx_buf]);
+                encode_argmax(&encoder, device, logits, argmax_idx_buf, out_l.rows as u32)?;
+                mrs.end_op(&[logits.as_ref()], &[argmax_idx_buf]);
+                (1, false)
+            } else {
+                (out_l.rows, false)
+            }
+        } else {
+            // final_norm ran but no lm_head — download normalized hidden
+            // and mark x_buf resident for the next apply_gpu.
+            (hidden_dim, true)
+        }
+    } else if sandwich {
+        (hidden_dim, false)
+    } else {
+        // No final_norm: still apply the deferred last-layer FFN residual.
+        mrs.begin_op(&encoder, &[h_buf, down_buf], &[h_buf]);
+        encode_vec_add(&encoder, device, h_buf, down_buf, hidden_dim as u32)?;
+        mrs.end_op(&[h_buf, down_buf], &[h_buf]);
+        (hidden_dim, false)
+    };
+
+    encoder.endEncoding();
+    cmd_buf.commit();
+    cmd_buf.waitUntilCompleted();
+    crate::gpu::gpu_timing_note(&cmd_buf, "dense-decode/tok", 32);
+
+    for kv in kvs.iter_mut() {
+        kv.seq_len = pos + 1;
+    }
+
+    // If final_norm ran but no lm_head, mark normalized hidden (x_buf)
+    // as resident so the next apply_gpu can skip re-upload.
+    if norm_resident {
+        crate::gpu::set_resident_activation(x_buf, hidden_dim);
+    }
+
+    if argmax_only && download_n == 1 && output.is_some() {
+        let ptr = argmax_idx_buf.contents();
+        let idx = unsafe { *(ptr.as_ptr() as *const u32) as usize };
+        return Ok(vec![idx as f32]);
+    }
+
+    let src: &ProtocolObject<dyn MTLBuffer> = if norm_resident {
+        x_buf
+    } else if download_n == hidden_dim {
+        h_buf
+    } else {
+        logits_buf.expect("logits buffer when downloading logits")
+    };
+    let out_ptr = src.contents();
+    Ok(unsafe { std::slice::from_raw_parts(out_ptr.as_ptr() as *const f32, download_n).to_vec() })
+}

--- a/crates/ferrox-metal/src/dispatch.rs
+++ b/crates/ferrox-metal/src/dispatch.rs
@@ -1,0 +1,155 @@
+//! The one place this crate encodes a compute dispatch, and the counters
+//! that measure what a decode token costs the host.
+//!
+//! GitHub issue #149 measured that ferrox's Metal kernels already finish
+//! faster than llama.cpp's whole token, and that 26-29% of decode wall
+//! time is host-side command encoding: `dispatchThreadgroups`,
+//! `emitComputeProgramVariantAndArguments`, `memoryBarrierWithResources`.
+//! The lever is FEWER ENCODED DISPATCHES AND FEWER BARRIERS per token,
+//! which is only actionable if both are counted.
+//!
+//! So every `dispatchThreadgroups_threadsPerThreadgroup` in the crate
+//! goes through [`dispatch_counted`], and every barrier through
+//! [`note_barrier`]. Two counters that must agree with what is actually
+//! encoded is the repo's dominant bug shape, so nothing is allowed to
+//! bypass them: [`no_encode_site_bypasses_the_counter`] scans the crate's
+//! own source and fails if a raw call reappears.
+//!
+//! Read the counters with [`metal_encode_stats`], reset them with
+//! [`metal_encode_stats_reset`]. `FERROX_METAL_GPU_TIMING=1` prints them
+//! per token beside the GPU-versus-wall time.
+
+use objc2::runtime::ProtocolObject;
+use objc2_metal::{MTLComputeCommandEncoder, MTLSize};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static DISPATCH_COUNT: AtomicU64 = AtomicU64::new(0);
+static BARRIER_COUNT: AtomicU64 = AtomicU64::new(0);
+static BEGIN_OP_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// What one encode pass cost the host, in the two units that matter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct EncodeStats {
+    /// Compute dispatches encoded.
+    pub dispatches: u64,
+    /// `memoryBarrierWithResources` calls emitted.
+    pub barriers: u64,
+    /// Hazard checks performed, i.e. ops offered to the tracker. The
+    /// `barriers / begin_ops` ratio is 1.00 for a fully serialised pass
+    /// and lower when dispatches overlap.
+    pub begin_ops: u64,
+}
+
+/// Snapshot the process-wide counters.
+pub fn metal_encode_stats() -> EncodeStats {
+    EncodeStats {
+        dispatches: DISPATCH_COUNT.load(Ordering::Relaxed),
+        barriers: BARRIER_COUNT.load(Ordering::Relaxed),
+        begin_ops: BEGIN_OP_COUNT.load(Ordering::Relaxed),
+    }
+}
+
+pub fn metal_encode_stats_reset() {
+    DISPATCH_COUNT.store(0, Ordering::Relaxed);
+    BARRIER_COUNT.store(0, Ordering::Relaxed);
+    BEGIN_OP_COUNT.store(0, Ordering::Relaxed);
+}
+
+/// Encode one compute dispatch, counting it.
+///
+/// The counting is the point: see the module docs. Every call site in
+/// the crate uses this instead of the raw Metal method.
+#[inline]
+pub(crate) fn dispatch_counted(
+    enc: &ProtocolObject<dyn MTLComputeCommandEncoder>,
+    threadgroups: MTLSize,
+    threads_per_threadgroup: MTLSize,
+) {
+    DISPATCH_COUNT.fetch_add(1, Ordering::Relaxed);
+    enc.dispatchThreadgroups_threadsPerThreadgroup(threadgroups, threads_per_threadgroup);
+}
+
+/// Record one emitted barrier, returning the new running total.
+///
+/// Called from the two barrier primitives in [`crate::gpu`], which are
+/// the only places the crate touches Metal's barrier API, so this counts
+/// barriers from the hazard tracker AND the hand-placed ones in the MoE
+/// encode paths.
+#[inline]
+pub(crate) fn note_barrier() -> u64 {
+    BARRIER_COUNT.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+/// Record one hazard check offered to the tracker (barrier or not).
+#[inline]
+pub(crate) fn note_begin_op() {
+    BEGIN_OP_COUNT.fetch_add(1, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    /// A dispatch that does not go through [`super::dispatch_counted`] is
+    /// invisible to the per-token accounting, and the accounting is the
+    /// only evidence that a fusion removed work. A counter beside the
+    /// thing it counts, with nothing forcing them to agree, is this
+    /// repo's dominant defect shape, so make the disagreement a red test
+    /// rather than a wrong number in a PR body.
+    #[test]
+    fn no_encode_site_bypasses_the_counter() {
+        // Every `.rs` in this crate, read at compile time so a new file
+        // that is not listed here also fails to compile this test.
+        let sources: &[(&str, &str)] = &[
+            ("attn.rs", include_str!("attn.rs")),
+            ("capability.rs", include_str!("capability.rs")),
+            ("decode_dense.rs", include_str!("decode_dense.rs")),
+            ("dispatch.rs", include_str!("dispatch.rs")),
+            ("elem.rs", include_str!("elem.rs")),
+            ("embd.rs", include_str!("embd.rs")),
+            ("gpu.rs", include_str!("gpu.rs")),
+            ("lib.rs", include_str!("lib.rs")),
+            ("mem_ranges.rs", include_str!("mem_ranges.rs")),
+            ("moe_ids.rs", include_str!("moe_ids.rs")),
+        ];
+        // This file holds the wrapper (the one legitimate caller of the
+        // raw dispatch method) and the patterns this test searches for,
+        // so it is not itself a subject.
+        let subjects = || sources.iter().filter(|(name, _)| *name != "dispatch.rs");
+
+        let mut raw = Vec::new();
+        for (name, src) in subjects() {
+            for (i, line) in src.lines().enumerate() {
+                if line.contains(".dispatchThreadgroups_threadsPerThreadgroup(") {
+                    raw.push(format!("{name}:{}: {}", i + 1, line.trim()));
+                }
+            }
+        }
+        assert!(
+            raw.is_empty(),
+            "these dispatches bypass dispatch_counted, so the per-token \
+             dispatch count under-reports what the host actually encodes: {raw:#?}"
+        );
+
+        // And the same for barriers. `memory_barrier_buffers` /
+        // `memory_barrier_resources` in gpu.rs are the crate's only
+        // callers of Metal's barrier API, and they count what they emit.
+        let mut raw_barriers = Vec::new();
+        for (name, src) in subjects() {
+            for (i, line) in src.lines().enumerate() {
+                if !line.contains(".memoryBarrierWith") {
+                    continue;
+                }
+                let inside_the_primitive = *name == "gpu.rs"
+                    && (line.contains("encoder.memoryBarrierWithScope(MTLBarrierScope::Buffers)")
+                        || line.contains("encoder.memoryBarrierWithResources_count("));
+                if !inside_the_primitive {
+                    raw_barriers.push(format!("{name}:{}: {}", i + 1, line.trim()));
+                }
+            }
+        }
+        assert!(
+            raw_barriers.is_empty(),
+            "these barriers bypass the counting primitives in gpu.rs and are \
+             therefore invisible to the per-token barrier count: {raw_barriers:#?}"
+        );
+    }
+}

--- a/crates/ferrox-metal/src/elem.rs
+++ b/crates/ferrox-metal/src/elem.rs
@@ -2,6 +2,7 @@
 //! add, and SiLU×up (SwiGLU pair). Used by the fused dense-layer path
 //! so activations stay on-GPU between attention and FFN.
 
+use crate::dispatch::dispatch_counted;
 use crate::gpu::{ensure_pipeline, MetalError};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
@@ -499,7 +500,8 @@ pub(crate) fn encode_rms_norm_at(
         // One float per simdgroup (simd_sum path).
         encoder.setThreadgroupMemoryLength_atIndex(((tg as usize) / 32) * 4, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: 1,
             height: 1,
@@ -555,7 +557,8 @@ pub(crate) fn encode_rms_norm_batch(
         );
         encoder.setThreadgroupMemoryLength_atIndex(((tg as usize) / 32) * 4, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: batch as usize,
             height: 1,
@@ -606,7 +609,8 @@ pub(crate) fn encode_rms_norm_f32_to_f16_batch(
         );
         encoder.setThreadgroupMemoryLength_atIndex(((tg as usize) / 32) * 4, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: batch as usize,
             height: 1,
@@ -653,7 +657,8 @@ pub(crate) fn encode_f32_to_f16(
     }
     let tg = 256usize;
     let n_tg = (n as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -691,7 +696,8 @@ pub(crate) fn encode_vec_add_at(
     }
     let tg = 256usize;
     let n_tg = (n as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -742,7 +748,8 @@ pub(crate) fn encode_add_rms_norm(
         // One float per simdgroup (tg/32).
         encoder.setThreadgroupMemoryLength_atIndex(((tg as usize) / 32) * 4, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: 1,
             height: 1,
@@ -799,7 +806,8 @@ pub(crate) fn encode_add_rms_norm_batch(
         );
         encoder.setThreadgroupMemoryLength_atIndex(((tg as usize) / 32) * 4, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: batch as usize,
             height: 1,
@@ -863,7 +871,8 @@ pub(crate) fn encode_add_rms_norm_f32_to_f16_batch(
         );
         encoder.setThreadgroupMemoryLength_atIndex(((tg as usize) / 32) * 4, 0);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: batch as usize,
             height: 1,
@@ -923,7 +932,8 @@ pub(crate) fn encode_rms_norm_per_head_batch(
             3,
         );
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: (n_heads * batch) as usize,
             height: 1,
@@ -961,7 +971,8 @@ pub(crate) fn encode_silu_mul(
     }
     let tg = 256usize;
     let n_tg = (n as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -1005,7 +1016,8 @@ pub(crate) fn encode_axpy(
     }
     let tg = 256usize;
     let n_tg = (n as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -1054,7 +1066,8 @@ pub(crate) fn encode_act_mul_f32_to_f16(
     }
     let tg = 256usize;
     let n_tg = (n as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -1092,7 +1105,8 @@ pub(crate) fn encode_gelu_mul(
     }
     let tg = 256usize;
     let n_tg = (n as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,
@@ -1131,7 +1145,8 @@ pub(crate) fn encode_argmax(
         encoder.setThreadgroupMemoryLength_atIndex((tg as usize) * 4, 0);
         encoder.setThreadgroupMemoryLength_atIndex((tg as usize) * 4, 1);
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: 1,
             height: 1,

--- a/crates/ferrox-metal/src/embd.rs
+++ b/crates/ferrox-metal/src/embd.rs
@@ -5,6 +5,7 @@
 //! `copy_f32_into` into the dense-stack scratch — a pure host edge before
 //! an otherwise fused CB. These kernels write straight into `scratch.h`.
 
+use crate::dispatch::dispatch_counted;
 use crate::gpu::{
     ensure_pipeline, resident_weight_buffer, shared_metal, MetalError, ResidentWeightBuffer,
 };
@@ -163,7 +164,8 @@ pub(crate) fn encode_get_rows(
     }
     let tg = 256usize;
     let n_tg = (n_cols as usize).div_ceil(tg);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,

--- a/crates/ferrox-metal/src/gpu.rs
+++ b/crates/ferrox-metal/src/gpu.rs
@@ -51,6 +51,7 @@
 //! single-use access -- exactly matching what `launch_matvec` already
 //! does (a fresh command buffer/encoder every call, never stored).
 
+use crate::dispatch::dispatch_counted;
 use crate::moe_ids::IdsBinding;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
@@ -98,6 +99,7 @@ pub(crate) fn compute_encoder_concurrent(
 /// reads), which bubbles the GPU on OLMoE Concurrent encode.
 #[inline]
 pub(crate) fn memory_barrier_buffers(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>) {
+    crate::dispatch::note_barrier();
     encoder.memoryBarrierWithScope(MTLBarrierScope::Buffers);
 }
 
@@ -110,9 +112,11 @@ pub(crate) fn memory_barrier_resources(
     bufs: &[&ProtocolObject<dyn MTLBuffer>],
 ) {
     if bufs.is_empty() {
+        // Counted by the delegate.
         memory_barrier_buffers(encoder);
         return;
     }
+    crate::dispatch::note_barrier();
     // MTLBuffer: MTLResource — build a contiguous pointer list for the API.
     let mut resources: Vec<NonNull<ProtocolObject<dyn MTLResource>>> =
         Vec::with_capacity(bufs.len());
@@ -1572,7 +1576,8 @@ pub(crate) fn encode_q4_0_mul_mm(
         enc.setThreadgroupMemoryLength_atIndex((tg as usize) * 4, 0);
     }
 
-    enc.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        enc,
         MTLSize {
             width: rows,
             height: 1,
@@ -3590,7 +3595,8 @@ pub(crate) fn encode_moe_mm_id_map0(
         enc.setBytes_length_atIndex(NonNull::new(&mut nt as *mut u32 as *mut _).unwrap(), 4, 3);
         enc.setThreadgroupMemoryLength_atIndex(smem, 0);
     }
-    enc.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        enc,
         MTLSize {
             width: 1,
             height: 1,
@@ -3648,7 +3654,8 @@ pub(crate) fn encode_mul_mm_id_f16(
             );
         }
         enc.setThreadgroupMemoryLength_atIndex(8192, 0);
-        enc.dispatchThreadgroups_threadsPerThreadgroup(
+        dispatch_counted(
+            enc,
             MTLSize {
                 width: (n_tokens as usize).div_ceil(32),
                 height: (rows as usize).div_ceil(64),
@@ -3689,7 +3696,8 @@ pub(crate) fn encode_moe_router_mm_f32(
             );
         }
     }
-    enc.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        enc,
         MTLSize {
             width: n_experts as usize,
             height: n_tokens as usize,
@@ -3738,7 +3746,8 @@ pub(crate) fn encode_moe_topk_softmax_batch(
         }
         enc.setThreadgroupMemoryLength_atIndex((n as usize) * 4, 0);
     }
-    enc.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        enc,
         MTLSize {
             width: n_tokens as usize,
             height: 1,
@@ -3958,7 +3967,8 @@ pub(crate) fn encode_moe_prefill_weighted_sum(
         encoder.setBytes_length_atIndex(NonNull::new(&mut nt as *mut u32 as *mut _).unwrap(), 4, 5);
     }
     let sum_elems = (n_tokens as usize) * (hidden_rows as usize);
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: sum_elems.div_ceil(SUM_TG),
             height: 1,
@@ -4016,7 +4026,8 @@ pub(crate) fn encode_mul_mm_id(
             );
         }
         enc.setThreadgroupMemoryLength_atIndex(8192, 0);
-        enc.dispatchThreadgroups_threadsPerThreadgroup(
+        dispatch_counted(
+            enc,
             MTLSize {
                 width: (n_tokens as usize).div_ceil(32),
                 height: (rows as usize).div_ceil(64),
@@ -4135,7 +4146,8 @@ pub(crate) fn encode_mul_mm_sg_f16(
             );
         }
         enc.setThreadgroupMemoryLength_atIndex(smem, 0);
-        enc.dispatchThreadgroups_threadsPerThreadgroup(
+        dispatch_counted(
+            enc,
             MTLSize {
                 width: batch_size.div_ceil(32),
                 height: l.rows.div_ceil(64),
@@ -4209,7 +4221,8 @@ pub(crate) fn encode_mul_mm_sg_offset_ex(
             );
         }
         enc.setThreadgroupMemoryLength_atIndex(smem, 0);
-        enc.dispatchThreadgroups_threadsPerThreadgroup(
+        dispatch_counted(
+            enc,
             MTLSize {
                 width: batch_size.div_ceil(32),
                 height: l.rows.div_ceil(64),
@@ -4417,7 +4430,7 @@ fn launch_k_quant_mul_mm_sg(
             height: 1,
             depth: 1,
         };
-        enc.dispatchThreadgroups_threadsPerThreadgroup(grid, tg);
+        dispatch_counted(&enc, grid, tg);
     }
     enc.endEncoding();
     let t_gpu = std::time::Instant::now();
@@ -4466,8 +4479,29 @@ pub(crate) fn mm_timing_add(setup: u128, gpu: u128, read: u128) {
 /// `GPUStartTime`/`GPUEndTime` measure the command buffer's own occupancy
 /// and stay usable while the machine is busy, so A/B evidence in
 /// `docs/plans/llama-cpp-parity-push.md` is taken from these.
-static GPU_TIMING: std::sync::Mutex<Vec<(&'static str, u64, u64)>> =
-    std::sync::Mutex::new(Vec::new());
+static GPU_TIMING: std::sync::Mutex<Vec<TimingSlot>> = std::sync::Mutex::new(Vec::new());
+
+/// One tag's running GPU-time total, plus what the host encoded to
+/// produce it.
+///
+/// The encode counters in [`crate::dispatch`] are process-wide, so a
+/// per-submission figure has to come from the DELTA between consecutive
+/// submissions of the same tag rather than from a total divided by a
+/// count -- otherwise a prefill's dispatches land in the decode average.
+/// GitHub issue #149 is about the host cost of encoding, so this number
+/// belongs next to the GPU time it bought, not in a separate readout
+/// somebody has to line up by hand.
+struct TimingSlot {
+    tag: &'static str,
+    n: u64,
+    acc_ns: u64,
+    /// Counter snapshot at the previous submission under this tag.
+    prev: crate::dispatch::EncodeStats,
+    /// Encode work attributed to this tag, summed over `n` submissions.
+    acc_dispatches: u64,
+    acc_barriers: u64,
+    acc_begin_ops: u64,
+}
 
 /// True when `FERROX_METAL_GPU_TIMING` is set (cached; read once).
 pub(crate) fn gpu_timing_enabled() -> bool {
@@ -4486,24 +4520,44 @@ pub(crate) fn gpu_timing_note(
         return;
     }
     let dt_ns = ((cmd_buf.GPUEndTime() - cmd_buf.GPUStartTime()) * 1e9).max(0.0) as u64;
+    let now = crate::dispatch::metal_encode_stats();
     let Ok(mut slots) = GPU_TIMING.lock() else {
         return;
     };
-    let slot = match slots.iter_mut().find(|(t, _, _)| *t == tag) {
+    let slot = match slots.iter_mut().find(|s| s.tag == tag) {
         Some(s) => s,
         None => {
-            slots.push((tag, 0, 0));
+            slots.push(TimingSlot {
+                tag,
+                n: 0,
+                acc_ns: 0,
+                prev: now,
+                acc_dispatches: 0,
+                acc_barriers: 0,
+                acc_begin_ops: 0,
+            });
             slots.last_mut().expect("just pushed")
         }
     };
-    slot.1 += 1;
-    slot.2 += dt_ns;
-    let (n, acc) = (slot.1, slot.2);
+    slot.n += 1;
+    slot.acc_ns += dt_ns;
+    slot.acc_dispatches += now.dispatches.saturating_sub(slot.prev.dispatches);
+    slot.acc_barriers += now.barriers.saturating_sub(slot.prev.barriers);
+    slot.acc_begin_ops += now.begin_ops.saturating_sub(slot.prev.begin_ops);
+    slot.prev = now;
+    let n = slot.n;
     if n.is_multiple_of(every.max(1)) {
+        let per = |acc: u64| acc as f64 / n as f64;
         eprintln!(
-            "ferrox: metal gpu[{tag}] {:.3} ms avg over {n} (last {:.3} ms)",
-            (acc as f64 / n as f64) / 1e6,
+            "ferrox: metal gpu[{tag}] {:.3} ms avg over {n} (last {:.3} ms); \
+             encode/submission: {:.1} dispatches, {:.1} barriers, \
+             {:.1} hazard checks ({:.2} bar/op)",
+            (slot.acc_ns as f64 / n as f64) / 1e6,
             dt_ns as f64 / 1e6,
+            per(slot.acc_dispatches),
+            per(slot.acc_barriers),
+            per(slot.acc_begin_ops),
+            slot.acc_barriers as f64 / slot.acc_begin_ops.max(1) as f64,
         );
     }
 }
@@ -4589,7 +4643,8 @@ pub fn launch_q4_k_mul_mm(
         enc.setThreadgroupMemoryLength_atIndex((tg as usize) * 4, 0);
     }
 
-    enc.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        &enc,
         MTLSize {
             width: rows,
             height: 1,
@@ -5918,7 +5973,8 @@ fn encode_moe_matvec_id(
             encoder.setThreadgroupMemoryLength_atIndex(disp.tg_mem, 0);
         }
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: (n_rows as usize).div_ceil(disp.rows_per_tg),
             height: 1,
@@ -5997,7 +6053,8 @@ fn encode_moe_down_id(
             encoder.setThreadgroupMemoryLength_atIndex(disp.tg_mem, 0);
         }
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: (hidden_rows as usize).div_ceil(disp.rows_per_tg),
             height: 1,
@@ -6406,7 +6463,8 @@ pub(crate) fn encode_q4_0_moe_id(
                 4,
             );
         }
-        encoder.dispatchThreadgroups_threadsPerThreadgroup(
+        dispatch_counted(
+            encoder,
             MTLSize {
                 width: packed.hidden_rows.div_ceil(SUM_TG),
                 height: 1,
@@ -6444,7 +6502,8 @@ pub(crate) fn encode_q4_0_moe_id(
             );
         }
         let sum_elems = (n_tokens as usize) * packed.hidden_rows;
-        encoder.dispatchThreadgroups_threadsPerThreadgroup(
+        dispatch_counted(
+            encoder,
             MTLSize {
                 width: sum_elems.div_ceil(SUM_TG),
                 height: 1,
@@ -6821,7 +6880,8 @@ pub(crate) fn encode_q4_0_moe_topk(
             21,
         );
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: experts.len() * ffn.div_ceil(ROWS_PER_TG),
             height: 1,
@@ -6877,7 +6937,8 @@ pub(crate) fn encode_q4_0_moe_topk(
             14,
         );
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: experts.len() * hidden.div_ceil(ROWS_PER_TG),
             height: 1,
@@ -6915,7 +6976,8 @@ pub(crate) fn encode_q4_0_moe_topk(
         );
     }
     const SUM_TG: usize = 256;
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: hidden.div_ceil(SUM_TG),
             height: 1,
@@ -7277,7 +7339,8 @@ pub(crate) fn encode_matvec_with_offsets(
         // threadgroup, NSG = min(4, ceil(ne00/128)) simdgroups sharing the
         // reduction axis. `MAX_NSG` in the kernel is 8.
         let nsg = cols.div_ceil(128).clamp(1, 4);
-        encoder.dispatchThreadgroups_threadsPerThreadgroup(
+        dispatch_counted(
+            encoder,
             MTLSize {
                 width: launch.rows.div_ceil(2),
                 height: 1,
@@ -7348,7 +7411,8 @@ pub(crate) fn encode_matvec_with_offsets(
             encoder.setThreadgroupMemoryLength_atIndex(tg_mem_bytes, 0);
         }
     }
-    encoder.dispatchThreadgroups_threadsPerThreadgroup(
+    dispatch_counted(
+        encoder,
         MTLSize {
             width: n_tg,
             height: 1,

--- a/crates/ferrox-metal/src/gpu.rs
+++ b/crates/ferrox-metal/src/gpu.rs
@@ -103,20 +103,44 @@ pub(crate) fn memory_barrier_buffers(encoder: &ProtocolObject<dyn MTLComputeComm
     encoder.memoryBarrierWithScope(MTLBarrierScope::Buffers);
 }
 
-/// Resource-scoped Concurrent barrier: only the listed buffers are ordered.
-/// Subsequent dispatches that don't touch these resources can overlap with
-/// in-flight work on other buffers (e.g. weight reads from a prior matvec).
+/// Resource-scoped Concurrent barrier over an ALREADY-BUILT resource list.
+///
+/// Only the listed buffers are ordered, so subsequent dispatches that
+/// don't touch them can overlap with in-flight work on other buffers
+/// (e.g. weight reads from a prior matvec).
+///
+/// This takes the list rather than building one because the hazard
+/// tracker already holds the pending set in exactly this form and reuses
+/// its allocation across the ~160 barriers a decode token emits;
+/// [`memory_barrier_resources`] is the convenience wrapper for the
+/// handful of call sites that name their buffers inline.
+#[inline]
+pub(crate) fn memory_barrier_resource_list(
+    encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
+    resources: &mut [NonNull<ProtocolObject<dyn MTLResource>>],
+) {
+    if resources.is_empty() {
+        // Nothing named: fall back to scope-Buffers, which is counted by
+        // the delegate.
+        memory_barrier_buffers(encoder);
+        return;
+    }
+    let head = NonNull::new(resources.as_mut_ptr()).expect("non-empty slice has a non-null base");
+    crate::dispatch::note_barrier();
+    // SAFETY: `head` points at `resources.len()` live resource pointers,
+    // each taken from a buffer bound into this encoder's command buffer
+    // and therefore alive for the whole encode pass.
+    unsafe {
+        encoder.memoryBarrierWithResources_count(head, resources.len());
+    }
+}
+
+/// Resource-scoped Concurrent barrier over buffers named inline.
 #[inline]
 pub(crate) fn memory_barrier_resources(
     encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
     bufs: &[&ProtocolObject<dyn MTLBuffer>],
 ) {
-    if bufs.is_empty() {
-        // Counted by the delegate.
-        memory_barrier_buffers(encoder);
-        return;
-    }
-    crate::dispatch::note_barrier();
     // MTLBuffer: MTLResource — build a contiguous pointer list for the API.
     let mut resources: Vec<NonNull<ProtocolObject<dyn MTLResource>>> =
         Vec::with_capacity(bufs.len());
@@ -124,12 +148,7 @@ pub(crate) fn memory_barrier_resources(
         let r: &ProtocolObject<dyn MTLResource> = ProtocolObject::from_ref(*b);
         resources.push(NonNull::from(r));
     }
-    unsafe {
-        encoder.memoryBarrierWithResources_count(
-            NonNull::new(resources.as_mut_ptr()).unwrap(),
-            resources.len(),
-        );
-    }
+    memory_barrier_resource_list(encoder, &mut resources);
 }
 
 /// Thread-local pointer + length for a Metal-resident activation buffer

--- a/crates/ferrox-metal/src/lib.rs
+++ b/crates/ferrox-metal/src/lib.rs
@@ -24,13 +24,16 @@ pub mod attn;
 pub mod decode_dense;
 
 #[cfg(feature = "metal")]
+mod dispatch;
+
+#[cfg(feature = "metal")]
 mod mem_ranges;
 
 #[cfg(feature = "metal")]
 mod moe_ids;
 
 #[cfg(feature = "metal")]
-pub use mem_ranges::{metal_barrier_stats, metal_barrier_stats_reset};
+pub use dispatch::{metal_encode_stats, metal_encode_stats_reset, EncodeStats};
 
 #[cfg(feature = "metal")]
 pub mod elem;

--- a/crates/ferrox-metal/src/lib.rs
+++ b/crates/ferrox-metal/src/lib.rs
@@ -21,6 +21,9 @@ pub mod gpu;
 pub mod attn;
 
 #[cfg(feature = "metal")]
+pub mod decode_dense;
+
+#[cfg(feature = "metal")]
 mod mem_ranges;
 
 #[cfg(feature = "metal")]

--- a/crates/ferrox-metal/src/mem_ranges.rs
+++ b/crates/ferrox-metal/src/mem_ranges.rs
@@ -179,7 +179,7 @@ mod declaration_tests {
     /// cache it writes an f16 dequant scratch no caller can name).
     #[test]
     fn every_encode_in_the_decode_stack_declares_its_hazards() {
-        let src = include_str!("attn.rs");
+        let src = include_str!("decode_dense.rs");
         let start = src
             .find("pub fn launch_decode_dense_stack(")
             .expect("decode stack function");

--- a/crates/ferrox-metal/src/mem_ranges.rs
+++ b/crates/ferrox-metal/src/mem_ranges.rs
@@ -16,7 +16,7 @@
 //! alloc — equivalent for our non-view scratch buffers, each of which is
 //! its own `MTLBuffer` and is always touched whole).
 //!
-//! Barriers use [`memory_barrier_resources`] on the pending set (not
+//! Barriers use [`memory_barrier_resource_list`] on the pending set (not
 //! scope-Buffers as llama does) so weight-buffer traffic from prior
 //! matvecs does not stall the next activation-only dispatch — measured
 //! ~2× GPU-idle on OLMoE when every conflict used scope-Buffers.
@@ -27,9 +27,10 @@
 //! overlapping.
 
 use crate::dispatch::{metal_encode_stats, note_begin_op};
-use crate::gpu::memory_barrier_resources;
+use crate::gpu::memory_barrier_resource_list;
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLBuffer, MTLComputeCommandEncoder};
+use objc2_metal::{MTLBuffer, MTLComputeCommandEncoder, MTLResource};
+use std::ptr::NonNull;
 
 /// True when barrier logging is requested (cached; read once).
 fn barrier_log_enabled() -> bool {
@@ -39,10 +40,20 @@ fn barrier_log_enabled() -> bool {
 
 #[derive(Default)]
 pub(crate) struct MemRanges {
-    /// Pending Concurrent-set buffers (srcs ∪ dsts), for resource barriers.
-    bufs: Vec<*const ProtocolObject<dyn MTLBuffer>>,
+    /// Buffer identities read by a pending op.
     srcs: Vec<usize>,
+    /// Buffer identities written by a pending op.
     dsts: Vec<usize>,
+    /// The same buffers as `srcs ∪ dsts`, in the form the barrier API
+    /// wants. Written only by [`MemRanges::push_src`] /
+    /// [`MemRanges::push_dst`], which push here and to the key list in
+    /// the same call, so the resource list cannot fall out of step with
+    /// the ranges it is supposed to order.
+    ///
+    /// Kept across barriers (cleared, not dropped) because a decode token
+    /// takes ~160 of them and this used to allocate twice per barrier on
+    /// the per-token path.
+    res: Vec<NonNull<ProtocolObject<dyn MTLResource>>>,
 }
 
 #[inline]
@@ -56,9 +67,55 @@ impl MemRanges {
     }
 
     pub(crate) fn reset(&mut self) {
-        self.bufs.clear();
         self.srcs.clear();
         self.dsts.clear();
+        self.res.clear();
+    }
+
+    /// The hazard rule, stated once on opaque identities so it can be
+    /// tested without a GPU: an op conflicts with the pending set when it
+    /// READS something pending writes, or WRITES something pending reads
+    /// or writes. Two reads of the same buffer do not conflict.
+    fn keys_conflict(
+        &self,
+        srcs: impl Iterator<Item = usize>,
+        dsts: impl Iterator<Item = usize>,
+    ) -> bool {
+        for k in srcs {
+            if self.dsts.contains(&k) {
+                return true;
+            }
+        }
+        for k in dsts {
+            if self.srcs.contains(&k) || self.dsts.contains(&k) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn push_res(&mut self, b: &ProtocolObject<dyn MTLBuffer>) {
+        let r: &ProtocolObject<dyn MTLResource> = ProtocolObject::from_ref(b);
+        let p = NonNull::from(r);
+        if !self.res.contains(&p) {
+            self.res.push(p);
+        }
+    }
+
+    fn push_src(&mut self, b: &ProtocolObject<dyn MTLBuffer>) {
+        let k = buf_key(b);
+        if !self.srcs.contains(&k) {
+            self.srcs.push(k);
+        }
+        self.push_res(b);
+    }
+
+    fn push_dst(&mut self, b: &ProtocolObject<dyn MTLBuffer>) {
+        let k = buf_key(b);
+        if !self.dsts.contains(&k) {
+            self.dsts.push(k);
+        }
+        self.push_res(b);
     }
 
     /// Return false if `srcs`/`dsts` conflict with the pending Concurrent set.
@@ -67,19 +124,10 @@ impl MemRanges {
         srcs: &[&ProtocolObject<dyn MTLBuffer>],
         dsts: &[&ProtocolObject<dyn MTLBuffer>],
     ) -> bool {
-        for s in srcs {
-            let k = buf_key(s);
-            if self.dsts.contains(&k) {
-                return false;
-            }
-        }
-        for d in dsts {
-            let k = buf_key(d);
-            if self.srcs.contains(&k) || self.dsts.contains(&k) {
-                return false;
-            }
-        }
-        true
+        !self.keys_conflict(
+            srcs.iter().map(|b| buf_key(b)),
+            dsts.iter().map(|b| buf_key(b)),
+        )
     }
 
     pub(crate) fn add(
@@ -88,28 +136,21 @@ impl MemRanges {
         dsts: &[&ProtocolObject<dyn MTLBuffer>],
     ) {
         for s in srcs {
-            let k = buf_key(s);
-            if !self.srcs.contains(&k) {
-                self.srcs.push(k);
-            }
-            let p: *const ProtocolObject<dyn MTLBuffer> = *s;
-            if !self.bufs.contains(&p) {
-                self.bufs.push(p);
-            }
+            self.push_src(s);
         }
         for d in dsts {
-            let k = buf_key(d);
-            if !self.dsts.contains(&k) {
-                self.dsts.push(k);
-            }
-            let p: *const ProtocolObject<dyn MTLBuffer> = *d;
-            if !self.bufs.contains(&p) {
-                self.bufs.push(p);
-            }
+            self.push_dst(d);
         }
     }
 
     /// llama `concurrency_check` + optional `concurrency_reset` (barrier).
+    ///
+    /// A barrier is emitted ONLY on a real hazard, never per op: an op
+    /// whose reads and writes are disjoint from everything pending is
+    /// encoded straight into the concurrent pass. `FERROX_METAL_GPU_TIMING`
+    /// reports the resulting barriers-per-op ratio, which on a dense decode
+    /// token is ~0.99 -- the chain really is serial -- while the four
+    /// intra-group pairs (Q∥K∥V, gate∥up) overlap for free.
     pub(crate) fn begin_op(
         &mut self,
         encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>,
@@ -118,12 +159,8 @@ impl MemRanges {
     ) {
         note_begin_op();
         if !self.check(srcs, dsts) {
-            // SAFETY: pointers were taken from live encoder-bound scratch /
-            // weight buffers that outlive this encode pass.
-            let refs: Vec<&ProtocolObject<dyn MTLBuffer>> =
-                self.bufs.iter().map(|&p| unsafe { &*p }).collect();
             // Counts itself: see `crate::dispatch`.
-            memory_barrier_resources(encoder, &refs);
+            memory_barrier_resource_list(encoder, &mut self.res);
             self.reset();
             if barrier_log_enabled() {
                 let s = metal_encode_stats();
@@ -145,6 +182,79 @@ impl MemRanges {
         dsts: &[&ProtocolObject<dyn MTLBuffer>],
     ) {
         self.add(srcs, dsts);
+    }
+}
+
+#[cfg(test)]
+mod hazard_tests {
+    use super::MemRanges;
+
+    /// Build a tracker whose pending set is the given identities. The
+    /// hazard rule is pure -- it compares buffer identities, never touches
+    /// the GPU -- so it is tested here with plain integers rather than
+    /// behind `#[ignore]` on hardware.
+    fn pending(srcs: &[usize], dsts: &[usize]) -> MemRanges {
+        MemRanges {
+            srcs: srcs.to_vec(),
+            dsts: dsts.to_vec(),
+            res: Vec::new(),
+        }
+    }
+
+    /// A barrier per encoded op would read as correctness and cost the
+    /// whole point of the concurrent encoder: on a Llama-3.2-1B decode
+    /// token that is ~240 `memoryBarrierWithResources` calls instead of
+    /// ~160, and command encoding is 26-29% of Metal decode wall time
+    /// (GitHub issue #149). Disjoint work must stay barrier-free.
+    #[test]
+    fn a_write_then_a_read_of_a_different_buffer_needs_no_barrier() {
+        // Pending: op wrote buffer 2, reading buffer 1.
+        let m = pending(&[1], &[2]);
+        // A later op reading 3 and writing 4 touches neither.
+        assert!(
+            !m.keys_conflict([3].into_iter(), [4].into_iter()),
+            "disjoint ranges must not force a barrier"
+        );
+        // Two READS of the same buffer are also free: SRC∩SRC is allowed.
+        assert!(
+            !m.keys_conflict([1].into_iter(), [4].into_iter()),
+            "two ops reading the same buffer must not force a barrier"
+        );
+    }
+
+    /// And the other half: an overlap really is ordered, exactly once.
+    #[test]
+    fn a_read_after_a_pending_write_needs_exactly_one_barrier() {
+        let m = pending(&[1], &[2]);
+        // Read-after-write on buffer 2.
+        assert!(m.keys_conflict([2].into_iter(), [4].into_iter()));
+        // Write-after-write on buffer 2.
+        assert!(m.keys_conflict([3].into_iter(), [2].into_iter()));
+        // Write-after-read on buffer 1.
+        assert!(m.keys_conflict([3].into_iter(), [1].into_iter()));
+
+        // One conflicting op reports ONE conflict however many buffers it
+        // names, so the encode loop emits one barrier and resets, rather
+        // than one barrier per overlapping buffer.
+        assert!(m.keys_conflict([2, 2, 2].into_iter(), [1, 2].into_iter()));
+    }
+
+    /// `reset` after a barrier must clear the resource list too, or the
+    /// next barrier orders buffers no pending op touches -- which is a
+    /// silently wider barrier, not a wrong answer, and so would never
+    /// show up as a failure anywhere else.
+    #[test]
+    fn a_barrier_reset_clears_the_resource_list_with_the_ranges() {
+        let mut m = pending(&[1], &[2]);
+        m.res.push(std::ptr::NonNull::dangling());
+        m.reset();
+        assert!(m.srcs.is_empty());
+        assert!(m.dsts.is_empty());
+        assert!(
+            m.res.is_empty(),
+            "the resource list is the pending set in another form; \
+             clearing one without the other is how they drift"
+        );
     }
 }
 

--- a/crates/ferrox-metal/src/mem_ranges.rs
+++ b/crates/ferrox-metal/src/mem_ranges.rs
@@ -26,32 +26,15 @@
 //! 1.00 means the pass is fully serialised, lower means dispatches are
 //! overlapping.
 
+use crate::dispatch::{metal_encode_stats, note_begin_op};
 use crate::gpu::memory_barrier_resources;
 use objc2::runtime::ProtocolObject;
 use objc2_metal::{MTLBuffer, MTLComputeCommandEncoder};
-use std::sync::atomic::{AtomicU64, Ordering};
-
-/// Process-wide barrier count across every tracked encode pass.
-static BARRIER_COUNT: AtomicU64 = AtomicU64::new(0);
-static BEGIN_OP_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// True when barrier logging is requested (cached; read once).
 fn barrier_log_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var_os("FERROX_METAL_BARRIER_LOG").is_some())
-}
-
-/// Snapshot `(barriers, begin_ops)` since last reset (test / debug).
-pub fn metal_barrier_stats() -> (u64, u64) {
-    (
-        BARRIER_COUNT.load(Ordering::Relaxed),
-        BEGIN_OP_COUNT.load(Ordering::Relaxed),
-    )
-}
-
-pub fn metal_barrier_stats_reset() {
-    BARRIER_COUNT.store(0, Ordering::Relaxed);
-    BEGIN_OP_COUNT.store(0, Ordering::Relaxed);
 }
 
 #[derive(Default)]
@@ -133,21 +116,25 @@ impl MemRanges {
         srcs: &[&ProtocolObject<dyn MTLBuffer>],
         dsts: &[&ProtocolObject<dyn MTLBuffer>],
     ) {
-        BEGIN_OP_COUNT.fetch_add(1, Ordering::Relaxed);
+        note_begin_op();
         if !self.check(srcs, dsts) {
             // SAFETY: pointers were taken from live encoder-bound scratch /
             // weight buffers that outlive this encode pass.
             let refs: Vec<&ProtocolObject<dyn MTLBuffer>> =
                 self.bufs.iter().map(|&p| unsafe { &*p }).collect();
+            // Counts itself: see `crate::dispatch`.
             memory_barrier_resources(encoder, &refs);
             self.reset();
-            let n = BARRIER_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
-            if barrier_log_enabled() && n.is_multiple_of(4096) {
-                let begins = BEGIN_OP_COUNT.load(Ordering::Relaxed);
-                eprintln!(
-                    "ferrox: metal barriers={n} begin_ops={begins} (~{:.2} bar/op)",
-                    n as f64 / begins.max(1) as f64
-                );
+            if barrier_log_enabled() {
+                let s = metal_encode_stats();
+                if s.barriers.is_multiple_of(4096) {
+                    eprintln!(
+                        "ferrox: metal barriers={} begin_ops={} (~{:.2} bar/op)",
+                        s.barriers,
+                        s.begin_ops,
+                        s.barriers as f64 / s.begin_ops.max(1) as f64
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Closes part of #149.

#149 measured that ferrox's Metal kernels already finish faster than llama.cpp's
whole token, and that 26-29% of decode wall time is host-side command encoding.
It then asked two questions it could not answer, because neither thing was
counted:

1. how many dispatches ferrox encodes per decode token, against ~14 ops per
   layer for a 16-layer dense decode;
2. whether `MemRanges::begin_op` emits a barrier per op or only on a real
   read-after-write.

This answers both, then removes what the answer showed was removable.

## 1. The instrument

Every `dispatchThreadgroups` in `ferrox-metal` now goes through
`dispatch::dispatch_counted`, and Metal's two barrier calls through the two
`gpu.rs` primitives that count them. `FERROX_METAL_GPU_TIMING=1` already printed
GPU-clock milliseconds per command buffer; it now prints the encode work that
bought them, on the same line:

```
ferrox: metal gpu[dense-decode/tok] 4.803 ms avg over 256 (last 4.786 ms);
  encode/submission: 242.1 dispatches, 176.3 barriers, 177.3 hazard checks (0.99 bar/op)
```

Counts are attributed by DELTA between consecutive submissions of the same tag,
so a prefill's dispatches cannot land in the decode average.

A counter beside the thing it counts, with nothing forcing them to agree, is
this repo's dominant defect shape. `no_encode_site_bypasses_the_counter` scans
the crate's own source and fails if a raw dispatch or barrier call reappears
anywhere but inside the primitives. It goes red under sabotage in both halves
(a raw `encoder.dispatchThreadgroups...` reintroduced in `elem.rs`; the
`memory_barrier_buffers` body changed so its call no longer matches the
primitive).

## 2. The answers

**Dispatches.** Llama-3.2-1B Q4_K_M, 16 layers, `--ngl 99`, M2 Pro:
**242.1 dispatches per decode token**, i.e. **15.1 per layer** against the
issue's estimate of ~14. So ferrox is NOT encoding a wildly excessive graph.
The count is close to what the graph needs.

**Barriers.** `begin_op` was **already hazard-driven**, never per op. What the
counter shows instead is that it barely matters: **0.99 barriers per hazard
check**. The dense decode chain is genuinely serial (norm -> QKV -> RoPE -> KV
append -> GQA -> O -> norm -> gate/up -> act -> down), so nearly every op the
tracker checks is a real read-after-write. The concurrent encoder buys exactly
the four intra-group overlaps (Q parallel K parallel V, gate parallel up, the
two RoPEs, the two KV appends) and nothing else.

Since the tracker did not need changing, its rule is now pinned instead:
`hazard_tests` states it on plain integers rather than GPU buffers, so a write
then a read on DISJOINT ranges emitting no barrier, and an OVERLAPPING one
emitting exactly one, is a test that runs everywhere rather than behind
`#[ignore]`. Sabotaging the rule to also fire on SRC-SRC (i.e. per op) turns it
red.

## 3. What was removed

Three things per layer, none of which changes a kernel result.

**RoPE Q and K were two dispatches.** Same theta, position, `head_dim` and freq
factors; disjoint buffers; already inside one hazard group. The kernels take a
second destination and rotate both ranges in one dispatch. `encode_rope` takes
`second: Option<RopeTarget>` rather than gaining a fused twin, so the one- and
two-destination paths cannot drift; `launch_rope_host` passes `None`.

**The K and V cache appends were the same shape.** No caller appends one plane
without the other at the same offset and length, so the three append kernels
take a second pair of buffers and the grid's HEIGHT selects between them.
`KvPlane` is deleted rather than left as a single-plane entry point to keep in
step, and the three near-identical encoders behind it (f16, Q8_0, Turbo4)
collapse into one table of kernel + block geometry.

**A barrier around zero work.** `encode_attn_extras` encodes nothing for a model
with no QKV bias and no QK-norm, but the decode stack wrapped it in
`begin_op`/`end_op` unconditionally, and a hazard check on a serial chain is a
real `memoryBarrierWithResources`. Llama-3.2-1B paid **16 of its 176 barriers**
to order nothing against nothing. `AttnExtras::encodes_anything` is now the one
predicate deciding it, and `attn_extras_predicate_lists_every_field_that_encodes`
destructures the struct with no `..`, so a new field cannot be added without
deciding which side it falls on. (`attn_logit_softcap` is deliberately on the
"encodes nothing" side: it is read inside the GQA kernel.)

Also on the per-token path, `MemRanges` allocated TWICE per barrier, roughly 320
allocations per decode token. It now holds the pending set in the form the
barrier API wants and reuses that allocation, with `push_src`/`push_dst` writing
the key list and the resource list in one call so they cannot fall out of step.

## Counts, before and after

Llama-3.2-1B-Instruct-Q4_K_M, 16 layers, `-p 0 -n 128 --n-gpu-layers 99`,
`FERROX_METAL_GPU_TIMING=1`. These are deterministic and load-immune.

| per decode token | before | after | delta |
|---|---:|---:|---:|
| dispatches | 242.1 | **210.2** | -13.2% |
| barriers | 176.3 | **160.4** | -9.0% |
| hazard checks | 177.3 | 161.4 | -9.0% |
| barriers / hazard check | 0.99 | 0.99 | unchanged |
| dispatches per layer | 15.1 | **13.1** | -2 |
| barriers per layer | 11.0 | **10.0** | -1 |

## GPU versus wall, before and after

**Taken on a loaded laptop.** This M2 Pro is the only Metal hardware available,
and it is not quiet: sibling agents were building the workspace for most of this
session. Ratios within one process are what is reported here; **no tok/s figure
from these runs is publishable and `benchmarks/RESULTS.md` is untouched.**

Interleaved before/after/before/after, four pairs, taken at the quietest point
reached (`load1` 2.1-2.3, no process above 44% of a core). Raw sequence, not a
selected subset:

| # | build | wall ms/tok | GPU ms/tok | host ms/tok | host % |
|---|---|---:|---:|---:|---:|
| 1 | before | 6.591 | 4.872 | 1.719 | 26.1 |
| 1 | after  | 6.497 | 4.820 | 1.677 | 25.8 |
| 2 | before | 6.533 | 4.786 | 1.747 | 26.7 |
| 2 | after  | 6.508 | 4.824 | 1.684 | 25.9 |
| 3 | before | 6.527 | 4.803 | 1.724 | 26.4 |
| 3 | after  | 6.506 | 4.847 | 1.659 | 25.5 |
| 4 | before | 6.529 | 4.825 | 1.704 | 26.1 |
| 4 | after  | 6.570 | 4.855 | 1.715 | 26.1 |

Means: host **1.724 ms (26.3%) before, 1.684 ms (25.8%) after** — host time down
~2.3%. GPU time is 4.822 before and 4.837 after, i.e. unchanged within noise,
which is the point: the kernels do the same work, the host encodes less of it.

An earlier interleaved set taken while a sibling agent held the machine
(`load1` 10-20) produced host shares from 26% to 51% on both builds and is not
quoted; it is why the quiet-point set above was waited for.

## The finding that matters more than the 2.3%

**Removing 11.5% of the encode operations (48 of 418 per token) bought 2.3% of
the host time.** Host cost is therefore NOT proportional to dispatch + barrier
count, so counting dispatches was the wrong unit and the issue's framing needs
narrowing: the remaining term is almost certainly the per-dispatch ARGUMENT
BINDING, which these fusions barely touched. The rope encoder issues nine
`setBuffer`/`setBytes` calls per dispatch and the fused version still issues ten
once instead of nine twice; the KV append issues six once instead of four twice.
At roughly 2400 encoder calls per token against 418 dispatches and barriers,
that is where the milliseconds are.

The arithmetic before pulling the next lever, per #149's own rule: at 4.82 ms of
GPU time against llama.cpp's 6.77 ms per token, removing the host cost ENTIRELY
would reach 0.71x. It is worth doing. But it will take packing kernel arguments
into single `setBytes` structs, not more fusion of adjacent dispatch pairs, and
the counters added here now report both halves so the next attempt can be
judged before it is merged.

## Correctness

- **`ferrox parity -m models/Llama-3.2-1B-Instruct-Q8_0.gguf` on Metal:
  MATCH.** Tokenizer MATCH (19 cases / 358 tokens). Logits KL(llama||ferrox)
  7.219e-4 nats against a libllama built from `.scratch/llama.cpp`, two orders
  under the WRONG line; top-1 12366 for both engines. Same before and after.
- **`ferrox verify` (Metal against the CPU reference, `--prompt-tokens 64` so
  prefill is covered): token-identical on all five models tried** —
  Llama-3.2-1B Q8_0 and Q4_K_M, Llama-3.2-3B Q4_K_M, Gemma-2-2B (sandwich norms
  + softcap, and the eager-residual path) and Qwen2.5-1.5B (`qkv_bias`, so the
  extras barrier is still taken and the skip is proven conditional).
- **Every KV wire format the changed append kernels serve**: `q8_0`, `turbo8`,
  `fp8`, `turbo4`, all token-identical.
- `cargo test -p ferrox-metal --features metal -- --ignored`: **54 passed**, on
  the real GPU.

## Gates

`cargo test --workspace` (61 suites, 0 failures), `cargo clippy --workspace
--all-targets -- -D warnings` debug and `--release`, the same with
`--features metal` for `ferrox-metal`/`ferrox-cli`/`ferrox-server`, and
`cargo fmt --all --check`.

## File sizes

The first commit is a pure move, and the seam is the one #149 points at:
`attn.rs` **9317 -> 8715** lines, with the decode encode loop now readable in
full in `decode_dense.rs` (670). `dispatch.rs` (155) and the collapsed KV append
table account for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
