### PR TITLE
release: 0.18.0, and correct the docs the merges made wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,118 @@ Entries name what changed and, where it matters, what was wrong
 before. A fix that closed a silent-wrong-answer class says so — those
 are the ones worth reading twice.
 
+## [0.18.0] - 2026-09-09
+
+### Added
+
+- **The four missing samplers**, so the chain is llama.cpp's full nine
+  steps in upstream's order: `dry`, `xtc`, `typ_p` and `top_n_sigma`
+  join `penalties`, `top_k`, `top_p`, `min_p` and `temperature`. Golden
+  values were read out of `libllama` rather than reasoned about. Every
+  new step is a no-op at its neutral value, so a default run is
+  unchanged. `mirostat` and `infill` remain refused by name, and the
+  reason mirostat is refused is written down: upstream *replaces* the
+  chain with it and it carries per-sequence state ferrox has nowhere to
+  put (#160).
+- **`ferrox gguf-split`**, a port of `llama-gguf-split`: split by tensor
+  count or by size, merge, `--dry-run`, the same shard names and the
+  same `split.*` metadata keys. Cross-checked against the real tool,
+  which produced 6 of 6 shards of identical size, and each tool merges
+  the other's output (#154).
+- **Three more architectures run with evidence**: `gemma`,
+  `hunyuan-dense` and `ernie4_5-moe` at step 1, each with a
+  libllama-golden fixture. Audited 23 to 26, unaudited refusals 34 to
+  31, and **the fixture-away class is now empty**: every row that needed
+  only evidence has it, so everything left needs code (#161).
+- **`ferrox quantize` writes Q5_K_M and Q6_K**, byte-identically (#162).
+- **CUDA gains Q2_K, Q3_K, IQ4_NL, IQ4_XS and MXFP4**, each with both a
+  matvec and a GEMM, since landing half of a kind is forbidden. Verified
+  on the host across 11 kinds, 33 shapes and 75,042 positions with zero
+  mismatches. **None has run on a GPU** (#157).
+- **AVX2 GEMMs for all five interleaved repack kinds on x86**, with one
+  per-workload dispatch rule shared by ten call sites. Verified by
+  execution on real AVX2 silicon, not emulation, and **not yet
+  benchmarked** (#159).
+
+### Fixed
+
+- **Q4_K quantization was not byte-identical, and the documented reason
+  it "could never be" was wrong.** llama.cpp's `sumlx += w*x[i]*l` is
+  contracted by its compiler into a single fused multiply-add; Rust does
+  not contract, so the strict transcription that shipped was the defect.
+  One unit in the last place flips a comparison and rewrites a whole
+  super-block, which is why 1.15% of super-blocks differed rather than a
+  rounding-sized fraction. Spelling the fusion as `mul_add` takes Q4_K,
+  Q5_K and Q6_K to **zero differing super-blocks across all 147 tensors**
+  of a real model (#162).
+- **The int-dot matvec repacked every weight matrix on every call.** It
+  passed a hand-written "uncacheable" identity where every other matvec
+  passed a real cache key, so the interleaved layout was rebuilt and
+  copied per token. It was 89% to 90% of decode work on Q8_0 and Q4_0
+  models. This also corrects the premise of #128: the cost is
+  proportional to gate and up projection bytes rather than fixed, and
+  fires only on those two formats (#155).
+- **`FERROX_CUDA=0` did not mean CPU.** The matvec launcher never
+  honoured the disable flag, on the strength of a comment claiming CUDA
+  needed no guard because launchers return an error with no device.
+  That is true of Metal and false of CUDA, where the binding panics, so
+  any quantized matvec on a CUDA build without a driver aborted the
+  process (#157).
+- **The CUDA host-check harness had silently stopped compiling** when
+  the `float4` inner loop landed, so it verified nothing while still
+  exiting green-adjacent. It now iterates the kind table rather than a
+  hand-kept list (#157).
+- **`ferrox gguf-split` was unreachable**: the CLI module existed but
+  was never registered, so the subcommand would have fallen through to
+  an implicit `ferrox run` and started generating text (#154).
+- Three pre-existing test races on a process-global override, which
+  passed only because the two halves of the int-dot tier used to move
+  together (#159).
+
+### Changed
+
+- **The CPU scheduler is chosen by work size**, not by
+  `FERROX_CPU_POOL`. One predicate decides per operation and the
+  environment variable is now an A/B override. The crossover constant is
+  **bracketed by the published measurements rather than swept**, and no
+  quiet-host before-and-after has been run, so this is not yet a
+  performance claim (#155).
+- **The repack cache has a derived byte budget with eviction.** The fix
+  above retains the packed copy, which cost +527 MB at 1.1B on Q8_0 and
+  would scale per expert on a mixture-of-experts model. The budget is
+  available memory minus a shared headroom constant minus committed
+  expert bytes, then a quarter share, so it spends the same pool as
+  `expert_store` rather than opening a second one. Zero disables the
+  cache and reproduces the previous behaviour exactly (#158).
+- **Metal encodes less per token**: 13% fewer dispatches and 9% fewer
+  barriers, by fusing RoPE for Q and K, folding the K and V cache append
+  into one grid, and deleting a barrier that guarded zero work on models
+  without QKV bias or QK-norm (#156).
+
+### Measured
+
+- **The Metal suite was re-measured on a quiet M2 Pro** and the stale
+  0.13.3 rows retired. Prefill spans **1.01× to 1.10×** and decode
+  **0.64× to 1.11×**, with **12 of 14 comparable decode rows faster than
+  llama.cpp**. MoE decode on OLMoE moved from ~1.41× to **0.96×**.
+  Gemma-2-2B at 1.11× is the worst row, confirming the 1.12× that the
+  concurrent-encode work predicted. Mistral-7B leaves the table because
+  `--fit-host` refuses it at ~10 GiB needed against 11.2 GiB free, and a
+  run from swap measures the swap (#163).
+
+### Retired hypotheses
+
+Both of these were the stated cause of an open issue, and both are now
+disproven by measurement rather than argument.
+
+- **Metal host cost is not dispatch count.** Removing 11.5% of encode
+  operations bought **2.3%** of host time, and barriers were already
+  hazard-driven rather than per-operation. What remains is per-dispatch
+  argument binding: roughly 2400 encoder calls per token against 418
+  dispatches and barriers combined (#149, #156).
+- **The CPU per-token cost is not fixed.** See the repack fix above
+  (#128, #155).
+
 ## [0.17.1] - 2026-09-04 
 
 ### Fixed
@@ -310,6 +422,7 @@ benchmark ledger.
 First tag. GGUF mmap loader, quantized CPU kernels, Metal backend,
 `ferrox` CLI and `ferrox-server`.
 
+[0.18.0]: https://github.com/antonellof/ferrox/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/antonellof/ferrox/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/antonellof/ferrox/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/antonellof/ferrox/compare/v0.15.3...v0.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-api"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cli"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-core"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cuda"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "cudarc",
  "ferrox-quant",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-gguf"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-inference"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "ferrox-api",
  "ferrox-core",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-metal"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "ferrox-quant",
  "half",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-models"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-moe"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "ferrox-core",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-quant"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "half",
  "thiserror",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-safetensors"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "byteorder",
  "memmap2",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-server"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-vulkan"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "ash",
  "ferrox-quant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/antonellof/ferrox"
@@ -57,19 +57,19 @@ minijinja = { version = "2.21", features = ["loop_controls", "json"] }
 libc = "0.2"
 
 # Internal crates — path for local builds, version for crates.io.
-ferrox-api = { version = "0.17.1", path = "crates/ferrox-api" }
-ferrox-gguf = { version = "0.17.1", path = "crates/ferrox-gguf" }
-ferrox-quant = { version = "0.17.1", path = "crates/ferrox-quant" }
-ferrox-safetensors = { version = "0.17.1", path = "crates/ferrox-safetensors" }
-ferrox-cuda = { version = "0.17.1", path = "crates/ferrox-cuda" }
-ferrox-metal = { version = "0.17.1", path = "crates/ferrox-metal" }
-ferrox-vulkan = { version = "0.17.1", path = "crates/ferrox-vulkan" }
-ferrox-core = { version = "0.17.1", path = "crates/ferrox-core" }
-ferrox-moe = { version = "0.17.1", path = "crates/ferrox-moe" }
-ferrox-models = { version = "0.17.1", path = "crates/ferrox-models" }
-ferrox-inference = { version = "0.17.1", path = "crates/ferrox-inference" }
+ferrox-api = { version = "0.18.0", path = "crates/ferrox-api" }
+ferrox-gguf = { version = "0.18.0", path = "crates/ferrox-gguf" }
+ferrox-quant = { version = "0.18.0", path = "crates/ferrox-quant" }
+ferrox-safetensors = { version = "0.18.0", path = "crates/ferrox-safetensors" }
+ferrox-cuda = { version = "0.18.0", path = "crates/ferrox-cuda" }
+ferrox-metal = { version = "0.18.0", path = "crates/ferrox-metal" }
+ferrox-vulkan = { version = "0.18.0", path = "crates/ferrox-vulkan" }
+ferrox-core = { version = "0.18.0", path = "crates/ferrox-core" }
+ferrox-moe = { version = "0.18.0", path = "crates/ferrox-moe" }
+ferrox-models = { version = "0.18.0", path = "crates/ferrox-models" }
+ferrox-inference = { version = "0.18.0", path = "crates/ferrox-inference" }
 # Only ferrox-cli depends on this, and only behind its optional `serve`
 # feature. The server's dependency set is a strict superset of the CLI's
 # (+98 crates, +6 MB), so an unconditional dependency would make
 # `cargo install ferrox-cli` compile an HTTP and TLS stack it never runs.
-ferrox-server = { version = "0.17.1", path = "crates/ferrox-server" }
+ferrox-server = { version = "0.18.0", path = "crates/ferrox-server" }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -589,24 +589,39 @@ multimodal patch tables and audio codebooks. `token_embd.weight` and
 output head to Q6_K in other mixes is gated on the target not being
 Q8_0.
 
-`Q4_K_S` and `Q4_K_M` are also written, with `--pure`. Everything else
-(the remaining K-quants, the IQ tiers, MXFP4, imatrix) is refused by
-name rather than approximated. Tracked as
-[#70](https://github.com/antonellof/ferrox/issues/70).
+`Q4_K_S`, `Q4_K_M`, `Q5_K_M` and `Q6_K` are also written. Everything
+else (the IQ tiers, MXFP4, imatrix) is refused by name rather than
+approximated.
 
-**Q4_K is not byte-identical to llama.cpp's, and cannot be.** Compared
-tensor by tensor against `llama-quantize --pure`, 113 of 311 tensors
-match exactly and 198 differ in about 0.05% of their bytes. The cause is
-not the algorithm: `ggml-quants.c.o` carries 1957 FMA instructions
-because clang contracts `a*b+c` into a fused multiply-add by default for
-C, and Rust does not, so `quantize_row_q4_K_ref`'s exact output is a
-property of the compiler that built the reference. llama.cpp built with
-contraction off would not reproduce it either. Q8_0 IS byte-identical,
-because its arithmetic has no accumulated multiply-add to contract.
+**Q4_K is byte-identical too, and the claim that it could never be was
+wrong.** This document previously said the difference was a property of
+the compiler that built the reference: clang contracts `a*b+c` into a
+fused multiply-add for C and Rust does not, so a strict transcription
+could not match. The first half of that is true and the conclusion was
+not. The fix is to spell the contraction out. `sumlx += w*x[i]*l` in
+`ggml-quants.c` is **one** FMA, and writing it as `mul_add` in Rust
+reproduces it exactly; one unit in the last place flips
+`sumlx*sumlx > best*suml2` and rewrites an entire super-block, which is
+why 1.15% of super-blocks differed rather than a rounding-sized
+fraction.
 
-What is equal is the thing that matters. Perplexity of the two files, on
-the same corpus through the same engine: **25.1444** for ferrox's
-against **25.1805** for llama.cpp's, 2.4% of one standard error apart.
+Measured against `llama-quantize` b7650 over an F16 Llama-3.2-1B, whole
+model rather than a fixture:
+
+| Target | Tensors identical | Super-blocks differing |
+|---|---|---|
+| Q8_0 (control) | 147 / 147 | 0 |
+| Q4_K_M | 147 / 147 | 0 of 3,244,032 Q4_K, 0 of 1,583,104 Q6_K |
+| Q5_K_M | 147 / 147 | 0 of 3,244,032 Q5_K, 0 of 1,583,104 Q6_K |
+| Q6_K | 147 / 147 | 0 of 4,827,136 Q6_K |
+
+Two things that discipline needs. Goldens must come from the
+**installed** binary: a local release build of the same b7650 source
+disagrees on exactly these knife-edge blocks, and pinned the wrong
+bytes once. And the fixture must be able to fail: the original
+synthetic one stayed green with every `mul_add` removed, so it now
+carries eight real weight blocks, one per fusion site, of which nine of
+thirteen sites redden a golden.
 
 One refusal to know about: a tensor whose row width is not a multiple of
 256 stops the run. llama.cpp answers that case by changing the tensor's

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,22 +10,28 @@ Measured against llama.cpp on the same host and the same GGUF with
 `ferrox bench`. Gap = `llama / ferrox`, so anything under 1 means Ferrox
 is faster.
 
-- **Dense GQA**: TinyLlama, Llama 3.2, Mistral-7B, SmolLM2,
-  Qwen2.5/Qwen3, Gemma-3/4. Metal decode leads on several small models
-  (SmolLM2 **~0.67×**, Qwen2.5-0.5B **~0.70×**, Qwen3-0.6B **~0.71×**,
-  Gemma-3-1B **~0.88×**), and Llama-3.2-3B sits at **~0.96×**, ahead of
-  llama.cpp rather than behind it. Mistral-7B and Llama-3.2-1B Q4_K_M
-  land on 1.00×. Dense Metal prefill is closed: every dense `pp512` row
-  is 1.02–1.08×. **CPU decode is still behind everywhere (~1.17–2.44×),
-  and CPU prefill is behind on 6 of 8 rows.**
+- **Dense GQA**: TinyLlama, Llama 3.2, SmolLM2, Qwen2.5/Qwen3,
+  Gemma-2/3/4, Phi-4-mini. Re-measured on 2026-09-09 on a quiet M2 Pro:
+  **12 of 14 comparable Metal `tg128` rows are faster than llama.cpp**
+  (SmolLM2-135M **0.64×**, Qwen2.5-0.5B **0.65×**, Qwen3-0.6B **0.76×**,
+  Gemma-3-1B **0.80×**, TinyLlama **0.86×**, down to Llama-3.1-8B and
+  Phi-4-mini at **0.98×**). The two that are not: Llama-3.2-3B at 1.03×
+  and Gemma-2-2B at **1.11×**, which is the worst Metal row. Dense Metal
+  prefill spans **1.01× to 1.10×**. **CPU is a different story and is
+  behind on every row**: prefill 6.3× to 10.1× and decode 1.06× to
+  1.92× on x86, though the AVX2 GEMM tier that closes the prefill half
+  landed unmeasured.
 - **Phi-4**: CPU **and** Metal. Partial rotary (`n_rot < head_dim`) and
   LongRoPE `attn_factor` ride the Metal RoPE kernels as `rot_dim` and
   `mscale` uniforms, matching ggml's `rope_yarn` (the magnitude scale
-  reaches the rotated channels only). The published Metal speed rows
-  predate that fix and need measuring again before you quote them.
-- **MoE**: OLMoE-1B-7B, still behind on Metal decode (~1.41×). Metal
-  Concurrent plus fused encode groups, `MemRanges`, `mul_mv_id` and
-  prefill `mul_mm_id`. On CPU: int-dot and interleaved Q4_K.
+  reaches the rotated channels only). Now measured with that fix in
+  place: `pp512` 1.02×, `tg128` 0.98×.
+- **MoE**: OLMoE-1B-7B, and Metal decode is no longer the weak spot it
+  was. It read ~1.41× when this line was first written and reads
+  **0.96×** on the 2026-09-09 suite, so MoE decode is now faster than
+  llama.cpp rather than half again slower. Metal Concurrent plus fused
+  encode groups, `MemRanges`, `mul_mv_id` and prefill `mul_mm_id`. On
+  CPU: int-dot and interleaved Q4_K.
 - **MLA**: dense-lead and MoE-after-dense `deepseek2` / `mistral4`.
 - **Gemma-4**: dedicated engine (per-layer embeddings, shared KV,
   SWA/full), an SPM-style `gemma4` BPE tokenizer, and the `<|turn>` chat
@@ -77,7 +83,7 @@ Full matrix: [`MODELS.md`](MODELS.md) ·
 |---|---|
 | **CPU** | Dense and MoE. int8×int8 matvec on by default (`FERROX_CPU_INT_DOT=0` opts out), interleaved Q4_Kx8 / Q8_0x4 GEMV, Q8_0x4 batch GEMM for prefill, Q5/Q6 int-dot, pool sized to performance cores |
 | **Metal** | FA-vec attention (decode d=64/96/128/256, prefill d=128/256), concurrent FFN/QKV encode, MoE Concurrent with fused groups, `MemRanges`, `mul_mm_id` prefill, quantized KV (`q8_0` / `turbo8` / `fp8` / `turbo4`) |
-| **CUDA** | Matvec, resident weights, FFN fuse (`--features cuda`), plus a batched `Q8_0`/`Q4_0` GEMM that **has never executed on a GPU** |
+| **CUDA** | Matvec, resident weights, FFN fuse (`--features cuda`), plus batched GEMMs for `Q8_0`, `Q4_0`, `Q5_0`, `Q4_K`, `Q5_K`, `Q6_K`, `Q2_K`, `Q3_K`, `IQ4_NL`, `IQ4_XS` and `MXFP4` that **have never executed on a GPU** |
 | **Vulkan** | `Q8_0` matvec only, no GEMM (`--features vulkan`). A beachhead, not a backend: see below |
 
 **Vulkan is one kernel, and calling it a backend would be generous.**
@@ -98,17 +104,20 @@ thread-by-thread scalar twin held against `ferrox-quant`'s independent
 dequantize-then-GEMM, and a host harness that compiles and *executes*
 the emitted CUDA C against a barrier shim
 (`crates/ferrox-cuda/tools/mul_mm_host_check/run.sh`) with zero
-mismatches on both kinds. Its hardware test is `#[ignore]`d with "NEVER
-RUN" as the reason, and NVRTC is not clang, so "it compiles here" is not
-"NVRTC accepts it". Below the width threshold a single token stays on
-the matvec kernels, which are the arm that *has* run on a GPU.
+mismatches across **11 kinds, 33 shapes and 75,042 compared positions**.
+Its hardware test is `#[ignore]`d, and NVRTC is not clang, so "it
+compiles here" is not "NVRTC accepts it". Below the width threshold a
+single token stays on the matvec kernels, which are the arm that *has*
+run on a GPU. That harness is worth no more than its own health: it had
+silently stopped compiling once already, which is why it now runs over
+every kind in the table rather than a hand-kept list.
 
-**CUDA compiles and runs, and nobody has benchmarked it.** Every number
-in this repo was taken on CPU or Apple Metal. GPU acceleration on
-Windows and Linux means CUDA, and the bar CUDA is held to is "must
-compile". There is no pinned benchmark host for it and no published
-timings. Treat a Windows or Linux install as **CPU-only in practice**
-until that changes. `/health` reports the same thing per capability,
+**CUDA is benchmarked and far behind.** It has receipts now, on an RTX
+3060: prefill 22.6× to 33.8× and decode 2.2× to 5.0× against llama.cpp
+on the same box. So a Windows or Linux install runs, and answers
+correctly, and should not be chosen for speed yet. The newest kernels
+in the table above are a further step back from that: they are verified
+on the host and have never run on a card at all. `/health` reports the same thing per capability,
 with a reason string, instead of quietly greying a control out.
 
 ## CLI
@@ -127,12 +136,17 @@ and the startup banner says so when the flag is being ignored.
 llama.cpp's method, agreeing with `llama-perplexity` to within a fifth
 of one standard error on five checkpoints. Where the two differ, the gap
 is monotone in the quant and has the sign the documented `vec_dot_type`
-difference predicts. `ferrox quantize` writes `Q8_0` byte-identically to
-`llama_model_quantize()`, plus `Q4_K_S` and `Q4_K_M` with `--pure`, and
-refuses every other target by name. Q4_K is not byte-identical and
-cannot be, because the C reference is compiled with FP contraction; it
-matches on perplexity instead. See
-[`CLI.md`](CLI.md).
+difference predicts. `ferrox quantize` writes **`Q8_0`, `Q4_K_S`,
+`Q4_K_M`, `Q5_K_M` and `Q6_K` byte-identically** to
+`llama_model_quantize()`, and refuses every other target by name.
+**The claim that Q4_K could never be byte-identical was wrong**, and it
+was wrong for an instructive reason: llama.cpp's `sumlx += w*x[i]*l`
+is contracted by its compiler into a single fused multiply-add, and
+Rust does not contract, so a strict transcription of the C was the
+defect. One unit in the last place flips a comparison and rewrites a
+whole super-block. With the fusion spelled out as `mul_add`, Q4_K went
+from 1.15% of super-blocks differing to zero, across all 147 tensors of
+a real model. See [`CLI.md`](CLI.md).
 
 The sampler flags carry llama.cpp's own defaults on `--temp` (0.8),
 `--top-k` (40), `--top-p` (0.95), `--min-p` (0.05) and `--repeat-last-n`
@@ -291,10 +305,11 @@ checked against the code rather than asserted. The gap is the roadmap.
 | NVIDIA RTX 30/40/50 | **Compiles, never measured.** CUDA has no in-tree benchmark receipt and no GPU in CI. |
 
 Two honest notes. Ferrox runs on Apple Metal, which that description
-does not cover, and Metal is where it is fastest: every dense `pp512`
-row is 0.98x to 1.10x against llama.cpp and 8 of 12 `tg128` rows are
-faster. And the single largest gap is not on this table: running a model
-that does not fit in memory works as policy and not as execution.
+does not cover, and Metal is where it is fastest: every `pp512` row is
+1.01x to 1.10x against llama.cpp and **12 of 14** comparable `tg128`
+rows are faster. And the single largest gap is not on this table:
+running a model that does not fit in memory works as policy and not as
+execution.
 
 ## Serving policy
 


### PR DESCRIPTION
Version bump to 0.18.0, the changelog entry for #154 through #163, and a documentation pass over what those merges made untrue.

## Two retractions, which are the point of this PR

**`docs/CLI.md` said Q4_K could never be byte-identical.** It explained why, convincingly and wrongly: clang contracts `a*b+c` into a fused multiply-add for C, Rust does not, so the reference's exact bytes are a property of the compiler that built it. The first half is true. The conclusion was not. Spelling the contraction out as `mul_add` reproduces it exactly, and Q4_K, Q5_K and Q6_K now write **zero differing super-blocks across all 147 tensors** of a real model. The doc now carries the table and the two discipline notes that came with it: goldens must come from the installed binary, and the fixture had to be rebuilt because it could not fail.

**`docs/FEATURES.md` said CUDA had no published timings** and to treat a Windows or Linux install as CPU-only. It has receipts on an RTX 3060, and is 22.6x to 33.8x behind on prefill. Stating that is more useful than leaving it vague.

## Stale Metal claims, now corrected against the re-measured suite

The Metal figures in FEATURES.md were from 0.13.3. One was not merely stale but inverted: **MoE decode on OLMoE read ~1.41x and now reads 0.96x**, so the line saying MoE decode was behind said the opposite of what the suite shows.

- Dense decode: 12 of 14 comparable `tg128` rows are faster than llama.cpp, from 0.64x to 0.98x. The two that are not are Llama-3.2-3B at 1.03x and Gemma-2-2B at 1.11x.
- Dense prefill: 1.01x to 1.10x.
- Phi-4's rows no longer "predate that fix"; they were measured with it in place.
- The CUDA kind list gains Q2_K, Q3_K, IQ4_NL, IQ4_XS and MXFP4, and the host-check coverage figure is now 11 kinds over 33 shapes.

## Changelog

Grouped as Added, Fixed, Changed, Measured, and a final section for **retired hypotheses**, because two open issues had a stated cause that measurement disproved: Metal host cost is not dispatch count (11.5% fewer encode operations bought 2.3% of host time), and the CPU per-token cost is not fixed (it is proportional to gate and up projection bytes, on two formats only).

## Gates

`cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` all clean locally; the full suite passed on the merged tree before the bump and CI re-runs it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
