### PR TITLE
feat(sampling): port llama.cpp's four missing chain steps (typical_p, top_n_sigma, xtc, dry), end to end

### DIFF
--- a/crates/ferrox-cli/src/run.rs
+++ b/crates/ferrox-cli/src/run.rs
@@ -142,6 +142,71 @@ pub struct InferArgs {
     #[arg(long = "repeat-penalty", default_value_t = 1.1)]
     pub repeat_penalty: f32,
 
+    /// Locally typical sampling, llama.cpp's `--typical` (`1.0` = off).
+    ///
+    /// Keeps the candidates whose surprisal is closest to the
+    /// distribution's entropy, from the middle outward, rather than the
+    /// most likely ones -- so it can drop the most likely token.
+    #[arg(long = "typical", visible_alias = "typical-p", default_value_t = 1.0)]
+    pub typical_p: f32,
+
+    /// Truncate at `n` standard deviations of the logits below the
+    /// maximum, llama.cpp's `--top-nsigma` (`-1.0` = off).
+    #[arg(
+        long = "top-nsigma",
+        visible_alias = "top-n-sigma",
+        default_value_t = -1.0
+    )]
+    pub top_n_sigma: f32,
+
+    /// The probability that XTC removes the top candidates on any one
+    /// token, llama.cpp's `--xtc-probability` (`0.0` = off).
+    #[arg(long = "xtc-probability", default_value_t = 0.0)]
+    pub xtc_probability: f32,
+
+    /// The probability a candidate must reach before XTC may remove it,
+    /// llama.cpp's `--xtc-threshold`. **Above 0.5 disables XTC**, which
+    /// is upstream's guard: above a half at most one candidate can clear
+    /// it and XTC never removes the last one.
+    #[arg(long = "xtc-threshold", default_value_t = 0.1)]
+    pub xtc_threshold: f32,
+
+    /// DRY sequence-repetition penalty multiplier, llama.cpp's
+    /// `--dry-multiplier` (`0.0` = off).
+    ///
+    /// Unlike `--repeat-penalty`, which looks at single tokens, DRY
+    /// penalises the token that would EXTEND a repeated sequence, by
+    /// `multiplier * base ^ (length - allowed-length)`.
+    #[arg(long = "dry-multiplier", default_value_t = 0.0)]
+    pub dry_multiplier: f32,
+
+    /// The base of DRY's exponential, llama.cpp's `--dry-base`. Below
+    /// 1.0 disables DRY.
+    #[arg(long = "dry-base", default_value_t = 1.75)]
+    pub dry_base: f32,
+
+    /// Repetitions this long or shorter are free, llama.cpp's
+    /// `--dry-allowed-length`.
+    #[arg(long = "dry-allowed-length", default_value_t = 2)]
+    pub dry_allowed_length: i32,
+
+    /// How many recent tokens DRY scans for repetitions, llama.cpp's
+    /// `--dry-penalty-last-n` (`0` = off, `-1` = the context size).
+    #[arg(long = "dry-penalty-last-n", default_value_t = -1)]
+    pub dry_penalty_last_n: i32,
+
+    /// A string DRY refuses to look past, llama.cpp's
+    /// `--dry-sequence-breaker`. Repeatable.
+    ///
+    /// Giving any breaker CLEARS llama.cpp's defaults (`\n`, `:`, `"`,
+    /// `*`), exactly as upstream's flag does (`common/arg.cpp:2119`),
+    /// and the literal `none` clears them without adding one. The
+    /// strings are tokenised against the loaded model's own vocabulary,
+    /// so a checkpoint with no real vocabulary refuses DRY rather than
+    /// running it with no breakers.
+    #[arg(long = "dry-sequence-breaker", value_name = "STRING")]
+    pub dry_sequence_breaker: Vec<String>,
+
     /// The order the sampler chain runs in, `;`-separated, llama.cpp's
     /// `--samplers`.
     ///
@@ -338,12 +403,20 @@ impl TokenStep {
     /// when nothing needs to look at the vocabulary first, and a grammar
     /// does. Read by the Metal greedy guard, which used to test the
     /// temperature alone.
+    ///
+    /// `sampling` is taken because the CHAIN can need the vocabulary
+    /// too: `xtc` and `typ_p` remove candidates the argmax may be one
+    /// of, and `dry` moves logits, so at `temperature <= 0` the answer
+    /// is not the argmax of what the device would fold.
+    /// `SamplingParams::greedy_equals_argmax` is the one predicate that
+    /// decides it, shared with the sampler's own greedy fast path and
+    /// with `ferrox_server::generate`'s copy of this gate.
     // Read only by the Metal greedy guard, so a CPU-only build has no
     // fold to refuse and this is genuinely dead there. Same shape and
     // same reason as `ferrox-models`'s `FoldedLmHead`.
     #[cfg_attr(not(feature = "metal"), allow(dead_code))]
-    pub fn needs_vocab_logits(&self) -> bool {
-        self.grammar.is_some()
+    pub fn needs_vocab_logits(&self, sampling: &ferrox_models::sampling::SamplingParams) -> bool {
+        self.grammar.is_some() || !sampling.greedy_equals_argmax()
     }
 
     /// `Ok(None)` means the grammar is SATISFIED and has no legal
@@ -427,6 +500,34 @@ impl InferArgs {
         Ok(None)
     }
 
+    /// The DRY configuration these flags spell, before its sequence
+    /// breakers are tokenised.
+    ///
+    /// llama.cpp's `--dry-sequence-breaker` CLEARS the defaults the
+    /// first time it is given (`common/arg.cpp:2119-2126`) and reads
+    /// the literal `none` as "no breakers at all". Both are reproduced
+    /// here, and `none` anywhere in the list clears it, because a caller
+    /// who wrote it meant it.
+    pub fn dry_request(&self) -> ferrox_models::dry::DryRequest {
+        let sequence_breakers = if self.dry_sequence_breaker.is_empty() {
+            ferrox_models::dry::DEFAULT_SEQUENCE_BREAKERS
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        } else if self.dry_sequence_breaker.iter().any(|s| s == "none") {
+            Vec::new()
+        } else {
+            self.dry_sequence_breaker.clone()
+        };
+        ferrox_models::dry::DryRequest {
+            multiplier: self.dry_multiplier,
+            base: self.dry_base,
+            allowed_length: self.dry_allowed_length,
+            penalty_last_n: self.dry_penalty_last_n,
+            sequence_breakers,
+        }
+    }
+
     /// The sampler these flags describe.
     ///
     /// One function rather than one copy per generation path. There were
@@ -435,18 +536,34 @@ impl InferArgs {
     /// repo's most expensive failure: adding `--min-p` meant editing
     /// four places, and a sampler added to three of them would be
     /// silently absent from the fourth with every test still green.
-    pub fn sampling(&self) -> SamplingParams {
-        SamplingParams {
+    ///
+    /// Fallible, and taking the vocabulary, because of DRY: its sequence
+    /// breakers are STRINGS that only mean something against a
+    /// particular tokenizer, so a checkpoint with no real vocabulary
+    /// must refuse `--dry-multiplier` rather than run DRY with no
+    /// breakers. `vocab` is `None` for exactly those checkpoints, and
+    /// `ctx_size` is what `--dry-penalty-last-n -1` resolves to.
+    pub fn sampling(
+        &self,
+        vocab: Option<&dyn ferrox_models::dry::DryVocab>,
+        ctx_size: usize,
+    ) -> anyhow::Result<SamplingParams> {
+        Ok(SamplingParams {
             temperature: self.temperature,
             top_p: self.top_p,
             min_p: self.min_p,
             top_k: self.top_k,
+            typical_p: self.typical_p,
+            top_n_sigma: self.top_n_sigma,
+            xtc_probability: self.xtc_probability,
+            xtc_threshold: self.xtc_threshold,
+            dry: self.dry_request().resolve(vocab, ctx_size)?,
             repetition_penalty: self.repeat_penalty,
             penalty_last_n: self.repeat_last_n,
             presence_penalty: self.presence_penalty,
             frequency_penalty: self.frequency_penalty,
             sampler_order: self.samplers,
-        }
+        })
     }
 }
 
@@ -830,6 +947,35 @@ impl CliTokenizer {
             CliTokenizer::Spm(_) => "gguf-spm",
             CliTokenizer::Unigram(_) => "gguf-unigram",
         }
+    }
+
+    fn vocab_size(&self) -> usize {
+        match self {
+            CliTokenizer::Bpe(t) => t.vocab_size(),
+            CliTokenizer::Spm(t) => t.vocab_size(),
+            CliTokenizer::Unigram(t) => t.vocab_size(),
+        }
+    }
+}
+
+/// What the DRY sampler needs to tokenise its sequence breakers.
+///
+/// `ferrox-server` implements the same trait for its own tokenizer enum.
+/// Two implementations rather than one shared type because the two
+/// enums genuinely differ (the server carries a byte-level fallback the
+/// CLI does not), but they are held to ONE trait so the flag and the
+/// request field cannot mean different things.
+impl ferrox_models::dry::DryVocab for CliTokenizer {
+    fn n_tokens(&self) -> usize {
+        self.vocab_size()
+    }
+
+    fn detokenize(&self, token: usize) -> String {
+        self.decode(&[token])
+    }
+
+    fn tokenize(&self, text: &str) -> Vec<usize> {
+        self.encode(text)
     }
 }
 
@@ -1251,7 +1397,7 @@ pub fn run_infer(args: InferArgs) -> anyhow::Result<()> {
         (args.n_predict as usize).min(room)
     };
 
-    let sampling = args.sampling();
+    let sampling = args.sampling(Some(&tokenizer), ctx_size)?;
     let seed = seed_from_args(args.seed);
     let sampler = Sampler::new(seed);
     let mut step = token_step(
@@ -1280,7 +1426,7 @@ pub fn run_infer(args: InferArgs) -> anyhow::Result<()> {
         // for `json_object`, and the third instance of it. The rule is
         // the server's: the fold is sound only when NOTHING needs to
         // inspect the vocabulary before a token is chosen.
-        if sampling.temperature <= 0.0 && !step.needs_vocab_logits() {
+        if sampling.temperature <= 0.0 && !step.needs_vocab_logits(&sampling) {
             ferrox_models::set_metal_greedy_argmax(true);
             Some(Guard)
         } else {
@@ -1429,7 +1575,7 @@ fn run_mla_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow::Re
         (args.n_predict as usize).min(room)
     };
 
-    let sampling = args.sampling();
+    let sampling = args.sampling(Some(&tokenizer), ctx_size)?;
     let sampler = Sampler::new(seed_from_args(args.seed));
     let mut step = token_step(
         &args,
@@ -1560,7 +1706,7 @@ fn run_gemma4_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow:
         (args.n_predict as usize).min(room)
     };
 
-    let sampling = args.sampling();
+    let sampling = args.sampling(Some(&tokenizer), ctx_size)?;
     let sampler = Sampler::new(seed_from_args(args.seed));
     let mut step = token_step(
         &args,
@@ -1690,7 +1836,7 @@ fn run_glm52_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow::
         (args.n_predict as usize).min(room)
     };
 
-    let sampling = args.sampling();
+    let sampling = args.sampling(Some(&tokenizer), ctx_size)?;
     let sampler = Sampler::new(seed_from_args(args.seed));
     let mut step = token_step(
         &args,
@@ -2053,11 +2199,14 @@ mod tests {
     /// same chain, so the two cannot drift apart.
     #[test]
     fn samplers_defaults_to_the_chain_ferrox_already_ran() {
-        let default = args(&["-m", "x.gguf"]).sampling().sampler_order;
+        let default = args(&["-m", "x.gguf"])
+            .sampling(None, 4096)
+            .expect("no dry, so no vocabulary is needed")
+            .sampler_order;
         assert_eq!(default, ferrox_models::SamplerOrder::default());
         assert_eq!(
             default.to_string(),
-            "penalties;top_k;top_p;min_p;temperature"
+            "penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature"
         );
     }
 
@@ -2065,13 +2214,15 @@ mod tests {
     #[test]
     fn a_caller_supplied_order_reaches_the_sampler() {
         let order = args(&["-m", "x.gguf", "--samplers", "penalties;temperature;top_k"])
-            .sampling()
+            .sampling(None, 4096)
+            .expect("no dry")
             .sampler_order;
         assert_eq!(order.to_string(), "penalties;temperature;top_k");
         // llama.cpp's own aliases, so an upstream command line works.
         assert_eq!(
             args(&["-m", "x.gguf", "--samplers", "top-k;min-p;temp"])
-                .sampling()
+                .sampling(None, 4096)
+                .expect("no dry")
                 .sampler_order
                 .to_string(),
             "top_k;min_p;temperature"
@@ -2092,12 +2243,23 @@ mod tests {
             "-m",
             "x.gguf",
             "--samplers",
-            "dry;top_k;typ_p;top_p;min_p;xtc;temperature",
+            "penalties;mirostat;temperature",
         ])
-        .expect_err("upstream's default names samplers ferrox lacks")
+        .expect_err("mirostat is not a chain member here")
         .to_string();
-        assert!(err.contains("dry"), "{err}");
+        assert!(err.contains("mirostat"), "{err}");
         assert!(err.contains("not implemented"), "{err}");
+
+        // And llama.cpp's OWN default string now parses, which is the
+        // point of this change: pasting an upstream command line works.
+        Cli::try_parse_from([
+            "ferrox",
+            "-m",
+            "x.gguf",
+            "--samplers",
+            "penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature",
+        ])
+        .expect("llama.cpp's default chain is ferrox's default chain");
 
         let unknown = Cli::try_parse_from(["ferrox", "-m", "x.gguf", "--samplers", "top_kk"])
             .expect_err("no such sampler")

--- a/crates/ferrox-models/src/draft_model.rs
+++ b/crates/ferrox-models/src/draft_model.rs
@@ -253,10 +253,15 @@ impl Drafter for DraftModelSpeculator {
             // same sequence the target's would. The block used to clone
             // `history` per call to concatenate the two; the window
             // borrows both halves instead.
+            // The XTC roll comes off THIS drafter's own stream, so the
+            // distribution reported as `q` below is the one the token
+            // was actually drawn from even when XTC is configured.
+            let xtc_roll = self.rng.xtc_roll(&self.sampling);
             let probs = sampling_distribution(
                 &logits,
                 &self.sampling,
                 PenaltyWindow::new(history, &tokens),
+                xtc_roll,
             );
             let token = self.rng.sample_from(&probs);
 

--- a/crates/ferrox-models/src/dry.rs
+++ b/crates/ferrox-models/src/dry.rs
@@ -1,0 +1,995 @@
+//! The DRY repetition sampler ("Don't Repeat Yourself"), ported from
+//! llama.cpp's `llama_sampler_dry` (`src/llama-sampler.cpp:3078-3400`),
+//! which is itself a port of Koboldcpp PR 982 by pi6am.
+//!
+//! # What it does that the repetition penalty cannot
+//!
+//! `penalties` looks at SINGLE tokens: a token that occurred in the
+//! window is made less likely, once. DRY looks at SEQUENCES. It asks,
+//! for every token the model could emit next, "how long a repetition of
+//! earlier context would emitting this token continue?", and penalises
+//! by `multiplier * base ^ (that length - allowed_length)`. A model
+//! looping on a four-token phrase is not emitting one over-represented
+//! token, so the repetition penalty barely moves it while DRY's
+//! exponential grows every time round the loop.
+//!
+//! # The three parts, and where each one comes from
+//!
+//! * [`DryBreakers`] is `get_overlapping_token_sequences`
+//!   (`src/llama-sampler.cpp:3095`): the sequence breakers a caller
+//!   gives as STRINGS, tokenised against the loaded vocabulary. A
+//!   breaker is a point the repetition detector refuses to look past,
+//!   so `"\n"` stops one paragraph's phrasing from penalising the next.
+//!   It has to be done against the model's own vocabulary because a
+//!   breaker string is usually not a whole token: `":"` may only ever
+//!   appear as the tail of `"foo:"`, so the entry is keyed on the token
+//!   that CONTAINS it and carries whatever tokens must follow.
+//! * [`DryParams::penalties`] is `llama_sampler_dry_apply`
+//!   (`src/llama-sampler.cpp:3151`), including the reverse Z-algorithm
+//!   that finds, in one linear pass, how long a suffix ending at each
+//!   position also occurs elsewhere in the window.
+//! * [`crate::sampler_chain::Candidates::dry`] subtracts the result.
+//!
+//! # Why the parameters are a struct with private fields
+//!
+//! Because enabling DRY without tokenising its breakers is a silent
+//! wrong answer, not an error: the sampler runs, penalises across
+//! newlines it was told to stop at, and nothing says so. So there is no
+//! way to build an ENABLED [`DryParams`] without handing it a
+//! [`DryBreakers`], and the only way to build a non-empty
+//! [`DryBreakers`] is [`DryBreakers::from_vocab`], which needs a
+//! vocabulary. A caller that genuinely wants none writes
+//! [`DryBreakers::none`] and that is visible in the diff.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use crate::penalty_window::PenaltyWindow;
+
+/// llama.cpp's `MAX_CHAR_LEN` (`src/llama-sampler.cpp:3382`): a
+/// sequence breaker longer than this is truncated rather than refused.
+const MAX_CHAR_LEN: usize = 40;
+
+/// llama.cpp's `MAX_SEQ_LEN` (`src/llama-sampler.cpp:3383`): the tail
+/// of a breaker is clamped to this many tokens, which is what keeps the
+/// restart-sequence scan in [`DryParams::penalties`] linear in the
+/// window length rather than quadratic.
+const MAX_SEQ_LEN: usize = 20;
+
+/// llama.cpp's `FLOAT_MAX_LOG` (`src/llama-sampler.cpp:3312`), the
+/// approximate natural log of `FLT_MAX`. The exponent is clamped to
+/// `FLOAT_MAX_LOG / ln(base)` so `base ^ exponent` cannot overflow to
+/// infinity on a long repetition.
+const FLOAT_MAX_LOG: f32 = 88.722_84;
+
+/// llama.cpp's default sequence breakers
+/// (`common/common.h:259`, `dry_sequence_breakers = {"\n", ":", "\"", "*"}`).
+///
+/// One definition, read by the CLI flag's default and by the server's,
+/// because two lists that must agree about four strings is this repo's
+/// dominant defect shape at its smallest.
+pub const DEFAULT_SEQUENCE_BREAKERS: [&str; 4] = ["\n", ":", "\"", "*"];
+
+/// What DRY needs from a loaded model's vocabulary, and nothing else.
+///
+/// Three methods rather than a dependency on any particular tokenizer
+/// type: `ferrox-models` has four of those and `ferrox-server` wraps
+/// them in a fifth, so a concrete type here would either pick one or
+/// force an enum that grows with every new vocabulary format.
+pub trait DryVocab {
+    /// The number of token ids in the vocabulary. Every id in
+    /// `0..n_tokens()` must be valid for [`Self::detokenize`].
+    fn n_tokens(&self) -> usize;
+
+    /// The text of ONE token, special tokens rendered rather than
+    /// hidden -- llama.cpp's `vocab.detokenize({token_id}, true)`
+    /// (`src/llama-sampler.cpp:3097`).
+    fn detokenize(&self, token: usize) -> String;
+
+    /// `text` as token ids, with no BOS and no special-token parsing --
+    /// llama.cpp's `vocab.tokenize(str.substr(i), false, false)`
+    /// (`src/llama-sampler.cpp:3114`).
+    fn tokenize(&self, text: &str) -> Vec<usize>;
+}
+
+/// Sequence breakers, tokenised against one model's vocabulary.
+///
+/// Keyed on the token that HOLDS the start of the breaker string, with
+/// the tokens that must follow it as the value. An empty tail means the
+/// token by itself is a whole breaker, which is both the common case and
+/// the one that suppresses a penalty entirely (see
+/// [`DryParams::penalties`] step 4).
+///
+/// A token may head more than one breaker -- llama.cpp keeps a
+/// `std::unordered_multimap` for exactly that -- so the value is a list
+/// of tails, deduplicated as upstream deduplicates it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DryBreakers {
+    /// The strings this was built from, kept so a cache key can name
+    /// the configuration without hashing the whole tokenised map.
+    raw: Vec<String>,
+    heads: HashMap<usize, Vec<Vec<usize>>>,
+}
+
+impl DryBreakers {
+    /// No breakers: the repetition scan may look back across anything.
+    ///
+    /// This is what `--dry-sequence-breaker none` asks for upstream, and
+    /// what a caller with no vocabulary to tokenise against must write
+    /// explicitly rather than get by accident.
+    pub fn none() -> Self {
+        DryBreakers::default()
+    }
+
+    /// The strings these breakers were built from, in the order given.
+    pub fn raw(&self) -> &[String] {
+        &self.raw
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.heads.is_empty()
+    }
+
+    /// Tokenise `breakers` against `vocab`.
+    ///
+    /// This is `get_overlapping_token_sequences`
+    /// (`src/llama-sampler.cpp:3095-3134`), and the "overlapping" is the
+    /// whole point: a breaker is rarely a token of its own. The scan
+    /// walks every token in the vocabulary and asks either
+    ///
+    /// * does this token's text CONTAIN the breaker? Then the token
+    ///   alone breaks the sequence (an empty tail); or
+    /// * does this token's text END with a prefix of the breaker? Then
+    ///   the token breaks the sequence only when the REST of the breaker
+    ///   follows, and that rest is tokenised and kept as the tail.
+    ///
+    /// **Cost.** One `detokenize` per vocabulary entry per breaker
+    /// string, which is upstream's cost too (`llama_sampler_init_dry` at
+    /// `:3399` runs it per sampler, and llama.cpp's server builds a
+    /// sampler per request). It is paid only when DRY is switched on --
+    /// [`DryParams::new`] is the only caller and it is only reached for
+    /// a non-zero multiplier.
+    ///
+    /// An empty breaker is skipped rather than refused, as upstream
+    /// skips it (`:3388`); one longer than [`MAX_CHAR_LEN`] bytes is
+    /// truncated.
+    pub fn from_vocab(vocab: &dyn DryVocab, breakers: &[String]) -> Self {
+        let mut out = DryBreakers {
+            raw: breakers.to_vec(),
+            heads: HashMap::new(),
+        };
+        for breaker in breakers {
+            if breaker.is_empty() {
+                continue;
+            }
+            let mut bytes = breaker.as_bytes();
+            if bytes.len() > MAX_CHAR_LEN {
+                bytes = &bytes[..MAX_CHAR_LEN];
+            }
+            out.add_overlapping(vocab, bytes);
+        }
+        out
+    }
+
+    /// Breakers given directly as token sequences.
+    ///
+    /// This is `llama_sampler_init_dry_testing`
+    /// (`src/llama-sampler.cpp:3420`), the entry point llama.cpp's own
+    /// `tests/test-sampling.cpp` uses, and it exists here for the same
+    /// reason: the golden values in [`mod tests`](self::tests) were
+    /// produced by running that function against `libllama`, and a test
+    /// that had to build a vocabulary first would be testing the
+    /// tokenizer as well as the sampler.
+    ///
+    /// The first token of each sequence is the head, the rest the tail,
+    /// exactly as upstream splits it.
+    pub fn from_token_sequences(sequences: &[Vec<usize>]) -> Self {
+        let mut heads: HashMap<usize, Vec<Vec<usize>>> = HashMap::new();
+        for sequence in sequences {
+            let Some((&head, tail)) = sequence.split_first() else {
+                continue;
+            };
+            let mut tail = tail.to_vec();
+            tail.truncate(MAX_SEQ_LEN);
+            let entry = heads.entry(head).or_default();
+            if !entry.contains(&tail) {
+                entry.push(tail);
+            }
+        }
+        DryBreakers {
+            raw: Vec::new(),
+            heads,
+        }
+    }
+
+    fn tails(&self, token: usize) -> Option<&[Vec<usize>]> {
+        self.heads.get(&token).map(|v| v.as_slice())
+    }
+
+    /// True when this token is a breaker all by itself, which is what
+    /// makes upstream skip its penalty entirely (`:3325-3334`).
+    fn is_single_token_breaker(&self, token: usize) -> bool {
+        self.heads
+            .get(&token)
+            .is_some_and(|tails| tails.iter().any(|tail| tail.is_empty()))
+    }
+
+    fn push(&mut self, head: usize, tail: Vec<usize>) {
+        let entry = self.heads.entry(head).or_default();
+        // Upstream's `equal_range` duplicate check (`:3117-3126`).
+        if !entry.contains(&tail) {
+            entry.push(tail);
+        }
+    }
+
+    /// One breaker string against the whole vocabulary.
+    ///
+    /// Byte-wise rather than char-wise because upstream is:
+    /// `word.find(str[0], pos + 1)` indexes `std::string` by byte, and a
+    /// token's text is not guaranteed to split on a character boundary
+    /// where the breaker does. The tail is only tokenised when the
+    /// remaining bytes are valid UTF-8, which they are whenever the
+    /// breaker itself is.
+    fn add_overlapping(&mut self, vocab: &dyn DryVocab, breaker: &[u8]) {
+        for token in 0..vocab.n_tokens() {
+            let word = vocab.detokenize(token);
+            let word = word.as_bytes();
+            if contains_subslice(word, breaker) {
+                self.push(token, Vec::new());
+                continue;
+            }
+            let mut from = 0usize;
+            while from < word.len() {
+                let Some(offset) = word[from..].iter().position(|&c| c == breaker[0]) else {
+                    break;
+                };
+                let pos = from + offset;
+                from = pos + 1;
+                // How many bytes of the breaker this occurrence
+                // matched before running off the end of the token.
+                let mut i = 1usize;
+                let mut matched = true;
+                while i < breaker.len() && i + pos < word.len() {
+                    if word[pos + i] != breaker[i] {
+                        matched = false;
+                        break;
+                    }
+                    i += 1;
+                }
+                if !matched {
+                    continue;
+                }
+                let Ok(rest) = std::str::from_utf8(&breaker[i..]) else {
+                    // A breaker whose tail starts mid-character cannot
+                    // be tokenised; upstream would hand the tokenizer
+                    // the same broken bytes and get nothing useful.
+                    continue;
+                };
+                let mut tail = vocab.tokenize(rest);
+                tail.truncate(MAX_SEQ_LEN);
+                self.push(token, tail);
+            }
+        }
+    }
+}
+
+fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return needle.is_empty();
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// One request's DRY configuration.
+///
+/// Fields are private and there is no `Default` that can be enabled:
+/// [`DryParams::off`] is the only way to get a disabled one and
+/// [`DryParams::new`] the only way to get an enabled one, and it takes
+/// the breakers. See the module docs for why that is a type invariant
+/// rather than a convention.
+#[derive(Debug, Clone)]
+pub struct DryParams {
+    /// llama.cpp's `dry_multiplier` (`common/common.h:242`), `0.0` off.
+    multiplier: f32,
+    /// llama.cpp's `dry_base` (`common/common.h:243`), default 1.75.
+    /// Below 1.0 disables DRY, exactly as upstream's guard reads
+    /// (`src/llama-sampler.cpp:3154`).
+    base: f32,
+    /// llama.cpp's `dry_allowed_length` (`common/common.h:244`),
+    /// default 2: a repetition this long or shorter is free.
+    allowed_length: i32,
+    /// llama.cpp's `dry_penalty_last_n` (`common/common.h:245`),
+    /// default `-1` meaning "the whole context"; `0` disables.
+    penalty_last_n: i32,
+    /// llama.cpp's `n_ctx_train`, the ceiling every window is clamped
+    /// to (`src/llama-sampler.cpp:3158-3159`).
+    total_context_size: usize,
+    /// Shared rather than cloned: this is a map over the vocabulary and
+    /// [`crate::sampling::SamplingParams`] is cloned per request.
+    breakers: Arc<DryBreakers>,
+}
+
+impl DryParams {
+    /// DRY switched off, which is llama.cpp's default
+    /// (`dry_multiplier = 0.0f`, `common/common.h:242`).
+    pub fn off() -> Self {
+        DryParams {
+            multiplier: 0.0,
+            base: 1.75,
+            allowed_length: 2,
+            penalty_last_n: -1,
+            total_context_size: 0,
+            breakers: Arc::new(DryBreakers::none()),
+        }
+    }
+
+    /// DRY with the given configuration and breakers.
+    ///
+    /// `total_context_size` is llama.cpp's `n_ctx_train`: the ceiling a
+    /// `penalty_last_n` of `-1` resolves to, and the clamp every window
+    /// is passed through.
+    pub fn new(
+        multiplier: f32,
+        base: f32,
+        allowed_length: i32,
+        penalty_last_n: i32,
+        total_context_size: usize,
+        breakers: DryBreakers,
+    ) -> Self {
+        DryParams {
+            multiplier,
+            base,
+            allowed_length,
+            penalty_last_n,
+            total_context_size,
+            breakers: Arc::new(breakers),
+        }
+    }
+
+    /// The single predicate for "DRY does nothing", transcribed from the
+    /// guard both `llama_sampler_dry_accept` (`:3143`) and
+    /// `llama_sampler_dry_apply` (`:3154`) open with, and the same three
+    /// conditions `llama_sampler_init_dry` reads to return an empty
+    /// sampler (`:3387`).
+    ///
+    /// One function rather than the three copies upstream has, because
+    /// this is read by the chain, by the CLI banner and by the server's
+    /// refusal, and a disagreement between them is a sampler that is
+    /// reported on but not run.
+    pub fn is_enabled(&self) -> bool {
+        self.multiplier != 0.0 && self.base >= 1.0 && self.penalty_last_n != 0
+    }
+
+    pub fn multiplier(&self) -> f32 {
+        self.multiplier
+    }
+
+    pub fn base(&self) -> f32 {
+        self.base
+    }
+
+    pub fn allowed_length(&self) -> i32 {
+        self.allowed_length
+    }
+
+    pub fn penalty_last_n(&self) -> i32 {
+        self.penalty_last_n
+    }
+
+    pub fn total_context_size(&self) -> usize {
+        self.total_context_size
+    }
+
+    pub fn breakers(&self) -> &DryBreakers {
+        &self.breakers
+    }
+
+    /// How many of the most recent tokens the scan looks at:
+    /// `dry_penalty_last_n` resolved against the context size, exactly
+    /// as `src/llama-sampler.cpp:3158` resolves it.
+    fn effective_last_n(&self) -> usize {
+        if self.penalty_last_n == -1 {
+            self.total_context_size
+        } else {
+            self.penalty_last_n.max(0) as usize
+        }
+    }
+
+    /// The penalty to SUBTRACT from each token's logit, keyed by token
+    /// id. Empty when DRY is off or has nothing to say.
+    ///
+    /// `llama_sampler_dry_apply` (`src/llama-sampler.cpp:3151-3345`),
+    /// in its four documented steps:
+    ///
+    /// 1. walk backwards for a sequence breaker, and clamp how far a
+    ///    repetition may reach (`rep_limit`);
+    /// 2. the reverse Z-algorithm, which fills `repeat_count[i]` with
+    ///    the length of the window's suffix that also occurs ending at
+    ///    position `i`;
+    /// 3. for each non-zero count, the token that WOULD extend that
+    ///    repetition is the one to penalise, and the longest repetition
+    ///    ending in it wins;
+    /// 4. `multiplier * base ^ (length - allowed_length)`, skipped for a
+    ///    token that is a whole sequence breaker by itself.
+    ///
+    /// `history` is the same [`PenaltyWindow`] the repetition penalties
+    /// use, for the same reason: llama.cpp's DRY sampler is fed by
+    /// `common_sampler_accept`, which both front ends call for prompt
+    /// tokens as well as generated ones (see [`crate::penalty_window`]).
+    pub fn penalties(&self, history: PenaltyWindow<'_>) -> HashMap<usize, f32> {
+        let empty = HashMap::new();
+        if !self.is_enabled() {
+            return empty;
+        }
+        // `last_tokens` is a ring buffer of `effective_last_n` capacity
+        // upstream, so its size is already clamped; here the window is
+        // asked for that many and clamped again by the context size,
+        // which is upstream's second `std::min` (`:3159`).
+        let effective = self.effective_last_n();
+        let recent: Vec<usize> = history
+            .recent(effective.min(self.total_context_size))
+            .collect();
+        let n = recent.len();
+        if n as i32 <= self.allowed_length {
+            return empty;
+        }
+        // `rat(i)`: llama.cpp's `ring_buffer::rat`, i tokens back from
+        // the most recent. `recent` is oldest-first.
+        let rat = |i: usize| recent[n - 1 - i];
+
+        // Step 1: how far back a repetition may reach before it hits a
+        // sequence breaker.
+        let mut rep_limit = n as i32;
+        for i in 0..n {
+            let Some(tails) = self.breakers.tails(rat(i)) else {
+                continue;
+            };
+            let mut longest_match: i32 = -1;
+            for tail in tails {
+                let seq_len = tail.len() as i32;
+                // `<= i`: the tail has to fit in the window behind the
+                // head, and the head itself is already matched.
+                if seq_len <= longest_match || seq_len > i as i32 {
+                    continue;
+                }
+                let matched = (0..tail.len()).all(|offset| tail[offset] == rat(i - offset - 1));
+                if matched {
+                    longest_match = seq_len;
+                }
+            }
+            if longest_match >= 0 {
+                rep_limit = i as i32 - longest_match;
+                break;
+            }
+        }
+        if rep_limit < self.allowed_length {
+            return empty;
+        }
+
+        // Step 2: the reverse Z-algorithm (`:3243-3283`).
+        let mut repeat_count = vec![0i32; n];
+        let last = n - 1;
+        let mut lt = 0usize;
+        let mut rt = 0usize;
+        for k in 1..n {
+            if k > rt {
+                // Outside the current Z-box: compare naively.
+                let mut matched = 0usize;
+                while matched + k < n && rat(matched) == rat(matched + k) {
+                    matched += 1;
+                }
+                repeat_count[last - k] = (matched as i32).min(rep_limit);
+                if matched > 0 {
+                    lt = k;
+                    rt = k + matched - 1;
+                }
+            } else {
+                let p = k - lt;
+                let right_part_len = (rt - k + 1) as i32;
+                if repeat_count[last - p] < right_part_len {
+                    repeat_count[last - k] = repeat_count[last - p].min(rep_limit);
+                } else {
+                    let mut i = rt + 1;
+                    while i < n && rat(i) == rat(i - k) {
+                        i += 1;
+                    }
+                    repeat_count[last - k] = ((i - k) as i32).min(rep_limit);
+                    lt = k;
+                    rt = i - 1;
+                }
+            }
+        }
+
+        // Step 3: the token that would EXTEND each repetition
+        // (`:3296-3308`). `repeat_count[i]` is about the window position
+        // `i`, so the token that follows it is `recent[i + 1]`, which is
+        // upstream's `rat(last_n_repeat - 2 - i)`.
+        let mut max_token_repeat: HashMap<usize, i32> = HashMap::new();
+        for i in 0..n - 1 {
+            let repeat_len = repeat_count[i];
+            if repeat_len < self.allowed_length {
+                continue;
+            }
+            let token = recent[i + 1];
+            let slot = max_token_repeat.entry(token).or_insert(repeat_len);
+            if *slot < repeat_len {
+                *slot = repeat_len;
+            }
+        }
+
+        // Step 4: the exponential (`:3310-3343`).
+        let mut max_exponent = 0i32;
+        if self.base > 1.000_001 {
+            max_exponent = (FLOAT_MAX_LOG / self.base.ln()) as i32;
+        }
+        let mut out = HashMap::with_capacity(max_token_repeat.len());
+        for (&token, &max_repeat) in &max_token_repeat {
+            // A token that is a whole sequence breaker is exempt: it is
+            // the thing repetition is allowed to run into.
+            if self.breakers.is_single_token_breaker(token) {
+                continue;
+            }
+            let mut repeat_exp = max_repeat - self.allowed_length;
+            if max_exponent > 0 && repeat_exp > max_exponent {
+                repeat_exp = max_exponent;
+            }
+            // `std::pow(float, int)` promotes to double upstream, and
+            // the product is narrowed back to float on assignment;
+            // computing it in f32 throughout drifts on long repeats.
+            let penalty = (self.multiplier as f64) * (self.base as f64).powi(repeat_exp);
+            out.insert(token, penalty as f32);
+        }
+        out
+    }
+}
+
+/// DRY as a caller SPELLS it: four numbers and a list of strings, with
+/// the breakers not yet tokenised.
+///
+/// This is the shape a CLI flag set and an HTTP request body arrive in,
+/// and it exists so that both front ends resolve them the same way.
+/// [`Self::resolve`] is the only bridge to [`DryParams`], and it is the
+/// one place that decides what happens when DRY is asked for and there
+/// is no vocabulary to tokenise the breakers against.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DryRequest {
+    pub multiplier: f32,
+    pub base: f32,
+    pub allowed_length: i32,
+    pub penalty_last_n: i32,
+    pub sequence_breakers: Vec<String>,
+}
+
+impl Default for DryRequest {
+    /// llama.cpp's defaults (`common/common.h:242-245, 259`), which are
+    /// DISABLED: `dry_multiplier` is 0.
+    fn default() -> Self {
+        DryRequest {
+            multiplier: 0.0,
+            base: 1.75,
+            allowed_length: 2,
+            penalty_last_n: -1,
+            sequence_breakers: DEFAULT_SEQUENCE_BREAKERS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+}
+
+/// DRY was asked for and there is no vocabulary to tokenise its
+/// sequence breakers against.
+///
+/// A refusal rather than a silent fallback to no breakers, because DRY
+/// without its breakers is not DRY with fewer features: it scans across
+/// the newline the caller told it to stop at, and the output looks like
+/// working DRY. The only checkpoints this can happen on are the ones
+/// with no real vocabulary at all (`ByteTokenizer`, the synthetic-weight
+/// demo model), where no sampler configured by text could mean what it
+/// says anyway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DryVocabMissing;
+
+impl fmt::Display for DryVocabMissing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            "the DRY sampler needs the model's vocabulary to tokenise its sequence \
+             breakers, and this checkpoint has none loaded. Pass \
+             `--dry-sequence-breaker none` to run DRY with no breakers, or \
+             `--dry-multiplier 0` to switch DRY off",
+        )
+    }
+}
+
+impl std::error::Error for DryVocabMissing {}
+
+impl DryRequest {
+    /// The same three conditions [`DryParams::is_enabled`] reads, asked
+    /// before the breakers have been tokenised -- so the expensive
+    /// vocabulary walk is skipped for the overwhelming majority of
+    /// requests, which leave DRY off.
+    pub fn is_enabled(&self) -> bool {
+        self.multiplier != 0.0 && self.base >= 1.0 && self.penalty_last_n != 0
+    }
+
+    /// Tokenise the breakers and build the sampler's parameters.
+    ///
+    /// `vocab` is `None` when the loaded checkpoint has no real
+    /// vocabulary. That is fine while DRY is off and a refusal when it
+    /// is on; see [`DryVocabMissing`].
+    ///
+    /// An EMPTY breaker list needs no vocabulary either: it is the
+    /// caller's `--dry-sequence-breaker none`, and there is nothing to
+    /// tokenise.
+    pub fn resolve(
+        &self,
+        vocab: Option<&dyn DryVocab>,
+        total_context_size: usize,
+    ) -> Result<DryParams, DryVocabMissing> {
+        if !self.is_enabled() {
+            return Ok(DryParams::off());
+        }
+        let breakers = match (self.sequence_breakers.is_empty(), vocab) {
+            (true, _) => DryBreakers::none(),
+            (false, Some(vocab)) => DryBreakers::from_vocab(vocab, &self.sequence_breakers),
+            (false, None) => return Err(DryVocabMissing),
+        };
+        Ok(DryParams::new(
+            self.multiplier,
+            self.base,
+            self.allowed_length,
+            self.penalty_last_n,
+            total_context_size,
+            breakers,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every expected value below was produced by calling the real
+    /// `llama_sampler_init_dry_testing` in `libllama` (llama.cpp b7650,
+    /// `.scratch/llama.cpp`) from a small C++ harness and reading the
+    /// logits back, not by reasoning about the algorithm. The harness
+    /// applied the sampler to logits `ln(p)` for the probabilities
+    /// llama.cpp's own `tests/test-sampling.cpp:357-361` uses, so these
+    /// cases are upstream's cases with the arithmetic checked against
+    /// upstream's code as it actually runs.
+    fn dry(
+        multiplier: f32,
+        base: f32,
+        allowed: i32,
+        last_n: i32,
+        breakers: &[Vec<usize>],
+    ) -> DryParams {
+        DryParams::new(
+            multiplier,
+            base,
+            allowed,
+            last_n,
+            1024,
+            DryBreakers::from_token_sequences(breakers),
+        )
+    }
+
+    fn penalties_of(params: &DryParams, history: &[usize]) -> Vec<(usize, f32)> {
+        let mut out: Vec<(usize, f32)> = params
+            .penalties(PenaltyWindow::new(&[], history))
+            .into_iter()
+            .collect();
+        out.sort_unstable_by_key(|&(token, _)| token);
+        out
+    }
+
+    /// The window `a b c a b` repeats its own two-token suffix `a b` at
+    /// its head, so emitting `c` would extend that repetition to three.
+    /// At `allowed_length = 2` the exponent is `2 - 2 = 0`, so the
+    /// penalty is the bare multiplier.
+    ///
+    /// libllama: logit `ln(0.25) = -1.3862944` became `-2.3862944` for
+    /// token 2 and nothing else moved.
+    #[test]
+    fn a_repeated_suffix_penalises_only_the_token_that_would_extend_it() {
+        let params = dry(1.0, 1.1, 2, 5, &[]);
+        assert_eq!(penalties_of(&params, &[0, 1, 2, 0, 1]), vec![(2, 1.0)]);
+
+        // The multiplier scales it linearly: libllama gave -3.6094379
+        // from ln(0.2) = -1.6094379, i.e. exactly 2.0.
+        let doubled = dry(2.0, 1.1, 2, 5, &[]);
+        assert_eq!(penalties_of(&doubled, &[0, 1, 2, 0, 1]), vec![(2, 2.0)]);
+    }
+
+    /// A window no longer than `allowed_length` cannot contain a
+    /// repetition worth penalising, and upstream returns before it looks
+    /// (`src/llama-sampler.cpp:3161`).
+    ///
+    /// libllama left all four logits at `ln(0.25)`.
+    #[test]
+    fn a_window_within_the_allowed_length_is_never_penalised() {
+        let params = dry(1.0, 1.1, 2, 4, &[]);
+        assert!(penalties_of(&params, &[0, 1]).is_empty());
+    }
+
+    /// `allowed_length` really is a free allowance: the window
+    /// `0 1 2 3 4 0 1` repeats a two-token suffix, and at
+    /// `allowed_length = 4` that is below the threshold, so nothing is
+    /// penalised at all.
+    ///
+    /// libllama left all five logits at `ln(0.2)`.
+    #[test]
+    fn a_repetition_shorter_than_the_allowed_length_is_free() {
+        let params = dry(1.0, 1.1, 4, 7, &[]);
+        assert!(penalties_of(&params, &[0, 1, 2, 3, 4, 0, 1]).is_empty());
+    }
+
+    /// The exponent is the repetition length MINUS the allowance, and it
+    /// grows the penalty geometrically -- which is the whole reason DRY
+    /// exists where a flat repetition penalty does not.
+    ///
+    /// Window `0 1 2 3 0 1 2 3 0 1 2` (11 tokens): its seven-token
+    /// suffix `0 1 2 3 0 1 2` also occurs at the head, so emitting `3`
+    /// would extend a repetition of length 7. At `allowed_length = 2`
+    /// and llama.cpp's default `base = 1.75` that is
+    /// `0.8 * 1.75^5 = 13.130469`.
+    ///
+    /// libllama: logit `0.0` became `-13.1304693` for token 3, and no
+    /// other logit moved.
+    #[test]
+    fn the_penalty_is_multiplier_times_base_to_the_length_over_the_allowance() {
+        let params = dry(0.8, 1.75, 2, -1, &[]);
+        let got = penalties_of(&params, &[0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2]);
+        assert_eq!(got.len(), 1, "only token 3 extends the repetition: {got:?}");
+        assert_eq!(got[0].0, 3);
+        assert!(
+            (got[0].1 - 13.130_469).abs() < 1e-4,
+            "0.8 * 1.75^5 = 13.130469, got {}",
+            got[0].1
+        );
+    }
+
+    /// A sequence breaker stops the scan, and a breaker that is a whole
+    /// token by itself is additionally exempt from being penalised.
+    ///
+    /// Window `0 1 3 4 0 1` with `3` as a single-token breaker: the
+    /// suffix `0 1` does repeat, and the token that would extend it is
+    /// `3` -- which is the breaker, so upstream skips it
+    /// (`src/llama-sampler.cpp:3325-3334`) and NOTHING is penalised.
+    ///
+    /// libllama left all five logits at `ln(0.2)`. Without the breaker
+    /// the same window penalises token 3, which is what the second half
+    /// asserts: a test that only checked the breaker case would pass for
+    /// an implementation that penalised nothing ever.
+    #[test]
+    fn a_single_token_sequence_breaker_is_never_itself_penalised() {
+        let with_breaker = dry(1.0, 1.1, 2, 6, &[vec![3]]);
+        assert!(penalties_of(&with_breaker, &[0, 1, 3, 4, 0, 1]).is_empty());
+
+        let without = dry(1.0, 1.1, 2, 6, &[]);
+        assert_eq!(penalties_of(&without, &[0, 1, 3, 4, 0, 1]), vec![(3, 1.0)]);
+    }
+
+    /// Each of the three switches upstream reads turns DRY off on its
+    /// own (`src/llama-sampler.cpp:3154`), and
+    /// [`DryParams::is_enabled`] is the one place that decides.
+    #[test]
+    fn a_zero_multiplier_a_base_below_one_or_a_zero_window_all_disable_it() {
+        let history = [0usize, 1, 2, 0, 1];
+        for params in [
+            DryParams::off(),
+            dry(0.0, 1.75, 2, -1, &[]),
+            dry(1.0, 0.5, 2, -1, &[]),
+            dry(1.0, 1.75, 2, 0, &[]),
+        ] {
+            assert!(!params.is_enabled(), "{params:?} must be disabled");
+            assert!(
+                params
+                    .penalties(PenaltyWindow::new(&[], &history))
+                    .is_empty(),
+                "{params:?} penalised something while disabled"
+            );
+        }
+        assert!(dry(1.0, 1.75, 2, -1, &[]).is_enabled());
+    }
+
+    /// `dry_penalty_last_n` bounds how far back the scan looks, so a
+    /// repetition that has fallen out of the window stops being
+    /// penalised. `-1` means the whole context.
+    #[test]
+    fn the_scan_only_sees_the_last_n_tokens() {
+        let history = [0usize, 1, 2, 0, 1];
+        // The whole window: the `0 1` prefix is visible, so token 2 is
+        // penalised (the case pinned against libllama above).
+        assert_eq!(
+            penalties_of(&dry(1.0, 1.1, 2, 5, &[]), &history),
+            vec![(2, 1.0)]
+        );
+        // Only the last three tokens `2 0 1`: no repetition left.
+        assert!(penalties_of(&dry(1.0, 1.1, 2, 3, &[]), &history).is_empty());
+        // `-1` resolves to the context size, which is wide enough here.
+        assert_eq!(
+            penalties_of(&dry(1.0, 1.1, 2, -1, &[]), &history),
+            vec![(2, 1.0)]
+        );
+    }
+
+    /// The window is the tail of PROMPT ++ GENERATED, like every other
+    /// penalty in this engine: llama.cpp feeds prompt tokens to the DRY
+    /// sampler through `common_sampler_accept` exactly as it feeds
+    /// generated ones (see [`crate::penalty_window`]).
+    ///
+    /// The same five tokens split differently across the seam must give
+    /// the same answer, or the seam is being treated as a boundary DRY
+    /// does not have.
+    #[test]
+    fn the_scan_reads_across_the_prompt_and_generation_seam() {
+        let params = dry(1.0, 1.1, 2, 5, &[]);
+        let whole = params.penalties(PenaltyWindow::new(&[], &[0, 1, 2, 0, 1]));
+        let split = params.penalties(PenaltyWindow::new(&[0, 1, 2], &[0, 1]));
+        let all_prompt = params.penalties(PenaltyWindow::new(&[0, 1, 2, 0, 1], &[]));
+        assert_eq!(whole, split);
+        assert_eq!(whole, all_prompt);
+        assert_eq!(whole.len(), 1);
+    }
+
+    /// The exponent is clamped so `base ^ exponent` cannot overflow to
+    /// infinity, which would make the penalty NaN once subtracted from
+    /// a `-inf` logit (`src/llama-sampler.cpp:3310-3318`).
+    ///
+    /// A 400-token repetition at base 1.75 would ask for `1.75 ^ 398`,
+    /// which is `inf` in an f32.
+    #[test]
+    fn a_very_long_repetition_clamps_the_exponent_rather_than_overflowing() {
+        let params = dry(1.0, 1.75, 2, -1, &[]);
+        let mut history: Vec<usize> = vec![0usize; 400];
+        history.push(1);
+        history.extend(std::iter::repeat_n(0usize, 400));
+        let penalties = params.penalties(PenaltyWindow::new(&[], &history));
+        for (token, penalty) in penalties {
+            assert!(
+                penalty.is_finite(),
+                "token {token} got a non-finite penalty {penalty}"
+            );
+        }
+    }
+
+    /// A vocabulary whose tokens are whole words, so a breaker string
+    /// can be contained in one token, span the end of one, or be absent.
+    struct WordVocab {
+        words: Vec<&'static str>,
+    }
+
+    impl DryVocab for WordVocab {
+        fn n_tokens(&self) -> usize {
+            self.words.len()
+        }
+        fn detokenize(&self, token: usize) -> String {
+            self.words[token].to_string()
+        }
+        fn tokenize(&self, text: &str) -> Vec<usize> {
+            // Longest-match-first over the same word list, which is
+            // enough to tokenise the short tails a breaker leaves.
+            let mut out = Vec::new();
+            let mut rest = text;
+            'outer: while !rest.is_empty() {
+                let mut candidates: Vec<usize> = (0..self.words.len()).collect();
+                candidates.sort_by_key(|&i| std::cmp::Reverse(self.words[i].len()));
+                for i in candidates {
+                    let w = self.words[i];
+                    if !w.is_empty() && rest.starts_with(w) {
+                        out.push(i);
+                        rest = &rest[w.len()..];
+                        continue 'outer;
+                    }
+                }
+                break;
+            }
+            out
+        }
+    }
+
+    /// A breaker that is a whole token gets an EMPTY tail, and one that
+    /// only ever appears at the end of a longer token gets the tokens
+    /// that must follow it.
+    ///
+    /// This is the half of `get_overlapping_token_sequences` a naive
+    /// "is this token equal to the breaker" implementation misses
+    /// entirely: with a vocabulary where `":"` is only ever the tail of
+    /// `"foo:"`, such an implementation finds no breakers at all and DRY
+    /// silently scans across every boundary it was told to stop at.
+    #[test]
+    fn a_breaker_is_found_inside_a_token_and_across_a_token_boundary() {
+        let vocab = WordVocab {
+            words: vec!["foo", "bar", ":", "ab", "c", "abc", "xab"],
+        };
+        // ":" is token 2 outright.
+        let colon = DryBreakers::from_vocab(&vocab, &[":".to_string()]);
+        assert_eq!(colon.tails(2), Some([Vec::new()].as_slice()));
+        assert_eq!(colon.tails(0), None, "`foo` does not contain a colon");
+        assert!(colon.is_single_token_breaker(2));
+
+        // "abc" is token 5 outright, is CONTAINED by nothing else, and
+        // OVERLAPS the end of "ab" (token 3, tail "c" = token 4) and of
+        // "xab" (token 6, same tail).
+        let abc = DryBreakers::from_vocab(&vocab, &["abc".to_string()]);
+        assert_eq!(abc.tails(5), Some([Vec::new()].as_slice()));
+        assert_eq!(abc.tails(3), Some([vec![4usize]].as_slice()));
+        assert_eq!(abc.tails(6), Some([vec![4usize]].as_slice()));
+        assert!(!abc.is_single_token_breaker(3), "`ab` needs `c` to follow");
+        assert!(abc.is_single_token_breaker(5));
+        assert_eq!(abc.tails(0), None);
+    }
+
+    /// A multi-token breaker only fires when its tail actually FOLLOWS,
+    /// which is the reason the tail is stored at all.
+    ///
+    /// Two windows differing in one token, and the token differs only in
+    /// whether it completes the breaker:
+    ///
+    /// * `foo bar : ab c foo bar : ab c` -- `ab`(3) is immediately
+    ///   followed by `c`(4), so the breaker matches one token from the
+    ///   end and `rep_limit` collapses to 0, below `allowed_length`;
+    /// * `foo bar : ab xab foo bar : ab xab` -- `ab` is followed by
+    ///   `xab`(6) instead, which is not its tail, so no breaker matches,
+    ///   the five-token suffix is found repeating, and `foo` is
+    ///   penalised for extending it.
+    ///
+    /// The third case is the control: the FIRST window with no breakers
+    /// configured at all penalises too, so the emptiness above is the
+    /// breaker's doing and not the window's.
+    #[test]
+    fn a_breaker_with_a_tail_only_stops_the_scan_when_the_tail_follows() {
+        let vocab = WordVocab {
+            words: vec!["foo", "bar", ":", "ab", "c", "abc", "xab"],
+        };
+        let breakers = DryBreakers::from_vocab(&vocab, &["abc".to_string()]);
+        assert_eq!(breakers.tails(3), Some([vec![4usize]].as_slice()));
+        let params = DryParams::new(1.0, 1.1, 2, -1, 1024, breakers);
+
+        let broken = [0usize, 1, 2, 3, 4, 0, 1, 2, 3, 4];
+        let unbroken = [0usize, 1, 2, 3, 6, 0, 1, 2, 3, 6];
+        assert!(
+            params
+                .penalties(PenaltyWindow::new(&[], &broken))
+                .is_empty(),
+            "`ab` followed by `c` is the breaker, one token from the end"
+        );
+        assert!(
+            !params
+                .penalties(PenaltyWindow::new(&[], &unbroken))
+                .is_empty(),
+            "`ab` followed by `xab` is not the breaker, so the scan runs"
+        );
+
+        let no_breakers = DryParams::new(1.0, 1.1, 2, -1, 1024, DryBreakers::none());
+        assert!(
+            !no_breakers
+                .penalties(PenaltyWindow::new(&[], &broken))
+                .is_empty(),
+            "the same window without breakers repeats, so the first \
+             assertion is about the breaker and not about the window"
+        );
+    }
+
+    /// An empty breaker string is skipped rather than turning every
+    /// token into a breaker: `word.find("")` is 0 for every string, so a
+    /// missing guard here would exempt the entire vocabulary from DRY
+    /// while leaving it switched on.
+    #[test]
+    fn an_empty_breaker_string_is_skipped() {
+        let vocab = WordVocab {
+            words: vec!["foo", "bar"],
+        };
+        let breakers = DryBreakers::from_vocab(&vocab, &[String::new()]);
+        assert!(breakers.is_empty());
+        assert_eq!(breakers.raw(), &[String::new()]);
+    }
+
+    /// llama.cpp's defaults, spelled once and read by both front ends.
+    #[test]
+    fn the_default_breakers_are_llama_cpps_four() {
+        assert_eq!(DEFAULT_SEQUENCE_BREAKERS, ["\n", ":", "\"", "*"]);
+    }
+}

--- a/crates/ferrox-models/src/lib.rs
+++ b/crates/ferrox-models/src/lib.rs
@@ -19,6 +19,7 @@ pub mod deepseek_v4_budget;
 pub mod deepseek_v4_decoder;
 pub mod device_budget;
 pub mod draft_model;
+pub mod dry;
 pub mod embedding_model;
 pub mod encoder;
 pub mod engine;

--- a/crates/ferrox-models/src/sampler_chain.rs
+++ b/crates/ferrox-models/src/sampler_chain.rs
@@ -170,6 +170,216 @@ impl Candidates {
         self.truncate(i);
     }
 
+    /// `llama_sampler_typical_apply`
+    /// (`src/llama-sampler.cpp:1713-1769`): locally typical sampling.
+    ///
+    /// Not a truncation of the TOP of the distribution. It computes the
+    /// distribution's entropy `H`, scores each candidate by how far its
+    /// surprisal `-ln p` is from `H`, and keeps the smallest set of
+    /// candidates -- ordered by that distance, so from the MIDDLE of the
+    /// distribution outward -- whose probabilities exceed `p`. A token
+    /// that is far more likely than typical is dropped just as a token
+    /// far less likely is.
+    ///
+    /// Two details that separate this from top-p, both upstream's:
+    ///
+    /// * the cutoff is `cum_sum > p`, strictly, where top-p uses `>=`;
+    /// * the surviving set is written back in DISTANCE order and
+    ///   upstream marks the array unsorted (`cur_p->sorted = false`).
+    ///   This module holds the sorted invariant instead, so the
+    ///   survivors are re-sorted by logit. The SET is what the rest of
+    ///   the chain reads, and the set is identical.
+    ///
+    /// `p >= 1.0` disables it, which is llama.cpp's default
+    /// (`typ_p = 1.00f`, `common/common.h:230`).
+    pub(crate) fn typical_p(&mut self, p: f32) {
+        if p >= 1.0 || self.logits.is_empty() {
+            return;
+        }
+        self.softmax();
+        let entropy: f32 = self.probs.iter().map(|&q| -q * q.ln()).sum();
+        // The absolute difference between surprisal and entropy, which
+        // is what "typical" means here.
+        let shifted: Vec<f32> = self
+            .probs
+            .iter()
+            .map(|&q| (-q.ln() - entropy).abs())
+            .collect();
+        let mut order: Vec<usize> = (0..self.len()).collect();
+        // Ties broken on the index, where upstream's `std::sort` leaves
+        // them unspecified: a generation reproducible from a seed must
+        // not depend on a sort's tie-breaking.
+        order.sort_by(|&a, &b| shifted[a].total_cmp(&shifted[b]).then(a.cmp(&b)));
+
+        let mut cum_sum = 0.0f32;
+        let mut last_idx = order.len();
+        for (i, &idx) in order.iter().enumerate() {
+            cum_sum += self.probs[idx];
+            if cum_sum > p {
+                last_idx = i + 1;
+                break;
+            }
+        }
+        let mut keep: Vec<usize> = order[..last_idx].to_vec();
+        keep.sort_unstable();
+        self.retain_positions(&keep);
+    }
+
+    /// `llama_sampler_top_n_sigma_apply`
+    /// (`src/llama-sampler.cpp:3002-3039`): mask every candidate more
+    /// than `n` standard deviations of the LOGITS below the maximum.
+    ///
+    /// The statistic is over the raw logits, not the probabilities, and
+    /// `-inf` entries (a candidate an earlier step already masked) are
+    /// excluded from the mean and the deviation but still masked.
+    ///
+    /// Upstream sets the losing logits to `-inf` rather than removing
+    /// them, and this does the same: the candidates stay in the list
+    /// with zero probability, so a later `top_k` still counts them, as
+    /// it does upstream. Because the list is held sorted by descending
+    /// logit and the cut is a threshold, the masked candidates are
+    /// always a suffix, so the invariant survives untouched.
+    ///
+    /// `n <= 0.0` disables it, which is llama.cpp's default
+    /// (`top_n_sigma = -1.00f`, `common/common.h:250`). Note that `0.0`
+    /// is a no-op and NOT greedy decoding, as of upstream PR 13345.
+    pub(crate) fn top_n_sigma(&mut self, n: f32) {
+        if n <= 0.0 || self.len() <= 1 {
+            return;
+        }
+        let mut max = self.logits[0];
+        let mut logits_sum = 0.0f32;
+        let mut valid_count = 0usize;
+        for &l in self.logits.iter() {
+            if l != f32::NEG_INFINITY {
+                max = max.max(l);
+                logits_sum += l;
+                valid_count += 1;
+            }
+        }
+        let mean = if valid_count > 0 {
+            logits_sum / valid_count as f32
+        } else {
+            0.0
+        };
+        // Upstream accumulates a float from a double `pow`, so each
+        // addition rounds to f32 while the square itself does not.
+        let mut acc = 0.0f32;
+        for &l in self.logits.iter() {
+            if l != f32::NEG_INFINITY {
+                acc = (acc as f64 + ((l - mean) as f64).powi(2)) as f32;
+            }
+        }
+        let std = if valid_count > 0 {
+            (acc as f64 / valid_count as f64).sqrt() as f32
+        } else {
+            0.0
+        };
+        let threshold = max - n * std;
+        for l in self.logits.iter_mut() {
+            if *l < threshold {
+                *l = f32::NEG_INFINITY;
+            }
+        }
+    }
+
+    /// `llama_sample_xtc_apply` (`src/llama-sampler.cpp:2137-2168`):
+    /// "exclude top choices".
+    ///
+    /// The only sampler here that removes candidates from the TOP. With
+    /// probability `probability` it drops every candidate whose
+    /// probability is at or above `threshold` EXCEPT the least likely of
+    /// them, on the theory that the most obvious continuation is the
+    /// boring one. `chance` is the draw that decides, and it comes from
+    /// the generation's own seeded stream -- see
+    /// [`crate::sampling::Sampler::xtc_roll`] for why it is a parameter
+    /// here rather than an RNG this module owns.
+    ///
+    /// Three guards, all upstream's: a non-positive probability, a
+    /// threshold above 0.5 (above which more than one candidate can
+    /// never clear it and the sampler is meaningless), and a list with
+    /// fewer than two candidates. `min_keep` is folded out at 0, as
+    /// everywhere else in this module.
+    ///
+    /// `pos_last > 0` is what keeps the last-remaining candidate: when
+    /// only the top candidate clears the threshold, nothing is removed.
+    pub(crate) fn xtc(&mut self, probability: f32, threshold: f32, chance: f32) {
+        if probability <= 0.0 || threshold > 0.5 || self.len() < 2 {
+            return;
+        }
+        if chance > probability {
+            return;
+        }
+        self.softmax();
+        let mut pos_last = 0usize;
+        for i in 0..self.len() {
+            if self.probs[i] >= threshold {
+                pos_last = i;
+            } else {
+                break;
+            }
+        }
+        if pos_last > 0 {
+            self.drop_front(pos_last);
+        }
+    }
+
+    /// `llama_sampler_dry_apply`'s step 4 (`src/llama-sampler.cpp:3320`):
+    /// subtract the DRY penalty from each candidate that has one.
+    ///
+    /// The penalties themselves are [`crate::dry::DryParams::penalties`],
+    /// which is where the Z-algorithm and the sequence breakers live;
+    /// this is only the subtraction, and the re-sort that keeps this
+    /// module's invariant after logits have moved by different amounts.
+    /// Upstream marks the array unsorted here for the same reason.
+    pub(crate) fn dry(&mut self, penalties: &std::collections::HashMap<usize, f32>) {
+        if penalties.is_empty() {
+            return;
+        }
+        let mut moved = false;
+        for (id, logit) in self.ids.iter().zip(self.logits.iter_mut()) {
+            if let Some(&penalty) = penalties.get(id) {
+                *logit -= penalty;
+                moved = true;
+            }
+        }
+        if moved {
+            self.resort();
+        }
+    }
+
+    /// Keep the candidates at these positions, which must be ascending
+    /// and in range. The order is preserved, so the sorted invariant
+    /// survives a filter that only ever removes.
+    fn retain_positions(&mut self, keep: &[usize]) {
+        let ids: Vec<usize> = keep.iter().map(|&i| self.ids[i]).collect();
+        let logits: Vec<f32> = keep.iter().map(|&i| self.logits[i]).collect();
+        self.probs.truncate(ids.len());
+        self.ids = ids;
+        self.logits = logits;
+    }
+
+    /// Drop the `n` most likely candidates. Only XTC does this.
+    fn drop_front(&mut self, n: usize) {
+        self.ids.drain(..n);
+        self.logits.drain(..n);
+        self.probs.truncate(self.ids.len());
+    }
+
+    /// Restore the descending-logit invariant after logits have been
+    /// changed by different amounts. Ties break on the token id, for the
+    /// same reproducibility reason [`Self::new`] does.
+    fn resort(&mut self) {
+        let mut order: Vec<usize> = (0..self.len()).collect();
+        order.sort_unstable_by(|&a, &b| {
+            self.logits[b]
+                .total_cmp(&self.logits[a])
+                .then(self.ids[a].cmp(&self.ids[b]))
+        });
+        self.ids = order.iter().map(|&i| self.ids[i]).collect();
+        self.logits = order.iter().map(|&i| self.logits[i]).collect();
+    }
+
     /// `llama_sampler_temp_impl` (`src/llama-sampler.cpp:265`) for
     /// `temp > 0`: divide every surviving logit by the temperature.
     ///
@@ -299,5 +509,234 @@ mod tests {
         assert_eq!(probs[3], 0.0);
         // temp 0.5 doubles the logit gap: e^2 / (e^2 + 1) = 0.8808.
         assert!((probs[0] - 0.880_797).abs() < 1e-5, "got {}", probs[0]);
+    }
+
+    /// Logits whose softmax is exactly `probs`, so a case lifted from
+    /// llama.cpp's `tests/test-sampling.cpp` (which builds its candidate
+    /// array as `logit = logf(p)`) can be run here unchanged.
+    fn from_probs(probs: &[f32]) -> Vec<f32> {
+        probs.iter().map(|p| p.ln()).collect()
+    }
+
+    /// Locally typical sampling keeps the candidates CLOSEST to the
+    /// distribution's entropy, which is not the same set as the most
+    /// likely ones -- and on a flat-ish distribution it drops the leader.
+    ///
+    /// Both rows are llama.cpp's own
+    /// (`tests/test-sampling.cpp:345-346`), re-run against `libllama`
+    /// (b7650) to read the surviving TOKEN IDS rather than only the
+    /// probabilities, because upstream writes the survivors back in
+    /// distance order and this module re-sorts them:
+    ///
+    /// * `{0.97, 0.01, 0.01, 0.01}` at `p = 0.5` keeps `{0}`;
+    /// * `{0.4, 0.2, 0.2, 0.2}` at `p = 0.5` keeps `{1, 2, 3}` -- the
+    ///   0.4 leader is the ATYPICAL one and is dropped.
+    ///
+    /// A top-p implementation given the same two rows keeps `{0}` in
+    /// both, so the second row is what makes this a test of typical-p.
+    #[test]
+    fn typical_p_keeps_the_candidates_nearest_the_entropy_and_can_drop_the_leader() {
+        let mut c = Candidates::new(&from_probs(&[0.97, 0.01, 0.01, 0.01]));
+        c.typical_p(0.5);
+        assert_eq!(c.ids, vec![0]);
+
+        let mut c = Candidates::new(&from_probs(&[0.4, 0.2, 0.2, 0.2]));
+        c.typical_p(0.5);
+        assert_eq!(c.ids, vec![1, 2, 3], "the 0.4 leader is atypical here");
+
+        // And the contrast that names what this is not: top-p at the
+        // same 0.5 KEEPS the leader (and one more), where typical-p
+        // dropped it. No truncation-from-the-top filter can produce the
+        // set above.
+        let mut c = Candidates::new(&from_probs(&[0.4, 0.2, 0.2, 0.2]));
+        c.top_p(0.5);
+        assert_eq!(c.ids, vec![0, 1]);
+    }
+
+    /// The cutoff is `cum_sum > p` STRICTLY, where top-p's is `>=`, and
+    /// the candidate that crosses it is kept.
+    ///
+    /// Logits `[3, 2, 1, 0]`, hand-computed: the softmax is
+    /// `[0.6439, 0.2369, 0.0871, 0.0321]`, the entropy is `0.9477`, and
+    /// the distances `|-ln p - H|` are `[0.5074, 0.4925, 1.4927,
+    /// 2.4919]`, so the visiting order is `1, 0, 2, 3` and the running
+    /// sums are `0.2369, 0.8808, 0.9679`. At `p = 0.5` the second sum
+    /// already exceeds it, so two survive; at `p = 0.9` the third does,
+    /// so three do. libllama returns exactly `[1, 0]` and `[1, 0, 2]`.
+    #[test]
+    fn typical_p_cuts_on_a_strict_running_sum_over_the_distance_order() {
+        let mut c = Candidates::new(&[3.0f32, 2.0, 1.0, 0.0]);
+        c.typical_p(0.5);
+        assert_eq!(c.ids, vec![0, 1], "0.2369 then 0.8808 crosses 0.5");
+
+        let mut c = Candidates::new(&[3.0f32, 2.0, 1.0, 0.0]);
+        c.typical_p(0.9);
+        assert_eq!(c.ids, vec![0, 1, 2], "0.8808 is not > 0.9; 0.9679 is");
+
+        // 1.0 disables it, which is llama.cpp's default and is what
+        // keeps the nine-step default chain a no-op.
+        let mut c = Candidates::new(&[3.0f32, 2.0, 1.0, 0.0]);
+        c.typical_p(1.0);
+        assert_eq!(c.ids, vec![0, 1, 2, 3]);
+    }
+
+    /// The `>` is STRICT, and llama.cpp's `top_p` beside it is not.
+    ///
+    /// Four equal logits give four probabilities of exactly 0.25, whose
+    /// partial sums (0.25, 0.5, 0.75) are exact in an f32 -- so this is
+    /// the one shape where strict and inclusive give different answers
+    /// without depending on rounding. libllama (b7650) returns 2, 3 and
+    /// 4 survivors at p = 0.25, 0.5 and 0.75; the inclusive reading
+    /// would return 1, 2 and 3.
+    ///
+    /// Only the COUNT is asserted. With every distance tied, upstream's
+    /// `std::sort` leaves the survivors in an unspecified order and
+    /// libllama actually returns `2, 0` for the first row; this module
+    /// breaks ties on the token id instead, because a generation
+    /// reproducible from a seed must not depend on a sort's internals.
+    #[test]
+    fn typical_ps_running_sum_is_strict_where_top_ps_is_inclusive() {
+        for (p, expected) in [(0.25f32, 2usize), (0.5, 3), (0.75, 4)] {
+            let mut c = Candidates::new(&[0.0f32; 4]);
+            c.typical_p(p);
+            assert_eq!(c.len(), expected, "typical_p({p})");
+        }
+        // The contrast, on the same exact sums: top-p's `>=` keeps one
+        // fewer at each threshold.
+        for (p, expected) in [(0.25f32, 1usize), (0.5, 2), (0.75, 3)] {
+            let mut c = Candidates::new(&[0.0f32; 4]);
+            c.top_p(p);
+            assert_eq!(c.len(), expected, "top_p({p})");
+        }
+    }
+
+    /// top-n-sigma masks on the standard deviation of the LOGITS, and
+    /// masks to `-inf` rather than removing.
+    ///
+    /// Hand-computed for `probs {0.1, 0.2, 0.3, 0.4}`, whose logits are
+    /// `[-2.3026, -1.6094, -1.2040, -0.9163]`: the mean is `-1.5081`,
+    /// the deviations square to `1.0840` in total, so `sigma = 0.5206`
+    /// and the threshold at `n = 1` is `-0.9163 - 0.5206 = -1.4369`.
+    /// The two smallest logits fall below it. libllama returns exactly
+    /// that: ids 0 and 1 at `-inf`, ids 2 and 3 untouched.
+    #[test]
+    fn top_n_sigma_masks_everything_more_than_n_sigma_below_the_top_logit() {
+        let mut c = Candidates::new(&from_probs(&[0.1, 0.2, 0.3, 0.4]));
+        c.top_n_sigma(1.0);
+        // Sorted descending, so the surviving order is 3, 2, 1, 0.
+        assert_eq!(c.ids, vec![3, 2, 1, 0], "masking must not remove");
+        assert!(c.logits[0].is_finite() && c.logits[1].is_finite());
+        assert_eq!(c.logits[2], f32::NEG_INFINITY);
+        assert_eq!(c.logits[3], f32::NEG_INFINITY);
+        // The mask is what the rest of the chain sees: zero probability.
+        let probs = c.into_distribution(4);
+        assert_eq!(probs[0], 0.0);
+        assert_eq!(probs[1], 0.0);
+        assert!(probs[2] > 0.0 && probs[3] > 0.0);
+    }
+
+    /// `n` is a knob, not a switch: tightening it masks more.
+    ///
+    /// Logits `[4, 3, 2, 1, 0]` have mean 2 and `sigma = sqrt(2) =
+    /// 1.4142`. At `n = 1` the threshold is `4 - 1.4142 = 2.5858`, so
+    /// the 4 and the 3 survive; at `n = 0.5` it is `3.2929`, so only the
+    /// 4 does. libllama returns exactly those two masks.
+    ///
+    /// `n <= 0` disables it, and `0.0` is a NO-OP rather than greedy
+    /// decoding as of upstream PR 13345 -- a reading worth pinning,
+    /// because the obvious one (zero sigmas means keep only the max) is
+    /// what llama.cpp used to do and no longer does.
+    #[test]
+    fn a_smaller_n_masks_more_and_a_non_positive_n_masks_nothing() {
+        let masked = |n: f32| {
+            let mut c = Candidates::new(&[4.0f32, 3.0, 2.0, 1.0, 0.0]);
+            c.top_n_sigma(n);
+            c.logits.iter().filter(|l| l.is_finite()).count()
+        };
+        assert_eq!(masked(1.0), 2, "threshold 4 - sqrt(2) = 2.5858");
+        assert_eq!(masked(0.5), 1, "threshold 4 - 0.7071 = 3.2929");
+        assert_eq!(masked(3.0), 5, "threshold 4 - 4.2426 keeps everything");
+        assert_eq!(masked(0.0), 5, "0.0 is a no-op, not greedy");
+        assert_eq!(masked(-1.0), 5, "the default, disabled");
+    }
+
+    /// XTC removes the top candidates ABOVE the threshold, keeping the
+    /// least likely of them -- the only filter here that cuts from the
+    /// top.
+    ///
+    /// Every row is llama.cpp's own
+    /// (`tests/test-sampling.cpp:338-343`) re-run against `libllama`,
+    /// on `probs {0.4, 0.3, 0.2, 0.1}`:
+    ///
+    /// | threshold | survivors |
+    /// |---|---|
+    /// | 0.09 | `{3}` |
+    /// | 0.19 | `{2, 3}` |
+    /// | 0.29 | `{1, 2, 3}` |
+    /// | 0.39 | all four |
+    ///
+    /// The last row is the guard that matters: only the 0.4 candidate
+    /// clears 0.39, so `pos_last` is 0 and XTC removes NOTHING. An
+    /// implementation that dropped every candidate at or above the
+    /// threshold would empty the list on that row.
+    #[test]
+    fn xtc_removes_every_candidate_above_the_threshold_except_the_least_likely() {
+        for (threshold, expected) in [
+            (0.09f32, vec![3usize]),
+            (0.19, vec![2, 3]),
+            (0.29, vec![1, 2, 3]),
+            (0.39, vec![0, 1, 2, 3]),
+        ] {
+            let mut c = Candidates::new(&from_probs(&[0.4, 0.3, 0.2, 0.1]));
+            // A chance below the probability, so the draw always fires.
+            c.xtc(0.99, threshold, 0.0);
+            assert_eq!(c.ids, expected, "threshold {threshold}");
+        }
+    }
+
+    /// XTC is a coin flip, and the coin is the caller's.
+    ///
+    /// `chance > probability` skips, so a draw above the configured
+    /// probability leaves the list alone. This is the whole reason
+    /// `Sampler::xtc_roll` exists: pass a roll the chain never made and
+    /// the filter silently never runs.
+    #[test]
+    fn xtc_only_fires_when_the_draw_falls_under_the_probability() {
+        let fired = |probability: f32, chance: f32| {
+            let mut c = Candidates::new(&from_probs(&[0.4, 0.3, 0.2, 0.1]));
+            c.xtc(probability, 0.09, chance);
+            c.ids.len() < 4
+        };
+        assert!(fired(0.5, 0.49));
+        assert!(fired(0.5, 0.5), "the test is `chance > probability`");
+        assert!(!fired(0.5, 0.51));
+        // And both of upstream's disabling guards.
+        assert!(!fired(0.0, 0.0), "probability 0.0 disables");
+        let mut above_half = Candidates::new(&from_probs(&[0.4, 0.3, 0.2, 0.1]));
+        above_half.xtc(1.0, 0.51, 0.0);
+        assert_eq!(above_half.ids.len(), 4, "a threshold above 0.5 disables");
+    }
+
+    /// DRY subtracts per-token penalties and the list stays sorted.
+    ///
+    /// The sorted invariant is not decoration: every filter after this
+    /// one reads `logits[0]` as the maximum, so a DRY penalty that
+    /// pushed the leader below its neighbour without a re-sort would
+    /// give min-p and top-p the wrong reference point. Upstream marks
+    /// its array unsorted here for the same reason.
+    #[test]
+    fn dry_subtracts_its_penalty_and_leaves_the_list_sorted() {
+        let mut penalties = std::collections::HashMap::new();
+        penalties.insert(0usize, 2.5f32);
+        let mut c = Candidates::new(&[3.0f32, 2.0, 1.0]);
+        c.dry(&penalties);
+        assert_eq!(c.ids, vec![1, 2, 0], "3.0 - 2.5 = 0.5 now sorts last");
+        assert_eq!(c.logits, vec![2.0, 1.0, 0.5]);
+        // An empty penalty map is a no-op, which is what keeps `dry` in
+        // the default chain free.
+        let mut c = Candidates::new(&[3.0f32, 2.0, 1.0]);
+        c.dry(&std::collections::HashMap::new());
+        assert_eq!(c.ids, vec![0, 1, 2]);
+        assert_eq!(c.logits, vec![3.0, 2.0, 1.0]);
     }
 }

--- a/crates/ferrox-models/src/sampler_order.rs
+++ b/crates/ferrox-models/src/sampler_order.rs
@@ -33,12 +33,14 @@
 //!
 //! # Partial support, stated
 //!
-//! ferrox implements five of llama.cpp's samplers. The rest are named
-//! in the table purely so that asking for one is a refusal that says
-//! WHICH sampler is missing, rather than an unknown-name error or, far
-//! worse, a chain quietly built without it. A caller who asked for
-//! `xtc` and was served a chain with no XTC in it got a different
-//! sampler than they requested and no way to tell.
+//! ferrox implements llama.cpp's whole default chain: `penalties`,
+//! `dry`, `top_n_sigma`, `top_k`, `typ_p`, `top_p`, `min_p`, `xtc` and
+//! `temperature`. `mirostat` and `infill` are named in the table purely
+//! so that asking for one is a refusal that says WHICH sampler is
+//! missing, rather than an unknown-name error or, far worse, a chain
+//! quietly built without it. A caller who asked for `mirostat` and was
+//! served a chain without it got a different sampler than they
+//! requested and no way to tell.
 
 use std::fmt;
 use std::str::FromStr;
@@ -111,9 +113,16 @@ sampler_names! {
 pub enum ChainStep {
     /// The repetition / presence / frequency penalties.
     Penalties,
+    /// The DRY sequence-repetition penalty; see [`crate::dry`].
+    Dry,
+    TopNSigma,
     TopK,
+    /// Locally typical sampling, llama.cpp's `typ_p`.
+    TypP,
     TopP,
     MinP,
+    /// "Exclude top choices", llama.cpp's `xtc`.
+    Xtc,
     Temperature,
 }
 
@@ -123,11 +132,31 @@ impl ChainStep {
     pub const fn name(self) -> SamplerName {
         match self {
             ChainStep::Penalties => SamplerName::Penalties,
+            ChainStep::Dry => SamplerName::Dry,
+            ChainStep::TopNSigma => SamplerName::TopNSigma,
             ChainStep::TopK => SamplerName::TopK,
+            ChainStep::TypP => SamplerName::TypP,
             ChainStep::TopP => SamplerName::TopP,
             ChainStep::MinP => SamplerName::MinP,
+            ChainStep::Xtc => SamplerName::Xtc,
             ChainStep::Temperature => SamplerName::Temperature,
         }
+    }
+
+    /// Every step this engine can run, DERIVED from the name table
+    /// rather than restated beside it.
+    ///
+    /// A hand-written list here would be a second structure that had to
+    /// agree with [`SamplerName::implemented`], which is the defect
+    /// shape this whole module is built to avoid. Derived, "is a step"
+    /// and "has a name that maps to it" are the same statement, and
+    /// `tests::every_step_the_name_table_yields_names_itself_back`
+    /// closes the loop in the other direction.
+    pub fn all() -> Vec<ChainStep> {
+        SamplerName::ALL
+            .iter()
+            .filter_map(|n| n.implemented().ok())
+            .collect()
     }
 }
 
@@ -143,29 +172,14 @@ impl SamplerName {
     pub const fn implemented(self) -> Result<ChainStep, &'static str> {
         match self {
             SamplerName::Penalties => Ok(ChainStep::Penalties),
+            SamplerName::Dry => Ok(ChainStep::Dry),
+            SamplerName::TopNSigma => Ok(ChainStep::TopNSigma),
             SamplerName::TopK => Ok(ChainStep::TopK),
+            SamplerName::TypP => Ok(ChainStep::TypP),
             SamplerName::TopP => Ok(ChainStep::TopP),
             SamplerName::MinP => Ok(ChainStep::MinP),
+            SamplerName::Xtc => Ok(ChainStep::Xtc),
             SamplerName::Temperature => Ok(ChainStep::Temperature),
-            SamplerName::Dry => Err(
-                "the DRY repetition sampler is not implemented: it needs the n-gram \
-                 breaker state llama.cpp keeps per sequence, which this engine has no \
-                 equivalent of",
-            ),
-            SamplerName::TypP => Err(
-                "locally typical sampling (`typ_p`) is not implemented: no filter in \
-                 this engine ranks candidates by their distance from the distribution's \
-                 entropy",
-            ),
-            SamplerName::Xtc => Err(
-                "the XTC sampler is not implemented: it removes the TOP candidates with \
-                 a probability, which is the only sampler here that would need its own \
-                 draw off the RNG stream",
-            ),
-            SamplerName::TopNSigma => Err(
-                "top-n-sigma truncation is not implemented: no filter here cuts on the \
-                 standard deviation of the logits",
-            ),
             SamplerName::Mirostat => Err(
                 "mirostat is not implemented. It is not a chain member upstream either \
                  (llama.cpp spells it `--mirostat` and it REPLACES the chain), so there \
@@ -270,19 +284,29 @@ pub struct SamplerOrder {
     len: usize,
 }
 
-/// ferrox's chain, which is llama.cpp's default chain restricted to the
-/// samplers ferrox has: penalties, top-k, top-p, min-p, and
-/// **temperature last**.
+/// llama.cpp's default chain, verbatim: `penalties, dry, top_n_sigma,
+/// top_k, typical_p, top_p, min_p, xtc, temperature`
+/// (`common/common.h:259-269`), with **temperature last**.
+///
+/// The four steps ferrox gained in `feat/sampler-parity` are all
+/// NO-OPS at their neutral defaults (`dry_multiplier 0.0`,
+/// `top_n_sigma -1.0`, `typical_p 1.0`, `xtc_probability 0.0`), so
+/// adding them to the default chain changes no run that did not
+/// configure them -- asserted bit-for-bit by
+/// `sampling::tests::the_default_order_is_the_chain_ferrox_already_ran`,
+/// which compares against the five-step chain ferrox used to run.
 ///
 /// This is the single definition of "the default". Changing it changes
-/// every run that did not pass `--samplers`, which
-/// `sampling::tests::the_default_order_is_the_chain_ferrox_already_ran`
-/// exists to catch.
-const DEFAULT_STEPS: [ChainStep; 5] = [
+/// every run that did not pass `--samplers`.
+const DEFAULT_STEPS: [ChainStep; 9] = [
     ChainStep::Penalties,
+    ChainStep::Dry,
+    ChainStep::TopNSigma,
     ChainStep::TopK,
+    ChainStep::TypP,
     ChainStep::TopP,
     ChainStep::MinP,
+    ChainStep::Xtc,
     ChainStep::Temperature,
 ];
 
@@ -426,19 +450,72 @@ impl std::hash::Hash for SamplerOrder {
 mod tests {
     use super::*;
 
-    /// The default chain is the one ferrox already ran, spelled out.
+    /// The default chain is llama.cpp's default chain, spelled out.
     ///
-    /// The distribution-level proof is
+    /// The distribution-level proof that adding the four new steps
+    /// changed nothing is
     /// `sampling::tests::the_default_order_is_the_chain_ferrox_already_ran`;
-    /// this is the cheap statement of the same fact, so a reordering of
-    /// `DEFAULT_STEPS` is visible in one line of diff.
+    /// this is the cheap statement of the order itself, so a reordering
+    /// of `DEFAULT_STEPS` is visible in one line of diff.
     #[test]
-    fn the_default_chain_is_penalties_top_k_top_p_min_p_then_temperature() {
+    fn the_default_chain_is_llama_cpps_default_chain() {
         assert_eq!(
             SamplerOrder::default().to_string(),
-            "penalties;top_k;top_p;min_p;temperature"
+            "penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature"
         );
         assert!(SamplerOrder::default().has_penalties());
+    }
+
+    /// Every step the name table can produce names itself back, and
+    /// every step [`ChainStep::all`] lists is one the table produces.
+    ///
+    /// This is the closing half of the "one table" guarantee. The
+    /// compiler already forces [`ChainStep::name`] to cover every
+    /// variant and [`SamplerName::implemented`] to cover every name; what
+    /// neither forces is that a step given a name is a name that maps
+    /// BACK to it. A `ChainStep::Xtc => SamplerName::TopK` typo compiles,
+    /// and would make `xtc` build a chain running top-k twice.
+    #[test]
+    fn every_step_the_name_table_yields_names_itself_back() {
+        let steps = ChainStep::all();
+        assert!(!steps.is_empty());
+        for step in &steps {
+            assert_eq!(
+                step.name().implemented(),
+                Ok(*step),
+                "{step:?} is spelled `{}`, which maps to a different step",
+                step.name().as_str()
+            );
+        }
+        // And no two steps share a spelling, which would make the
+        // round-trip above pass while one step was unreachable.
+        let mut names: Vec<&str> = steps.iter().map(|s| s.name().as_str()).collect();
+        names.sort_unstable();
+        let before = names.len();
+        names.dedup();
+        assert_eq!(before, names.len(), "two steps share a name");
+    }
+
+    /// Every step this engine implements is in the DEFAULT chain, and in
+    /// llama.cpp's order.
+    ///
+    /// A step that were implemented, parseable and left out of the
+    /// default would run only for callers who named it explicitly --
+    /// which is llama.cpp's shape for `mirostat` and NOT for anything in
+    /// its default chain, so it would be a silent divergence from
+    /// upstream for every unconfigured run.
+    #[test]
+    fn the_default_chain_contains_every_step_this_engine_implements() {
+        let mut implemented = ChainStep::all();
+        let mut defaulted = SamplerOrder::default().steps().to_vec();
+        assert_eq!(
+            defaulted, implemented,
+            "the default chain and the implemented set must be the same steps \
+             in the same order"
+        );
+        implemented.sort_by_key(|s| s.name().as_str());
+        defaulted.sort_by_key(|s| s.name().as_str());
+        assert_eq!(defaulted, implemented);
     }
 
     /// Every name in the generated table parses back to itself, which is
@@ -509,12 +586,12 @@ mod tests {
     /// The samplers llama.cpp has and ferrox does not are refused BY
     /// NAME, with the reason, rather than dropped from the chain.
     ///
-    /// A caller who asked for `xtc` and was handed a chain without it
-    /// was given a different sampler and served a 200. This is the whole
-    /// reason those names are in the table at all.
+    /// A caller who asked for `mirostat` and was handed a chain without
+    /// it was given a different sampler and served a 200. This is the
+    /// whole reason those names are in the table at all.
     #[test]
     fn a_real_but_unimplemented_sampler_is_refused_with_its_reason() {
-        for name in ["dry", "xtc", "typ_p", "mirostat", "top_n_sigma", "infill"] {
+        for name in ["mirostat", "infill"] {
             let err = format!("top_k;{name};temperature")
                 .parse::<SamplerOrder>()
                 .expect_err(&format!("`{name}` must be refused, not skipped"));
@@ -548,16 +625,18 @@ mod tests {
     /// MESSAGE is asserted and not just the failure.
     #[test]
     fn an_unimplemented_sampler_names_itself_and_says_what_is_implemented() {
-        let err = "top_k;xtc".parse::<SamplerOrder>().expect_err("no xtc");
+        let err = "top_k;mirostat"
+            .parse::<SamplerOrder>()
+            .expect_err("no mirostat");
         assert_eq!(
             err,
             SamplerOrderError::Unimplemented {
-                name: "xtc",
-                reason: SamplerName::Xtc.implemented().unwrap_err(),
+                name: "mirostat",
+                reason: SamplerName::Mirostat.implemented().unwrap_err(),
             }
         );
         let message = err.to_string();
-        assert!(message.contains("`xtc`"), "{message}");
+        assert!(message.contains("`mirostat`"), "{message}");
         assert!(
             message.contains("top_k"),
             "must list what IS there: {message}"

--- a/crates/ferrox-models/src/sampling.rs
+++ b/crates/ferrox-models/src/sampling.rs
@@ -1,6 +1,13 @@
-//! Token sampling from a decoder's output logits: temperature, top-k,
-//! top-p (nucleus), and repetition penalty, on top of the greedy argmax
-//! ferrox previously always used unconditionally.
+//! Token sampling from a decoder's output logits: llama.cpp's whole
+//! default sampler chain, on top of the greedy argmax ferrox previously
+//! always used unconditionally.
+//!
+//! The chain is `penalties, dry, top_n_sigma, top_k, typical_p, top_p,
+//! min_p, xtc, temperature` (`common/common.h:259-269`), which is
+//! [`crate::sampler_order::SamplerOrder`]'s default and llama.cpp's.
+//! The filters themselves are in [`crate::sampler_chain`], the DRY
+//! penalty in [`crate::dry`], the three history penalties in
+//! [`penalties`], the parameters in [`params`].
 //!
 //! `crate::speculative` verifies draft tokens against
 //! [`sampling_distribution`] -- the exact distribution [`Sampler`]
@@ -14,391 +21,70 @@
 //! dependency tree the same minimal, pure-Rust shape as the rest of
 //! this crate.
 
+mod params;
+mod penalties;
+mod recommended;
+mod rng;
+
+pub use params::SamplingParams;
+pub use recommended::{RecommendedSampling, RequestedSampling};
+pub use rng::{LogitMask, Sampler};
+
 use crate::penalty_window::PenaltyWindow;
 use crate::sampler_chain::Candidates;
-use crate::sampler_order::{ChainStep, SamplerOrder};
+use crate::sampler_order::ChainStep;
+use penalties::apply_history_penalties;
 
-/// Sampling parameters for one generation request. `temperature <= 0.0`
-/// means "sample nothing, take the greedy argmax" -- the same
-/// deterministic behavior ferrox always had before this module existed.
-#[derive(Debug, Clone)]
-pub struct SamplingParams {
-    pub temperature: f32,
-    /// Nucleus sampling threshold in (0.0, 1.0]. 1.0 disables top-p
-    /// filtering (every token with nonzero probability is eligible).
-    pub top_p: f32,
-    /// Keep only candidates at least `min_p` times as likely as the most
-    /// likely one. `0.0` disables it; llama.cpp's `--min-p`, whose
-    /// default is **0.05** (`common/common.h:231`) rather than off.
-    ///
-    /// That default is why this is a parity item and not a feature:
-    /// llama.cpp truncates with min-p on every run nobody configured,
-    /// so without it ferrox could not reproduce llama.cpp's *own*
-    /// out-of-the-box output for any prompt.
-    ///
-    /// The struct default here stays `0.0` (disabled) for the same
-    /// reason `temperature` defaults to greedy: `SamplingParams::default`
-    /// is ferrox's "do nothing the caller did not ask for" baseline, and
-    /// llama.cpp's CLI numbers live on the CLI flags.
-    pub min_p: f32,
-    /// Keep only the `top_k` highest-probability tokens before
-    /// sampling. 0 disables top-k filtering.
-    pub top_k: usize,
-    /// > 1.0 discourages repeating a token already in the
-    /// > [`PenaltyWindow`] -- prompt included; 1.0
-    /// > disables repetition penalty. Uses the standard convention
-    /// > (divide positive logits, multiply negative ones) so the penalty
-    /// > always pushes toward *less* likely, regardless of logit sign.
-    pub repetition_penalty: f32,
-    /// How many of the most recent tokens the penalties look at, as
-    /// llama.cpp's `penalty_last_n` (`common/common.h:238`, default 64).
-    ///
-    /// `0` disables the penalties entirely. ferrox had no window at all
-    /// and scanned the WHOLE history, so on a long generation it
-    /// penalised a steadily growing set of tokens where llama.cpp
-    /// penalises the last 64 -- the divergence grew with output length,
-    /// which is exactly when a repetition penalty matters most.
-    pub penalty_last_n: usize,
-    /// OpenAI-style presence penalty: subtract from logits of tokens
-    /// that already appeared in the [`PenaltyWindow`] (once per
-    /// distinct token).
-    pub presence_penalty: f32,
-    /// OpenAI-style frequency penalty: subtract `frequency_penalty *
-    /// count` from logits for each token id seen in the
-    /// [`PenaltyWindow`].
-    pub frequency_penalty: f32,
-    /// The ORDER the chain above runs in, llama.cpp's `--samplers`.
-    ///
-    /// Not a cosmetic setting. Each filter renormalises over the
-    /// survivors of the last one, so moving a step changes which
-    /// candidates the next step can see -- ferrox has already shipped
-    /// that bug once, with temperature running first.
-    ///
-    /// The default is ferrox's existing chain
-    /// (`penalties;top_k;top_p;min_p;temperature`), so a caller that
-    /// never touches this field samples exactly what it always did. See
-    /// [`crate::sampler_order`].
-    pub sampler_order: SamplerOrder,
-}
-
-impl Default for SamplingParams {
-    /// Greedy decoding: identical behavior to ferrox's original
-    /// argmax-only generation loop.
-    fn default() -> Self {
-        SamplingParams {
-            temperature: 0.0,
-            top_p: 1.0,
-            min_p: 0.0,
-            top_k: 0,
-            repetition_penalty: 1.0,
-            penalty_last_n: 64,
-            presence_penalty: 0.0,
-            frequency_penalty: 0.0,
-            sampler_order: SamplerOrder::default(),
-        }
-    }
-}
-
-/// The sampling a **checkpoint recommends for itself**, one `Option`
-/// per field so that "this model says nothing about top_p" stays
-/// distinguishable from "this model recommends top_p = 1.0". This is
-/// sglang's `sampling_defaults='model'`, ported from FreeToken
-/// `python/freetoken/utils/hf.py:92 load_generation_sampling`.
+/// A deterministic, uninteresting-on-purpose logit vector: no ties, a
+/// wide dynamic range, and a few negatives so the penalty's sign
+/// convention is exercised.
 ///
-/// Every field is `None` for a checkpoint that recommends nothing,
-/// which is the overwhelming majority, and
-/// [`RecommendedSampling::resolve`] then reproduces ferrox's existing
-/// defaults exactly -- a recommendation may only fill a gap the request
-/// left, never override it.
-///
-/// Why this exists at all: reasoning checkpoints are tuned for a
-/// specific sampler (Qwen3.5 ships temperature 1.0, top_k 20, top_p
-/// 0.95) and ship those numbers with the weights. Served under a
-/// generic greedy-or-0.8 default they fall into repetition loops --
-/// fluent output that never terminates -- which reads as a broken model
-/// rather than as a serving default nobody read off the file.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
-pub struct RecommendedSampling {
-    pub temperature: Option<f32>,
-    pub top_p: Option<f32>,
-    pub top_k: Option<usize>,
+/// Shared with [`rng`]'s tests rather than written out twice, because
+/// two "the same logits" that were not the same logits is the smallest
+/// possible instance of this repo's dominant defect.
+#[cfg(test)]
+pub(crate) fn spread_logits(vocab: usize) -> Vec<f32> {
+    (0..vocab)
+        .map(|i| ((i as f32 * 12.9898).sin() * 43_758.547).fract() * 8.0 - 3.0)
+        .collect()
 }
 
-/// The sampling fields **one request** actually specified. `None` means
-/// the request said nothing about that field, so the checkpoint's
-/// recommendation (and then the framework default) may speak for it.
+/// The token greedy decoding picks, given a chain that may or may not be
+/// able to move the argmax.
 ///
-/// Collapsing this to a plain [`SamplingParams`] at the wire boundary
-/// -- `temperature: req.temperature.unwrap_or(0.0)` -- is what destroys
-/// the distinction: a request that omitted `temperature` becomes
-/// indistinguishable from one that explicitly asked for greedy, and no
-/// recommendation can ever apply.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
-pub struct RequestedSampling {
-    pub temperature: Option<f32>,
-    pub top_p: Option<f32>,
-    pub top_k: Option<usize>,
-}
-
-impl RecommendedSampling {
-    /// True when the checkpoint recommended nothing at all, i.e.
-    /// [`Self::resolve`] is guaranteed to return the framework defaults
-    /// for any request. Useful for telling an operator whether
-    /// "model defaults" had anything to act on.
-    pub fn is_empty(&self) -> bool {
-        *self == RecommendedSampling::default()
-    }
-
-    /// Precedence, exactly as FreeToken's `resolve_sampling.pick`
-    /// (`python/freetoken/server/generation.py:170`) applies it: the
-    /// **request's** own value, else the **checkpoint's**
-    /// recommendation, else the **framework** default carried by
-    /// `framework` (ferrox's `SamplingParams::default()` unless a caller
-    /// has its own).
-    ///
-    /// The penalty fields are taken from `framework` untouched: nothing
-    /// in the reference reads a recommended penalty, and inventing one
-    /// here would be this function changing generation on its own.
-    ///
-    /// Getting the order wrong in either direction is a silent
-    /// behaviour change: recommendation-over-request makes a client's
-    /// explicit `temperature: 0` unreachable on a model that recommends
-    /// 1.0, and framework-over-recommendation is the greedy repetition
-    /// loop this whole path exists to avoid.
-    pub fn resolve(
-        &self,
-        requested: RequestedSampling,
-        framework: SamplingParams,
-    ) -> SamplingParams {
-        SamplingParams {
-            temperature: requested
-                .temperature
-                .or(self.temperature)
-                .unwrap_or(framework.temperature),
-            top_p: requested.top_p.or(self.top_p).unwrap_or(framework.top_p),
-            top_k: requested.top_k.or(self.top_k).unwrap_or(framework.top_k),
-            ..framework
-        }
-    }
-
-    /// The recommendation in a HuggingFace-style `generation_config.json`
-    /// body.
-    ///
-    /// Two rules, both from the reference
-    /// (`hf.py:92 load_generation_sampling`):
-    ///
-    /// * `do_sample: false` means the checkpoint recommends **greedy**,
-    ///   which is returned as `temperature = 0` and *nothing else* --
-    ///   the top_k/top_p in such a file describe a sampler the model
-    ///   asks not to be used.
-    /// * otherwise only the keys **actually present** are returned. An
-    ///   absent key stays `None`; filling it with a house default (the
-    ///   naive reading, and what HF's own `GenerationConfig` object does
-    ///   for you) would turn silence into a recommendation and let a
-    ///   file that says only `temperature: 0.6` also pin top_p to 1.0,
-    ///   overriding the server's own default for a value the checkpoint
-    ///   never expressed.
-    ///
-    /// A file that does not parse, or is not a JSON object, recommends
-    /// nothing -- a malformed sidecar must not be able to change how a
-    /// model is sampled.
-    pub fn from_generation_config(json: &str) -> Self {
-        let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<serde_json::Value>(json)
-        else {
-            return RecommendedSampling::default();
-        };
-        if map.get("do_sample").and_then(|v| v.as_bool()) == Some(false) {
-            return RecommendedSampling {
-                temperature: Some(0.0),
-                ..RecommendedSampling::default()
-            };
-        }
-        RecommendedSampling {
-            temperature: map
-                .get("temperature")
-                .and_then(|v| v.as_f64())
-                .map(|v| v as f32),
-            top_p: map.get("top_p").and_then(|v| v.as_f64()).map(|v| v as f32),
-            top_k: map
-                .get("top_k")
-                .and_then(|v| v.as_u64())
-                .map(|v| v as usize),
-        }
-    }
-
-    /// [`Self::from_generation_config`] for the `generation_config.json`
-    /// beside a checkpoint's weights (an HF-format model directory).
-    ///
-    /// A directory with no such file recommends nothing, exactly like a
-    /// GGUF with no `general.sampling.*` keys: the absence of a
-    /// recommendation is the normal case and must never be an error that
-    /// stops a model from loading.
-    pub fn from_model_dir(dir: &std::path::Path) -> Self {
-        match std::fs::read_to_string(dir.join("generation_config.json")) {
-            Ok(text) => Self::from_generation_config(&text),
-            Err(_) => RecommendedSampling::default(),
-        }
-    }
-}
-
-/// Sets logits a caller wants to forbid to `-inf`, in place, before the
-/// sampler looks at them.
+/// llama.cpp does NOT special-case `temp <= 0`: it runs the whole chain
+/// and lets `llama_sampler_temp_impl` (`src/llama-sampler.cpp:271-286`)
+/// set every logit but the maximum to `-inf`, so `dist` picks whatever
+/// the filters left. Two of those filters can therefore change greedy
+/// output, and both of them are new here: `xtc` removes the TOP
+/// candidates by construction, and `typ_p` selects outward from the
+/// distribution's entropy and may drop the most likely token.
 ///
-/// Two callers today, and they COMPOSE rather than exclude each other --
-/// a masked logit stays masked, so the order they run in cannot matter:
-/// JSON-object mode's character-class filter
-/// (`ferrox_server::json_mode`), and grammar-constrained decoding
-/// ([`crate::grammar_sampler::GrammarSampler::mask_logits`]).
-///
-/// The signature returns nothing because the callback runs from inside
-/// the sampler, which has no error to return one through. A mask that
-/// CAN fail -- a grammar that dead-ends leaves every logit at `-inf`,
-/// and sampling from that is how an "impossible" request becomes
-/// arbitrary text with a 200 -- records its refusal in the closure's own
-/// captured state, and the decode loop reads it after the sample and
-/// throws the token away. `ferrox_server::sample_step::sample_next` is
-/// the one place that pairing lives.
-pub type LogitMask<'a> = &'a mut dyn FnMut(&mut [f32]);
-
-/// A small, seedable xorshift64* generator. Not cryptographically
-/// secure -- sampling doesn't need that -- but reproducible given a
-/// seed, which greedy argmax already was for free.
-pub struct Sampler {
-    state: u64,
-}
-
-impl Sampler {
-    pub fn new(seed: u64) -> Self {
-        // xorshift64* requires a nonzero seed.
-        Sampler {
-            state: if seed == 0 { 0x9E3779B97F4A7C15 } else { seed },
-        }
+/// ferrox keeps its `argmax` fast path, because building and sorting a
+/// 128k-entry candidate list per token to reach an answer that cannot
+/// differ would be a decode-speed regression on the most common
+/// configuration there is. [`SamplingParams::greedy_equals_argmax`] is
+/// the one predicate that decides which path is exact, and it is read
+/// here and by the Metal `lm_head + argmax` fold's guard, so a chain
+/// that can move the argmax also stops the GPU from folding it away.
+fn greedy_choice(
+    scores: Vec<f32>,
+    params: &SamplingParams,
+    history: PenaltyWindow<'_>,
+    xtc_roll: Option<f32>,
+) -> usize {
+    if params.greedy_equals_argmax() {
+        return argmax(&scores);
     }
-
-    fn next_u64(&mut self) -> u64 {
-        self.state ^= self.state << 13;
-        self.state ^= self.state >> 7;
-        self.state ^= self.state << 17;
-        // The `*` in xorshift64*. Without it this is plain xorshift64,
-        // whose state IS its output, and a small seed's first output is
-        // therefore still small: for every seed below ~4000 the first
-        // draw landed in the bottom eighth of [0, 1), so a request that
-        // asked for `seed: 42` always got its first token from the
-        // bottom of the CDF. The multiply is what decorrelates the
-        // output from a low-entropy state; see
-        // `low_seeds_do_not_bias_the_first_draw`.
-        self.state.wrapping_mul(0x2545F491_4F6CDD1D)
-    }
-
-    /// Uniform float in [0.0, 1.0).
-    fn next_f32(&mut self) -> f32 {
-        (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32
-    }
-
-    /// Samples one token id from `logits`, given `params` and the
-    /// [`PenaltyWindow`] the penalties look back over. Falls back to
-    /// plain greedy argmax when `params.temperature <= 0.0`.
-    ///
-    /// `history` is a window and not a slice on purpose: it carries the
-    /// PROMPT as well as the generated tokens, which is what llama.cpp
-    /// penalises over. See [`crate::penalty_window`].
-    ///
-    /// A length-1 `logits` vector is treated as a precomputed greedy token
-    /// id (`logits[0] as usize`) — used by the Metal dense-stack path that
-    /// returns GPU argmax instead of downloading the full vocab.
-    pub fn sample(
-        &mut self,
-        logits: &[f32],
-        params: &SamplingParams,
-        history: PenaltyWindow<'_>,
-    ) -> usize {
-        self.sample_with_mask(logits, params, history, None)
-    }
-
-    /// Like [`Self::sample`], but optionally zeroes disallowed logits via
-    /// `mask` before argmax / nucleus sampling (used for JSON-object mode).
-    pub fn sample_with_mask(
-        &mut self,
-        logits: &[f32],
-        params: &SamplingParams,
-        history: PenaltyWindow<'_>,
-        mut mask: Option<LogitMask<'_>>,
-    ) -> usize {
-        if params.temperature <= 0.0 && mask.is_none() {
-            if logits.len() == 1 {
-                return logits[0] as usize;
-            }
-            let mut scores = logits.to_vec();
-            apply_history_penalties(&mut scores, params, history);
-            return argmax(&scores);
-        }
-
-        let mut scores: Vec<f32> = logits.to_vec();
-        apply_history_penalties(&mut scores, params, history);
-
-        if let Some(m) = mask.as_mut() {
-            m(&mut scores);
-        }
-
-        if params.temperature <= 0.0 {
-            if scores.len() == 1 {
-                return scores[0] as usize;
-            }
-            return argmax(&scores);
-        }
-
-        let probs = filtered_distribution(scores, params);
-        self.sample_from(&probs)
-    }
-
-    /// A uniform draw in `[0.0, 1.0)`.
-    ///
-    /// Exposed because speculative decoding's accept test is a coin
-    /// flip against `p_target(x) / p_draft(x)` rather than a draw from
-    /// a distribution, and it must come off the same seeded stream as
-    /// every other draw in the run or a "reproducible given a seed"
-    /// generation stops being reproducible.
-    pub fn uniform(&mut self) -> f32 {
-        self.next_f32()
-    }
-
-    /// Draws one index from an already-normalised distribution.
-    ///
-    /// Split out of [`Self::sample_with_mask`] so speculative decoding
-    /// can sample from a distribution it had to compute anyway (the
-    /// rejection rule needs `p_target` itself, not just a draw from it)
-    /// and still go through *exactly* the same draw as ordinary
-    /// sampling. Two separate copies of this loop would be two chances
-    /// to be subtly non-lossless.
-    pub fn sample_from(&mut self, probs: &[f32]) -> usize {
-        let draw = self.next_f32();
-        let mut cumulative = 0.0f32;
-        for (i, &p) in probs.iter().enumerate() {
-            cumulative += p;
-            if draw < cumulative {
-                return i;
-            }
-        }
-        // Floating-point rounding may leave `draw` fractionally above
-        // the final cumulative sum; the last nonzero-probability token
-        // is the correct fallback, not index 0.
-        probs
-            .iter()
-            .enumerate()
-            .rev()
-            .find(|&(_, &p)| p > 0.0)
-            .map(|(i, _)| i)
-            .unwrap_or(0)
-    }
+    argmax(&filtered_distribution(scores, params, history, xtc_roll))
 }
 
 /// The **exact** distribution [`Sampler::sample`] draws from for these
 /// logits, params and history: penalties applied over the
-/// `penalty_last_n` window, then top-k, top-p and min-p, then
-/// temperature, renormalised to sum to 1.
+/// `penalty_last_n` window, then llama.cpp's chain in
+/// `params.sampler_order`, renormalised to sum to 1.
 ///
-/// That is llama.cpp's chain order, and it is the order
-/// `filtered_distribution` runs -- **temperature last**, not first.
+/// That is llama.cpp's chain order -- **temperature last**, not first.
 /// This comment used to say "temperature divided in, top-k and top-p
 /// filtered", which described the pre-2026-09-01 pipeline and omitted
 /// min-p entirely.
@@ -412,23 +98,34 @@ impl Sampler {
 /// a model nobody is running.
 ///
 /// Greedy (`temperature <= 0.0`) is a distribution too: the point mass
-/// on the argmax. Returning it as one rather than as a special case is
-/// why the same verification code is correct at every temperature.
+/// on the token [`greedy_choice`] would pick. Returning it as one rather
+/// than as a special case is why the same verification code is correct
+/// at every temperature.
+///
+/// `xtc_roll` is [`Sampler::xtc_roll`]'s answer, and it is a REQUIRED
+/// argument rather than something this function draws or defaults,
+/// because XTC is stochastic and the caller owns the seeded stream. A
+/// caller that passes `None` while XTC is configured gets a chain with
+/// no XTC in it, which is why every caller in this workspace obtains it
+/// from `Sampler::xtc_roll` and not by writing `None`.
 pub fn sampling_distribution(
     logits: &[f32],
     params: &SamplingParams,
     history: PenaltyWindow<'_>,
+    xtc_roll: Option<f32>,
 ) -> Vec<f32> {
     let mut scores = logits.to_vec();
     apply_history_penalties(&mut scores, params, history);
     if params.temperature <= 0.0 {
-        let mut probs = vec![0.0f32; scores.len()];
-        if let Some(p) = probs.get_mut(argmax(&scores)) {
+        let vocab = scores.len();
+        let chosen = greedy_choice(scores, params, history, xtc_roll);
+        let mut probs = vec![0.0f32; vocab];
+        if let Some(p) = probs.get_mut(chosen) {
             *p = 1.0;
         }
         return probs;
     }
-    filtered_distribution(scores, params)
+    filtered_distribution(scores, params, history, xtc_roll)
 }
 
 /// Shared tail of [`Sampler::sample_with_mask`] and
@@ -440,7 +137,7 @@ pub fn sampling_distribution(
 ///
 /// llama.cpp's default chain is `penalties, dry, top_n_sigma, top_k,
 /// typical_p, top_p, min_p, xtc, temperature` (`common/common.h:259-269`,
-/// consumed by `common/sampling.cpp:349-397`). The penalties already ran
+/// consumed by `common/sampling.cpp:346-397`). The penalties already ran
 /// in [`apply_history_penalties`]; this function is the rest of it, in
 /// that order, and **temperature is last**.
 ///
@@ -464,7 +161,7 @@ pub fn sampling_distribution(
 /// including the renormalisation between steps that a keep-mask cannot
 /// express. See that module's header.
 ///
-/// # The order is now the caller's
+/// # The order is the caller's
 ///
 /// `params.sampler_order` says which steps run and in what sequence,
 /// which is llama.cpp's `--samplers`. It DEFAULTS to the sequence
@@ -477,7 +174,12 @@ pub fn sampling_distribution(
 /// something to run. And because [`SamplerOrder`] can only be built out
 /// of steps ferrox implements, there is no arm here that means "asked
 /// for, silently not done".
-fn filtered_distribution(scores: Vec<f32>, params: &SamplingParams) -> Vec<f32> {
+fn filtered_distribution(
+    scores: Vec<f32>,
+    params: &SamplingParams,
+    history: PenaltyWindow<'_>,
+    xtc_roll: Option<f32>,
+) -> Vec<f32> {
     let vocab = scores.len();
     let mut candidates = Candidates::new(&scores);
     for &step in params.sampler_order.steps() {
@@ -487,86 +189,32 @@ fn filtered_distribution(scores: Vec<f32>, params: &SamplingParams) -> Vec<f32> 
             // first precisely so that this is the same position the
             // caller asked for; see `SamplerOrderError::PenaltiesNotFirst`.
             ChainStep::Penalties => {}
+            ChainStep::Dry => candidates.dry(&params.dry.penalties(history)),
+            ChainStep::TopNSigma => candidates.top_n_sigma(params.top_n_sigma),
             ChainStep::TopK => candidates.top_k(params.top_k),
+            ChainStep::TypP => candidates.typical_p(params.typical_p),
             ChainStep::TopP => candidates.top_p(params.top_p),
             ChainStep::MinP => candidates.min_p(params.min_p),
+            // `xtc_roll` is `None` exactly when
+            // `SamplingParams::xtc_can_fire` is false, which is the same
+            // predicate `Candidates::xtc` re-checks. See
+            // `Sampler::xtc_roll`.
+            ChainStep::Xtc => {
+                if let Some(chance) = xtc_roll {
+                    candidates.xtc(params.xtc_probability, params.xtc_threshold, chance);
+                }
+            }
             ChainStep::Temperature => candidates.temperature(params.temperature),
         }
     }
     candidates.into_distribution(vocab)
 }
 
-/// Penalise tokens that already appear in `history`, once each.
-///
-/// `history` is a [`PenaltyWindow`], so "already appear" includes the
-/// PROMPT. That is llama.cpp's rule and the module docs of
-/// [`crate::penalty_window`] carry the upstream lines; before it, every
-/// caller in this workspace picked its own slice and four of the five
-/// picked differently.
-///
-/// ONCE EACH is the whole subtlety, and ferrox used to get it wrong.
-/// llama.cpp walks the CANDIDATE list and looks each candidate up in a
-/// count map (`llama-sampler.cpp:2735-2756`), so a token repeated `n`
-/// times is divided by `penalty_repeat` exactly once. ferrox walked the
-/// HISTORY, so the same token was divided `n` times and the effective
-/// penalty was `penalty^n`.
-///
-/// That was live on every `ferrox run`: `--repeat-penalty` defaults to
-/// 1.1, so a token seen five times was penalised 1.61x rather than
-/// 1.1x, and the divergence grew with the length of the output.
-///
-/// The sign convention is llama.cpp's and its comment explains it:
-/// dividing alone would make tokens with NEGATIVE logits more likely,
-/// so negatives are multiplied instead.
-///
-/// A chain that does not name `penalties` does not penalise. llama.cpp
-/// reads an omitted sampler as "do not run it", and this function is the
-/// one place the penalties happen -- on the greedy path as well as the
-/// sampled one -- so the check belongs here rather than beside the
-/// candidate list, where the greedy path would never see it.
-fn apply_history_penalties(
-    scores: &mut [f32],
-    params: &SamplingParams,
-    history: PenaltyWindow<'_>,
-) {
-    if !params.sampler_order.has_penalties() {
-        return;
-    }
-    if params.repetition_penalty == 1.0
-        && params.presence_penalty == 0.0
-        && params.frequency_penalty == 0.0
-    {
-        return;
-    }
-    // Only the last `penalty_last_n`, as llama.cpp's ring buffer does.
-    if params.penalty_last_n == 0 {
-        return;
-    }
-    let mut counts = std::collections::HashMap::<usize, usize>::new();
-    for tok in history.recent(params.penalty_last_n) {
-        *counts.entry(tok).or_insert(0) += 1;
-    }
-    for (tok, count) in counts {
-        let Some(s) = scores.get_mut(tok) else {
-            continue;
-        };
-        if params.repetition_penalty != 1.0 {
-            *s = if *s > 0.0 {
-                *s / params.repetition_penalty
-            } else {
-                *s * params.repetition_penalty
-            };
-        }
-        *s -= params.frequency_penalty * count as f32;
-        *s -= params.presence_penalty;
-    }
-}
-
 fn argmax(logits: &[f32]) -> usize {
     logits
         .iter()
         .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
         .map(|(i, _)| i)
         .unwrap_or(0)
 }
@@ -574,19 +222,11 @@ fn argmax(logits: &[f32]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dry::{DryBreakers, DryParams};
     use crate::sampler_order::SamplerOrder;
 
-    /// A deterministic, uninteresting-on-purpose logit vector: no ties,
-    /// a wide dynamic range, and a few negatives so the penalty's sign
-    /// convention is exercised.
-    fn spread_logits(vocab: usize) -> Vec<f32> {
-        (0..vocab)
-            .map(|i| ((i as f32 * 12.9898).sin() * 43_758.547).fract() * 8.0 - 3.0)
-            .collect()
-    }
-
-    /// The chain `filtered_distribution` ran BEFORE the order became a
-    /// parameter, written out by hand.
+    /// The chain `filtered_distribution` ran BEFORE llama.cpp's four
+    /// missing samplers were added, written out by hand.
     ///
     /// Deliberately not built from `SamplerOrder`: a reference that read
     /// the order it is supposed to be pinning would agree with any
@@ -608,17 +248,23 @@ mod tests {
     }
 
     /// **A run that does not ask for an order samples exactly what it
-    /// always did.** Bit-for-bit, against the chain written out by hand
-    /// rather than read back off `SamplerOrder`.
+    /// always did.** Bit-for-bit, against the five-step chain written out
+    /// by hand rather than read back off `SamplerOrder`.
     ///
-    /// This is the assertion that makes `--samplers` safe to add at all.
-    /// The order is not a reordering of independent steps: each filter
-    /// renormalises over the survivors of the last, so a default that
-    /// drifted by one position would change every generation on every
-    /// model, silently, with every other test in this file still green.
+    /// This is now doing double duty. It is still the assertion that
+    /// makes `--samplers` safe to expose -- the order is not a
+    /// reordering of independent steps, so a default that drifted by one
+    /// position would change every generation on every model. And it is
+    /// the assertion that adding `dry`, `top_n_sigma`, `typ_p` and `xtc`
+    /// to the DEFAULT chain changed nothing: at their neutral values
+    /// (`dry_multiplier 0.0`, `top_n_sigma -1.0`, `typical_p 1.0`,
+    /// `xtc_probability 0.0`) all four are no-ops, so the nine-step
+    /// default must produce bit-identical probabilities to the five-step
+    /// chain it replaced.
     ///
-    /// Swap any two entries of `sampler_order::DEFAULT_STEPS` and this
-    /// goes red.
+    /// Swap any two entries of `sampler_order::DEFAULT_STEPS`, or make
+    /// any of the four new filters do something at its neutral value,
+    /// and this goes red.
     #[test]
     fn the_default_order_is_the_chain_ferrox_already_ran() {
         let logits = spread_logits(64);
@@ -653,7 +299,7 @@ mod tests {
             };
             let window = || PenaltyWindow::new(&prompt, &generated);
             let expected = the_chain_ferrox_used_to_hardcode(&logits, &params, window());
-            let actual = sampling_distribution(&logits, &params, window());
+            let actual = sampling_distribution(&logits, &params, window(), None);
             for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
                 assert_eq!(
                     a.to_bits(),
@@ -682,7 +328,7 @@ mod tests {
             ..SamplingParams::default()
         };
         let spelled = SamplingParams {
-            sampler_order: "penalties;top_k;top_p;min_p;temperature"
+            sampler_order: "penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature"
                 .parse::<SamplerOrder>()
                 .expect("the default chain must parse"),
             ..base.clone()
@@ -699,15 +345,8 @@ mod tests {
         assert_eq!(draw(&base), draw(&spelled));
     }
 
-    /// **The flag does something.** A chain that runs the temperature
-    /// before top-p keeps a different candidate set than the default,
-    /// which is the whole reason the order is worth exposing -- and the
-    /// reason getting it wrong is a silent quality regression rather
-    /// than an error.
-    ///
-    /// A hot temperature flattens the distribution, so a top-p applied
-    /// after it sums smaller probabilities and reaches `p` later,
-    /// keeping MORE candidates.
+    /// A run that never asks for XTC must not consume a draw for it, or
+    /// every seeded generation in the workspace shifts by one.
     #[test]
     fn running_the_temperature_first_keeps_a_different_candidate_set() {
         let logits = vec![6.0f32, 4.0, 2.0, 0.0, -2.0, -4.0];
@@ -720,7 +359,7 @@ mod tests {
             ..SamplingParams::default()
         };
         let support = |order: &str| -> Vec<bool> {
-            sampling_distribution(&logits, &params(order), PenaltyWindow::new(&[], &[]))
+            sampling_distribution(&logits, &params(order), PenaltyWindow::new(&[], &[]), None)
                 .iter()
                 .map(|&p| p > 0.0)
                 .collect()
@@ -745,32 +384,78 @@ mod tests {
     /// knob is set -- llama.cpp reads an omitted sampler as "do not run
     /// it", and a chain that ran it anyway would be honouring a request
     /// nobody made.
+    ///
+    /// Checked for every filter that has a knob, not just min-p: the
+    /// four samplers added for llama.cpp parity each have their own arm
+    /// in `filtered_distribution`, and an arm that ignored the chain
+    /// would be invisible to a test that only exercised one of them.
     #[test]
     fn a_sampler_absent_from_the_chain_does_not_filter() {
         let logits = vec![4.0f32, 3.0, 2.0, 1.0];
-        let with_min_p = SamplingParams {
-            temperature: 1.0,
-            min_p: 0.2,
-            ..SamplingParams::default()
-        };
-        let survivors = |params: &SamplingParams| {
-            sampling_distribution(&logits, params, PenaltyWindow::new(&[], &[]))
+        let survivors = |params: &SamplingParams, roll: Option<f32>| {
+            sampling_distribution(&logits, params, PenaltyWindow::new(&[], &[]), roll)
                 .iter()
                 .filter(|&&p| p > 0.0)
                 .count()
         };
-        // The default chain runs min-p: 4 + ln(0.2) = 2.3905 keeps two.
-        assert_eq!(survivors(&with_min_p), 2);
-
-        let without_min_p = SamplingParams {
-            sampler_order: "penalties;top_k;top_p;temperature".parse().expect("chain"),
-            ..with_min_p.clone()
-        };
-        assert_eq!(
-            survivors(&without_min_p),
-            4,
-            "`min_p` is set but not in the chain, so nothing should truncate"
-        );
+        // (the knob, a chain WITHOUT its step, the roll to pass)
+        let cases: Vec<(SamplingParams, &str, Option<f32>)> = vec![
+            (
+                SamplingParams {
+                    temperature: 1.0,
+                    min_p: 0.2,
+                    ..SamplingParams::default()
+                },
+                "penalties;top_k;top_p;temperature",
+                None,
+            ),
+            (
+                SamplingParams {
+                    temperature: 1.0,
+                    typical_p: 0.5,
+                    ..SamplingParams::default()
+                },
+                "penalties;top_k;top_p;min_p;temperature",
+                None,
+            ),
+            (
+                SamplingParams {
+                    temperature: 1.0,
+                    top_n_sigma: 0.5,
+                    ..SamplingParams::default()
+                },
+                "penalties;top_k;top_p;min_p;temperature",
+                None,
+            ),
+            (
+                SamplingParams {
+                    temperature: 1.0,
+                    xtc_probability: 1.0,
+                    xtc_threshold: 0.05,
+                    ..SamplingParams::default()
+                },
+                "penalties;top_k;top_p;min_p;temperature",
+                Some(0.0),
+            ),
+        ];
+        for (with, chain_without, roll) in cases {
+            let filtered = survivors(&with, roll);
+            assert!(
+                filtered < 4,
+                "the knob must bite when its step IS in the chain, \
+                 or the second half proves nothing: {with:?}"
+            );
+            let without = SamplingParams {
+                sampler_order: chain_without.parse().expect("chain"),
+                ..with.clone()
+            };
+            assert_eq!(
+                survivors(&without, roll),
+                4,
+                "the knob is set but its step is not in `{chain_without}`, \
+                 so nothing should truncate: {without:?}"
+            );
+        }
     }
 
     /// Leaving `penalties` out of the chain disables the penalties, on
@@ -819,8 +504,8 @@ mod tests {
             ..sampled.clone()
         };
         assert_ne!(
-            sampling_distribution(&logits, &sampled, history()),
-            sampling_distribution(&logits, &with, history())
+            sampling_distribution(&logits, &sampled, history(), None),
+            sampling_distribution(&logits, &with, history(), None)
         );
     }
 
@@ -904,122 +589,6 @@ mod tests {
         );
     }
 
-    /// The repetition penalty is applied ONCE per token, however many
-    /// times that token appears in the history.
-    ///
-    /// ferrox walked the history and divided once per OCCURRENCE, so the
-    /// effective penalty was `penalty^n`. llama.cpp walks the candidates
-    /// and looks each up in a count map, so it is `penalty` flat
-    /// (`llama-sampler.cpp:2735-2756`).
-    ///
-    /// Live on every `ferrox run`: `--repeat-penalty` defaults to 1.1,
-    /// so a token seen five times was penalised 1.61x, and the
-    /// divergence grew with the length of the output. Twenty-four
-    /// sampling tests passed with the bug in place, which is why this
-    /// one exists.
-    #[test]
-    fn the_repetition_penalty_does_not_compound_with_repeats() {
-        let params = SamplingParams {
-            temperature: 1.0,
-            top_p: 1.0,
-            top_k: 0,
-            repetition_penalty: 2.0,
-            ..SamplingParams::default()
-        };
-        let logits = vec![4.0f32, 1.0, 1.0];
-
-        // Token 0 appears five times. Penalised once, its score is 2.0;
-        // compounded it would be 4 / 2^5 = 0.125.
-        let mut scores = logits.clone();
-        apply_history_penalties(
-            &mut scores,
-            &params,
-            PenaltyWindow::new(&[], &[0, 0, 0, 0, 0]),
-        );
-        assert!(
-            (scores[0] - 2.0).abs() < 1e-6,
-            "expected one division (2.0), got {} -- {} would be 2^5",
-            scores[0],
-            4.0f32 / 32.0
-        );
-
-        // And once really is once: one occurrence and five occurrences
-        // must land on the same score, or the count still leaks in.
-        let mut once = logits.clone();
-        apply_history_penalties(&mut once, &params, PenaltyWindow::new(&[], &[0]));
-        assert_eq!(once[0].to_bits(), scores[0].to_bits());
-
-        // A NEGATIVE logit is multiplied rather than divided, or the
-        // penalty would make it more likely -- llama.cpp's own comment.
-        let mut negative = vec![-4.0f32];
-        apply_history_penalties(&mut negative, &params, PenaltyWindow::new(&[], &[0, 0, 0]));
-        assert!((negative[0] + 8.0).abs() < 1e-6, "got {}", negative[0]);
-    }
-
-    /// The penalties look at the last `penalty_last_n` tokens, not the
-    /// whole history.
-    ///
-    /// llama.cpp keeps a ring buffer of `penalty_last_n` (default 64,
-    /// `common/common.h:238`); ferrox scanned everything generated so
-    /// far. On a long generation that is a steadily growing set of
-    /// penalised tokens against llama.cpp's fixed 64 -- the divergence
-    /// grows with output length, which is when a repetition penalty
-    /// matters most.
-    #[test]
-    fn the_penalties_only_see_the_last_n_tokens() {
-        let params = SamplingParams {
-            repetition_penalty: 2.0,
-            penalty_last_n: 2,
-            ..SamplingParams::default()
-        };
-        let mut scores = vec![8.0f32, 8.0, 8.0];
-        // Token 0 fell out of the window; tokens 1 and 2 are in it.
-        apply_history_penalties(&mut scores, &params, PenaltyWindow::new(&[], &[0, 1, 2]));
-        assert_eq!(
-            scores[0].to_bits(),
-            8.0f32.to_bits(),
-            "token 0 is outside the window"
-        );
-        assert!((scores[1] - 4.0).abs() < 1e-6, "got {}", scores[1]);
-        assert!((scores[2] - 4.0).abs() < 1e-6, "got {}", scores[2]);
-
-        // `0` disables the penalties outright, as llama.cpp documents.
-        let off = SamplingParams {
-            penalty_last_n: 0,
-            ..params
-        };
-        let mut untouched = vec![8.0f32; 3];
-        apply_history_penalties(&mut untouched, &off, PenaltyWindow::new(&[], &[0, 1, 2]));
-        assert_eq!(untouched, vec![8.0f32; 3]);
-
-        // A window longer than the history is not an overflow.
-        let wide = SamplingParams {
-            penalty_last_n: 1000,
-            ..params
-        };
-        let mut short = vec![8.0f32];
-        apply_history_penalties(&mut short, &wide, PenaltyWindow::new(&[], &[0]));
-        assert!((short[0] - 4.0).abs() < 1e-6);
-    }
-
-    /// Frequency penalty still scales with the count, while the
-    /// repetition penalty does not.
-    ///
-    /// Both live in the same loop, so a fix that made the repetition
-    /// penalty flat by dropping the counts would break this one.
-    #[test]
-    fn the_frequency_penalty_still_counts_repeats() {
-        let params = SamplingParams {
-            frequency_penalty: 0.5,
-            presence_penalty: 0.25,
-            ..SamplingParams::default()
-        };
-        let mut scores = vec![10.0f32];
-        apply_history_penalties(&mut scores, &params, PenaltyWindow::new(&[], &[0, 0, 0, 0]));
-        // 10 - 0.5*4 - 0.25 = 7.75
-        assert!((scores[0] - 7.75).abs() < 1e-6, "got {}", scores[0]);
-    }
-
     /// Top-p cuts the UNSCALED distribution; the temperature reshapes
     /// only the survivors.
     ///
@@ -1039,7 +608,7 @@ mod tests {
                 top_k: 0,
                 ..SamplingParams::default()
             };
-            sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]))
+            sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]), None)
                 .iter()
                 .map(|&p| p > 0.0)
                 .collect()
@@ -1079,7 +648,7 @@ mod tests {
             min_p: 0.2,
             ..SamplingParams::default()
         };
-        let probs = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]));
+        let probs = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]), None);
         assert!(probs[0] > 0.0 && probs[1] > 0.0);
         assert_eq!(probs[2], 0.0, "2.0 is below 4 + ln(0.2) = 2.3905");
         assert_eq!(probs[3], 0.0);
@@ -1095,7 +664,7 @@ mod tests {
             min_p: 0.0,
             ..params.clone()
         };
-        let unfiltered = sampling_distribution(&logits, &off, PenaltyWindow::new(&[], &[]));
+        let unfiltered = sampling_distribution(&logits, &off, PenaltyWindow::new(&[], &[]), None);
         assert!(unfiltered.iter().all(|&p| p > 0.0));
     }
 
@@ -1121,7 +690,7 @@ mod tests {
                 min_p: 0.2,
                 ..SamplingParams::default()
             };
-            sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]))
+            sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]), None)
                 .iter()
                 .map(|&p| p > 0.0)
                 .collect()
@@ -1154,7 +723,7 @@ mod tests {
             min_p: 0.2,
             ..SamplingParams::default()
         };
-        let probs = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]));
+        let probs = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]), None);
         assert_eq!(
             probs.iter().map(|&p| p > 0.0).collect::<Vec<_>>(),
             vec![true, true, false, false]
@@ -1169,7 +738,7 @@ mod tests {
             ..params.clone()
         };
         assert_eq!(
-            sampling_distribution(&logits, &top_p_only, PenaltyWindow::new(&[], &[]))
+            sampling_distribution(&logits, &top_p_only, PenaltyWindow::new(&[], &[]), None)
                 .iter()
                 .filter(|&&p| p > 0.0)
                 .count(),
@@ -1177,214 +746,125 @@ mod tests {
         );
     }
 
+    /// DRY reaches the sampled token through the chain, not just the
+    /// penalty table.
+    ///
+    /// Window `0 1 2 0 1` at `allowed_length 2`: emitting `2` would make
+    /// it a three-token repetition, so DRY subtracts
+    /// `multiplier * base^0 = 6.0` from token 2's logit of 5.0 -- more
+    /// than enough to move the greedy argmax off it. That is the whole
+    /// claim: a sampler wired into `filtered_distribution` but not
+    /// reached from the greedy path would leave this at 2.
     #[test]
-    fn temperature_zero_accepts_precomputed_argmax_singleton() {
-        let mut sampler = Sampler::new(1);
-        let params = SamplingParams::default();
-        assert_eq!(
-            sampler.sample(&[42.0], &params, PenaltyWindow::new(&[], &[])),
-            42
-        );
-        // Non-greedy must not treat a singleton as a token id.
-        let sampled = SamplingParams {
-            temperature: 0.8,
+    fn dry_moves_the_chosen_token_on_both_the_greedy_and_the_sampled_path() {
+        let logits = vec![0.0f32, 0.0, 5.0, 0.0];
+        let history = || PenaltyWindow::new(&[], &[0, 1, 2, 0, 1]);
+        let dry = DryParams::new(6.0, 1.1, 2, -1, 1024, DryBreakers::none());
+        let greedy = SamplingParams {
+            temperature: 0.0,
+            dry: dry.clone(),
             ..SamplingParams::default()
         };
-        // Softmax of a single logit → only token 0 is eligible.
+        let mut sampler = Sampler::new(5);
         assert_eq!(
-            sampler.sample(&[42.0], &sampled, PenaltyWindow::new(&[], &[])),
+            sampler.sample(&logits, &SamplingParams::default(), history()),
+            2,
+            "without DRY token 2 is the argmax"
+        );
+        assert_ne!(
+            sampler.sample(&logits, &greedy, history()),
+            2,
+            "DRY subtracts 4.0 from token 2's logit of 5.0, so it loses"
+        );
+
+        // Same on the sampled path, read off the distribution.
+        let sampled = SamplingParams {
+            temperature: 1.0,
+            ..greedy.clone()
+        };
+        let with = sampling_distribution(&logits, &sampled, history(), None);
+        let without = sampling_distribution(
+            &logits,
+            &SamplingParams {
+                dry: DryParams::off(),
+                ..sampled
+            },
+            history(),
+            None,
+        );
+        assert!(with[2] < without[2], "with={with:?} without={without:?}");
+    }
+
+    /// XTC removes the TOP candidates, so it can change greedy output --
+    /// and ferrox's greedy fast path knows that.
+    ///
+    /// `greedy_equals_argmax` is the predicate that decides whether the
+    /// `argmax` shortcut is exact. Make it return `true`
+    /// unconditionally and this goes red: the shortcut would return
+    /// token 0 while llama.cpp's chain, which runs XTC before the
+    /// temperature at every temperature, returns something else.
+    #[test]
+    fn xtc_changes_the_greedy_choice_because_it_removes_the_top() {
+        let logits = vec![3.0f32, 2.9, -10.0];
+        let params = SamplingParams {
+            temperature: 0.0,
+            // Always fires, and both leading candidates clear the
+            // threshold, so the more likely of the two is removed.
+            xtc_probability: 1.0,
+            xtc_threshold: 0.05,
+            ..SamplingParams::default()
+        };
+        assert!(!params.greedy_equals_argmax());
+        let mut sampler = Sampler::new(11);
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            1,
+            "XTC drops token 0, so the greedy answer is token 1"
+        );
+        // Without XTC the argmax stands, which is what makes the
+        // assertion above about XTC and not about the logits.
+        assert_eq!(
+            sampler.sample(
+                &logits,
+                &SamplingParams::default(),
+                PenaltyWindow::new(&[], &[])
+            ),
             0
         );
     }
 
+    /// The same for typical-p: it selects outward from the entropy and
+    /// can drop the most likely token, so the greedy shortcut is not
+    /// exact when it is live.
     #[test]
-    fn temperature_zero_is_deterministic_greedy_argmax() {
-        let logits = vec![0.1, 0.9, 0.3, -0.2];
-        let params = SamplingParams::default();
-        let mut sampler = Sampler::new(42);
-        assert_eq!(
-            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
-            1
-        );
-        // Must be deterministic regardless of RNG state advancing.
-        assert_eq!(
-            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
-            1
-        );
-    }
-
-    #[test]
-    fn high_temperature_can_pick_a_non_argmax_token_over_many_draws() {
-        let logits = vec![1.0, 1.0, 1.0, 1.0];
+    fn typical_p_can_drop_the_argmax_so_greedy_must_run_the_chain() {
+        // One near-certain token and three equal small ones. The
+        // entropy is dominated by the small tokens, so the near-certain
+        // one is the ATYPICAL member and typical-p at 0.5 keeps it
+        // alone here -- while at 0.5 on a flatter distribution it drops
+        // the leader. The property under test is the predicate.
         let params = SamplingParams {
-            temperature: 1.0,
+            temperature: 0.0,
+            typical_p: 0.5,
             ..SamplingParams::default()
         };
-        let mut sampler = Sampler::new(7);
-        let mut seen = std::collections::HashSet::new();
-        for _ in 0..200 {
-            seen.insert(sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])));
+        assert!(!params.greedy_equals_argmax());
+        assert!(SamplingParams {
+            typical_p: 1.0,
+            ..params.clone()
         }
-        assert!(
-            seen.len() > 1,
-            "uniform logits at temperature=1.0 must produce more than one distinct token across 200 draws"
-        );
-    }
+        .greedy_equals_argmax());
 
-    #[test]
-    fn top_k_one_is_equivalent_to_greedy() {
-        let logits = vec![0.1, 0.9, 0.3, -0.2];
-        let params = SamplingParams {
-            temperature: 1.0,
-            top_k: 1,
-            ..SamplingParams::default()
-        };
-        let mut sampler = Sampler::new(123);
-        for _ in 0..20 {
-            assert_eq!(
-                sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
-                1
-            );
-        }
-    }
-
-    #[test]
-    fn top_p_near_zero_is_equivalent_to_greedy() {
-        let logits = vec![0.1, 5.0, 0.3, -0.2];
-        let params = SamplingParams {
-            temperature: 1.0,
-            top_p: 0.001,
-            ..SamplingParams::default()
-        };
-        let mut sampler = Sampler::new(9);
-        for _ in 0..20 {
-            assert_eq!(
-                sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
-                1
-            );
-        }
-    }
-
-    #[test]
-    fn presence_and_frequency_penalties_reduce_seen_token_logits() {
-        let logits = vec![0.0, 5.0, 0.0];
-        let params = SamplingParams {
-            temperature: 1.0,
-            presence_penalty: 10.0,
-            frequency_penalty: 0.0,
-            ..SamplingParams::default()
-        };
-        let mut sampler = Sampler::new(1);
-        let mut counts = [0usize; 3];
-        for _ in 0..500 {
-            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1]))] += 1;
-        }
-        assert!(
-            counts[1] < 250,
-            "presence_penalty should discourage token 1; counts={counts:?}"
-        );
-
-        let params = SamplingParams {
-            temperature: 1.0,
-            presence_penalty: 0.0,
-            frequency_penalty: 10.0,
-            ..SamplingParams::default()
-        };
-        let mut sampler = Sampler::new(2);
-        counts = [0; 3];
-        for _ in 0..500 {
-            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1, 1, 1]))] += 1;
-        }
-        assert!(
-            counts[1] < 250,
-            "frequency_penalty should discourage repeated token 1; counts={counts:?}"
-        );
-    }
-
-    #[test]
-    fn repetition_penalty_reduces_probability_of_recently_seen_token() {
-        let logits = vec![0.0, 5.0, 0.0];
-        let params = SamplingParams {
-            temperature: 1.0,
-            repetition_penalty: 1000.0,
-            ..SamplingParams::default()
-        };
+        // logits ln(0.4), ln(0.2) x3: llama.cpp keeps the three 0.2
+        // candidates and drops the 0.4 leader (`tests/test-sampling.cpp:346`),
+        // so the greedy answer must not be token 0.
+        let logits: Vec<f32> = [0.4f32, 0.2, 0.2, 0.2].iter().map(|p| p.ln()).collect();
         let mut sampler = Sampler::new(3);
-        let mut counts = [0usize; 3];
-        for _ in 0..500 {
-            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1]))] += 1;
-        }
-        assert!(
-            counts[1] < 250,
-            "heavily penalizing token 1 (already in history) should make it far less likely than its raw logit alone would suggest; got counts={counts:?}"
+        assert_ne!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            0,
+            "typical-p drops the most likely token here"
         );
-    }
-
-    #[test]
-    fn low_seeds_do_not_bias_the_first_draw() {
-        // Every generation seeds a fresh `Sampler` (the server does it
-        // per request, from the caller's `seed`), so the FIRST draw off
-        // a freshly seeded generator is the one users actually see.
-        // Plain xorshift64 returns its own state, so seeds 1..4000 all
-        // produced a first draw in the bottom eighth of [0, 1) -- the
-        // first sampled token of every seeded request came off the
-        // bottom of the CDF.
-        let vocab = 8;
-        let logits = vec![0.0f32; vocab];
-        let params = SamplingParams {
-            temperature: 1.0,
-            ..SamplingParams::default()
-        };
-        let seeds = 4_000u64;
-        let mut counts = vec![0usize; vocab];
-        for seed in 1..=seeds {
-            counts[Sampler::new(seed).sample(&logits, &params, PenaltyWindow::new(&[], &[]))] += 1;
-        }
-        let expected = seeds as f64 / vocab as f64;
-        for (token, &c) in counts.iter().enumerate() {
-            assert!(
-                (c as f64 - expected).abs() < expected * 0.25,
-                "uniform logits: token {token} came up {c} times across {seeds} seeds, \
-                 expected about {expected:.0} (counts={counts:?})"
-            );
-        }
-    }
-
-    #[test]
-    fn the_published_distribution_is_the_one_sample_actually_draws_from() {
-        // `sampling_distribution` is load-bearing for lossless
-        // speculative verification: if it disagreed with what `sample`
-        // draws from, every accept/reject decision would be measured
-        // against the wrong target. Check them against each other
-        // empirically, with filters on so the two code paths have
-        // something to disagree about.
-        let logits = vec![0.4, 2.0, -1.0, 1.2, 0.9, -0.3];
-        let params = SamplingParams {
-            temperature: 0.8,
-            top_p: 0.9,
-            top_k: 4,
-            repetition_penalty: 1.3,
-            ..SamplingParams::default()
-        };
-        let history = [1usize, 4];
-        let claimed = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &history));
-        assert!((claimed.iter().sum::<f32>() - 1.0).abs() < 1e-5);
-
-        let draws = 100_000;
-        let mut counts = vec![0usize; logits.len()];
-        let mut sampler = Sampler::new(0xC0FFEE);
-        for _ in 0..draws {
-            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &history))] += 1;
-        }
-        for (i, &c) in counts.iter().enumerate() {
-            let empirical = c as f64 / draws as f64;
-            assert!(
-                (empirical - claimed[i] as f64).abs() < 0.01,
-                "token {i}: sample() draws it {empirical:.4} of the time but \
-                 sampling_distribution claims {:.4}",
-                claimed[i]
-            );
-        }
     }
 
     #[test]
@@ -1394,6 +874,7 @@ mod tests {
             &logits,
             &SamplingParams::default(),
             PenaltyWindow::new(&[], &[]),
+            None,
         );
         assert_eq!(probs, vec![0.0, 1.0, 0.0, 0.0]);
         // Penalties still apply at temperature 0, so the point mass
@@ -1405,165 +886,9 @@ mod tests {
                 ..SamplingParams::default()
             },
             PenaltyWindow::new(&[], &[1]),
+            None,
         );
         assert_eq!(penalized[1], 0.0);
         assert_eq!(penalized.iter().sum::<f32>(), 1.0);
-    }
-
-    #[test]
-    fn degenerate_all_zero_probability_falls_back_to_greedy() {
-        // top_k=1 combined with a top_p that would exclude even that
-        // one surviving token is a contradictory/degenerate
-        // configuration; must not panic or sample index 0 blindly.
-        let logits = vec![0.1, 0.9, 0.3, -0.2];
-        let params = SamplingParams {
-            temperature: 1.0,
-            top_k: 1,
-            top_p: 1.0,
-            ..SamplingParams::default()
-        };
-        let mut sampler = Sampler::new(1);
-        assert_eq!(
-            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
-            1
-        );
-    }
-
-    /// Only the keys the file actually carries become a recommendation.
-    ///
-    /// **This test fails if an absent key is filled with a house
-    /// default** (the naive reading, and what HF's own
-    /// `GenerationConfig` object does): `top_p` and `top_k` would come
-    /// back as `Some(1.0)` / `Some(0)` and would then override whatever
-    /// the server itself defaults to, for values this checkpoint never
-    /// expressed.
-    #[test]
-    fn an_absent_generation_config_key_stays_absent_rather_than_taking_a_default() {
-        let recommended = RecommendedSampling::from_generation_config(r#"{"temperature": 0.6}"#);
-        assert_eq!(recommended.temperature, Some(0.6));
-        assert_eq!(recommended.top_p, None, "top_p was not in the file");
-        assert_eq!(recommended.top_k, None, "top_k was not in the file");
-        // An explicit JSON null is silence too (the reference's
-        // `if val is not None`).
-        let nulled = RecommendedSampling::from_generation_config(r#"{"top_p": null}"#);
-        assert_eq!(nulled, RecommendedSampling::default());
-    }
-
-    /// A reasoning checkpoint's full recommendation survives intact --
-    /// the case the whole path exists for (Qwen3.5: temp 1.0, top_k 20,
-    /// top_p 0.95).
-    #[test]
-    fn every_generation_config_key_present_is_recommended() {
-        let recommended = RecommendedSampling::from_generation_config(
-            r#"{"do_sample": true, "temperature": 1.0, "top_k": 20, "top_p": 0.95}"#,
-        );
-        assert_eq!(
-            recommended,
-            RecommendedSampling {
-                temperature: Some(1.0),
-                top_p: Some(0.95),
-                top_k: Some(20),
-            }
-        );
-    }
-
-    /// `do_sample: false` recommends greedy, expressed as temperature 0
-    /// and *nothing else*: the top_k/top_p such a file also carries
-    /// describe a sampler it is asking not to be used, so returning them
-    /// would filter a distribution the model wants collapsed to its
-    /// argmax.
-    #[test]
-    fn do_sample_false_recommends_greedy_and_no_other_field() {
-        let recommended = RecommendedSampling::from_generation_config(
-            r#"{"do_sample": false, "temperature": 0.7, "top_k": 50, "top_p": 0.9}"#,
-        );
-        assert_eq!(recommended.temperature, Some(0.0));
-        assert_eq!(recommended.top_p, None);
-        assert_eq!(recommended.top_k, None);
-    }
-
-    /// A sidecar that does not parse must not be able to change how the
-    /// model is sampled.
-    #[test]
-    fn a_malformed_generation_config_recommends_nothing() {
-        for text in ["", "not json", "[1, 2, 3]", "null"] {
-            assert!(
-                RecommendedSampling::from_generation_config(text).is_empty(),
-                "{text:?} must recommend nothing"
-            );
-        }
-    }
-
-    /// Precedence: the request wins over the checkpoint, and the
-    /// checkpoint only fills what the request left unset. An explicit
-    /// `temperature: 0` from a client must stay reachable on a model
-    /// that recommends 1.0.
-    #[test]
-    fn a_request_outranks_the_recommendation_which_outranks_the_framework_default() {
-        let recommended = RecommendedSampling {
-            temperature: Some(1.0),
-            top_p: Some(0.95),
-            top_k: Some(20),
-        };
-        let resolved = recommended.resolve(
-            RequestedSampling {
-                temperature: Some(0.0),
-                ..RequestedSampling::default()
-            },
-            SamplingParams::default(),
-        );
-        assert_eq!(resolved.temperature, 0.0, "the request asked for greedy");
-        assert_eq!(resolved.top_p, 0.95, "the request said nothing about top_p");
-        assert_eq!(resolved.top_k, 20, "the request said nothing about top_k");
-        // Penalties are never recommended, only carried through.
-        assert_eq!(resolved.repetition_penalty, 1.0);
-    }
-
-    /// A checkpoint that recommends nothing must leave ferrox's existing
-    /// behaviour bit-identical: greedy, unfiltered, exactly
-    /// `SamplingParams::default()`.
-    #[test]
-    fn a_checkpoint_that_recommends_nothing_leaves_the_framework_defaults_alone() {
-        let resolved = RecommendedSampling::default()
-            .resolve(RequestedSampling::default(), SamplingParams::default());
-        let default = SamplingParams::default();
-        assert_eq!(resolved.temperature, default.temperature);
-        assert_eq!(resolved.top_p, default.top_p);
-        assert_eq!(resolved.top_k, default.top_k);
-    }
-
-    /// A model directory with no `generation_config.json` recommends
-    /// nothing rather than failing: the absence of a recommendation is
-    /// the normal case for most checkpoints.
-    #[test]
-    fn a_model_directory_without_a_generation_config_recommends_nothing() {
-        let dir = std::env::temp_dir().join(format!(
-            "ferrox_test_no_generation_config_{}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        assert!(RecommendedSampling::from_model_dir(&dir).is_empty());
-        std::fs::remove_dir_all(&dir).ok();
-    }
-
-    /// The sidecar is read from the directory beside the weights, the
-    /// same place HF's `GenerationConfig.from_pretrained` looks.
-    #[test]
-    fn a_model_directory_generation_config_is_read_from_beside_the_weights() {
-        let dir = std::env::temp_dir().join(format!(
-            "ferrox_test_generation_config_dir_{}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("generation_config.json"),
-            r#"{"temperature": 0.6, "top_p": 0.95}"#,
-        )
-        .unwrap();
-        let recommended = RecommendedSampling::from_model_dir(&dir);
-        std::fs::remove_dir_all(&dir).ok();
-        assert_eq!(recommended.temperature, Some(0.6));
-        assert_eq!(recommended.top_p, Some(0.95));
-        assert_eq!(recommended.top_k, None);
     }
 }

--- a/crates/ferrox-models/src/sampling/params.rs
+++ b/crates/ferrox-models/src/sampling/params.rs
@@ -1,0 +1,245 @@
+//! [`SamplingParams`]: everything one generation request says about how
+//! the sampler chain should behave.
+//!
+//! Split out of `sampling.rs` because it is a different concept from the
+//! RNG and the chain runner that read it, and because it is the struct
+//! the whole workspace agrees about: the CLI flags build one, the two
+//! OpenAI routes and llama.cpp's native `/completion` build one, the
+//! response cache destructures one EXHAUSTIVELY (`ferrox_server::
+//! response_cache::sampling_key`) so that a knob added here and
+//! forgotten there stops that crate compiling.
+//!
+//! Every field's default is the value that makes its sampler a NO-OP,
+//! and where llama.cpp has a neutral value the two agree. llama.cpp's
+//! own CLI numbers (`--temp 0.8`, `--top-k 40`, `--min-p 0.05`) live on
+//! ferrox's CLI flags, where the person who typed them can see them, and
+//! not here: `SamplingParams::default()` is the "do nothing the caller
+//! did not ask for" baseline that an HTTP request with an empty body
+//! resolves to.
+
+use crate::dry::DryParams;
+use crate::sampler_order::{ChainStep, SamplerOrder};
+
+/// Sampling parameters for one generation request. `temperature <= 0.0`
+/// means "sample nothing, take the greedy argmax" -- the same
+/// deterministic behavior ferrox always had before this module existed.
+#[derive(Debug, Clone)]
+pub struct SamplingParams {
+    pub temperature: f32,
+    /// Nucleus sampling threshold in (0.0, 1.0]. 1.0 disables top-p
+    /// filtering (every token with nonzero probability is eligible).
+    pub top_p: f32,
+    /// Keep only candidates at least `min_p` times as likely as the most
+    /// likely one. `0.0` disables it; llama.cpp's `--min-p`, whose
+    /// default is **0.05** (`common/common.h:231`) rather than off.
+    ///
+    /// That default is why this is a parity item and not a feature:
+    /// llama.cpp truncates with min-p on every run nobody configured,
+    /// so without it ferrox could not reproduce llama.cpp's *own*
+    /// out-of-the-box output for any prompt.
+    ///
+    /// The struct default here stays `0.0` (disabled) for the same
+    /// reason `temperature` defaults to greedy: `SamplingParams::default`
+    /// is ferrox's "do nothing the caller did not ask for" baseline, and
+    /// llama.cpp's CLI numbers live on the CLI flags.
+    pub min_p: f32,
+    /// Keep only the `top_k` highest-probability tokens before
+    /// sampling. 0 disables top-k filtering.
+    pub top_k: usize,
+    /// Locally typical sampling, llama.cpp's `typ_p`
+    /// (`common/common.h:230`, default **1.0 = disabled**).
+    ///
+    /// Keeps the candidates whose surprisal is CLOSEST to the
+    /// distribution's entropy, from the middle outward, rather than the
+    /// most likely ones -- see
+    /// [`crate::sampler_chain::Candidates::typical_p`].
+    pub typical_p: f32,
+    /// Truncate at `n` standard deviations of the logits below the
+    /// maximum, llama.cpp's `top_n_sigma` (`common/common.h:250`,
+    /// default **-1.0 = disabled**).
+    pub top_n_sigma: f32,
+    /// The probability that XTC removes the top candidates on any one
+    /// token, llama.cpp's `xtc_probability` (`common/common.h:228`,
+    /// default **0.0 = disabled**).
+    pub xtc_probability: f32,
+    /// The probability a candidate must reach to be a candidate XTC
+    /// might remove, llama.cpp's `xtc_threshold` (`common/common.h:229`,
+    /// default 0.1). **Above 0.5 disables XTC**, which is upstream's
+    /// guard and not a range check: above 0.5 at most one candidate can
+    /// ever clear it, and XTC never removes the last one.
+    pub xtc_threshold: f32,
+    /// The DRY sequence-repetition penalty. Disabled by default; see
+    /// [`crate::dry`] for why its breakers are a type invariant rather
+    /// than four more `f32`s here.
+    pub dry: DryParams,
+    /// > 1.0 discourages repeating a token already in the
+    /// > [`crate::penalty_window::PenaltyWindow`] -- prompt included;
+    /// > 1.0 disables repetition penalty. Uses the standard convention
+    /// > (divide positive logits, multiply negative ones) so the penalty
+    /// > always pushes toward *less* likely, regardless of logit sign.
+    pub repetition_penalty: f32,
+    /// How many of the most recent tokens the penalties look at, as
+    /// llama.cpp's `penalty_last_n` (`common/common.h:238`, default 64).
+    ///
+    /// `0` disables the penalties entirely. ferrox had no window at all
+    /// and scanned the WHOLE history, so on a long generation it
+    /// penalised a steadily growing set of tokens where llama.cpp
+    /// penalises the last 64 -- the divergence grew with output length,
+    /// which is exactly when a repetition penalty matters most.
+    pub penalty_last_n: usize,
+    /// OpenAI-style presence penalty: subtract from logits of tokens
+    /// that already appeared in the window (once per distinct token).
+    pub presence_penalty: f32,
+    /// OpenAI-style frequency penalty: subtract `frequency_penalty *
+    /// count` from logits for each token id seen in the window.
+    pub frequency_penalty: f32,
+    /// The ORDER the chain above runs in, llama.cpp's `--samplers`.
+    ///
+    /// Not a cosmetic setting. Each filter renormalises over the
+    /// survivors of the last one, so moving a step changes which
+    /// candidates the next step can see -- ferrox has already shipped
+    /// that bug once, with temperature running first.
+    ///
+    /// The default is llama.cpp's own default chain
+    /// (`penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature`),
+    /// and every step ferrox added to it is a no-op at the neutral
+    /// values above. See [`crate::sampler_order`].
+    pub sampler_order: SamplerOrder,
+}
+
+impl Default for SamplingParams {
+    /// Greedy decoding: identical behavior to ferrox's original
+    /// argmax-only generation loop.
+    fn default() -> Self {
+        SamplingParams {
+            temperature: 0.0,
+            top_p: 1.0,
+            min_p: 0.0,
+            top_k: 0,
+            typical_p: 1.0,
+            top_n_sigma: -1.0,
+            xtc_probability: 0.0,
+            xtc_threshold: 0.1,
+            dry: DryParams::off(),
+            repetition_penalty: 1.0,
+            penalty_last_n: 64,
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
+            sampler_order: SamplerOrder::default(),
+        }
+    }
+}
+
+impl SamplingParams {
+    /// The single predicate for "XTC can remove something".
+    ///
+    /// llama.cpp tests the same two conditions in two places --
+    /// `llama_sampler_init_xtc` returns an empty sampler at `:2208` and
+    /// `llama_sample_xtc_apply` returns early at `:2139` -- and this is
+    /// one function because ferrox reads it in two places too: the RNG
+    /// draw ([`super::Sampler::xtc_roll`]) and the filter itself. If
+    /// those disagreed, either the seeded stream would advance on a run
+    /// XTC never touched (making an existing generation irreproducible)
+    /// or XTC would ask for a draw nobody made.
+    pub fn xtc_can_fire(&self) -> bool {
+        self.xtc_probability > 0.0 && self.xtc_threshold <= 0.5
+    }
+
+    /// True when no step in this chain can move the argmax, so greedy
+    /// decoding may skip building the candidate list entirely -- and a
+    /// backend may fold `lm_head + argmax` into its decode stack.
+    ///
+    /// llama.cpp does not special-case `temp <= 0`: it runs the whole
+    /// chain and lets the temperature step set every logit but the
+    /// maximum to `-inf` (`src/llama-sampler.cpp:271-286`), so a filter
+    /// that removed the maximum changes greedy output. Exactly two do:
+    ///
+    /// * `xtc` removes the TOP candidates, by construction;
+    /// * `typ_p` selects outward from the distribution's entropy and can
+    ///   drop the most likely token -- llama.cpp's own test case
+    ///   `test_typical({0.4, 0.2, 0.2, 0.2}, {0.2, 0.2, 0.2}, 0.5)`
+    ///   (`tests/test-sampling.cpp:346`) drops it.
+    ///
+    /// `dry` changes logits rather than removing candidates, but it can
+    /// change WHICH logit is the maximum, so it counts too. `top_k`,
+    /// `top_p`, `min_p` and `top_n_sigma` all keep the maximum by
+    /// construction, and `penalties` is applied to the whole vocabulary
+    /// before the candidate list exists.
+    ///
+    /// **One predicate, three readers**, because the alternative is this
+    /// repo's dominant defect: the sampler's own greedy shortcut
+    /// ([`super::greedy_choice`]), the Metal `lm_head + argmax` fold in
+    /// `ferrox_server::generate` and the same fold in `ferrox_cli::run`
+    /// must agree about it. A fold that ran while `xtc` was configured
+    /// would hand the sampler a single precomputed id with no
+    /// vocabulary left to remove anything from, and XTC would silently
+    /// not run.
+    ///
+    /// Chain membership is checked, not just the knob: a caller who set
+    /// `xtc_probability` but left `xtc` out of `--samplers` asked for no
+    /// XTC, and must keep the fast path.
+    pub fn greedy_equals_argmax(&self) -> bool {
+        let runs = |step| self.sampler_order.steps().contains(&step);
+        !(runs(ChainStep::Xtc) && self.xtc_can_fire())
+            && !(runs(ChainStep::TypP) && self.typical_p < 1.0)
+            && !(runs(ChainStep::Dry) && self.dry.is_enabled())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every knob this struct defaults to is the value that makes its
+    /// sampler do nothing, which is what lets llama.cpp's full default
+    /// chain be ferrox's default chain without changing any existing
+    /// run's output.
+    ///
+    /// The neutral values are llama.cpp's own (`common/common.h:228-250`):
+    /// `typ_p 1.00`, `top_n_sigma -1.00`, `xtc_probability 0.00`,
+    /// `dry_multiplier 0.0`. `xtc_threshold` defaults to upstream's
+    /// 0.10, which is NOT neutral on its own -- the probability is what
+    /// switches XTC off -- so it is pinned here rather than assumed.
+    #[test]
+    fn every_new_sampler_defaults_to_its_own_no_op() {
+        let d = SamplingParams::default();
+        assert_eq!(d.typical_p, 1.0, "1.0 disables typical-p");
+        assert_eq!(d.top_n_sigma, -1.0, "<= 0 disables top-n-sigma");
+        assert_eq!(d.xtc_probability, 0.0, "0.0 disables xtc");
+        assert_eq!(d.xtc_threshold, 0.1, "llama.cpp's default threshold");
+        assert!(!d.xtc_can_fire());
+        assert!(!d.dry.is_enabled(), "dry_multiplier 0.0 disables dry");
+    }
+
+    /// Both halves of the XTC guard, because only one of them is
+    /// obvious. A threshold above 0.5 disables XTC outright upstream: at
+    /// most one candidate can hold more than half the mass, and XTC
+    /// never removes the last candidate above the threshold.
+    #[test]
+    fn a_threshold_above_a_half_disables_xtc_as_surely_as_a_zero_probability() {
+        let live = SamplingParams {
+            xtc_probability: 0.5,
+            xtc_threshold: 0.1,
+            ..SamplingParams::default()
+        };
+        assert!(live.xtc_can_fire());
+        assert!(!SamplingParams {
+            xtc_threshold: 0.51,
+            ..live.clone()
+        }
+        .xtc_can_fire());
+        assert!(
+            SamplingParams {
+                xtc_threshold: 0.5,
+                ..live.clone()
+            }
+            .xtc_can_fire(),
+            "0.5 itself is still live"
+        );
+        assert!(!SamplingParams {
+            xtc_probability: 0.0,
+            ..live
+        }
+        .xtc_can_fire());
+    }
+}

--- a/crates/ferrox-models/src/sampling/penalties.rs
+++ b/crates/ferrox-models/src/sampling/penalties.rs
@@ -1,0 +1,197 @@
+//! The three history penalties -- repetition, presence, frequency --
+//! applied to the whole vocabulary before the candidate list exists.
+//!
+//! Split out of `sampling.rs`: this is `llama_sampler_penalties`, one
+//! step of the chain, and it is the only step that runs on the GREEDY
+//! path as well as the sampled one, which is why it lives beside the
+//! window rather than beside the candidate-list filters.
+
+use super::SamplingParams;
+use crate::penalty_window::PenaltyWindow;
+
+/// Penalise tokens that already appear in `history`, once each.
+///
+/// `history` is a [`PenaltyWindow`], so "already appear" includes the
+/// PROMPT. That is llama.cpp's rule and the module docs of
+/// [`crate::penalty_window`] carry the upstream lines; before it, every
+/// caller in this workspace picked its own slice and four of the five
+/// picked differently.
+///
+/// ONCE EACH is the whole subtlety, and ferrox used to get it wrong.
+/// llama.cpp walks the CANDIDATE list and looks each candidate up in a
+/// count map (`llama-sampler.cpp:2735-2756`), so a token repeated `n`
+/// times is divided by `penalty_repeat` exactly once. ferrox walked the
+/// HISTORY, so the same token was divided `n` times and the effective
+/// penalty was `penalty^n`.
+///
+/// That was live on every `ferrox run`: `--repeat-penalty` defaults to
+/// 1.1, so a token seen five times was penalised 1.61x rather than
+/// 1.1x, and the divergence grew with the length of the output.
+///
+/// The sign convention is llama.cpp's and its comment explains it:
+/// dividing alone would make tokens with NEGATIVE logits more likely,
+/// so negatives are multiplied instead.
+///
+/// A chain that does not name `penalties` does not penalise. llama.cpp
+/// reads an omitted sampler as "do not run it", and this function is the
+/// one place the penalties happen -- on the greedy path as well as the
+/// sampled one -- so the check belongs here rather than beside the
+/// candidate list, where the greedy path would never see it.
+pub(crate) fn apply_history_penalties(
+    scores: &mut [f32],
+    params: &SamplingParams,
+    history: PenaltyWindow<'_>,
+) {
+    if !params.sampler_order.has_penalties() {
+        return;
+    }
+    if params.repetition_penalty == 1.0
+        && params.presence_penalty == 0.0
+        && params.frequency_penalty == 0.0
+    {
+        return;
+    }
+    // Only the last `penalty_last_n`, as llama.cpp's ring buffer does.
+    if params.penalty_last_n == 0 {
+        return;
+    }
+    let mut counts = std::collections::HashMap::<usize, usize>::new();
+    for tok in history.recent(params.penalty_last_n) {
+        *counts.entry(tok).or_insert(0) += 1;
+    }
+    for (tok, count) in counts {
+        let Some(s) = scores.get_mut(tok) else {
+            continue;
+        };
+        if params.repetition_penalty != 1.0 {
+            *s = if *s > 0.0 {
+                *s / params.repetition_penalty
+            } else {
+                *s * params.repetition_penalty
+            };
+        }
+        *s -= params.frequency_penalty * count as f32;
+        *s -= params.presence_penalty;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The repetition penalty is applied ONCE per token, however many
+    /// times that token appears in the history.
+    ///
+    /// ferrox walked the history and divided once per OCCURRENCE, so the
+    /// effective penalty was `penalty^n`. llama.cpp walks the candidates
+    /// and looks each up in a count map, so it is `penalty` flat
+    /// (`llama-sampler.cpp:2735-2756`).
+    ///
+    /// Live on every `ferrox run`: `--repeat-penalty` defaults to 1.1,
+    /// so a token seen five times was penalised 1.61x, and the
+    /// divergence grew with the length of the output. Twenty-four
+    /// sampling tests passed with the bug in place, which is why this
+    /// one exists.
+    #[test]
+    fn the_repetition_penalty_does_not_compound_with_repeats() {
+        let params = SamplingParams {
+            temperature: 1.0,
+            top_p: 1.0,
+            top_k: 0,
+            repetition_penalty: 2.0,
+            ..SamplingParams::default()
+        };
+        let logits = vec![4.0f32, 1.0, 1.0];
+
+        // Token 0 appears five times. Penalised once, its score is 2.0;
+        // compounded it would be 4 / 2^5 = 0.125.
+        let mut scores = logits.clone();
+        apply_history_penalties(
+            &mut scores,
+            &params,
+            PenaltyWindow::new(&[], &[0, 0, 0, 0, 0]),
+        );
+        assert!(
+            (scores[0] - 2.0).abs() < 1e-6,
+            "expected one division (2.0), got {} -- {} would be 2^5",
+            scores[0],
+            4.0f32 / 32.0
+        );
+
+        // And once really is once: one occurrence and five occurrences
+        // must land on the same score, or the count still leaks in.
+        let mut once = logits.clone();
+        apply_history_penalties(&mut once, &params, PenaltyWindow::new(&[], &[0]));
+        assert_eq!(once[0].to_bits(), scores[0].to_bits());
+
+        // A NEGATIVE logit is multiplied rather than divided, or the
+        // penalty would make it more likely -- llama.cpp's own comment.
+        let mut negative = vec![-4.0f32];
+        apply_history_penalties(&mut negative, &params, PenaltyWindow::new(&[], &[0, 0, 0]));
+        assert!((negative[0] + 8.0).abs() < 1e-6, "got {}", negative[0]);
+    }
+
+    /// The penalties look at the last `penalty_last_n` tokens, not the
+    /// whole history.
+    ///
+    /// llama.cpp keeps a ring buffer of `penalty_last_n` (default 64,
+    /// `common/common.h:238`); ferrox scanned everything generated so
+    /// far. On a long generation that is a steadily growing set of
+    /// penalised tokens against llama.cpp's fixed 64 -- the divergence
+    /// grows with output length, which is when a repetition penalty
+    /// matters most.
+    #[test]
+    fn the_penalties_only_see_the_last_n_tokens() {
+        let params = SamplingParams {
+            repetition_penalty: 2.0,
+            penalty_last_n: 2,
+            ..SamplingParams::default()
+        };
+        let mut scores = vec![8.0f32, 8.0, 8.0];
+        // Token 0 fell out of the window; tokens 1 and 2 are in it.
+        apply_history_penalties(&mut scores, &params, PenaltyWindow::new(&[], &[0, 1, 2]));
+        assert_eq!(
+            scores[0].to_bits(),
+            8.0f32.to_bits(),
+            "token 0 is outside the window"
+        );
+        assert!((scores[1] - 4.0).abs() < 1e-6, "got {}", scores[1]);
+        assert!((scores[2] - 4.0).abs() < 1e-6, "got {}", scores[2]);
+
+        // `0` disables the penalties outright, as llama.cpp documents.
+        let off = SamplingParams {
+            penalty_last_n: 0,
+            ..params.clone()
+        };
+        let mut untouched = vec![8.0f32; 3];
+        apply_history_penalties(&mut untouched, &off, PenaltyWindow::new(&[], &[0, 1, 2]));
+        assert_eq!(untouched, vec![8.0f32; 3]);
+
+        // A window longer than the history is not an overflow.
+        let wide = SamplingParams {
+            penalty_last_n: 1000,
+            ..params
+        };
+        let mut short = vec![8.0f32];
+        apply_history_penalties(&mut short, &wide, PenaltyWindow::new(&[], &[0]));
+        assert!((short[0] - 4.0).abs() < 1e-6);
+    }
+
+    /// Frequency penalty still scales with the count, while the
+    /// repetition penalty does not.
+    ///
+    /// Both live in the same loop, so a fix that made the repetition
+    /// penalty flat by dropping the counts would break this one.
+    #[test]
+    fn the_frequency_penalty_still_counts_repeats() {
+        let params = SamplingParams {
+            frequency_penalty: 0.5,
+            presence_penalty: 0.25,
+            ..SamplingParams::default()
+        };
+        let mut scores = vec![10.0f32];
+        apply_history_penalties(&mut scores, &params, PenaltyWindow::new(&[], &[0, 0, 0, 0]));
+        // 10 - 0.5*4 - 0.25 = 7.75
+        assert!((scores[0] - 7.75).abs() < 1e-6, "got {}", scores[0]);
+    }
+}

--- a/crates/ferrox-models/src/sampling/recommended.rs
+++ b/crates/ferrox-models/src/sampling/recommended.rs
@@ -1,0 +1,292 @@
+//! The sampling a **checkpoint recommends for itself**, and the
+//! precedence that resolves it against what one request asked for.
+//!
+//! Split out of `sampling.rs`: this is a policy about where a number
+//! comes from, not part of the sampler that consumes it.
+
+use super::SamplingParams;
+
+/// The sampling a **checkpoint recommends for itself**, one `Option`
+/// per field so that "this model says nothing about top_p" stays
+/// distinguishable from "this model recommends top_p = 1.0". This is
+/// sglang's `sampling_defaults='model'`, ported from FreeToken
+/// `python/freetoken/utils/hf.py:92 load_generation_sampling`.
+///
+/// Every field is `None` for a checkpoint that recommends nothing,
+/// which is the overwhelming majority, and
+/// [`RecommendedSampling::resolve`] then reproduces ferrox's existing
+/// defaults exactly -- a recommendation may only fill a gap the request
+/// left, never override it.
+///
+/// Why this exists at all: reasoning checkpoints are tuned for a
+/// specific sampler (Qwen3.5 ships temperature 1.0, top_k 20, top_p
+/// 0.95) and ship those numbers with the weights. Served under a
+/// generic greedy-or-0.8 default they fall into repetition loops --
+/// fluent output that never terminates -- which reads as a broken model
+/// rather than as a serving default nobody read off the file.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct RecommendedSampling {
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub top_k: Option<usize>,
+}
+
+/// The sampling fields **one request** actually specified. `None` means
+/// the request said nothing about that field, so the checkpoint's
+/// recommendation (and then the framework default) may speak for it.
+///
+/// Collapsing this to a plain [`SamplingParams`] at the wire boundary
+/// -- `temperature: req.temperature.unwrap_or(0.0)` -- is what destroys
+/// the distinction: a request that omitted `temperature` becomes
+/// indistinguishable from one that explicitly asked for greedy, and no
+/// recommendation can ever apply.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct RequestedSampling {
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub top_k: Option<usize>,
+}
+
+impl RecommendedSampling {
+    /// True when the checkpoint recommended nothing at all, i.e.
+    /// [`Self::resolve`] is guaranteed to return the framework defaults
+    /// for any request. Useful for telling an operator whether
+    /// "model defaults" had anything to act on.
+    pub fn is_empty(&self) -> bool {
+        *self == RecommendedSampling::default()
+    }
+
+    /// Precedence, exactly as FreeToken's `resolve_sampling.pick`
+    /// (`python/freetoken/server/generation.py:170`) applies it: the
+    /// **request's** own value, else the **checkpoint's**
+    /// recommendation, else the **framework** default carried by
+    /// `framework` (ferrox's `SamplingParams::default()` unless a caller
+    /// has its own).
+    ///
+    /// The penalty fields are taken from `framework` untouched: nothing
+    /// in the reference reads a recommended penalty, and inventing one
+    /// here would be this function changing generation on its own.
+    ///
+    /// Getting the order wrong in either direction is a silent
+    /// behaviour change: recommendation-over-request makes a client's
+    /// explicit `temperature: 0` unreachable on a model that recommends
+    /// 1.0, and framework-over-recommendation is the greedy repetition
+    /// loop this whole path exists to avoid.
+    pub fn resolve(
+        &self,
+        requested: RequestedSampling,
+        framework: SamplingParams,
+    ) -> SamplingParams {
+        SamplingParams {
+            temperature: requested
+                .temperature
+                .or(self.temperature)
+                .unwrap_or(framework.temperature),
+            top_p: requested.top_p.or(self.top_p).unwrap_or(framework.top_p),
+            top_k: requested.top_k.or(self.top_k).unwrap_or(framework.top_k),
+            ..framework
+        }
+    }
+
+    /// The recommendation in a HuggingFace-style `generation_config.json`
+    /// body.
+    ///
+    /// Two rules, both from the reference
+    /// (`hf.py:92 load_generation_sampling`):
+    ///
+    /// * `do_sample: false` means the checkpoint recommends **greedy**,
+    ///   which is returned as `temperature = 0` and *nothing else* --
+    ///   the top_k/top_p in such a file describe a sampler the model
+    ///   asks not to be used.
+    /// * otherwise only the keys **actually present** are returned. An
+    ///   absent key stays `None`; filling it with a house default (the
+    ///   naive reading, and what HF's own `GenerationConfig` object does
+    ///   for you) would turn silence into a recommendation and let a
+    ///   file that says only `temperature: 0.6` also pin top_p to 1.0,
+    ///   overriding the server's own default for a value the checkpoint
+    ///   never expressed.
+    ///
+    /// A file that does not parse, or is not a JSON object, recommends
+    /// nothing -- a malformed sidecar must not be able to change how a
+    /// model is sampled.
+    pub fn from_generation_config(json: &str) -> Self {
+        let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<serde_json::Value>(json)
+        else {
+            return RecommendedSampling::default();
+        };
+        if map.get("do_sample").and_then(|v| v.as_bool()) == Some(false) {
+            return RecommendedSampling {
+                temperature: Some(0.0),
+                ..RecommendedSampling::default()
+            };
+        }
+        RecommendedSampling {
+            temperature: map
+                .get("temperature")
+                .and_then(|v| v.as_f64())
+                .map(|v| v as f32),
+            top_p: map.get("top_p").and_then(|v| v.as_f64()).map(|v| v as f32),
+            top_k: map
+                .get("top_k")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize),
+        }
+    }
+
+    /// [`Self::from_generation_config`] for the `generation_config.json`
+    /// beside a checkpoint's weights (an HF-format model directory).
+    ///
+    /// A directory with no such file recommends nothing, exactly like a
+    /// GGUF with no `general.sampling.*` keys: the absence of a
+    /// recommendation is the normal case and must never be an error that
+    /// stops a model from loading.
+    pub fn from_model_dir(dir: &std::path::Path) -> Self {
+        match std::fs::read_to_string(dir.join("generation_config.json")) {
+            Ok(text) => Self::from_generation_config(&text),
+            Err(_) => RecommendedSampling::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only the keys the file actually carries become a recommendation.
+    ///
+    /// **This test fails if an absent key is filled with a house
+    /// default** (the naive reading, and what HF's own
+    /// `GenerationConfig` object does): `top_p` and `top_k` would come
+    /// back as `Some(1.0)` / `Some(0)` and would then override whatever
+    /// the server itself defaults to, for values this checkpoint never
+    /// expressed.
+    #[test]
+    fn an_absent_generation_config_key_stays_absent_rather_than_taking_a_default() {
+        let recommended = RecommendedSampling::from_generation_config(r#"{"temperature": 0.6}"#);
+        assert_eq!(recommended.temperature, Some(0.6));
+        assert_eq!(recommended.top_p, None, "top_p was not in the file");
+        assert_eq!(recommended.top_k, None, "top_k was not in the file");
+        // An explicit JSON null is silence too (the reference's
+        // `if val is not None`).
+        let nulled = RecommendedSampling::from_generation_config(r#"{"top_p": null}"#);
+        assert_eq!(nulled, RecommendedSampling::default());
+    }
+
+    /// A reasoning checkpoint's full recommendation survives intact --
+    /// the case the whole path exists for (Qwen3.5: temp 1.0, top_k 20,
+    /// top_p 0.95).
+    #[test]
+    fn every_generation_config_key_present_is_recommended() {
+        let recommended = RecommendedSampling::from_generation_config(
+            r#"{"do_sample": true, "temperature": 1.0, "top_k": 20, "top_p": 0.95}"#,
+        );
+        assert_eq!(
+            recommended,
+            RecommendedSampling {
+                temperature: Some(1.0),
+                top_p: Some(0.95),
+                top_k: Some(20),
+            }
+        );
+    }
+
+    /// `do_sample: false` recommends greedy, expressed as temperature 0
+    /// and *nothing else*: the top_k/top_p such a file also carries
+    /// describe a sampler it is asking not to be used, so returning them
+    /// would filter a distribution the model wants collapsed to its
+    /// argmax.
+    #[test]
+    fn do_sample_false_recommends_greedy_and_no_other_field() {
+        let recommended = RecommendedSampling::from_generation_config(
+            r#"{"do_sample": false, "temperature": 0.7, "top_k": 50, "top_p": 0.9}"#,
+        );
+        assert_eq!(recommended.temperature, Some(0.0));
+        assert_eq!(recommended.top_p, None);
+        assert_eq!(recommended.top_k, None);
+    }
+
+    /// A sidecar that does not parse must not be able to change how the
+    /// model is sampled.
+    #[test]
+    fn a_malformed_generation_config_recommends_nothing() {
+        for text in ["", "not json", "[1, 2, 3]", "null"] {
+            assert!(
+                RecommendedSampling::from_generation_config(text).is_empty(),
+                "{text:?} must recommend nothing"
+            );
+        }
+    }
+
+    /// Precedence: the request wins over the checkpoint, and the
+    /// checkpoint only fills what the request left unset. An explicit
+    /// `temperature: 0` from a client must stay reachable on a model
+    /// that recommends 1.0.
+    #[test]
+    fn a_request_outranks_the_recommendation_which_outranks_the_framework_default() {
+        let recommended = RecommendedSampling {
+            temperature: Some(1.0),
+            top_p: Some(0.95),
+            top_k: Some(20),
+        };
+        let resolved = recommended.resolve(
+            RequestedSampling {
+                temperature: Some(0.0),
+                ..RequestedSampling::default()
+            },
+            SamplingParams::default(),
+        );
+        assert_eq!(resolved.temperature, 0.0, "the request asked for greedy");
+        assert_eq!(resolved.top_p, 0.95, "the request said nothing about top_p");
+        assert_eq!(resolved.top_k, 20, "the request said nothing about top_k");
+        // Penalties are never recommended, only carried through.
+        assert_eq!(resolved.repetition_penalty, 1.0);
+    }
+
+    /// A checkpoint that recommends nothing must leave ferrox's existing
+    /// behaviour bit-identical: greedy, unfiltered, exactly
+    /// `SamplingParams::default()`.
+    #[test]
+    fn a_checkpoint_that_recommends_nothing_leaves_the_framework_defaults_alone() {
+        let resolved = RecommendedSampling::default()
+            .resolve(RequestedSampling::default(), SamplingParams::default());
+        let default = SamplingParams::default();
+        assert_eq!(resolved.temperature, default.temperature);
+        assert_eq!(resolved.top_p, default.top_p);
+        assert_eq!(resolved.top_k, default.top_k);
+    }
+
+    /// A model directory with no `generation_config.json` recommends
+    /// nothing rather than failing: the absence of a recommendation is
+    /// the normal case for most checkpoints.
+    #[test]
+    fn a_model_directory_without_a_generation_config_recommends_nothing() {
+        let dir = std::env::temp_dir().join(format!(
+            "ferrox_test_no_generation_config_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(RecommendedSampling::from_model_dir(&dir).is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The sidecar is read from the directory beside the weights, the
+    /// same place HF's `GenerationConfig.from_pretrained` looks.
+    #[test]
+    fn a_model_directory_generation_config_is_read_from_beside_the_weights() {
+        let dir = std::env::temp_dir().join(format!(
+            "ferrox_test_generation_config_dir_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("generation_config.json"),
+            r#"{"temperature": 0.6, "top_p": 0.95}"#,
+        )
+        .unwrap();
+        let recommended = RecommendedSampling::from_model_dir(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+        assert_eq!(recommended.temperature, Some(0.6));
+        assert_eq!(recommended.top_p, Some(0.95));
+        assert_eq!(recommended.top_k, None);
+    }
+}

--- a/crates/ferrox-models/src/sampling/rng.rs
+++ b/crates/ferrox-models/src/sampling/rng.rs
@@ -1,0 +1,472 @@
+//! The seeded generator every draw in a generation comes off, and the
+//! entry points that use it.
+//!
+//! Split out of `sampling.rs` so the chain runner beside it stays about
+//! the chain. The RNG is one concept and a small one, but it is the
+//! concept the whole run's reproducibility rests on: a request that
+//! passed `seed: 42` must draw the same tokens on every machine, so
+//! every draw -- the token, speculative decoding's accept coin, and
+//! XTC's -- has to come off this one stream in this one order.
+
+use super::penalties::apply_history_penalties;
+use super::{filtered_distribution, greedy_choice, SamplingParams};
+use crate::penalty_window::PenaltyWindow;
+
+/// Sets logits a caller wants to forbid to `-inf`, in place, before the
+/// sampler looks at them.
+///
+/// Two callers today, and they COMPOSE rather than exclude each other --
+/// a masked logit stays masked, so the order they run in cannot matter:
+/// JSON-object mode's character-class filter
+/// (`ferrox_server::json_mode`), and grammar-constrained decoding
+/// ([`crate::grammar_sampler::GrammarSampler::mask_logits`]).
+///
+/// The signature returns nothing because the callback runs from inside
+/// the sampler, which has no error to return one through. A mask that
+/// CAN fail -- a grammar that dead-ends leaves every logit at `-inf`,
+/// and sampling from that is how an "impossible" request becomes
+/// arbitrary text with a 200 -- records its refusal in the closure's own
+/// captured state, and the decode loop reads it after the sample and
+/// throws the token away. `ferrox_server::sample_step::sample_next` is
+/// the one place that pairing lives.
+pub type LogitMask<'a> = &'a mut dyn FnMut(&mut [f32]);
+
+/// A small, seedable xorshift64* generator. Not cryptographically
+/// secure -- sampling doesn't need that -- but reproducible given a
+/// seed, which greedy argmax already was for free.
+pub struct Sampler {
+    state: u64,
+}
+
+impl Sampler {
+    pub fn new(seed: u64) -> Self {
+        // xorshift64* requires a nonzero seed.
+        Sampler {
+            state: if seed == 0 { 0x9E3779B97F4A7C15 } else { seed },
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state ^= self.state << 13;
+        self.state ^= self.state >> 7;
+        self.state ^= self.state << 17;
+        // The `*` in xorshift64*. Without it this is plain xorshift64,
+        // whose state IS its output, and a small seed's first output is
+        // therefore still small: for every seed below ~4000 the first
+        // draw landed in the bottom eighth of [0, 1), so a request that
+        // asked for `seed: 42` always got its first token from the
+        // bottom of the CDF. The multiply is what decorrelates the
+        // output from a low-entropy state; see
+        // `low_seeds_do_not_bias_the_first_draw`.
+        self.state.wrapping_mul(0x2545F491_4F6CDD1D)
+    }
+
+    /// Uniform float in [0.0, 1.0).
+    fn next_f32(&mut self) -> f32 {
+        (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32
+    }
+
+    /// The one uniform draw XTC needs for this token, or `None` when XTC
+    /// cannot fire for these parameters.
+    ///
+    /// XTC is the only sampler in the chain that is itself stochastic
+    /// (`llama_sample_xtc_apply` draws from its own `std::mt19937`,
+    /// `src/llama-sampler.cpp:2146`), which is why the chain below takes
+    /// the roll as an argument instead of owning an RNG: the chain is
+    /// also what `sampling_distribution` runs for speculative
+    /// verification, and a filter that drew its own randomness there
+    /// would make "the distribution the sampler draws from" a different
+    /// distribution every time it was asked.
+    ///
+    /// **The draw is skipped when XTC cannot fire**, and that is not an
+    /// optimisation. Every draw advances the seeded stream, so drawing
+    /// unconditionally would shift every subsequent token of every
+    /// existing seeded generation, on every run that never asked for
+    /// XTC. [`SamplingParams::xtc_can_fire`] is the single predicate
+    /// this and [`Candidates::xtc`] share.
+    pub fn xtc_roll(&mut self, params: &SamplingParams) -> Option<f32> {
+        if params.xtc_can_fire() {
+            Some(self.next_f32())
+        } else {
+            None
+        }
+    }
+
+    /// Samples one token id from `logits`, given `params` and the
+    /// [`PenaltyWindow`] the penalties look back over. Falls back to
+    /// plain greedy argmax when `params.temperature <= 0.0`.
+    ///
+    /// `history` is a window and not a slice on purpose: it carries the
+    /// PROMPT as well as the generated tokens, which is what llama.cpp
+    /// penalises over. See [`crate::penalty_window`].
+    ///
+    /// A length-1 `logits` vector is treated as a precomputed greedy token
+    /// id (`logits[0] as usize`) — used by the Metal dense-stack path that
+    /// returns GPU argmax instead of downloading the full vocab.
+    pub fn sample(
+        &mut self,
+        logits: &[f32],
+        params: &SamplingParams,
+        history: PenaltyWindow<'_>,
+    ) -> usize {
+        self.sample_with_mask(logits, params, history, None)
+    }
+
+    /// Like [`Self::sample`], but optionally zeroes disallowed logits via
+    /// `mask` before argmax / nucleus sampling (used for JSON-object mode).
+    pub fn sample_with_mask(
+        &mut self,
+        logits: &[f32],
+        params: &SamplingParams,
+        history: PenaltyWindow<'_>,
+        mut mask: Option<LogitMask<'_>>,
+    ) -> usize {
+        let xtc_roll = self.xtc_roll(params);
+        if params.temperature <= 0.0 && mask.is_none() {
+            if logits.len() == 1 {
+                return logits[0] as usize;
+            }
+            let mut scores = logits.to_vec();
+            apply_history_penalties(&mut scores, params, history);
+            return greedy_choice(scores, params, history, xtc_roll);
+        }
+
+        let mut scores: Vec<f32> = logits.to_vec();
+        apply_history_penalties(&mut scores, params, history);
+
+        if let Some(m) = mask.as_mut() {
+            m(&mut scores);
+        }
+
+        if params.temperature <= 0.0 {
+            if scores.len() == 1 {
+                return scores[0] as usize;
+            }
+            return greedy_choice(scores, params, history, xtc_roll);
+        }
+
+        let probs = filtered_distribution(scores, params, history, xtc_roll);
+        self.sample_from(&probs)
+    }
+
+    /// A uniform draw in `[0.0, 1.0)`.
+    ///
+    /// Exposed because speculative decoding's accept test is a coin
+    /// flip against `p_target(x) / p_draft(x)` rather than a draw from
+    /// a distribution, and it must come off the same seeded stream as
+    /// every other draw in the run or a "reproducible given a seed"
+    /// generation stops being reproducible.
+    pub fn uniform(&mut self) -> f32 {
+        self.next_f32()
+    }
+
+    /// Draws one index from an already-normalised distribution.
+    ///
+    /// Split out of [`Self::sample_with_mask`] so speculative decoding
+    /// can sample from a distribution it had to compute anyway (the
+    /// rejection rule needs `p_target` itself, not just a draw from it)
+    /// and still go through *exactly* the same draw as ordinary
+    /// sampling. Two separate copies of this loop would be two chances
+    /// to be subtly non-lossless.
+    pub fn sample_from(&mut self, probs: &[f32]) -> usize {
+        let draw = self.next_f32();
+        let mut cumulative = 0.0f32;
+        for (i, &p) in probs.iter().enumerate() {
+            cumulative += p;
+            if draw < cumulative {
+                return i;
+            }
+        }
+        // Floating-point rounding may leave `draw` fractionally above
+        // the final cumulative sum; the last nonzero-probability token
+        // is the correct fallback, not index 0.
+        probs
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|&(_, &p)| p > 0.0)
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sampling::{sampling_distribution, spread_logits};
+
+    ///
+    /// This is the reason [`Sampler::xtc_roll`] is conditional rather
+    /// than unconditional. Delete the `xtc_can_fire` guard there and
+    /// this goes red on the first token.
+    #[test]
+    fn a_chain_without_xtc_does_not_consume_a_draw_for_it() {
+        let params = SamplingParams {
+            temperature: 1.0,
+            ..SamplingParams::default()
+        };
+        let logits = spread_logits(32);
+        assert!(
+            Sampler::new(99).xtc_roll(&params).is_none(),
+            "the guard must refuse the draw, not merely ignore it"
+        );
+
+        // ONE draw per token, taken by hand off a generator that never
+        // heard of XTC. An unconditional roll makes `sample` consume
+        // two values per token, so the very first token comes off the
+        // SECOND draw and this diverges immediately.
+        let mut sampled_by_chain = Sampler::new(99);
+        let mut by_hand = Sampler::new(99);
+        for step in 0..16 {
+            let sampled = sampled_by_chain.sample(&logits, &params, PenaltyWindow::new(&[], &[]));
+            let probs = sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &[]), None);
+            assert_eq!(
+                sampled,
+                by_hand.sample_from(&probs),
+                "token {step} came off a different position in the stream"
+            );
+        }
+        // And the two generators are still in lockstep afterwards.
+        assert_eq!(sampled_by_chain.uniform(), by_hand.uniform());
+    }
+
+    /// **The flag does something.** A chain that runs the temperature
+    /// before top-p keeps a different candidate set than the default,
+    /// which is the whole reason the order is worth exposing -- and the
+    /// reason getting it wrong is a silent quality regression rather
+    /// than an error.
+    ///
+    /// A hot temperature flattens the distribution, so a top-p applied
+    /// after it sums smaller probabilities and reaches `p` later,
+    /// keeping MORE candidates.
+
+    #[test]
+    fn temperature_zero_accepts_precomputed_argmax_singleton() {
+        let mut sampler = Sampler::new(1);
+        let params = SamplingParams::default();
+        assert_eq!(
+            sampler.sample(&[42.0], &params, PenaltyWindow::new(&[], &[])),
+            42
+        );
+        // Non-greedy must not treat a singleton as a token id.
+        let sampled = SamplingParams {
+            temperature: 0.8,
+            ..SamplingParams::default()
+        };
+        // Softmax of a single logit → only token 0 is eligible.
+        assert_eq!(
+            sampler.sample(&[42.0], &sampled, PenaltyWindow::new(&[], &[])),
+            0
+        );
+    }
+
+    #[test]
+    fn temperature_zero_is_deterministic_greedy_argmax() {
+        let logits = vec![0.1, 0.9, 0.3, -0.2];
+        let params = SamplingParams::default();
+        let mut sampler = Sampler::new(42);
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            1
+        );
+        // Must be deterministic regardless of RNG state advancing.
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            1
+        );
+    }
+
+    #[test]
+    fn high_temperature_can_pick_a_non_argmax_token_over_many_draws() {
+        let logits = vec![1.0, 1.0, 1.0, 1.0];
+        let params = SamplingParams {
+            temperature: 1.0,
+            ..SamplingParams::default()
+        };
+        let mut sampler = Sampler::new(7);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..200 {
+            seen.insert(sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])));
+        }
+        assert!(
+            seen.len() > 1,
+            "uniform logits at temperature=1.0 must produce more than one distinct token across 200 draws"
+        );
+    }
+
+    #[test]
+    fn top_k_one_is_equivalent_to_greedy() {
+        let logits = vec![0.1, 0.9, 0.3, -0.2];
+        let params = SamplingParams {
+            temperature: 1.0,
+            top_k: 1,
+            ..SamplingParams::default()
+        };
+        let mut sampler = Sampler::new(123);
+        for _ in 0..20 {
+            assert_eq!(
+                sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn top_p_near_zero_is_equivalent_to_greedy() {
+        let logits = vec![0.1, 5.0, 0.3, -0.2];
+        let params = SamplingParams {
+            temperature: 1.0,
+            top_p: 0.001,
+            ..SamplingParams::default()
+        };
+        let mut sampler = Sampler::new(9);
+        for _ in 0..20 {
+            assert_eq!(
+                sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn presence_and_frequency_penalties_reduce_seen_token_logits() {
+        let logits = vec![0.0, 5.0, 0.0];
+        let params = SamplingParams {
+            temperature: 1.0,
+            presence_penalty: 10.0,
+            frequency_penalty: 0.0,
+            ..SamplingParams::default()
+        };
+        let mut sampler = Sampler::new(1);
+        let mut counts = [0usize; 3];
+        for _ in 0..500 {
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1]))] += 1;
+        }
+        assert!(
+            counts[1] < 250,
+            "presence_penalty should discourage token 1; counts={counts:?}"
+        );
+
+        let params = SamplingParams {
+            temperature: 1.0,
+            presence_penalty: 0.0,
+            frequency_penalty: 10.0,
+            ..SamplingParams::default()
+        };
+        let mut sampler = Sampler::new(2);
+        counts = [0; 3];
+        for _ in 0..500 {
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1, 1, 1]))] += 1;
+        }
+        assert!(
+            counts[1] < 250,
+            "frequency_penalty should discourage repeated token 1; counts={counts:?}"
+        );
+    }
+
+    #[test]
+    fn repetition_penalty_reduces_probability_of_recently_seen_token() {
+        let logits = vec![0.0, 5.0, 0.0];
+        let params = SamplingParams {
+            temperature: 1.0,
+            repetition_penalty: 1000.0,
+            ..SamplingParams::default()
+        };
+        let mut sampler = Sampler::new(3);
+        let mut counts = [0usize; 3];
+        for _ in 0..500 {
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[1]))] += 1;
+        }
+        assert!(
+            counts[1] < 250,
+            "heavily penalizing token 1 (already in history) should make it far less likely than its raw logit alone would suggest; got counts={counts:?}"
+        );
+    }
+
+    #[test]
+    fn low_seeds_do_not_bias_the_first_draw() {
+        // Every generation seeds a fresh `Sampler` (the server does it
+        // per request, from the caller's `seed`), so the FIRST draw off
+        // a freshly seeded generator is the one users actually see.
+        // Plain xorshift64 returns its own state, so seeds 1..4000 all
+        // produced a first draw in the bottom eighth of [0, 1) -- the
+        // first sampled token of every seeded request came off the
+        // bottom of the CDF.
+        let vocab = 8;
+        let logits = vec![0.0f32; vocab];
+        let params = SamplingParams {
+            temperature: 1.0,
+            ..SamplingParams::default()
+        };
+        let seeds = 4_000u64;
+        let mut counts = vec![0usize; vocab];
+        for seed in 1..=seeds {
+            counts[Sampler::new(seed).sample(&logits, &params, PenaltyWindow::new(&[], &[]))] += 1;
+        }
+        let expected = seeds as f64 / vocab as f64;
+        for (token, &c) in counts.iter().enumerate() {
+            assert!(
+                (c as f64 - expected).abs() < expected * 0.25,
+                "uniform logits: token {token} came up {c} times across {seeds} seeds, \
+                 expected about {expected:.0} (counts={counts:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn the_published_distribution_is_the_one_sample_actually_draws_from() {
+        // `sampling_distribution` is load-bearing for lossless
+        // speculative verification: if it disagreed with what `sample`
+        // draws from, every accept/reject decision would be measured
+        // against the wrong target. Check them against each other
+        // empirically, with filters on so the two code paths have
+        // something to disagree about.
+        let logits = vec![0.4, 2.0, -1.0, 1.2, 0.9, -0.3];
+        let params = SamplingParams {
+            temperature: 0.8,
+            top_p: 0.9,
+            top_k: 4,
+            repetition_penalty: 1.3,
+            ..SamplingParams::default()
+        };
+        let history = [1usize, 4];
+        let claimed =
+            sampling_distribution(&logits, &params, PenaltyWindow::new(&[], &history), None);
+        assert!((claimed.iter().sum::<f32>() - 1.0).abs() < 1e-5);
+
+        let draws = 100_000;
+        let mut counts = vec![0usize; logits.len()];
+        let mut sampler = Sampler::new(0xC0FFEE);
+        for _ in 0..draws {
+            counts[sampler.sample(&logits, &params, PenaltyWindow::new(&[], &history))] += 1;
+        }
+        for (i, &c) in counts.iter().enumerate() {
+            let empirical = c as f64 / draws as f64;
+            assert!(
+                (empirical - claimed[i] as f64).abs() < 0.01,
+                "token {i}: sample() draws it {empirical:.4} of the time but \
+                 sampling_distribution claims {:.4}",
+                claimed[i]
+            );
+        }
+    }
+
+    #[test]
+    fn degenerate_all_zero_probability_falls_back_to_greedy() {
+        // top_k=1 combined with a top_p that would exclude even that
+        // one surviving token is a contradictory/degenerate
+        // configuration; must not panic or sample index 0 blindly.
+        let logits = vec![0.1, 0.9, 0.3, -0.2];
+        let params = SamplingParams {
+            temperature: 1.0,
+            top_k: 1,
+            top_p: 1.0,
+            ..SamplingParams::default()
+        };
+        let mut sampler = Sampler::new(1);
+        assert_eq!(
+            sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
+            1
+        );
+    }
+}

--- a/crates/ferrox-models/src/speculative.rs
+++ b/crates/ferrox-models/src/speculative.rs
@@ -582,10 +582,12 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
         // about every push, which is exactly the shape this fix exists
         // to remove.
         let (seen_prompt, seen_generated) = history.split_at(prompt_tokens.len());
+        let xtc_roll = rng.xtc_roll(&options.sampling);
         let probs = sampling_distribution(
             last,
             &options.sampling,
             PenaltyWindow::new(seen_prompt, seen_generated),
+            xtc_roll,
         );
         rng.sample_from(&probs)
     };
@@ -637,10 +639,12 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
         let mut replacement: Option<usize> = None;
         for (i, (&token, dist)) in draft.tokens().iter().zip(draft.dists()).enumerate() {
             let (seen_prompt, seen_generated) = history.split_at(prompt_tokens.len());
+            let xtc_roll = rng.xtc_roll(&options.sampling);
             let target = sampling_distribution(
                 &batch_logits[i],
                 &options.sampling,
                 PenaltyWindow::new(seen_prompt, seen_generated),
+                xtc_roll,
             );
             match accept_or_resample(&target, dist, token, &mut rng) {
                 None => {
@@ -687,10 +691,12 @@ pub fn speculative_decode_observed<D: Drafter + ?Sized>(
             // token that makes a fully-accepted block worth `k + 1`.
             None => {
                 let (seen_prompt, seen_generated) = history.split_at(prompt_tokens.len());
+                let xtc_roll = rng.xtc_roll(&options.sampling);
                 let probs = sampling_distribution(
                     &batch_logits[accepted],
                     &options.sampling,
                     PenaltyWindow::new(seen_prompt, seen_generated),
+                    xtc_roll,
                 );
                 rng.sample_from(&probs)
             }
@@ -984,7 +990,16 @@ mod tests {
             // `history` is already prompt-then-generated, and the
             // window only ever reads the tail of the two halves
             // together, so the whole sequence goes in the first one.
-            let probs = sampling_distribution(logits, params, PenaltyWindow::new(history, &[]));
+            // This helper enumerates the exact marginal over every
+            // continuation, so it must not depend on a random draw:
+            // `None` is correct here and only here, because the params
+            // it is called with never enable XTC.
+            debug_assert!(
+                !params.xtc_can_fire(),
+                "the exact marginal is not defined under XTC"
+            );
+            let probs =
+                sampling_distribution(logits, params, PenaltyWindow::new(history, &[]), None);
             for (token, &p) in probs.iter().enumerate() {
                 if p <= 0.0 {
                     continue;

--- a/crates/ferrox-server/src/anthropic.rs
+++ b/crates/ferrox-server/src/anthropic.rs
@@ -644,6 +644,11 @@ fn prepare_prompt(prompt: &PromptFields, model: String, max_tokens: usize) -> Pr
         min_p: None,
         top_k: None,
         repetition_penalty: None,
+        // Neither the Anthropic Messages wire nor the Responses wire
+        // carries llama.cpp's extra samplers, so they resolve to their
+        // neutral defaults and this chain is llama.cpp's default one
+        // doing nothing extra.
+        extra_samplers: Default::default(),
         // No seed on this wire, so the chat path's policy applies
         // unchanged: an unseeded sampled request draws fresh every time
         // rather than replaying one draw forever.
@@ -1398,7 +1403,8 @@ async fn messages_full(
     // The client's own list, kept apart from `params.stop`, which the
     // template adds its end-of-turn marker to. See `caller_stop`.
     let caller_stops = chat.stop_sequences();
-    let params = chat.generation_params_for_template(&template, active.name())?;
+    let params =
+        chat.generation_params_for_template(&template, active.name(), active.sampler_model())?;
 
     let (chunks, finish, usage) = crate::decode_task::buffered(
         crate::decode_task::DecodeHandles::take(&state, &active).map_err(anthropic_shape)?,
@@ -1456,7 +1462,8 @@ async fn messages_stream(
     let posture = OutputPosture::resolve(&served_model, &prompt);
     // See `messages_full`: the client's list, not the template's.
     let caller_stops = chat.stop_sequences();
-    let mut params = chat.generation_params_for_template(&template, &served_model)?;
+    let mut params =
+        chat.generation_params_for_template(&template, &served_model, active.sampler_model())?;
 
     // The same two-tier cancellation the chat stream has: the guard
     // rides with the generation task and deregisters however that task

--- a/crates/ferrox-server/src/completion/mod.rs
+++ b/crates/ferrox-server/src/completion/mod.rs
@@ -146,18 +146,7 @@ const UNSUPPORTED: &[Unsupported] = &[
         0.0,
         "dynamic temperature sampling is not implemented",
     ),
-    off_at(
-        "typical_p",
-        1.0,
-        "locally typical sampling is not implemented",
-    ),
-    off_at("xtc_probability", 0.0, "the XTC sampler is not implemented"),
     off_at("mirostat", 0.0, "mirostat sampling is not implemented"),
-    off_at(
-        "dry_multiplier",
-        0.0,
-        "DRY repetition sampling is not implemented",
-    ),
     off_at(
         "n_probs",
         0.0,
@@ -268,6 +257,11 @@ pub(crate) struct CompletionRequest {
     min_p: Option<f32>,
     #[serde(default)]
     top_k: Option<usize>,
+    /// llama.cpp's `typ_p`, `top_n_sigma`, `xtc_*` and `dry_*`, in ONE
+    /// struct shared with the other two routes that take them. See
+    /// `sampling_knobs::ExtraSamplerFields`.
+    #[serde(flatten)]
+    extra_samplers: crate::sampling_knobs::ExtraSamplerFields,
     /// llama.cpp's spelling of `repetition_penalty`.
     #[serde(default)]
     repeat_penalty: Option<f32>,
@@ -368,7 +362,7 @@ impl CompletionRequest {
     /// and `repeat_last_n` are llama.cpp's spellings, everything else
     /// happens to agree. Resolution -- what an absent knob means -- is
     /// `SamplingKnobs::resolve`'s, shared with both OpenAI routes.
-    fn sampling_knobs(&self) -> Result<SamplingKnobs, ApiError> {
+    pub(crate) fn sampling_knobs(&self) -> Result<SamplingKnobs, ApiError> {
         let penalty_last_n = match self.repeat_last_n {
             None => None,
             Some(n) if n >= 0 => Some(n as usize),
@@ -381,7 +375,7 @@ impl CompletionRequest {
                 ))
             }
         };
-        Ok(SamplingKnobs {
+        let mut knobs = SamplingKnobs {
             temperature: self.temperature,
             top_p: self.top_p,
             min_p: self.min_p,
@@ -394,7 +388,10 @@ impl CompletionRequest {
                 self.samplers.as_ref(),
                 ferrox_api::routes::COMPLETION,
             )?,
-        })
+            ..SamplingKnobs::default()
+        };
+        self.extra_samplers.apply(&mut knobs);
+        Ok(knobs)
     }
 
     /// `n_predict`, read as llama.cpp defines it.
@@ -536,7 +533,12 @@ pub(crate) async fn completion(
         // split that did not happen.
         reasoning: None,
         max_tokens: 0,
-        sampling: req.sampling_knobs()?.resolve(),
+        sampling: req
+            .sampling_knobs()?
+            .resolve(active.sampler_model())
+            .map_err(|e| {
+                crate::unsupported_feature(&format!("`dry_multiplier` on /completion: {e}"))
+            })?,
         seed: req.seed(),
         stop: req.stop.clone().unwrap_or_default(),
         json_object: false,
@@ -744,7 +746,8 @@ mod tests {
         }))
         .sampling_knobs()
         .expect("all supported")
-        .resolve();
+        .resolve(crate::sampling_knobs::SamplerModel::absent())
+        .expect("no dry");
         assert_eq!(knobs.temperature, 0.7);
         assert_eq!(knobs.top_p, 0.9);
         assert_eq!(knobs.min_p, 0.05);
@@ -762,8 +765,11 @@ mod tests {
         let mine = request(json!({"prompt": "hi"}))
             .sampling_knobs()
             .expect("nothing to refuse")
-            .resolve();
-        let shared = SamplingKnobs::default().resolve();
+            .resolve(crate::sampling_knobs::SamplerModel::absent())
+            .expect("no dry");
+        let shared = SamplingKnobs::default()
+            .resolve(crate::sampling_knobs::SamplerModel::absent())
+            .expect("no dry");
         assert_eq!(mine.temperature, shared.temperature);
         assert_eq!(mine.top_p, shared.top_p);
         assert_eq!(mine.min_p, shared.min_p);
@@ -939,10 +945,7 @@ mod tests {
     fn every_unsupported_option_is_refused_by_its_own_name() {
         let asking: &[(&str, Value)] = &[
             ("dynatemp_range", json!(0.5)),
-            ("typical_p", json!(0.95)),
-            ("xtc_probability", json!(0.5)),
             ("mirostat", json!(2)),
-            ("dry_multiplier", json!(0.8)),
             ("n_probs", json!(5)),
             ("post_sampling_probs", json!(true)),
             ("min_keep", json!(1)),
@@ -1062,7 +1065,8 @@ mod tests {
             request(json!({"prompt": "hi", "repeat_last_n": 0}))
                 .sampling_knobs()
                 .unwrap()
-                .resolve()
+                .resolve(crate::sampling_knobs::SamplerModel::absent())
+                .expect("no dry")
                 .penalty_last_n,
             0
         );

--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -1155,8 +1155,19 @@ impl GenerationParams {
     /// reason its output parses, so a folded argmax under a grammar is
     /// unconstrained text served against a `response_format` the caller
     /// was told was honoured.
+    ///
+    /// The sampler arm is the third such thing, and it arrived with
+    /// llama.cpp's `xtc` and `typ_p`. Both of those can remove the
+    /// MAXIMUM from the candidate list, and `dry` can move which logit
+    /// the maximum is, so at `temperature <= 0` the answer is no longer
+    /// the argmax of the raw logits. A device that folded the argmax
+    /// away would hand the sampler one precomputed id with no
+    /// vocabulary left for XTC to remove anything from, and XTC would
+    /// silently not run. `SamplingParams::greedy_equals_argmax` is the
+    /// single predicate deciding that, shared with the sampler's own
+    /// greedy fast path and with `ferrox_cli::run`'s copy of this gate.
     pub(crate) fn needs_vocab_logits(&self) -> bool {
-        self.json_object || self.grammar.is_some()
+        self.json_object || self.grammar.is_some() || !self.sampling.greedy_equals_argmax()
     }
 }
 

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -821,6 +821,41 @@ impl Model {
             Model::Glm52(m) => Some(ferrox_models::Engine::vocab_size(&m.engine)),
         }
     }
+
+    /// True when this checkpoint carries a real vocabulary rather than
+    /// the byte-level fallback the synthetic-weight demo model uses.
+    ///
+    /// Read by the DRY sampler, whose sequence breakers are strings that
+    /// only mean something against a real tokenizer; see
+    /// [`ferrox_models::dry::DryVocabMissing`].
+    fn has_real_vocabulary(&self) -> bool {
+        match self {
+            Model::Gguf(m) => !matches!(*m.tokenizer, model::ServerTokenizer::Byte),
+            Model::Kimi(_) => true,
+            Model::Mla(m) => !matches!(m.tokenizer, model::ServerTokenizer::Byte),
+            Model::Gemma4(m) => !matches!(m.tokenizer, model::ServerTokenizer::Byte),
+            Model::Glm52(m) => !matches!(m.tokenizer, model::ServerTokenizer::Byte),
+        }
+    }
+}
+
+/// What the DRY sampler needs to tokenise its sequence breakers.
+///
+/// One trait, two implementations (`ferrox_cli`'s `CliTokenizer` has the
+/// other), so `--dry-sequence-breaker` and the `dry_sequence_breakers`
+/// request field cannot come to mean different things.
+impl ferrox_models::dry::DryVocab for Model {
+    fn n_tokens(&self) -> usize {
+        self.vocab_size().unwrap_or(0)
+    }
+
+    fn detokenize(&self, token: usize) -> String {
+        self.decode(&[token])
+    }
+
+    fn tokenize(&self, text: &str) -> Vec<usize> {
+        self.encode(text)
+    }
 }
 
 pub(crate) struct AppState {
@@ -1340,6 +1375,11 @@ struct ChatCompletionRequest {
     top_k: Option<usize>,
     #[serde(default)]
     repetition_penalty: Option<f32>,
+    /// llama.cpp's `typ_p`, `top_n_sigma`, `xtc_*` and `dry_*`, in ONE
+    /// struct shared with the other two routes that take them. See
+    /// `sampling_knobs::ExtraSamplerFields`.
+    #[serde(flatten)]
+    extra_samplers: crate::sampling_knobs::ExtraSamplerFields,
     #[serde(default)]
     seed: Option<u64>,
     #[serde(default)]
@@ -1498,7 +1538,7 @@ impl ChatCompletionRequest {
     /// sampler this engine does not have is a refusal, never a chain
     /// built without it.
     fn sampling_knobs(&self) -> Result<SamplingKnobs, ApiError> {
-        Ok(SamplingKnobs {
+        let mut knobs = SamplingKnobs {
             temperature: self.temperature,
             top_p: self.top_p,
             min_p: self.min_p,
@@ -1514,11 +1554,19 @@ impl ChatCompletionRequest {
                 self.samplers.as_ref(),
                 "/v1/chat/completions",
             )?,
-        })
+            ..SamplingKnobs::default()
+        };
+        self.extra_samplers.apply(&mut knobs);
+        Ok(knobs)
     }
 
-    fn sampling_params(&self) -> Result<SamplingParams, ApiError> {
-        Ok(self.sampling_knobs()?.resolve())
+    fn sampling_params(
+        &self,
+        model: crate::sampling_knobs::SamplerModel<'_>,
+    ) -> Result<SamplingParams, ApiError> {
+        self.sampling_knobs()?.resolve(model).map_err(|e| {
+            unsupported_feature(&format!("`dry_multiplier` on /v1/chat/completions: {e}"))
+        })
     }
 
     fn stop_sequences(&self) -> Vec<String> {
@@ -1849,7 +1897,10 @@ impl ChatCompletionRequest {
     /// grammar, or a `response_format` this server cannot honour, is a
     /// refusal rather than a request served without the constraint it
     /// asked for.
-    fn generation_params(&self) -> Result<GenerationParams, ApiError> {
+    fn generation_params(
+        &self,
+        model: crate::sampling_knobs::SamplerModel<'_>,
+    ) -> Result<GenerationParams, ApiError> {
         Ok(GenerationParams {
             // Set by `generation_params_for_template`, which is the only
             // caller that knows the SERVED model name. Left `None` here
@@ -1857,7 +1908,7 @@ impl ChatCompletionRequest {
             // rather than claiming the model did not think.
             reasoning: None,
             max_tokens: self.max_tokens,
-            sampling: self.sampling_params()?,
+            sampling: self.sampling_params(model)?,
             seed: self.resolved_seed(),
             stop: self.effective_stop_sequences(),
             // Resolved by `run_generation_emit`, the layer that holds a
@@ -1890,8 +1941,9 @@ impl ChatCompletionRequest {
         &self,
         template: &chat_template::PromptTemplate,
         served_model: &str,
+        model: crate::sampling_knobs::SamplerModel<'_>,
     ) -> Result<GenerationParams, ApiError> {
-        let mut params = self.generation_params()?;
+        let mut params = self.generation_params(model)?;
         // The served model, not the request's `model` field -- see this
         // function's doc. Same name `OutputPosture::resolve` reads the
         // answer back with, so the count and the split cannot disagree
@@ -3190,7 +3242,8 @@ async fn chat_completions_full(
     // completion (#35). It also means an unparseable grammar is a 400
     // for the second caller too, rather than a 200 carrying prose
     // generated under no grammar at all.
-    let params = req.generation_params_for_template(&template, active.name())?;
+    let params =
+        req.generation_params_for_template(&template, active.name(), active.sampler_model())?;
     let key = req.is_cacheable().then(|| req.cache_key(&prompt, &params));
 
     let (completion, cache_status) = if let Some(cached) = key
@@ -3318,7 +3371,8 @@ async fn chat_completions_stream(
     let batcher = active.batcher.clone();
     let ceiling = active.ceiling.clone();
     let metal_private_decode_gate = state.metal_private_decode_gate.clone();
-    let mut params = req.generation_params_for_template(&template, active.name())?;
+    let mut params =
+        req.generation_params_for_template(&template, active.name(), active.sampler_model())?;
     let stats_state = Arc::clone(&state);
     // Read now, off the handle this stream will decode against. Read
     // later it would name whatever a swap had made current by then.
@@ -8263,7 +8317,11 @@ mod tests {
         let template = chat_template::PromptTemplate::plain();
 
         let thinks = req
-            .generation_params_for_template(&template, "Qwen3-8B")
+            .generation_params_for_template(
+                &template,
+                "Qwen3-8B",
+                crate::sampling_knobs::SamplerModel::absent(),
+            )
             .expect("params");
         assert!(
             thinks.reasoning.is_some(),
@@ -8271,7 +8329,11 @@ mod tests {
         );
 
         let plain = req
-            .generation_params_for_template(&template, "Llama-3.2-1B-Instruct")
+            .generation_params_for_template(
+                &template,
+                "Llama-3.2-1B-Instruct",
+                crate::sampling_knobs::SamplerModel::absent(),
+            )
             .expect("params");
         assert!(
             plain.reasoning.is_none(),
@@ -8296,7 +8358,7 @@ mod tests {
         req.validate_supported_fields()
             .expect("a valid grammar is a valid request");
         let params = req
-            .generation_params()
+            .generation_params(crate::sampling_knobs::SamplerModel::absent())
             .expect("a valid grammar compiles at params time too");
         assert!(
             params.grammar.is_some(),
@@ -8312,7 +8374,11 @@ mod tests {
             "model": "m",
             "messages": [{"role": "user", "content": "hi"}],
         }));
-        assert!(plain.generation_params().unwrap().grammar.is_none());
+        assert!(plain
+            .generation_params(crate::sampling_knobs::SamplerModel::absent())
+            .unwrap()
+            .grammar
+            .is_none());
     }
 
     fn tool_request(tool_choice: serde_json::Value) -> ChatCompletionRequest {
@@ -8337,7 +8403,11 @@ mod tests {
             req.validate_supported_fields()
                 .unwrap_or_else(|e| panic!("{choice} is a valid request: {e:?}"));
             let params = req
-                .generation_params_for_template(&graded_template(), "Qwen3-8B")
+                .generation_params_for_template(
+                    &graded_template(),
+                    "Qwen3-8B",
+                    crate::sampling_knobs::SamplerModel::absent(),
+                )
                 .unwrap_or_else(|e| panic!("{choice} compiles: {e:?}"));
             let grammar = params
                 .grammar
@@ -8373,7 +8443,11 @@ mod tests {
         for choice in [serde_json::json!("auto"), serde_json::json!("none")] {
             let req = tool_request(choice.clone());
             req.validate_supported_fields().expect("still supported");
-            let params = match req.generation_params_for_template(&graded_template(), "Qwen3-8B") {
+            let params = match req.generation_params_for_template(
+                &graded_template(),
+                "Qwen3-8B",
+                crate::sampling_knobs::SamplerModel::absent(),
+            ) {
                 Ok(p) => p,
                 Err((status, _)) => panic!("{choice} has no constraint to compile: {status}"),
             };
@@ -8430,11 +8504,14 @@ mod tests {
         // three `tool_grammar::wire::shape` still refuses, and it says
         // which of them and why.
         let req = tool_request(serde_json::json!("required"));
-        let (status, Json(body)) =
-            match req.generation_params_for_template(&graded_template(), "Gemma4-27B") {
-                Err(e) => e,
-                Ok(_) => panic!("a gemma4 call's arguments are not an object rule"),
-            };
+        let (status, Json(body)) = match req.generation_params_for_template(
+            &graded_template(),
+            "Gemma4-27B",
+            crate::sampling_knobs::SamplerModel::absent(),
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("a gemma4 call's arguments are not an object rule"),
+        };
         assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
         assert!(
             body["error"]["message"]
@@ -8459,7 +8536,11 @@ mod tests {
             .expect_err("this does not parse");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(body["error"]["param"], "grammar");
-        assert!(req.generation_params().is_err(), "and again at params time");
+        assert!(
+            req.generation_params(crate::sampling_knobs::SamplerModel::absent())
+                .is_err(),
+            "and again at params time"
+        );
     }
 
     /// `response_format: json_schema` used to be a 501 naming the
@@ -8480,7 +8561,9 @@ mod tests {
         }));
         req.validate_supported_fields()
             .expect("a boolean schema converts");
-        let params = req.generation_params().expect("and compiles");
+        let params = req
+            .generation_params(crate::sampling_knobs::SamplerModel::absent())
+            .expect("and compiles");
         let grammar = params.grammar.expect("the schema is the grammar");
         let mut g = (*grammar).clone();
         g.accept_token(0, b"true").expect("a boolean is accepted");
@@ -8515,7 +8598,11 @@ mod tests {
                 .contains("minimum"),
             "the refusal must name the keyword: {body}"
         );
-        assert!(req.generation_params().is_err(), "and again at params time");
+        assert!(
+            req.generation_params(crate::sampling_knobs::SamplerModel::absent())
+                .is_err(),
+            "and again at params time"
+        );
     }
 
     /// A forced `tool_choice` and a `response_format` schema are two
@@ -8567,14 +8654,23 @@ mod tests {
             "messages": [{"role": "user", "content": "hi"}],
             "min_p": 0.07,
         }));
-        assert_eq!(asked.sampling_params().expect("knobs").min_p, 0.07);
+        assert_eq!(
+            asked
+                .sampling_params(crate::sampling_knobs::SamplerModel::absent())
+                .expect("knobs")
+                .min_p,
+            0.07
+        );
 
         let silent = chat_request(serde_json::json!({
             "model": "m",
             "messages": [{"role": "user", "content": "hi"}],
         }));
         assert_eq!(
-            silent.sampling_params().expect("knobs").min_p,
+            silent
+                .sampling_params(crate::sampling_knobs::SamplerModel::absent())
+                .expect("knobs")
+                .min_p,
             0.0,
             "an unset min_p must be off, not llama.cpp's CLI default"
         );
@@ -8597,7 +8693,9 @@ mod tests {
         });
         let key_for = |body: serde_json::Value| {
             let req = chat_request(body);
-            let params = req.generation_params().expect("params");
+            let params = req
+                .generation_params(crate::sampling_knobs::SamplerModel::absent())
+                .expect("params");
             req.cache_key("prompt", &params)
         };
         let baseline = key_for(base.clone());
@@ -8642,7 +8740,9 @@ mod tests {
         });
         let key_for = |body: serde_json::Value| {
             let req = chat_request(body);
-            let params = req.generation_params().expect("params");
+            let params = req
+                .generation_params(crate::sampling_knobs::SamplerModel::absent())
+                .expect("params");
             req.cache_key("prompt", &params)
         };
         let baseline = key_for(base.clone());

--- a/crates/ferrox-server/src/loaded.rs
+++ b/crates/ferrox-server/src/loaded.rs
@@ -114,6 +114,33 @@ impl ActiveModel {
         }
     }
 
+    /// The model facts the sampler chain needs that a request body
+    /// cannot carry: the vocabulary DRY's sequence breakers are
+    /// tokenised against, and the context size `dry_penalty_last_n = -1`
+    /// resolves to.
+    ///
+    /// Taken off the PINNED `ActiveModel` rather than looked up again,
+    /// so a request cannot resolve its sampler against one checkpoint
+    /// and decode against the one `/admin/models/load` swapped in
+    /// afterwards.
+    pub(crate) fn sampler_model(&self) -> crate::sampling_knobs::SamplerModel<'_> {
+        let vocab = self
+            .generative_opt()
+            .filter(|m| m.has_real_vocabulary())
+            .map(|m| m.as_ref() as &dyn ferrox_models::dry::DryVocab);
+        crate::sampling_knobs::SamplerModel {
+            vocab,
+            // `usize::MAX` when this server could not price a ceiling:
+            // see `SamplerModel::context_size` for why that is the
+            // derived answer rather than a chosen constant.
+            context_size: self
+                .ceiling
+                .as_ref()
+                .and_then(|c| c.limit())
+                .unwrap_or(usize::MAX),
+        }
+    }
+
     /// The generation model when there is one, for the reporting
     /// surfaces (`/v1/models`, `/health`) that describe whatever is
     /// loaded rather than requiring a particular kind. They say less

--- a/crates/ferrox-server/src/openai_extra.rs
+++ b/crates/ferrox-server/src/openai_extra.rs
@@ -215,6 +215,11 @@ pub(crate) struct CompletionsRequest {
     top_k: Option<usize>,
     #[serde(default)]
     repetition_penalty: Option<f32>,
+    /// llama.cpp's `typ_p`, `top_n_sigma`, `xtc_*` and `dry_*`, in ONE
+    /// struct shared with the other two routes that take them. See
+    /// `sampling_knobs::ExtraSamplerFields`.
+    #[serde(flatten)]
+    extra_samplers: crate::sampling_knobs::ExtraSamplerFields,
     #[serde(default)]
     presence_penalty: Option<f32>,
     #[serde(default)]
@@ -285,8 +290,8 @@ impl CompletionsRequest {
     /// chat route uses. See `crate::sampling_knobs`.
     /// Fallible because `samplers` is parsed here; see the chat route's
     /// twin.
-    fn sampling_knobs(&self) -> Result<SamplingKnobs, ApiError> {
-        Ok(SamplingKnobs {
+    pub(crate) fn sampling_knobs(&self) -> Result<SamplingKnobs, ApiError> {
+        let mut knobs = SamplingKnobs {
             temperature: self.temperature,
             top_p: self.top_p,
             min_p: self.min_p,
@@ -301,7 +306,10 @@ impl CompletionsRequest {
                 self.samplers.as_ref(),
                 "/v1/completions",
             )?,
-        })
+            ..SamplingKnobs::default()
+        };
+        self.extra_samplers.apply(&mut knobs);
+        Ok(knobs)
     }
 
     fn stop_sequences(&self) -> Vec<String> {
@@ -484,7 +492,12 @@ pub async fn completions(
         // split that did not happen.
         reasoning: None,
         max_tokens: req.max_tokens,
-        sampling: req.sampling_knobs()?.resolve(),
+        sampling: req
+            .sampling_knobs()?
+            .resolve(active.sampler_model())
+            .map_err(|e| {
+                crate::unsupported_feature(&format!("`dry_multiplier` on /v1/completions: {e}"))
+            })?,
         seed: req.seed.unwrap_or(0),
         stop: req.stop_sequences(),
         json_object: false,
@@ -681,7 +694,8 @@ mod tests {
         }))
         .sampling_knobs()
         .expect("knobs")
-        .resolve();
+        .resolve(crate::sampling_knobs::SamplerModel::absent())
+        .expect("no dry");
 
         assert_eq!(resolved.temperature, 0.5);
         assert_eq!(resolved.top_p, 0.9);
@@ -717,14 +731,17 @@ mod tests {
         let completion = request(completion_body)
             .sampling_knobs()
             .expect("knobs")
-            .resolve();
+            .resolve(crate::sampling_knobs::SamplerModel::absent())
+            .expect("no dry");
 
         let mut chat_body = knobs;
         chat_body["model"] = serde_json::json!("m");
         chat_body["messages"] = serde_json::json!([{"role": "user", "content": "hi"}]);
         let chat: crate::ChatCompletionRequest =
             serde_json::from_value(chat_body).expect("chat request");
-        let chat = chat.sampling_params().expect("knobs");
+        let chat = chat
+            .sampling_params(crate::sampling_knobs::SamplerModel::absent())
+            .expect("knobs");
 
         assert_eq!(completion.temperature, chat.temperature);
         assert_eq!(completion.top_p, chat.top_p);

--- a/crates/ferrox-server/src/response_cache.rs
+++ b/crates/ferrox-server/src/response_cache.rs
@@ -195,10 +195,33 @@ pub struct SamplingKey {
     pub penalty_last_n: usize,
     pub presence_penalty_bits: u32,
     pub frequency_penalty_bits: u32,
+    pub typical_p_bits: u32,
+    pub top_n_sigma_bits: u32,
+    pub xtc_probability_bits: u32,
+    pub xtc_threshold_bits: u32,
+    /// DRY, as the configuration a caller SPELLED rather than as the
+    /// tokenised breaker map it resolved to. The map is a function of
+    /// that configuration and the model, and the model is already part
+    /// of [`CacheKey`], so hashing the strings keys the same answers
+    /// and costs a few bytes instead of a walk over the vocabulary.
+    pub dry: DryKey,
     /// The ORDER the chain ran in (llama.cpp's `samplers`). Two
     /// requests that differ only in it get different answers, so it is
     /// a key field like any other knob.
     pub sampler_order: ferrox_models::sampler_order::SamplerOrder,
+}
+
+/// The DRY half of [`SamplingKey`]. Its own struct because
+/// `DryParams` holds an `Arc` to a map that is neither `Hash` nor `Eq`,
+/// and because every field here is one a caller can change.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DryKey {
+    pub multiplier_bits: u32,
+    pub base_bits: u32,
+    pub allowed_length: i32,
+    pub penalty_last_n: i32,
+    pub total_context_size: usize,
+    pub sequence_breakers: Vec<String>,
 }
 
 /// The cache-key form of a resolved sampling configuration.
@@ -217,6 +240,11 @@ pub fn sampling_key(params: &SamplingParams) -> SamplingKey {
         top_p,
         min_p,
         top_k,
+        typical_p,
+        top_n_sigma,
+        xtc_probability,
+        xtc_threshold,
+        dry,
         repetition_penalty,
         penalty_last_n,
         presence_penalty,
@@ -228,6 +256,18 @@ pub fn sampling_key(params: &SamplingParams) -> SamplingKey {
         top_p_bits: top_p.to_bits(),
         min_p_bits: min_p.to_bits(),
         top_k: *top_k,
+        typical_p_bits: typical_p.to_bits(),
+        top_n_sigma_bits: top_n_sigma.to_bits(),
+        xtc_probability_bits: xtc_probability.to_bits(),
+        xtc_threshold_bits: xtc_threshold.to_bits(),
+        dry: DryKey {
+            multiplier_bits: dry.multiplier().to_bits(),
+            base_bits: dry.base().to_bits(),
+            allowed_length: dry.allowed_length(),
+            penalty_last_n: dry.penalty_last_n(),
+            total_context_size: dry.total_context_size(),
+            sequence_breakers: dry.breakers().raw().to_vec(),
+        },
         repetition_penalty_bits: repetition_penalty.to_bits(),
         penalty_last_n: *penalty_last_n,
         presence_penalty_bits: presence_penalty.to_bits(),

--- a/crates/ferrox-server/src/responses.rs
+++ b/crates/ferrox-server/src/responses.rs
@@ -621,6 +621,11 @@ fn to_chat_request(req: &ResponsesRequest) -> Result<ChatCompletionRequest, ApiE
         min_p: None,
         top_k: req.top_k,
         repetition_penalty: None,
+        // Neither the Anthropic Messages wire nor the Responses wire
+        // carries llama.cpp's extra samplers, so they resolve to their
+        // neutral defaults and this chain is llama.cpp's default one
+        // doing nothing extra.
+        extra_samplers: Default::default(),
         // No seed field on this surface, so the chat path's policy
         // applies unchanged: an unseeded sampled request draws fresh
         // every time rather than replaying one draw forever.
@@ -1445,7 +1450,8 @@ async fn responses_full(
     let offered = offered_tools(&chat);
     let prompt = prompt_from_messages(&chat.messages, &template, &offered, kwargs)?;
     let posture = OutputPosture::resolve(active.name(), &prompt);
-    let params = chat.generation_params_for_template(&template, active.name())?;
+    let params =
+        chat.generation_params_for_template(&template, active.name(), active.sampler_model())?;
 
     let (chunks, finish, usage) = crate::decode_task::buffered(
         crate::decode_task::DecodeHandles::take(&state, &active)?,
@@ -1505,7 +1511,8 @@ async fn responses_stream(
     let prompt = prompt_from_messages(&chat.messages, &template, &offered, kwargs)?;
     let served_model = active.name().to_string();
     let posture = OutputPosture::resolve(&served_model, &prompt);
-    let mut params = chat.generation_params_for_template(&template, &served_model)?;
+    let mut params =
+        chat.generation_params_for_template(&template, &served_model, active.sampler_model())?;
 
     // The same two-tier cancellation the chat stream has: the guard
     // rides with the generation task and deregisters however that task

--- a/crates/ferrox-server/src/sample_step.rs
+++ b/crates/ferrox-server/src/sample_step.rs
@@ -530,6 +530,31 @@ mod tests {
             r#"root ::= "cd""#,
             "c",
         )));
+
+        // And the third thing that needs the vocabulary: a SAMPLER that
+        // can move the argmax. `xtc` removes the top candidates, `typ_p`
+        // can drop the most likely one, and `dry` changes which logit is
+        // the maximum -- so a folded argmax at temperature 0 would be the
+        // answer to a chain the caller did not configure.
+        for live in [
+            ferrox_models::SamplingParams {
+                xtc_probability: 1.0,
+                xtc_threshold: 0.1,
+                ..ferrox_models::SamplingParams::default()
+            },
+            ferrox_models::SamplingParams {
+                typical_p: 0.5,
+                ..ferrox_models::SamplingParams::default()
+            },
+        ] {
+            let mut p = params(false, 0.0);
+            p.sampling = live;
+            assert!(
+                !greedy_gpu_fold_allowed(&p),
+                "a chain that can move the argmax must stop the fold: {:?}",
+                p.sampling
+            );
+        }
     }
 
     /// A grammar that waits for a trigger, with the trigger MANDATORY --

--- a/crates/ferrox-server/src/sampling_knobs.rs
+++ b/crates/ferrox-server/src/sampling_knobs.rs
@@ -14,6 +14,7 @@
 //! So the knobs are one struct and the defaults are one function. A knob
 //! added here is added to both routes at once, or to neither.
 
+use ferrox_models::dry::{DryRequest, DryVocab, DryVocabMissing};
 use ferrox_models::sampler_order::SamplerOrder;
 use ferrox_models::sampling::SamplingParams;
 
@@ -24,7 +25,7 @@ const DEFAULT_PENALTY_LAST_N: usize = 64;
 
 /// One request's sampler knobs, each `None` when the caller said
 /// nothing about it.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct SamplingKnobs {
     pub(crate) temperature: Option<f32>,
     pub(crate) top_p: Option<f32>,
@@ -39,6 +40,30 @@ pub(crate) struct SamplingKnobs {
     /// see it.
     pub(crate) min_p: Option<f32>,
     pub(crate) top_k: Option<usize>,
+    /// llama.cpp's `typical_p` / `typ_p`. `None` resolves to `1.0`,
+    /// which is off and is also upstream's default.
+    pub(crate) typical_p: Option<f32>,
+    /// llama.cpp's `top_n_sigma`. `None` resolves to `-1.0`, off.
+    pub(crate) top_n_sigma: Option<f32>,
+    /// llama.cpp's `xtc_probability`. `None` resolves to `0.0`, off.
+    pub(crate) xtc_probability: Option<f32>,
+    /// llama.cpp's `xtc_threshold`. `None` resolves to upstream's
+    /// `0.1`, which is NOT itself a disabling value -- the probability
+    /// is what switches XTC off -- so a request that sets only the
+    /// threshold still gets no XTC.
+    pub(crate) xtc_threshold: Option<f32>,
+    /// llama.cpp's `dry_multiplier`. `None` resolves to `0.0`, off.
+    pub(crate) dry_multiplier: Option<f32>,
+    /// llama.cpp's `dry_base`, default 1.75.
+    pub(crate) dry_base: Option<f32>,
+    /// llama.cpp's `dry_allowed_length`, default 2.
+    pub(crate) dry_allowed_length: Option<i32>,
+    /// llama.cpp's `dry_penalty_last_n`, default `-1` (the context).
+    pub(crate) dry_penalty_last_n: Option<i32>,
+    /// llama.cpp's `dry_sequence_breakers`. `None` is llama.cpp's own
+    /// four defaults; an explicit empty list is "no breakers", which is
+    /// what `--dry-sequence-breaker none` asks for on the command line.
+    pub(crate) dry_sequence_breakers: Option<Vec<String>>,
     pub(crate) repetition_penalty: Option<f32>,
     pub(crate) presence_penalty: Option<f32>,
     pub(crate) frequency_penalty: Option<f32>,
@@ -62,20 +87,162 @@ pub(crate) struct SamplingKnobs {
     pub(crate) sampler_order: Option<SamplerOrder>,
 }
 
+/// The sampler fields llama.cpp's chain gained over OpenAI's schema,
+/// as ONE `#[serde(flatten)]`ed struct rather than nine fields repeated
+/// in three request bodies.
+///
+/// `/v1/chat/completions`, `/v1/completions` and llama.cpp's native
+/// `/completion` are genuinely different shapes and cannot share a
+/// request struct -- but they can share this. Nine fields written out
+/// three times is nine chances to add one to two routes, and that exact
+/// defect has already shipped here twice: `logit_bias` declared on one
+/// route and not the other, and four sampler fields hardcoded on
+/// `/v1/completions` while the chat route read them.
+///
+/// The names are llama.cpp's server's own, so a client written against
+/// upstream works here unchanged.
+#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
+pub(crate) struct ExtraSamplerFields {
+    pub(crate) typical_p: Option<f32>,
+    pub(crate) top_n_sigma: Option<f32>,
+    pub(crate) xtc_probability: Option<f32>,
+    pub(crate) xtc_threshold: Option<f32>,
+    pub(crate) dry_multiplier: Option<f32>,
+    pub(crate) dry_base: Option<f32>,
+    pub(crate) dry_allowed_length: Option<i32>,
+    pub(crate) dry_penalty_last_n: Option<i32>,
+    pub(crate) dry_sequence_breakers: Option<Vec<String>>,
+}
+
+impl ExtraSamplerFields {
+    /// Copy these onto a [`SamplingKnobs`].
+    ///
+    /// **Exhaustive destructure, no `..`**, for the same reason
+    /// [`SamplingKnobs::resolve`] has one: a field added to the wire
+    /// struct and not copied here is an unused variable, and
+    /// `cargo clippy -- -D warnings` is a gate. A caller's field would
+    /// otherwise be deserialized, discarded, and answered with a 200.
+    pub(crate) fn apply(&self, knobs: &mut SamplingKnobs) {
+        let ExtraSamplerFields {
+            typical_p,
+            top_n_sigma,
+            xtc_probability,
+            xtc_threshold,
+            dry_multiplier,
+            dry_base,
+            dry_allowed_length,
+            dry_penalty_last_n,
+            dry_sequence_breakers,
+        } = self;
+        knobs.typical_p = *typical_p;
+        knobs.top_n_sigma = *top_n_sigma;
+        knobs.xtc_probability = *xtc_probability;
+        knobs.xtc_threshold = *xtc_threshold;
+        knobs.dry_multiplier = *dry_multiplier;
+        knobs.dry_base = *dry_base;
+        knobs.dry_allowed_length = *dry_allowed_length;
+        knobs.dry_penalty_last_n = *dry_penalty_last_n;
+        knobs.dry_sequence_breakers = dry_sequence_breakers.clone();
+    }
+}
+
+/// The model facts the sampler needs that a request body cannot carry:
+/// the vocabulary DRY's sequence breakers are tokenised against, and the
+/// context size `dry_penalty_last_n = -1` resolves to.
+///
+/// Passed rather than looked up, because the route already holds the
+/// pinned `ActiveModel` and a second lookup could see a different model
+/// after `/admin/models/load`.
+#[derive(Clone, Copy)]
+pub(crate) struct SamplerModel<'a> {
+    /// `None` for a checkpoint with no real vocabulary (the
+    /// synthetic-weight fallback), which makes DRY a refusal rather
+    /// than a sampler that silently ignores its breakers.
+    pub(crate) vocab: Option<&'a dyn DryVocab>,
+    /// llama.cpp's `n_ctx_train`. `usize::MAX` when this server could
+    /// not price a ceiling for the model: that reads as "no ceiling
+    /// smaller than the sequence itself", which is what upstream's
+    /// clamp degenerates to, and is derived rather than a chosen
+    /// constant that would silently truncate someone's window.
+    pub(crate) context_size: usize,
+}
+
+impl SamplerModel<'_> {
+    /// No vocabulary and no ceiling.
+    ///
+    /// For tests that resolve knobs without loading a checkpoint, and
+    /// it is deliberately the one value that makes DRY a REFUSAL rather
+    /// than a silently breaker-less sampler -- so a test that wants DRY
+    /// has to say which vocabulary it wants it against.
+    #[cfg(test)]
+    pub(crate) fn absent() -> Self {
+        SamplerModel {
+            vocab: None,
+            context_size: usize::MAX,
+        }
+    }
+}
+
 impl SamplingKnobs {
     /// Fill every gap the request left with this server's default.
-    pub(crate) fn resolve(&self) -> SamplingParams {
-        SamplingParams {
-            temperature: self.temperature.unwrap_or(0.0),
-            top_p: self.top_p.unwrap_or(1.0),
-            min_p: self.min_p.unwrap_or(0.0),
-            top_k: self.top_k.unwrap_or(0),
-            repetition_penalty: self.repetition_penalty.unwrap_or(1.0),
-            penalty_last_n: self.penalty_last_n.unwrap_or(DEFAULT_PENALTY_LAST_N),
-            presence_penalty: self.presence_penalty.unwrap_or(0.0),
-            frequency_penalty: self.frequency_penalty.unwrap_or(0.0),
-            sampler_order: self.sampler_order.unwrap_or_default(),
-        }
+    ///
+    /// **The destructure is exhaustive ON PURPOSE, with no `..`.** A
+    /// knob added to this struct and not read here is an `unused
+    /// variable` warning, and `cargo clippy -- -D warnings` is a gate in
+    /// this repo, so it does not compile. That is the whole defence
+    /// against the defect this module's header describes: a field the
+    /// wire accepts, serde deserializes, and the sampler never sees.
+    pub(crate) fn resolve(
+        &self,
+        model: SamplerModel<'_>,
+    ) -> Result<SamplingParams, DryVocabMissing> {
+        let SamplingKnobs {
+            temperature,
+            top_p,
+            min_p,
+            top_k,
+            typical_p,
+            top_n_sigma,
+            xtc_probability,
+            xtc_threshold,
+            dry_multiplier,
+            dry_base,
+            dry_allowed_length,
+            dry_penalty_last_n,
+            dry_sequence_breakers,
+            repetition_penalty,
+            presence_penalty,
+            frequency_penalty,
+            penalty_last_n,
+            sampler_order,
+        } = self;
+        let defaults = DryRequest::default();
+        let dry = DryRequest {
+            multiplier: dry_multiplier.unwrap_or(defaults.multiplier),
+            base: dry_base.unwrap_or(defaults.base),
+            allowed_length: dry_allowed_length.unwrap_or(defaults.allowed_length),
+            penalty_last_n: dry_penalty_last_n.unwrap_or(defaults.penalty_last_n),
+            sequence_breakers: dry_sequence_breakers
+                .clone()
+                .unwrap_or(defaults.sequence_breakers),
+        };
+        Ok(SamplingParams {
+            temperature: temperature.unwrap_or(0.0),
+            top_p: top_p.unwrap_or(1.0),
+            min_p: min_p.unwrap_or(0.0),
+            top_k: top_k.unwrap_or(0),
+            typical_p: typical_p.unwrap_or(1.0),
+            top_n_sigma: top_n_sigma.unwrap_or(-1.0),
+            xtc_probability: xtc_probability.unwrap_or(0.0),
+            xtc_threshold: xtc_threshold.unwrap_or(0.1),
+            dry: dry.resolve(model.vocab, model.context_size)?,
+            repetition_penalty: repetition_penalty.unwrap_or(1.0),
+            penalty_last_n: penalty_last_n.unwrap_or(DEFAULT_PENALTY_LAST_N),
+            presence_penalty: presence_penalty.unwrap_or(0.0),
+            frequency_penalty: frequency_penalty.unwrap_or(0.0),
+            sampler_order: sampler_order.unwrap_or_default(),
+        })
     }
 }
 
@@ -88,7 +255,9 @@ mod tests {
     /// `SamplingParams::default` is.
     #[test]
     fn an_empty_request_resolves_to_the_do_nothing_baseline() {
-        let resolved = SamplingKnobs::default().resolve();
+        let resolved = SamplingKnobs::default()
+            .resolve(crate::sampling_knobs::SamplerModel::absent())
+            .expect("no dry");
         let baseline = SamplingParams::default();
         assert_eq!(resolved.temperature, baseline.temperature);
         assert_eq!(resolved.top_p, baseline.top_p);
@@ -104,19 +273,33 @@ mod tests {
     #[test]
     fn the_penalty_window_is_honoured_including_the_value_that_disables_it() {
         assert_eq!(
-            SamplingKnobs::default().resolve().penalty_last_n,
+            SamplingKnobs::default()
+                .resolve(crate::sampling_knobs::SamplerModel::absent())
+                .expect("no dry")
+                .penalty_last_n,
             DEFAULT_PENALTY_LAST_N
         );
         let asked = SamplingKnobs {
             penalty_last_n: Some(0),
             ..SamplingKnobs::default()
         };
-        assert_eq!(asked.resolve().penalty_last_n, 0);
+        assert_eq!(
+            asked
+                .resolve(crate::sampling_knobs::SamplerModel::absent())
+                .expect("no dry")
+                .penalty_last_n,
+            0
+        );
         let wide = SamplingKnobs {
             penalty_last_n: Some(4096),
             ..SamplingKnobs::default()
         };
-        assert_eq!(wide.resolve().penalty_last_n, 4096);
+        assert_eq!(
+            wide.resolve(crate::sampling_knobs::SamplerModel::absent())
+                .expect("no dry")
+                .penalty_last_n,
+            4096
+        );
     }
 
     /// A request that said nothing about `samplers` gets the chain
@@ -130,7 +313,10 @@ mod tests {
     #[test]
     fn an_unset_sampler_order_is_the_chain_this_server_already_ran() {
         assert_eq!(
-            SamplingKnobs::default().resolve().sampler_order,
+            SamplingKnobs::default()
+                .resolve(crate::sampling_knobs::SamplerModel::absent())
+                .expect("no dry")
+                .sampler_order,
             SamplerOrder::default()
         );
         let asked = SamplingKnobs {
@@ -142,7 +328,11 @@ mod tests {
             ..SamplingKnobs::default()
         };
         assert_eq!(
-            asked.resolve().sampler_order.to_string(),
+            asked
+                .resolve(crate::sampling_knobs::SamplerModel::absent())
+                .expect("no dry")
+                .sampler_order
+                .to_string(),
             "penalties;temperature;top_k"
         );
     }
@@ -151,15 +341,309 @@ mod tests {
     /// truncate the distribution of every request nobody configured.
     #[test]
     fn min_p_defaults_to_off_rather_than_to_llama_cpps_cli_number() {
-        assert_eq!(SamplingKnobs::default().resolve().min_p, 0.0);
+        assert_eq!(
+            SamplingKnobs::default()
+                .resolve(crate::sampling_knobs::SamplerModel::absent())
+                .expect("no dry")
+                .min_p,
+            0.0
+        );
         assert_eq!(
             SamplingKnobs {
                 min_p: Some(0.05),
                 ..SamplingKnobs::default()
             }
-            .resolve()
+            .resolve(crate::sampling_knobs::SamplerModel::absent())
+            .expect("no dry")
             .min_p,
             0.05
         );
+    }
+
+    /// A vocabulary just large enough for DRY to tokenise a breaker
+    /// against, so a test can switch DRY on without loading a model.
+    struct TinyVocab;
+
+    impl DryVocab for TinyVocab {
+        fn n_tokens(&self) -> usize {
+            4
+        }
+        fn detokenize(&self, token: usize) -> String {
+            ["a", "b", "\n", "c"][token].to_string()
+        }
+        fn tokenize(&self, text: &str) -> Vec<usize> {
+            text.chars()
+                .filter_map(|c| match c {
+                    'a' => Some(0),
+                    'b' => Some(1),
+                    '\n' => Some(2),
+                    'c' => Some(3),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    fn tiny_model() -> SamplerModel<'static> {
+        SamplerModel {
+            vocab: Some(&TinyVocab),
+            context_size: 4096,
+        }
+    }
+
+    /// One live value per extra wire field, all set at once so the
+    /// `dry_*` fields have a non-zero multiplier to matter under.
+    fn live_fields() -> ExtraSamplerFields {
+        ExtraSamplerFields {
+            typical_p: Some(0.9),
+            top_n_sigma: Some(1.5),
+            xtc_probability: Some(0.3),
+            xtc_threshold: Some(0.2),
+            dry_multiplier: Some(0.8),
+            dry_base: Some(1.5),
+            dry_allowed_length: Some(3),
+            dry_penalty_last_n: Some(128),
+            dry_sequence_breakers: Some(vec!["\n".to_string()]),
+        }
+    }
+
+    /// **Every field the wire accepts changes what the sampler does.**
+    ///
+    /// This is the assertion for the defect `CLAUDE.md` names: a wire
+    /// struct and a sampler that silently disagree about which fields
+    /// exist, six parameters accepted and ignored. Serde deserializing a
+    /// field is not evidence that anything reads it.
+    ///
+    /// The coverage list is DERIVED, not restated: the field names come
+    /// out of `serde_json::to_value` on a fully populated
+    /// [`ExtraSamplerFields`], so a field added to that struct and not
+    /// probed here turns this red rather than passing unnoticed. And
+    /// each probe is checked through
+    /// [`crate::response_cache::sampling_key`], which is the exhaustive
+    /// destructure of `SamplingParams` -- so "reaches the sampler" and
+    /// "is in the cache key" are one assertion, and neither can be
+    /// satisfied without the other.
+    #[test]
+    fn every_extra_wire_sampler_field_changes_the_resolved_sampler() {
+        let live = live_fields();
+        let key_of = |fields: &ExtraSamplerFields| {
+            let mut knobs = SamplingKnobs::default();
+            fields.apply(&mut knobs);
+            crate::response_cache::sampling_key(
+                &knobs
+                    .resolve(tiny_model())
+                    .expect("the tiny vocab serves DRY"),
+            )
+        };
+        let baseline = key_of(&live);
+
+        let probes: Vec<(&str, ExtraSamplerFields)> = vec![
+            (
+                "typical_p",
+                ExtraSamplerFields {
+                    typical_p: Some(0.5),
+                    ..live.clone()
+                },
+            ),
+            (
+                "top_n_sigma",
+                ExtraSamplerFields {
+                    top_n_sigma: Some(2.5),
+                    ..live.clone()
+                },
+            ),
+            (
+                "xtc_probability",
+                ExtraSamplerFields {
+                    xtc_probability: Some(0.7),
+                    ..live.clone()
+                },
+            ),
+            (
+                "xtc_threshold",
+                ExtraSamplerFields {
+                    xtc_threshold: Some(0.4),
+                    ..live.clone()
+                },
+            ),
+            (
+                "dry_multiplier",
+                ExtraSamplerFields {
+                    dry_multiplier: Some(1.6),
+                    ..live.clone()
+                },
+            ),
+            (
+                "dry_base",
+                ExtraSamplerFields {
+                    dry_base: Some(2.0),
+                    ..live.clone()
+                },
+            ),
+            (
+                "dry_allowed_length",
+                ExtraSamplerFields {
+                    dry_allowed_length: Some(5),
+                    ..live.clone()
+                },
+            ),
+            (
+                "dry_penalty_last_n",
+                ExtraSamplerFields {
+                    dry_penalty_last_n: Some(64),
+                    ..live.clone()
+                },
+            ),
+            (
+                "dry_sequence_breakers",
+                ExtraSamplerFields {
+                    dry_sequence_breakers: Some(vec!["a".to_string()]),
+                    ..live.clone()
+                },
+            ),
+        ];
+
+        let probed: std::collections::BTreeSet<String> =
+            probes.iter().map(|(name, _)| name.to_string()).collect();
+        let declared: std::collections::BTreeSet<String> = serde_json::to_value(&live)
+            .expect("serialises")
+            .as_object()
+            .expect("an object")
+            .keys()
+            .cloned()
+            .collect();
+        assert_eq!(
+            probed, declared,
+            "a field on the wire is not probed here, so nothing would notice \
+             if the sampler stopped reading it"
+        );
+
+        for (name, fields) in probes {
+            assert_ne!(
+                key_of(&fields),
+                baseline,
+                "`{name}` is accepted on the wire and changes nothing in the \
+                 resolved sampler"
+            );
+        }
+    }
+
+    /// The three routes that take these fields resolve them the same
+    /// way, asserted through the real request types.
+    ///
+    /// A shared `#[serde(flatten)]` struct only helps if every route
+    /// both DECLARES it and calls `apply`. `/v1/completions` once
+    /// hardcoded four sampler fields the chat route read off the
+    /// request; this is the assertion that would have caught it.
+    #[test]
+    fn every_route_resolves_the_extra_sampler_fields_the_same_way() {
+        let extras = serde_json::json!({
+            "typical_p": 0.9,
+            "top_n_sigma": 1.5,
+            "xtc_probability": 0.3,
+            "xtc_threshold": 0.2,
+            "dry_multiplier": 0.8,
+            "dry_base": 1.5,
+            "dry_allowed_length": 3,
+            "dry_penalty_last_n": 128,
+            "dry_sequence_breakers": ["\n"],
+        });
+        let with = |mut body: serde_json::Value| {
+            for (k, v) in extras.as_object().expect("an object") {
+                body[k] = v.clone();
+            }
+            body
+        };
+        let chat: crate::ChatCompletionRequest = serde_json::from_value(with(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+        })))
+        .expect("chat request");
+        let completions: crate::openai_extra::CompletionsRequest =
+            serde_json::from_value(with(serde_json::json!({"prompt": "hi"})))
+                .expect("completions request");
+        let native: crate::completion::CompletionRequest =
+            serde_json::from_value(with(serde_json::json!({"prompt": "hi"})))
+                .expect("completion request");
+
+        let key = |knobs: SamplingKnobs| {
+            crate::response_cache::sampling_key(&knobs.resolve(tiny_model()).expect("dry"))
+        };
+        let chat_key = key(chat.sampling_knobs().expect("chat knobs"));
+        let completions_key = key(completions.sampling_knobs().expect("completions knobs"));
+        let native_key = key(native.sampling_knobs().expect("native knobs"));
+        assert_eq!(chat_key, completions_key, "chat and /v1/completions differ");
+        assert_eq!(chat_key, native_key, "chat and /completion differ");
+
+        // And the values really are the ones sent, not three copies of
+        // the defaults agreeing with each other.
+        let resolved = chat
+            .sampling_knobs()
+            .expect("knobs")
+            .resolve(tiny_model())
+            .expect("dry");
+        assert_eq!(resolved.typical_p, 0.9);
+        assert_eq!(resolved.top_n_sigma, 1.5);
+        assert_eq!(resolved.xtc_probability, 0.3);
+        assert_eq!(resolved.xtc_threshold, 0.2);
+        assert!(resolved.dry.is_enabled());
+        assert_eq!(resolved.dry.multiplier(), 0.8);
+        assert_eq!(resolved.dry.base(), 1.5);
+        assert_eq!(resolved.dry.allowed_length(), 3);
+        assert_eq!(resolved.dry.penalty_last_n(), 128);
+        assert_eq!(resolved.dry.breakers().raw(), ["\n".to_string()]);
+    }
+
+    /// A request that says nothing about the new samplers resolves to
+    /// values that make each of them a NO-OP, so llama.cpp's full
+    /// default chain leaves an unconfigured request exactly where it
+    /// was before these four samplers existed.
+    #[test]
+    fn an_unconfigured_request_leaves_every_new_sampler_switched_off() {
+        let resolved = SamplingKnobs::default()
+            .resolve(SamplerModel::absent())
+            .expect("no dry means no vocabulary is needed");
+        assert_eq!(resolved.typical_p, 1.0);
+        assert_eq!(resolved.top_n_sigma, -1.0);
+        assert_eq!(resolved.xtc_probability, 0.0);
+        assert_eq!(resolved.xtc_threshold, 0.1);
+        assert!(!resolved.dry.is_enabled());
+        assert!(!resolved.xtc_can_fire());
+        assert!(resolved.greedy_equals_argmax());
+    }
+
+    /// DRY asked for against a checkpoint with no vocabulary is a
+    /// REFUSAL, not DRY with no sequence breakers.
+    ///
+    /// A breaker-less DRY looks like working DRY and penalises across
+    /// every boundary the caller named. The refusal is reachable: it
+    /// fires for exactly the models `Model::has_real_vocabulary` says
+    /// have none.
+    #[test]
+    fn dry_without_a_vocabulary_is_refused_rather_than_run_without_breakers() {
+        let mut knobs = SamplingKnobs::default();
+        ExtraSamplerFields {
+            dry_multiplier: Some(0.8),
+            ..Default::default()
+        }
+        .apply(&mut knobs);
+        knobs
+            .resolve(SamplerModel::absent())
+            .expect_err("no vocabulary, so no breakers, so no DRY");
+
+        // The same request with the breakers explicitly emptied IS
+        // served: there is nothing left to tokenise.
+        let mut none = SamplingKnobs::default();
+        ExtraSamplerFields {
+            dry_multiplier: Some(0.8),
+            dry_sequence_breakers: Some(Vec::new()),
+            ..Default::default()
+        }
+        .apply(&mut none);
+        let resolved = none
+            .resolve(SamplerModel::absent())
+            .expect("no breakers needs no vocabulary");
+        assert!(resolved.dry.is_enabled());
+        assert!(resolved.dry.breakers().is_empty());
     }
 }

--- a/crates/ferrox-server/src/serving/batch/tests/batching.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/batching.rs
@@ -58,17 +58,11 @@ fn continuous_batching_composes_with_paged_kv() {
         let par = GenerationParams {
             reasoning: None,
             max_tokens: params[i].max_tokens,
-            sampling: SamplingParams {
-                temperature: params[i].sampling.temperature,
-                top_p: params[i].sampling.top_p,
-                min_p: params[i].sampling.min_p,
-                top_k: params[i].sampling.top_k,
-                repetition_penalty: params[i].sampling.repetition_penalty,
-                penalty_last_n: 64,
-                presence_penalty: params[i].sampling.presence_penalty,
-                frequency_penalty: params[i].sampling.frequency_penalty,
-                sampler_order: params[i].sampling.sampler_order,
-            },
+            // Cloned rather than field-by-field: a hand-written copy
+            // of `SamplingParams` is this repo's dominant defect at its
+            // smallest, and this one already omitted every sampler
+            // added after it was written.
+            sampling: params[i].sampling.clone(),
             seed: params[i].seed,
             stop: vec![],
             stop_token_ids: Vec::new(),
@@ -248,17 +242,11 @@ fn continuous_batch_matches_sequential_generate_token_ids() {
         let par = GenerationParams {
             reasoning: None,
             max_tokens: params[i].max_tokens,
-            sampling: SamplingParams {
-                temperature: params[i].sampling.temperature,
-                top_p: params[i].sampling.top_p,
-                min_p: params[i].sampling.min_p,
-                top_k: params[i].sampling.top_k,
-                repetition_penalty: params[i].sampling.repetition_penalty,
-                penalty_last_n: 64,
-                presence_penalty: params[i].sampling.presence_penalty,
-                frequency_penalty: params[i].sampling.frequency_penalty,
-                sampler_order: params[i].sampling.sampler_order,
-            },
+            // Cloned rather than field-by-field: a hand-written copy
+            // of `SamplingParams` is this repo's dominant defect at its
+            // smallest, and this one already omitted every sampler
+            // added after it was written.
+            sampling: params[i].sampling.clone(),
             seed: params[i].seed,
             stop: vec![],
             stop_token_ids: Vec::new(),

--- a/crates/ferrox-server/src/serving/batch/tests/mod.rs
+++ b/crates/ferrox-server/src/serving/batch/tests/mod.rs
@@ -50,17 +50,10 @@ fn greedy_params(max_tokens: usize, seed: u64) -> GenerationParams {
     GenerationParams {
         reasoning: None,
         max_tokens,
-        sampling: SamplingParams {
-            temperature: 0.0,
-            top_p: 1.0,
-            min_p: 0.0,
-            top_k: 0,
-            repetition_penalty: 1.0,
-            penalty_last_n: 64,
-            presence_penalty: 0.0,
-            frequency_penalty: 0.0,
-            sampler_order: ferrox_models::SamplerOrder::default(),
-        },
+        // `SamplingParams::default()` IS greedy with every filter
+        // off, so restating its fields here would be a second copy of
+        // the defaults that could drift from the first.
+        sampling: SamplingParams::default(),
         seed,
         stop: vec![],
         stop_token_ids: Vec::new(),

--- a/crates/ferrox-server/src/unsupported_sampling.rs
+++ b/crates/ferrox-server/src/unsupported_sampling.rs
@@ -43,10 +43,10 @@ use crate::{invalid_request, unsupported_feature, ApiError};
 ///
 /// ## Why a refusal and not a filtered chain
 ///
-/// ferrox implements five of upstream's samplers. Building the chain out
-/// of the names it recognises and dropping the rest would answer a
-/// request for `dry;top_k;typ_p;top_p;min_p;xtc;temperature` with a
-/// four-sampler chain, a 200, and no way for the caller to tell -- the
+/// ferrox implements llama.cpp's whole default chain but not `mirostat`
+/// or `infill`. Building the chain out of the names it recognises and
+/// dropping the rest would answer a request naming `mirostat` with a
+/// chain that has none, a 200, and no way for the caller to tell -- the
 /// same silence `logit_bias` is refused for.
 ///
 /// The status codes distinguish the two failures a caller can have:
@@ -221,7 +221,7 @@ mod tests {
     /// they did not ask for.
     #[test]
     fn a_sampler_ferrox_lacks_is_refused_by_name_as_not_implemented() {
-        for name in ["dry", "xtc", "typ_p", "mirostat", "top_n_sigma", "infill"] {
+        for name in ["mirostat", "infill"] {
             let body = serde_json::json!([name, "temperature"]);
             let (status, message) = parse_sampler_order(Some(&body), "/completion")
                 .expect_err("{name} must be refused, not skipped");
@@ -271,8 +271,25 @@ mod tests {
             (serde_json::json!(["top_k", "temperature"]), None),
             (serde_json::json!([]), None),
             (
-                serde_json::json!(["xtc", "temperature"]),
+                serde_json::json!(["mirostat", "temperature"]),
                 Some(StatusCode::NOT_IMPLEMENTED),
+            ),
+            // llama.cpp's own default chain, which every one of these
+            // routes must now accept: this list is the whole reason the
+            // four missing samplers were ported.
+            (
+                serde_json::json!([
+                    "penalties",
+                    "dry",
+                    "top_n_sigma",
+                    "top_k",
+                    "typ_p",
+                    "top_p",
+                    "min_p",
+                    "xtc",
+                    "temperature"
+                ]),
+                None,
             ),
             (
                 serde_json::json!(["top_kk", "temperature"]),

--- a/docs/API.md
+++ b/docs/API.md
@@ -61,6 +61,8 @@ conversation or a large `/v1/embeddings` batch past that comes back
 | `model`, `messages` | Supported |
 | `max_tokens` | Supported; **defaults to 32768**, not OpenAI's legacy 16. An explicit `0` is a 400 |
 | `temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`, `seed`, `stop` | Supported |
+| `typical_p`, `top_n_sigma`, `xtc_probability`, `xtc_threshold`, `dry_multiplier`, `dry_base`, `dry_allowed_length`, `dry_penalty_last_n`, `dry_sequence_breakers` | Supported. llama.cpp's own spellings; absent means the sampler is off |
+| `samplers` | Supported. The chain order, as a list of names or a `;`-separated string. Defaults to llama.cpp's own default chain |
 | `presence_penalty`, `frequency_penalty` | Supported |
 | `stream` | Supported (overlapped SSE when tools off and CB off) |
 | `tools` / `tool_choice: none\|auto` | Supported (prompt-engineered, parsed in eleven wire formats) |
@@ -977,8 +979,9 @@ from arriving as a number.
 `/v1/completions` honours `stop`, `max_tokens` (default 16, because the legacy
 floor is right *here*, where a caller completing a fragment usually
 wants a fragment back), `temperature`, `top_p`, `min_p`, `top_k`,
-`repetition_penalty`, `presence_penalty`, `frequency_penalty`, `seed`,
-`ignore_eos` and `grammar`.
+`typical_p`, `top_n_sigma`, `xtc_probability`, `xtc_threshold`, the five
+`dry_*` fields, `samplers`, `repetition_penalty`, `presence_penalty`,
+`frequency_penalty`, `seed`, `ignore_eos` and `grammar`.
 
 Four of those are recent. `top_k`, `repetition_penalty`,
 `presence_penalty` and `frequency_penalty` were undeclared on this
@@ -1037,9 +1040,26 @@ is a wire, not a second implementation.
 
 `prompt` (string, or `{"prompt_string": "…"}`) · `n_predict` ·
 `stream` · `stop` · `temperature` · `top_p` · `min_p` · `top_k` ·
+`typical_p` · `top_n_sigma` · `xtc_probability` · `xtc_threshold` ·
+`dry_multiplier` · `dry_base` · `dry_allowed_length` ·
+`dry_penalty_last_n` · `dry_sequence_breakers` ·
 `repeat_penalty` · `repeat_last_n` · `presence_penalty` ·
-`frequency_penalty` · `seed` (`-1` draws one) · `ignore_eos` ·
-`grammar` · `cache_prompt`.
+`frequency_penalty` · `samplers` · `seed` (`-1` draws one) ·
+`ignore_eos` · `grammar` · `cache_prompt`.
+
+The nine samplers of llama.cpp's default chain all run, in llama.cpp's
+order (`penalties, dry, top_n_sigma, top_k, typical_p, top_p, min_p,
+xtc, temperature`). An absent field resolves to the value that makes its
+sampler a no-op, so a request that names none of them is sampled exactly
+as it was before they existed.
+
+`dry_sequence_breakers` are STRINGS, tokenised against the loaded
+model's own vocabulary (llama.cpp's `get_overlapping_token_sequences`).
+A checkpoint with no real vocabulary — the synthetic-weight fallback —
+**refuses** `dry_multiplier` rather than running DRY with no breakers,
+because a breaker-less DRY looks like working DRY and penalises across
+every boundary the caller named. Send `dry_sequence_breakers: []` to ask
+for DRY with no breakers deliberately.
 
 `n_predict` keeps llama.cpp's meaning exactly, including the part that
 is easy to get wrong: **an absent `n_predict` is `-1`**, which means
@@ -1068,8 +1088,7 @@ because a stock client sends most of them explicitly and refusing
 `mirostat: 0` would be a false refusal. At any other value it is a 501
 naming the field:
 
-`dynatemp_range` · `typical_p` · `xtc_probability` · `mirostat` ·
-`dry_multiplier` · `samplers` (the sampler chain order is fixed) ·
+`dynatemp_range` · `mirostat` ·
 `n_probs` and `post_sampling_probs` (no per-token logprobs) ·
 `min_keep` · `return_tokens` (the decode loop hands this layer text,
 not ids) · `n_indent` · `n_keep` (ferrox refuses an oversized request
@@ -1089,10 +1108,9 @@ than ranked; upstream prefers `grammar` and drops the schema, which is
 a 200 whose answer need not match the schema the caller sent.
 
 Options that only *parameterise* a switched-off sampler (
-`mirostat_tau`, `mirostat_eta`, `dry_base`, `dry_allowed_length`,
-`dry_penalty_last_n`, `dry_sequence_breakers`, `xtc_threshold`,
-`dynatemp_exponent`) are deliberately not in that list: they do
-nothing while their switch is off, and their switch is. A field
+`mirostat_tau`, `mirostat_eta`, `dynatemp_exponent`) are deliberately
+not in that list: they do nothing while their switch is off, and their
+switch is. A field
 llama.cpp does not define either is ignored, exactly as upstream
 ignores it.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,6 +72,15 @@ Same via explicit subcommand: `ferrox run -m …`.
 | `--frequency-penalty` | Penalise a token in proportion to how often it has appeared. `0.0` = off |
 | `--hf-file` | Exact filename inside `--hf-repo`, llama.cpp's `-hff`. Skips quant resolution entirely |
 | `--repeat-last-n` | How many recent tokens the repetition / presence / frequency penalties consider. `0` = penalties off. Default `64`, llama.cpp's (`common/common.h:238`) |
+| `--typical` / `--typical-p` | Locally typical sampling. Keeps the candidates nearest the distribution's entropy, so it can drop the MOST likely token. `1.0` = off, llama.cpp's default (`common/common.h:230`) |
+| `--top-nsigma` / `--top-n-sigma` | Mask every candidate more than `n` standard deviations of the logits below the maximum. `-1.0` = off, llama.cpp's default. `0.0` is a no-op, not greedy |
+| `--xtc-probability` | Chance that XTC removes the top candidates on a token. `0.0` = off, llama.cpp's default |
+| `--xtc-threshold` | Probability a candidate must reach before XTC may remove it. Default `0.1`; **above `0.5` disables XTC**, as upstream |
+| `--dry-multiplier` | DRY sequence-repetition penalty. `0.0` = off, llama.cpp's default |
+| `--dry-base` | Base of DRY's exponential. Default `1.75`; below `1.0` disables DRY |
+| `--dry-allowed-length` | Repetitions this long or shorter are free. Default `2` |
+| `--dry-penalty-last-n` | How many recent tokens DRY scans. `0` = off, `-1` = the context size (default) |
+| `--dry-sequence-breaker` | Repeatable. A string DRY refuses to look past. Giving any CLEARS llama.cpp's defaults (`\n`, `:`, `"`, `*`), and the literal `none` clears them outright |
 | `-s` / `--seed` | `-1` = time-based |
 | `--samplers` / `--sampler-seq` | Order the chain runs in, semicolon-separated. A sampler ferrox lacks is refused by name, see below |
 | `--grammar` | Constrain generation to a GBNF grammar, llama.cpp's `--grammar` |
@@ -107,14 +116,18 @@ per token, which is why a model that fits at its full context on Metal
 can need `--ctx-size auto` on CPU. `ferrox inspect-plan` prices both.
 
 `--samplers` (llama.cpp's, also `--sampler-seq`) chooses the ORDER, as a
-semicolon-separated list: `--samplers "penalties;top_k;top_p;min_p;temperature"`
-is the default spelled out. llama.cpp's aliases parse, so `top-k`,
-`nucleus`, `temp` and `typical` all work.
+semicolon-separated list. The default is llama.cpp's own default chain,
+spelled out:
+`--samplers "penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature"`.
+llama.cpp's aliases parse, so `top-k`, `nucleus`, `temp` and `typical`
+all work, and an upstream command line pastes in unchanged.
 
 A sampler ferrox does not implement is **refused by name with the
-reason**, never skipped: `dry`, `typ_p`, `xtc` and `top_n_sigma` are
-real llama.cpp samplers, and a caller who asked for one and silently got
-a chain without it was handed a different sampler than the one they
+reason**, never skipped. That is now only `mirostat` and `infill`:
+`mirostat` REPLACES the chain upstream rather than joining it, so there
+is no position in this order that would honour it, and `infill` needs
+the model's FIM tokens. A caller who asked for one and silently got a
+chain without it was handed a different sampler than the one they
 requested.
 
 Order is not cosmetic, which is why it is worth exposing and why getting
@@ -125,9 +138,12 @@ temperature ran first, and top-p then summed probabilities temperature
 had already reshaped.
 
 **The sampler chain is llama.cpp's, in llama.cpp's order.** Penalties,
-then top-k, then top-p, then min-p, and **temperature last**
-(`common/common.h:259-269`; ferrox
-`crates/ferrox-models/src/sampling.rs`'s `filtered_distribution`).
+DRY, top-n-sigma, top-k, typical-p, top-p, min-p, XTC, and
+**temperature last** (`common/common.h:259-269`; ferrox
+`crates/ferrox-models/src/sampling.rs`'s `filtered_distribution`). Every
+one of those nine runs by default, and the four with no OpenAI
+equivalent sit at neutral values that make them exact no-ops, so a
+command line that does not name them samples what it always did.
 Ferrox used to divide by the temperature first and filter afterwards,
 which keeps a different candidate set for the same flags: top-p selects
 the smallest set summing to `p`, and temperature changes the

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -195,12 +195,16 @@ OpenAI-compatible HTTP API:
 - `POST /v1/responses`, the surface `codex` speaks, streaming and
   buffered. This server keeps no responses, so the two lookups by
   response id answer 404
-- Sampling matched to llama.cpp's own chain: `temperature`, `top_p`,
-  `top_k`, `min_p`, `repetition_penalty` over a 64-token penalty window,
-  presence and frequency penalties. Temperature runs **last**, after the
-  truncation filters, as llama.cpp orders it, and the repetition penalty
-  is applied once per candidate rather than once per occurrence. Both
-  routes read the same knobs through one `SamplingKnobs::resolve`
+- Sampling matched to llama.cpp's own chain, all nine steps of it in
+  upstream's order: `penalties`, `dry`, `top_n_sigma`, `top_k`,
+  `typ_p`, `top_p`, `min_p`, `xtc`, `temperature`
+  (`common/common.h:259-269`). Temperature runs **last**, after the
+  truncation filters, and the repetition penalty is applied once per
+  candidate rather than once per occurrence. DRY's sequence breakers are
+  tokenised against the loaded model's own vocabulary; a checkpoint with
+  none refuses DRY rather than running it breaker-less. `mirostat` and
+  `infill` are the two upstream samplers still refused, each by name.
+  Every route reads the same knobs through one `SamplingKnobs::resolve`
 - Grammar-constrained decoding, in every spelling: llama.cpp's own
   `grammar` field, OpenAI's `response_format: json_schema`, llama.cpp's
   bare `json_schema` field on `/completion`, and a forced `tool_choice`.


### PR DESCRIPTION
## What this closes

ferrox ran five of llama.cpp's nine default samplers. The other four
were named in the table only so that asking for one was a refusal
rather than a silently different chain — honest, but it meant
llama.cpp's own default `--samplers` string could not be pasted into
ferrox, and four real sampling behaviours were unavailable.

All four are now implemented with llama.cpp-exact semantics, wired end
to end, and pinned against golden values **read out of `libllama`
b7650** (a small C++ harness linked against
`.scratch/llama.cpp/build/bin/libllama.dylib`, calling the real
`llama_sampler_init_typical` / `_top_n_sigma` / `_xtc` /
`_dry_testing` and printing the logits back) rather than reasoned about.

`SamplerOrder`'s default is now llama.cpp's default chain verbatim
(`common/common.h:259-269`):
`penalties;dry;top_n_sigma;top_k;typ_p;top_p;min_p;xtc;temperature`.

## What was ported, with the upstream line

| Sampler | llama.cpp | Notes |
|---|---|---|
| `typical_p` | `llama_sampler_typical_apply`, `src/llama-sampler.cpp:1713-1769` | Keeps the candidates whose surprisal is nearest the entropy, ordered from the middle outward. Cutoff is a STRICT `cum_sum > p` where top-p's is `>=`. It can drop the most likely token. |
| `top_n_sigma` | `llama_sampler_top_n_sigma_apply`, `:3002-3039` | Masks to `-inf` rather than removing; statistic over the LOGITS, skipping `-inf` entries. `0.0` is a no-op, not greedy (upstream PR 13345). |
| `xtc` | `llama_sample_xtc_apply`, `:2137-2168`, init at `:2207` | Removes the top candidates at or above `xtc_threshold`, keeping the least likely of them, with probability `xtc_probability`. Threshold above 0.5 disables. |
| `dry` | `llama_sampler_dry_apply`, `:3151-3345`; `get_overlapping_token_sequences`, `:3095-3134`; init at `:3376` | Full port including the reverse Z-algorithm, `rep_limit` restart-sequence scan, the `FLOAT_MAX_LOG` exponent clamp, the single-token-breaker exemption, and the sequence breakers tokenised against the loaded model's vocabulary. |

`mirostat` and `infill` remain the two upstream samplers ferrox does
not have, and they are still refused BY NAME with the reason.

## Defaults are exact no-ops

`typical_p 1.0`, `top_n_sigma -1.0`, `xtc_probability 0.0`,
`xtc_threshold 0.1`, `dry_multiplier 0.0` — llama.cpp's own neutral
values. A run that configures none of them samples **bit-for-bit** what
it did before, asserted against the five-step chain written out by hand
(not read back off `SamplerOrder`) in
`sampling::tests::the_default_order_is_the_chain_ferrox_already_ran`.

`Sampler::xtc_roll` also refuses to draw when XTC cannot fire. Every
draw advances the seeded stream, so an unconditional roll would shift
every token of every existing seeded generation.

## Wired end to end

* `SamplingParams` — five new fields (`typical_p`, `top_n_sigma`,
  `xtc_probability`, `xtc_threshold`, `dry`).
* `ChainStep` — four new variants, `name()` still exhaustive;
  `ChainStep::all()` is DERIVED from `SamplerName::implemented()`
  rather than restated beside it.
* `--samplers` / the `samplers` request field — unchanged code, but the
  four names now parse instead of refusing.
* CLI: `--typical` / `--typical-p`, `--top-nsigma` / `--top-n-sigma`,
  `--xtc-probability`, `--xtc-threshold`, `--dry-multiplier`,
  `--dry-base`, `--dry-allowed-length`, `--dry-penalty-last-n`,
  `--dry-sequence-breaker` (repeatable; giving any clears llama.cpp's
  four defaults, and the literal `none` clears them outright, as
  `common/arg.cpp:2119-2126` does).
* Server: the same nine fields on `/v1/chat/completions`,
  `/v1/completions` and llama.cpp's native `/completion`, under
  upstream's own spellings. `typical_p`, `xtc_probability` and
  `dry_multiplier` come OUT of `/completion`'s refusal table, which is
  now down to `dynatemp_range` and `mirostat` among the samplers.
* `crates/ferrox-api` carries no sampling DTOs (routes and lifecycle
  only), so nothing changed there.

## The enforcement, not the patch

Three places where a future omission stops compiling or turns red:

1. **`SamplingKnobs::resolve` and `ExtraSamplerFields::apply` destructure
   exhaustively with no `..`.** A wire field added and not read is an
   unused variable, and `clippy -D warnings` is a gate here.
2. **The nine llama.cpp-only wire fields are ONE `#[serde(flatten)]`
   struct** shared by all three routes, rather than nine fields written
   out three times. `/v1/completions` once hardcoded four sampler fields
   the chat route read off the request; that shape is gone.
3. **`SamplingParams::greedy_equals_argmax` is one predicate** read by
   the sampler's own greedy fast path AND by both copies of the Metal
   `lm_head + argmax` fold guard. `xtc` and `typ_p` can remove the
   maximum and `dry` can move which logit it is, so at `temperature <= 0`
   a folded argmax would silently skip them. llama.cpp does not
   special-case `temp <= 0` at all — it runs the whole chain and lets the
   temperature step mask everything but the max.

DRY's breakers get a type invariant rather than a convention:
`DryParams` has private fields and no constructor that enables DRY
without a `DryBreakers`, and the only way to a non-empty `DryBreakers`
is `from_vocab`. A checkpoint with no real vocabulary **refuses** DRY
instead of running it breaker-less, which would look like working DRY
while penalising across every boundary the caller named.

## File sizes

`sampling.rs` was 1569 lines, so it was split before anything was added:
`sampling/params.rs` (245), `sampling/penalties.rs` (197),
`sampling/recommended.rs` (292), `sampling/rng.rs` (472), leaving
`sampling.rs` at 894. DRY is its own `dry.rs` (995); the four filters
live beside their siblings in `sampler_chain.rs` (742). Every file
touched is under 1000 lines.

## Which tests prove it

Golden, from libllama:

* `sampler_chain::typical_p_keeps_the_candidates_nearest_the_entropy_and_can_drop_the_leader`
  — llama.cpp's own `tests/test-sampling.cpp:345-346` rows, re-run to
  read the surviving token ids.
* `sampler_chain::typical_ps_running_sum_is_strict_where_top_ps_is_inclusive`
  — four equal logits give probabilities of exactly 0.25 whose partial
  sums are exact in an f32, the one shape where strict and inclusive
  differ without depending on rounding. libllama returns 2/3/4 at
  p = 0.25/0.5/0.75.
* `sampler_chain::top_n_sigma_masks_everything_more_than_n_sigma_below_the_top_logit`
  and `a_smaller_n_masks_more_and_a_non_positive_n_masks_nothing`.
* `sampler_chain::xtc_removes_every_candidate_above_the_threshold_except_the_least_likely`
  — upstream's four rows at thresholds 0.09/0.19/0.29/0.39, the last of
  which is the guard that keeps the list intact.
* `dry::*` — six cases against `llama_sampler_init_dry_testing`,
  including the `0.8 * 1.75^5 = 13.130469` exponent and the
  single-token-breaker exemption.

Hand-computed, arithmetic in the doc comment:
`typical_p_cuts_on_a_strict_running_sum_over_the_distance_order`,
`min_p_truncates_at_ln_p_below_the_top_logit`,
`a_repeated_suffix_penalises_only_the_token_that_would_extend_it`.

Wiring:

* `sampling_knobs::every_extra_wire_sampler_field_changes_the_resolved_sampler`
  — the coverage list is derived from `serde_json::to_value` on a
  populated `ExtraSamplerFields`, so a field added and not probed turns
  it red; each probe is checked through `response_cache::sampling_key`,
  which is the exhaustive destructure of `SamplingParams`.
* `sampling_knobs::every_route_resolves_the_extra_sampler_fields_the_same_way`
  — through the three real request types.
* `sampler_order::every_step_the_name_table_yields_names_itself_back`
  and `the_default_chain_contains_every_step_this_engine_implements`.
* `sample_step::a_constrained_request_may_never_fold_lm_head_into_a_gpu_argmax`
  — extended with the sampler arm.

## Sabotage-verified

Each mutation was applied, **grep-confirmed present in the file**, run,
and reverted:

| Mutation | Test that went red |
|---|---|
| typical-p `cum_sum > p` → `>=` | `typical_ps_running_sum_is_strict_where_top_ps_is_inclusive` |
| XTC `pos_last = i` → `i + 1` | `xtc_removes_every_candidate_above_the_threshold_except_the_least_likely`, `xtc_changes_the_greedy_choice_because_it_removes_the_top` |
| top-n-sigma `max - n * std` → `max - std` | `a_smaller_n_masks_more_and_a_non_positive_n_masks_nothing` |
| DRY `max_repeat - allowed_length` → `max_repeat` | four `dry::*` tests |
| `ExtraSamplerFields::apply` dropping `top_n_sigma` | both wiring tests |
| `Sampler::xtc_roll` drawing unconditionally | `a_chain_without_xtc_does_not_consume_a_draw_for_it` |
| `ChainStep::Xtc => SamplerName::TopK` | four `sampler_order::*` tests |
| `typical_p` default `1.0` → `0.95` | `the_default_order_is_the_chain_ferrox_already_ran` |

Two attempted mutations did **not** go red and were replaced rather than
believed: `pos_last > 0` → `>= 0` (identical, since `drop_front(0)` is a
no-op) and removing typical-p's `p >= 1.0` early return (identical at
exactly 1.0, since the running sum never strictly exceeds it). The first
version of `a_chain_without_xtc_does_not_consume_a_draw_for_it` also
survived its sabotage because both sides of the comparison drew the same
roll; it was rewritten to compare against a generator that never heard
of XTC, and then went red.

## What is NOT verified

* No real-checkpoint run. Every number here is a unit test or a golden
  value from `libllama`; nothing was decoded against a GGUF, and no
  `ferrox parity` comparison was made with these samplers switched on.
* No benchmark. DRY's breaker tokenisation walks the whole vocabulary
  once per request when DRY is enabled — that is llama.cpp's own cost
  (`llama_sampler_init_dry` runs it per sampler and upstream's server
  builds one per request), but it has not been measured here.
* No Metal or CUDA hardware run. `cargo build -p ferrox-cli -p
  ferrox-server --features metal` and `clippy --features metal` are
  clean; `cargo test -p ferrox-metal --features metal -- --ignored` was
  not run.
* Mirostat v1/v2 were **left out** deliberately. They do not fit this
  chain: upstream `common/sampling.cpp:405-412` REPLACES the whole
  sampler list with `temp` + mirostat, and mirostat is stateful across
  tokens (it carries a `mu` it updates from the surprisal of the token
  it just picked). There is no position in a `SamplerOrder` that would
  honour it and no per-sequence sampler state for `mu` to live in, so
  `mirostat` stays a named refusal rather than a half-wired feature.
* `dynatemp_range` / `dynatemp_exponent` also remain refused; they were
  not in scope.

## Checks run

`cargo test --workspace` (green), `cargo clippy --workspace
--all-targets -- -D warnings` in **debug and release** (clean),
`cargo clippy -p ferrox-cli -p ferrox-server --features metal
--all-targets -- -D warnings` (clean), `cargo fmt --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
