### PR TITLE
perf(cpu): enter the rayon pool once per forward, not once per matvec

### DIFF
--- a/crates/ferrox-core/src/par.rs
+++ b/crates/ferrox-core/src/par.rs
@@ -43,6 +43,8 @@
 //! the measured 13-16x small-model regression documented on
 //! [`crate::weight_matrix::WeightMatrix::min_rows_per_task`].
 
+use std::cell::Cell;
+
 use rayon::prelude::*;
 
 use crate::cpu_pool::CpuPool;
@@ -50,6 +52,125 @@ use crate::cpu_pool::CpuPool;
 pub mod policy;
 
 pub use policy::{backend, macs_per_row, with_op_work};
+
+thread_local! {
+    /// How many parallel regions THIS thread has opened while not being
+    /// a rayon worker. See [`on_workers`] for why that is the number
+    /// worth counting, and [`cold_regions`] for how a test reads it.
+    ///
+    /// Per thread rather than process-wide on purpose. A cold region is
+    /// always counted on the thread that submits it, so nothing is lost;
+    /// and a shared counter would make the assertion depend on whatever
+    /// else the test binary happened to be running at the time, which is
+    /// the difference between a guard and a flake.
+    static COLD_REGIONS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Parallel regions this thread has opened without being a rayon worker.
+///
+/// Monotonic, so a test reads it before and after the operation it cares
+/// about and asserts on the DIFFERENCE. It is not a benchmark: it is an
+/// operation count, which is load-immune, and it is the only thing that
+/// distinguishes "this decode step entered the pool once" from "it
+/// entered it a hundred and fifty times".
+pub fn cold_regions() -> u64 {
+    COLD_REGIONS.with(Cell::get)
+}
+
+/// Records one region about to be opened on the rayon arm.
+///
+/// Called from every rayon fallback in this module and nowhere else.
+/// The worker-index read is the same TLS lookup rayon is about to do
+/// anyway, and the counter is touched only on the cold path, which after
+/// [`on_workers`] is once per decode step rather than once per matvec.
+fn note_rayon_region() {
+    if rayon::current_thread_index().is_none() {
+        COLD_REGIONS.with(|c| c.set(c.get().saturating_add(1)));
+    }
+}
+
+/// Run `f` on a rayon worker, so every parallel region it opens takes
+/// rayon's IN-WORKER path instead of its cold-submission path.
+///
+/// # What this is for
+///
+/// `rayon::join` and the `par_iter` bridges both funnel through
+/// `Registry::in_worker`. That call has two arms and they do not cost
+/// the same thing:
+///
+/// - **From a worker** (`in_worker_hot`): the calling thread runs one
+///   half itself, the other half is posted for stealing, and the wait is
+///   a `SpinLatch`. No syscall.
+/// - **From any other thread** (`in_worker_cold`): the job is injected,
+///   and the caller blocks on a `LockLatch`, which is a pthread mutex
+///   and condvar. That is a park and a wake, per region, and the caller
+///   contributes no arithmetic while it sleeps.
+///
+/// A decode step opens roughly five regions per layer, so a 30-layer
+/// model paid ~150 of the cold arm per token. Measured on an M2 Pro with
+/// `sample` over SmolLM2-135M Q8_0 `tg128`, the main thread spent **74%
+/// of the token** inside `__psynch_cvwait` under `LockLatch`, and over
+/// that same window the six workers it was waiting for held only about
+/// an eighth as many samples in the matvec kernel: most of the wait was
+/// the round trip, not the work.
+///
+/// Wrapping the whole step in one `rayon::scope` turns those ~150 cold
+/// entries into ONE. The step then runs on worker 0 and every nested
+/// region is hot.
+///
+/// # Why it is not simply free
+///
+/// The caller still parks once, for the whole step, and the step no
+/// longer runs on the caller's thread. Both are deliberate: one park per
+/// token against one per matvec, and rayon's own worker count is
+/// unchanged, so the same number of cores do the work.
+///
+/// Nesting is free (a call from inside another `on_workers` returns
+/// `f()` directly), so an entry point may wrap unconditionally without
+/// having to know whether its caller already did.
+///
+/// # Two cases this deliberately does NOT promote
+///
+/// **A GPU backend.** Measured on an M2 Pro, moving the decode step off
+/// the process's main thread CHANGES METAL'S OUTPUT: `Llama-3.2-3B
+/// Q4_K_M --ngl 99`, greedy, diverges from the same build's main-thread
+/// answer at around the tenth token, deterministically on both sides.
+/// The Metal stack carries thread-local state across a step (the
+/// resident-activation hand-off from the dense stack to `output_head`,
+/// and the two thread-local mirrors of the pipeline and weight caches),
+/// so which thread runs the step is not the free choice it is on CPU.
+/// That is worth its own investigation and is not worth risking on a CPU
+/// scheduling change, so promotion asks
+/// [`crate::weight_matrix::active_backend`] first: the same cached
+/// predicate dispatch itself uses, not a second opinion about it. Under
+/// Metal or CUDA there is also almost nothing to win, because the
+/// parallel regions this saves are the ones the GPU is not running.
+///
+/// **The pinned spin pool.** Under `FERROX_CPU_POOL=spin` the rayon
+/// global pool is never used for work, and `rayon::scope` would BUILD
+/// it, spawning a second set of workers that then only sit there. So
+/// that pin short-circuits, exactly as [`num_threads`] avoids
+/// `rayon::current_num_threads` for the same reason.
+pub fn on_workers<R, F>(f: F) -> R
+where
+    F: FnOnce() -> R + Send,
+    R: Send,
+{
+    if crate::weight_matrix::active_backend() != crate::kernel_registry::Backend::Cpu {
+        return f();
+    }
+    if policy::pinned() == Some(Backend::Spin) {
+        return f();
+    }
+    if rayon::current_thread_index().is_some() {
+        return f();
+    }
+    // The one cold entry this whole design is willing to pay. Counted
+    // like any other, so [`cold_regions`] reports the true total and a
+    // test can assert it is exactly one.
+    note_rayon_region();
+    rayon::scope(move |_| f())
+}
 
 /// Which scheduler CPU parallel regions use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -176,6 +297,7 @@ where
             return;
         }
     }
+    note_rayon_region();
     (0..n)
         .into_par_iter()
         .with_min_len(min_len.max(1))
@@ -210,6 +332,7 @@ where
             return;
         }
     }
+    note_rayon_region();
     (0..n)
         .into_par_iter()
         .with_min_len(min_len.max(1))
@@ -245,6 +368,7 @@ where
             return;
         }
     }
+    note_rayon_region();
     data.par_iter_mut()
         .with_min_len(min_len.max(1))
         .enumerate()
@@ -295,6 +419,7 @@ where
             return;
         }
     }
+    note_rayon_region();
     a.par_chunks_mut(chunk_len)
         .zip(b.par_chunks_mut(chunk_len))
         .with_min_len(min_len.max(1))
@@ -334,6 +459,7 @@ where
             return;
         }
     }
+    note_rayon_region();
     data.par_chunks_mut(chunk_len)
         .with_min_len(min_len.max(1))
         .enumerate()
@@ -395,6 +521,7 @@ where
             return;
         }
     }
+    note_rayon_region();
     data.par_chunks_mut(chunk_len)
         .with_min_len(min_len.max(1))
         .enumerate()
@@ -416,7 +543,10 @@ where
     RB: Send,
 {
     match backend() {
-        Backend::Rayon => rayon::join(a, b),
+        Backend::Rayon => {
+            note_rayon_region();
+            rayon::join(a, b)
+        }
         Backend::Spin => (a(), b()),
     }
 }
@@ -433,6 +563,7 @@ where
 {
     match backend() {
         Backend::Rayon => {
+            note_rayon_region();
             let (ra, (rb, rc)) = rayon::join(a, || rayon::join(b, c));
             (ra, rb, rc)
         }
@@ -443,6 +574,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two configurations `on_workers` declines to promote in, and
+    /// so the two it cannot be asserted in. One predicate, shared by
+    /// every test below, rather than three spellings of it.
+    fn the_promotion_applies_here() -> bool {
+        policy::pinned().is_none()
+            && crate::weight_matrix::active_backend() == crate::kernel_registry::Backend::Cpu
+    }
+
     use std::sync::atomic::{AtomicU32, Ordering};
 
     /// With nothing published and nothing pinned, the helpers fork with
@@ -642,5 +782,120 @@ mod tests {
 
             assert_eq!(spun, forked, "n={n}");
         }
+    }
+
+    /// Every helper in this module must report the region it is about
+    /// to open, or the counter reads as coverage while measuring
+    /// nothing. This walks all eight of them rather than trusting that
+    /// a new one remembered, because a helper that forgot would leave
+    /// the counter reading low and every assertion built on it passing.
+    ///
+    /// Sabotage: delete any single `note_rayon_region()` call and the
+    /// helper whose name is in the failure message goes red.
+    #[test]
+    fn every_helper_reports_the_cold_region_it_opens() {
+        if !the_promotion_applies_here() {
+            return;
+        }
+        let mut buf = vec![0f32; 64];
+        let mut other = vec![0f32; 64];
+
+        // Spelled out one at a time rather than as a table of boxed
+        // closures: the slice helpers borrow `buf`, so a table could
+        // hold only half of them, and half a table is exactly the
+        // coverage illusion this test exists to avoid.
+        let before = cold_regions();
+        indices(64, 1, |_| {});
+        assert!(cold_regions() > before, "indices did not report");
+
+        let before = cold_regions();
+        indices_init(64, 1, || 0u8, |_, _| {});
+        assert!(cold_regions() > before, "indices_init did not report");
+
+        let before = cold_regions();
+        join2(|| (), || ());
+        assert!(cold_regions() > before, "join2 did not report");
+
+        let before = cold_regions();
+        join3(|| (), || (), || ());
+        assert!(cold_regions() > before, "join3 did not report");
+
+        let before = cold_regions();
+        items_mut(&mut buf, 1, |_, _| {});
+        assert!(cold_regions() > before, "items_mut did not report");
+
+        let before = cold_regions();
+        chunks_mut(&mut buf, 8, 1, |_, _| {});
+        assert!(cold_regions() > before, "chunks_mut did not report");
+
+        let before = cold_regions();
+        chunks_mut_init(&mut buf, 8, 1, || 0u8, |_, _, _| {});
+        assert!(cold_regions() > before, "chunks_mut_init did not report");
+
+        let before = cold_regions();
+        chunks_mut2(&mut buf, &mut other, 8, 1, |_, _, _| {});
+        assert!(cold_regions() > before, "chunks_mut2 did not report");
+    }
+
+    /// The whole claim of `on_workers`: many regions inside it cost ONE
+    /// cold entry into the pool, where the same regions outside it cost
+    /// one each.
+    ///
+    /// This is the operation-count form of the fix. It needs no clock
+    /// and no quiet host, which is why it is the guard rather than a
+    /// throughput assertion.
+    ///
+    /// Sabotage: make `on_workers` call `f()` unconditionally and the
+    /// `inside` count jumps from 1 to `REGIONS`, turning this red.
+    #[test]
+    fn on_workers_collapses_many_regions_into_one_cold_entry() {
+        if !the_promotion_applies_here() {
+            return;
+        }
+        const REGIONS: u64 = 16;
+        let open_them = || {
+            for _ in 0..REGIONS {
+                indices(64, 1, |_| {});
+            }
+        };
+
+        let before = cold_regions();
+        open_them();
+        let outside = cold_regions() - before;
+
+        let before = cold_regions();
+        on_workers(open_them);
+        let inside = cold_regions() - before;
+
+        assert_eq!(
+            outside, REGIONS,
+            "each region opened from a cold thread should count once"
+        );
+        assert_eq!(
+            inside, 1,
+            "the whole batch should enter the pool exactly once"
+        );
+    }
+
+    /// A nested call must not open a second entry, so an entry point can
+    /// wrap unconditionally without knowing what its caller did.
+    #[test]
+    fn a_nested_on_workers_opens_no_further_cold_entry() {
+        if !the_promotion_applies_here() {
+            return;
+        }
+        let before = cold_regions();
+        on_workers(|| {
+            on_workers(|| {
+                indices(64, 1, |_| {});
+            });
+        });
+        assert_eq!(cold_regions() - before, 1);
+    }
+
+    /// `on_workers` must return what `f` returns, not swallow it.
+    #[test]
+    fn on_workers_hands_back_the_closures_value() {
+        assert_eq!(on_workers(|| 41usize + 1), 42);
     }
 }

--- a/crates/ferrox-core/src/threads.rs
+++ b/crates/ferrox-core/src/threads.rs
@@ -576,10 +576,22 @@ pub fn for_each_chunk_init<S, I, F>(
     crate::par::chunks_mut_init(chunks, chunk_len, 1, init, |state, i, c| f(state, i, c));
 }
 
-/// Builds the global rayon pool with an explicit width and an explicit
-/// QoS, so neither depends on which thread first touched rayon. Safe to
-/// call more than once and from either binary; a pool that already
-/// exists is left alone.
+/// Stack each rayon worker gets.
+///
+/// Rust's default for a spawned thread is 2 MiB, and that was fine while
+/// workers only ever ran one matvec chunk. Since
+/// [`crate::par::on_workers`] a WHOLE forward pass runs on a worker: the
+/// decoder's layer loop, its Metal and CUDA arms, and every scratch
+/// buffer any of them puts on the stack. The thread that used to run
+/// that body is the process's main thread, which gets 8 MiB on macOS and
+/// Linux, so this matches it rather than quietly halving the headroom of
+/// code that never had to think about it.
+const WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
+
+/// Builds the global rayon pool with an explicit width, an explicit QoS
+/// and an explicit stack, so none of the three depends on which thread
+/// first touched rayon. Safe to call more than once and from either
+/// binary; a pool that already exists is left alone.
 ///
 /// Returns the thread count the pool was built with, or `None` if the
 /// global pool already existed.
@@ -587,6 +599,7 @@ pub fn init_cpu_pool() -> Option<usize> {
     let threads = resolve_cpu_threads();
     let built = rayon::ThreadPoolBuilder::new()
         .num_threads(threads)
+        .stack_size(WORKER_STACK_BYTES)
         .start_handler(move |_idx| set_user_interactive_qos())
         .build_global()
         .is_ok();

--- a/crates/ferrox-models/src/decoder.rs
+++ b/crates/ferrox-models/src/decoder.rs
@@ -13,6 +13,7 @@
 //! checkpoint to be present.
 
 mod attn_block;
+mod entry;
 mod ffn_act;
 pub mod kv_window;
 mod lm_head;
@@ -1670,10 +1671,9 @@ impl Decoder {
         )
     }
 
-    /// Runs one decode step for `token_id` at position `pos`, updating
-    /// `kv_caches` (one per layer) in place, and returns the logits over
-    /// the (test-scale) vocabulary.
-    pub fn forward_token(
+    /// The body of [`Self::forward_token`], already running on a
+    /// CPU-pool worker. See `entry.rs` for why the split exists.
+    fn forward_token_on_worker(
         &self,
         token_id: usize,
         pos: usize,
@@ -2586,25 +2586,9 @@ impl Decoder {
         logits
     }
 
-    /// Same computation as `forward_token`, but each layer's K/V cache
-    /// is a `PagedKvCache` (block-table-indexed into a per-layer
-    /// `PagedKvStore`) instead of a `KvCache`'s contiguous buffer --
-    /// exercises the paged attention kernel in a real decode loop
-    /// instead of only in isolation. `kv_caches`/`stores` are parallel
-    /// per-layer arrays, mirroring `forward_token`'s `kv_caches: &mut
-    /// [KvCache]`. Must produce bit-identical output to `forward_token`
-    /// given stores sized so no layer ever exhausts its blocks --
-    /// pinned by
-    /// `forward_token_paged_matches_forward_token_bit_identical` and,
-    /// per attention arm, by
-    /// `every_paged_attention_arm_is_bit_identical_to_its_contiguous_twin`.
-    ///
-    /// This used to refuse gpt-oss outright, because the paged kernel
-    /// had no attention-sink term and no sliding-window arm and would
-    /// have answered differently from the contiguous path without
-    /// saying so. It now mirrors all three arms of that dispatch, so
-    /// the refusal is gone rather than merely relaxed.
-    pub fn forward_token_paged(
+    /// The body of [`Self::forward_token_paged`], already running on a
+    /// CPU-pool worker. See `entry.rs` for why the split exists.
+    fn forward_token_paged_on_worker(
         &self,
         token_id: usize,
         pos: usize,
@@ -3351,76 +3335,6 @@ impl Decoder {
         )
     }
 
-    /// Processes multiple new positions in one call instead of calling
-    /// `forward_token` once per position. `tokens[i]` is the token at
-    /// absolute position `start_pos + i`; all positions attend
-    /// causally (position `i` sees positions `0..=i` of this batch
-    /// plus everything already in `kv_caches`, nothing later).
-    ///
-    /// The attention block's Q/K/V/O projections and the MoE router
-    /// are computed as batched matmuls (`WeightMatrix::apply_batch`),
-    /// which for quantized weights means each weight row is read from
-    /// memory once and dotted against every position in the batch,
-    /// not once per position -- see `apply_batch`'s doc comment for
-    /// why that's a real memory-bandwidth saving, not just fewer
-    /// function calls. The expert FFN stage is *not* batched: which
-    /// expert(s) a position routes to is data-dependent per position,
-    /// so positions routed to different experts can't share a single
-    /// matmul the way the shared Q/K/V/router projections can. RoPE
-    /// and attention itself (causal masking, softmax) are also
-    /// per-position, since they're cheap relative to the matmuls and
-    /// batching them would add complexity for little benefit.
-    ///
-    /// This is what makes prompt-lookup speculative decoding
-    /// (`speculative` module) actually save work rather than just
-    /// reshuffle it: verifying `k` draft tokens costs one batched call
-    /// here, not `k` calls to `forward_token`.
-    ///
-    /// Thin wrapper over [`Self::forward_hidden_batch`] + `output_head`.
-    pub fn forward_batch(
-        &self,
-        tokens: &[usize],
-        start_pos: usize,
-        kv_caches: &mut [KvCache],
-    ) -> Vec<Vec<f32>> {
-        let hiddens = self.forward_hidden_batch(tokens, start_pos, kv_caches);
-        if hiddens.is_empty() {
-            return Vec::new();
-        }
-        let batch_size = hiddens.len();
-        let flat: Vec<f32> = hiddens.into_iter().flatten().collect();
-        self.logits_from_flat_hidden(flat, batch_size)
-    }
-
-    /// [`Self::forward_batch`] that also hands back the final-layer
-    /// hidden state for every position instead of dropping it.
-    ///
-    /// `forward_batch` computes these and throws them away; a
-    /// hidden-state-conditioned drafter (EAGLE, MTP, dFlash) needs
-    /// exactly the vector for the last *verified* position, so
-    /// recomputing it would mean running the target model twice for
-    /// something the first pass already had in hand. The extra cost
-    /// here is one copy of `[batch x hidden]`, which is why
-    /// `forward_batch` keeps its move-only path for the prefill case
-    /// that does not want them.
-    ///
-    /// Returns `(logits_per_position, hidden_per_position)`, both
-    /// indexed by position in `tokens`.
-    pub fn forward_batch_with_hidden(
-        &self,
-        tokens: &[usize],
-        start_pos: usize,
-        kv_caches: &mut [KvCache],
-    ) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
-        let hiddens = self.forward_hidden_batch(tokens, start_pos, kv_caches);
-        if hiddens.is_empty() {
-            return (Vec::new(), Vec::new());
-        }
-        let batch_size = hiddens.len();
-        let flat: Vec<f32> = hiddens.iter().flatten().copied().collect();
-        (self.logits_from_flat_hidden(flat, batch_size), hiddens)
-    }
-
     /// One token's embedding row, scaled if this checkpoint scales it.
     ///
     /// `embedding_scale` is `sqrt(hidden_dim)` on the Gemma family and
@@ -3478,57 +3392,6 @@ impl Decoder {
             .collect()
     }
 
-    /// [`Self::forward_batch`] for the common case where only the final
-    /// position's logits are wanted: prefill a prompt, then sample the
-    /// next token. Runs `output_head` on **one** row instead of all
-    /// `batch_size` of them.
-    ///
-    /// The KV cache and every hidden state are identical either way —
-    /// only the vocabulary projection is skipped, and only for rows
-    /// whose logits the caller was going to drop. That projection is not
-    /// a rounding error: it is `[batch x hidden] x [hidden x vocab]`,
-    /// which for a large-vocabulary model with a small body is a large
-    /// share of prefill. `V*H / (V*H + L*P_layer)` comes to 30% on
-    /// Gemma-3-1B, 21% on Llama-3.2-1B and SmolLM2, 23% on Gemma-2-2B.
-    /// llama.cpp does not do this work at all during `pp512` —
-    /// `llama_batch_get_one` leaves `logits` unset, so `inp_out_ids`
-    /// selects a single row.
-    ///
-    /// [`Self::forward_batch`] stays for the callers that genuinely need
-    /// every row: speculative verification checks each draft position,
-    /// and `/v1/embeddings` pools over all of them.
-    pub fn forward_batch_last(
-        &self,
-        tokens: &[usize],
-        start_pos: usize,
-        kv_caches: &mut [KvCache],
-    ) -> Vec<f32> {
-        self.forward_batch_last_inner(tokens, start_pos, kv_caches, false)
-    }
-
-    /// [`Self::forward_batch_last`] for a caller that will READ the
-    /// caches afterwards rather than only decode from them.
-    ///
-    /// A Metal prefill otherwise leaves K/V on the device and the host
-    /// rows zero-filled, which is invisible to a caller that keeps
-    /// decoding (the device buffers stay authoritative) and fatal to
-    /// one that copies the rows somewhere else. Two callers do copy
-    /// them: `forward_batch_last_paged`, into the page store, and
-    /// `ferrox-server`'s prefix cache, into a snapshot a later request
-    /// restores from. Both used to get zeros, and both answered fluent
-    /// nonsense from a prompt the model never attended over.
-    ///
-    /// Costs one KV download per layer. Use [`Self::forward_batch_last`]
-    /// when nothing will read the caches back.
-    pub fn forward_batch_last_host_kv(
-        &self,
-        tokens: &[usize],
-        start_pos: usize,
-        kv_caches: &mut [KvCache],
-    ) -> Vec<f32> {
-        self.forward_batch_last_inner(tokens, start_pos, kv_caches, true)
-    }
-
     /// [`Self::forward_batch_last`], plus the choice of whether the host
     /// caches have to hold the real K/V when it returns. See
     /// [`Self::advance_host_kv_after_metal_prefill`] for why that is a
@@ -3548,45 +3411,9 @@ impl Decoder {
         self.logits_from_normed(last)
     }
 
-    /// [`Self::forward_batch_last`] over paged KV: the prefill twin of
-    /// [`Self::forward_token_paged`].
-    ///
-    /// # Why this gathers instead of paging the kernel
-    ///
-    /// `forward_hidden_batch`'s fast arm hands `cache.k` / `cache.v` to
-    /// `causal_gqa_attention_prefill_shared_kv_windowed`, which is Rayon
-    /// over `[query-block x head]` against one flat KV buffer. That
-    /// blocking is why CPU prefill is not the per-query path, and a
-    /// block table cannot be handed to it as a slice.
-    ///
-    /// The alternative was a second blocked kernel that reads through
-    /// the table. This file has just finished paying for what a second
-    /// copy of a rule costs: the paged decode path silently lost the
-    /// window arm, the sink term, the attention softcap, the embedding
-    /// scale and the final logit softcap, one at a time, because it was
-    /// a copy. A prefill kernel is a much larger surface to keep in
-    /// step than any of those. So the pages are materialised, the ONE
-    /// prefill implementation every other path uses runs against them,
-    /// and the new rows go back.
-    ///
-    /// Bit-identity is therefore by construction rather than by
-    /// agreement between two kernels: this calls the same function with
-    /// the same values. What the tests pin is that the gather and the
-    /// scatter are faithful, not that two implementations of attention
-    /// happen to match.
-    ///
-    /// The cost is one KV-sized copy per layer per call, against the
-    /// matmuls that dominate prefill. Decode is untouched: it still
-    /// reads through the block table and copies nothing, which is where
-    /// page sharing pays.
-    ///
-    /// # Failure is checked before anything is written
-    ///
-    /// Every layer's blocks are reserved up front, so a store too small
-    /// for the batch refuses with `PagedStoreExhausted` having mutated
-    /// no layer. A partial append would leave some layers longer than
-    /// others, and no caller can recover from that.
-    pub fn forward_batch_last_paged(
+    /// The body of [`Self::forward_batch_last_paged`], already running on a
+    /// CPU-pool worker. See `entry.rs` for why the split exists.
+    fn forward_batch_last_paged_on_worker(
         &self,
         tokens: &[usize],
         start_pos: usize,
@@ -3653,18 +3480,6 @@ impl Decoder {
                 .expect("blocks reserved above are still held by this sequence");
         }
         Ok(logits)
-    }
-
-    /// Like [`Self::forward_batch`], but returns final RMS-normed hidden
-    /// states (pre-`output_head`) — one `hidden_dim` vector per input
-    /// token. Used by `/v1/embeddings` pooling (mean / last).
-    pub fn forward_hidden_batch(
-        &self,
-        tokens: &[usize],
-        start_pos: usize,
-        kv_caches: &mut [KvCache],
-    ) -> Vec<Vec<f32>> {
-        self.forward_hidden_batch_inner(tokens, start_pos, kv_caches, false)
     }
 
     /// [`Self::forward_hidden_batch`] with one extra promise the public
@@ -4408,36 +4223,6 @@ impl Decoder {
             .collect()
     }
 
-    /// Continuous-batching primitive: one decode step across N
-    /// independent *sequences*, each contributing exactly one new
-    /// token at its own current position, sharing every layer's
-    /// projection/router matmuls the same way `forward_batch` shares
-    /// them across positions of a single sequence -- but each
-    /// sequence keeps its own `KvCache`, independent `seq_len`, and
-    /// independent position, so sequences admitted/evicted at
-    /// different times can still share one batched matmul per step
-    /// (this is what "continuous" batching means: the batch
-    /// membership can change every step, unlike `forward_batch`'s
-    /// fixed-size prompt-processing batch). `kv_caches[s][l]` is
-    /// sequence `s`'s layer-`l` cache; `tokens[s]`/`positions[s]` is
-    /// that sequence's next token and its position within its own
-    /// history. Returns one logits vector per sequence, same order as
-    /// `tokens`.
-    ///
-    /// Must produce bit-identical output to calling `forward_token`
-    /// once per sequence with that sequence's own cache/position --
-    /// batching independent sequences together is a scheduling detail,
-    /// not a math change (no sequence's attention ever reads another
-    /// sequence's cache).
-    pub fn forward_multi_seq(
-        &self,
-        tokens: &[usize],
-        positions: &[usize],
-        kv_caches: &mut [Vec<KvCache>],
-    ) -> Vec<Vec<f32>> {
-        self.forward_multi_seq_kv(tokens, positions, &mut MultiSeqKv::Contiguous(kv_caches))
-    }
-
     /// Appends one position to sequence `b`'s layer-`l` KV, then
     /// attends over everything that sequence holds.
     ///
@@ -4474,12 +4259,9 @@ impl Decoder {
         self.push_and_attend_row(step, l, k, v, q, oai)
     }
 
-    /// [`Self::forward_multi_seq`] over either KV backing.
-    ///
-    /// One body for both: the batched projections are identical, and
-    /// the per-sequence attention step is the only place the backing
-    /// shows through.
-    pub fn forward_multi_seq_kv(
+    /// The body of [`Self::forward_multi_seq_kv`], already running on a
+    /// CPU-pool worker. See `entry.rs` for why the split exists.
+    fn forward_multi_seq_kv_on_worker(
         &self,
         tokens: &[usize],
         positions: &[usize],

--- a/crates/ferrox-models/src/decoder/entry.rs
+++ b/crates/ferrox-models/src/decoder/entry.rs
@@ -1,0 +1,376 @@
+//! The public forward entry points of [`Decoder`], and the one place
+//! each of them enters the CPU worker pool.
+//!
+//! # Why these ten functions live in their own file
+//!
+//! Every one of them is a wrapper of the same shape:
+//! [`ferrox_core::par::on_workers`] around a body that lives in
+//! `decoder.rs`. That shape is the fix for the cost measured in #27 and
+//! #128, and it is worth exactly one file so that the rule is visible
+//! rather than repeated across a six-thousand-line module: **a forward
+//! pass enters the pool once, at its outermost boundary.**
+//!
+//! # What the wrapper buys
+//!
+//! `rayon::join` and the `par_iter` bridges cost very different things
+//! depending on who calls them. From a rayon worker the caller runs one
+//! half itself and waits on a spin latch; from any other thread the job
+//! is injected and the caller blocks on a pthread condvar, contributing
+//! no arithmetic while it sleeps. A decode step opens roughly five
+//! parallel regions per layer, so a 30-layer model was paying ~150 of
+//! the second kind per token.
+//!
+//! Sampled with `sample` on an M2 Pro over SmolLM2-135M Q8_0 `tg128`,
+//! the driving thread held **74% of the token** inside `__psynch_cvwait`
+//! under rayon's `LockLatch`, while the matvec kernel accounted for
+//! about a tenth of the same window across every thread in the process.
+//! Wrapping the step turns those ~150 cold entries into one, and
+//! [`ferrox_core::par::cold_regions`] is how a test says so without a
+//! stopwatch.
+//!
+//! # The invariant this file exists to hold
+//!
+//! `decoder.rs` declares no `pub fn forward_*` of its own; the bodies
+//! there are private and named `*_on_worker`, or are the `*_inner`
+//! helpers those call. `a_public_forward_may_not_be_declared_outside_
+//! this_file` is the test that keeps it that way, because an entry point
+//! added next door would silently reintroduce the per-region cost while
+//! every other entry point still read as fixed.
+
+use ferrox_core::cache::{KvCache, PagedKvCache, PagedStoreExhausted, SharedPagedKv};
+use ferrox_core::par;
+
+use super::{Decoder, MultiSeqKv};
+
+impl Decoder {
+    /// Runs one decode step for `token_id` at position `pos`, updating
+    /// `kv_caches` (one per layer) in place, and returns the logits over
+    /// the (test-scale) vocabulary.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_token(
+        &self,
+        token_id: usize,
+        pos: usize,
+        kv_caches: &mut [KvCache],
+    ) -> Vec<f32> {
+        par::on_workers(move || self.forward_token_on_worker(token_id, pos, kv_caches))
+    }
+
+    /// Same computation as `forward_token`, but each layer's K/V cache
+    /// is a `PagedKvCache` (block-table-indexed into a per-layer
+    /// `PagedKvStore`) instead of a `KvCache`'s contiguous buffer --
+    /// exercises the paged attention kernel in a real decode loop
+    /// instead of only in isolation. `kv_caches`/`stores` are parallel
+    /// per-layer arrays, mirroring `forward_token`'s `kv_caches: &mut
+    /// [KvCache]`. Must produce bit-identical output to `forward_token`
+    /// given stores sized so no layer ever exhausts its blocks --
+    /// pinned by
+    /// `forward_token_paged_matches_forward_token_bit_identical` and,
+    /// per attention arm, by
+    /// `every_paged_attention_arm_is_bit_identical_to_its_contiguous_twin`.
+    ///
+    /// This used to refuse gpt-oss outright, because the paged kernel
+    /// had no attention-sink term and no sliding-window arm and would
+    /// have answered differently from the contiguous path without
+    /// saying so. It now mirrors all three arms of that dispatch, so
+    /// the refusal is gone rather than merely relaxed.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_token_paged(
+        &self,
+        token_id: usize,
+        pos: usize,
+        kv_caches: &mut [PagedKvCache],
+        stores: &SharedPagedKv,
+    ) -> Result<Vec<f32>, PagedStoreExhausted> {
+        par::on_workers(move || {
+            self.forward_token_paged_on_worker(token_id, pos, kv_caches, stores)
+        })
+    }
+
+    /// Processes multiple new positions in one call instead of calling
+    /// `forward_token` once per position. `tokens[i]` is the token at
+    /// absolute position `start_pos + i`; all positions attend
+    /// causally (position `i` sees positions `0..=i` of this batch
+    /// plus everything already in `kv_caches`, nothing later).
+    ///
+    /// The attention block's Q/K/V/O projections and the MoE router
+    /// are computed as batched matmuls (`WeightMatrix::apply_batch`),
+    /// which for quantized weights means each weight row is read from
+    /// memory once and dotted against every position in the batch,
+    /// not once per position -- see `apply_batch`'s doc comment for
+    /// why that's a real memory-bandwidth saving, not just fewer
+    /// function calls. The expert FFN stage is *not* batched: which
+    /// expert(s) a position routes to is data-dependent per position,
+    /// so positions routed to different experts can't share a single
+    /// matmul the way the shared Q/K/V/router projections can. RoPE
+    /// and attention itself (causal masking, softmax) are also
+    /// per-position, since they're cheap relative to the matmuls and
+    /// batching them would add complexity for little benefit.
+    ///
+    /// This is what makes prompt-lookup speculative decoding
+    /// (`speculative` module) actually save work rather than just
+    /// reshuffle it: verifying `k` draft tokens costs one batched call
+    /// here, not `k` calls to `forward_token`.
+    ///
+    /// Thin wrapper over [`Self::forward_hidden_batch`] + `output_head`.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_batch(
+        &self,
+        tokens: &[usize],
+        start_pos: usize,
+        kv_caches: &mut [KvCache],
+    ) -> Vec<Vec<f32>> {
+        par::on_workers(move || {
+            let hiddens = self.forward_hidden_batch(tokens, start_pos, kv_caches);
+            if hiddens.is_empty() {
+                return Vec::new();
+            }
+            let batch_size = hiddens.len();
+            let flat: Vec<f32> = hiddens.into_iter().flatten().collect();
+            self.logits_from_flat_hidden(flat, batch_size)
+        })
+    }
+
+    /// [`Self::forward_batch`] that also hands back the final-layer
+    /// hidden state for every position instead of dropping it.
+    ///
+    /// `forward_batch` computes these and throws them away; a
+    /// hidden-state-conditioned drafter (EAGLE, MTP, dFlash) needs
+    /// exactly the vector for the last *verified* position, so
+    /// recomputing it would mean running the target model twice for
+    /// something the first pass already had in hand. The extra cost
+    /// here is one copy of `[batch x hidden]`, which is why
+    /// `forward_batch` keeps its move-only path for the prefill case
+    /// that does not want them.
+    ///
+    /// Returns `(logits_per_position, hidden_per_position)`, both
+    /// indexed by position in `tokens`.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_batch_with_hidden(
+        &self,
+        tokens: &[usize],
+        start_pos: usize,
+        kv_caches: &mut [KvCache],
+    ) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
+        par::on_workers(move || {
+            let hiddens = self.forward_hidden_batch(tokens, start_pos, kv_caches);
+            if hiddens.is_empty() {
+                return (Vec::new(), Vec::new());
+            }
+            let batch_size = hiddens.len();
+            let flat: Vec<f32> = hiddens.iter().flatten().copied().collect();
+            (self.logits_from_flat_hidden(flat, batch_size), hiddens)
+        })
+    }
+
+    /// [`Self::forward_batch`] for the common case where only the final
+    /// position's logits are wanted: prefill a prompt, then sample the
+    /// next token. Runs `output_head` on **one** row instead of all
+    /// `batch_size` of them.
+    ///
+    /// The KV cache and every hidden state are identical either way —
+    /// only the vocabulary projection is skipped, and only for rows
+    /// whose logits the caller was going to drop. That projection is not
+    /// a rounding error: it is `[batch x hidden] x [hidden x vocab]`,
+    /// which for a large-vocabulary model with a small body is a large
+    /// share of prefill. `V*H / (V*H + L*P_layer)` comes to 30% on
+    /// Gemma-3-1B, 21% on Llama-3.2-1B and SmolLM2, 23% on Gemma-2-2B.
+    /// llama.cpp does not do this work at all during `pp512` —
+    /// `llama_batch_get_one` leaves `logits` unset, so `inp_out_ids`
+    /// selects a single row.
+    ///
+    /// [`Self::forward_batch`] stays for the callers that genuinely need
+    /// every row: speculative verification checks each draft position,
+    /// and `/v1/embeddings` pools over all of them.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_batch_last(
+        &self,
+        tokens: &[usize],
+        start_pos: usize,
+        kv_caches: &mut [KvCache],
+    ) -> Vec<f32> {
+        par::on_workers(move || self.forward_batch_last_inner(tokens, start_pos, kv_caches, false))
+    }
+
+    /// [`Self::forward_batch_last`] for a caller that will READ the
+    /// caches afterwards rather than only decode from them.
+    ///
+    /// A Metal prefill otherwise leaves K/V on the device and the host
+    /// rows zero-filled, which is invisible to a caller that keeps
+    /// decoding (the device buffers stay authoritative) and fatal to
+    /// one that copies the rows somewhere else. Two callers do copy
+    /// them: `forward_batch_last_paged`, into the page store, and
+    /// `ferrox-server`'s prefix cache, into a snapshot a later request
+    /// restores from. Both used to get zeros, and both answered fluent
+    /// nonsense from a prompt the model never attended over.
+    ///
+    /// Costs one KV download per layer. Use [`Self::forward_batch_last`]
+    /// when nothing will read the caches back.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_batch_last_host_kv(
+        &self,
+        tokens: &[usize],
+        start_pos: usize,
+        kv_caches: &mut [KvCache],
+    ) -> Vec<f32> {
+        par::on_workers(move || self.forward_batch_last_inner(tokens, start_pos, kv_caches, true))
+    }
+
+    /// [`Self::forward_batch_last`] over paged KV: the prefill twin of
+    /// [`Self::forward_token_paged`].
+    ///
+    /// # Why this gathers instead of paging the kernel
+    ///
+    /// `forward_hidden_batch`'s fast arm hands `cache.k` / `cache.v` to
+    /// `causal_gqa_attention_prefill_shared_kv_windowed`, which is Rayon
+    /// over `[query-block x head]` against one flat KV buffer. That
+    /// blocking is why CPU prefill is not the per-query path, and a
+    /// block table cannot be handed to it as a slice.
+    ///
+    /// The alternative was a second blocked kernel that reads through
+    /// the table. This file has just finished paying for what a second
+    /// copy of a rule costs: the paged decode path silently lost the
+    /// window arm, the sink term, the attention softcap, the embedding
+    /// scale and the final logit softcap, one at a time, because it was
+    /// a copy. A prefill kernel is a much larger surface to keep in
+    /// step than any of those. So the pages are materialised, the ONE
+    /// prefill implementation every other path uses runs against them,
+    /// and the new rows go back.
+    ///
+    /// Bit-identity is therefore by construction rather than by
+    /// agreement between two kernels: this calls the same function with
+    /// the same values. What the tests pin is that the gather and the
+    /// scatter are faithful, not that two implementations of attention
+    /// happen to match.
+    ///
+    /// The cost is one KV-sized copy per layer per call, against the
+    /// matmuls that dominate prefill. Decode is untouched: it still
+    /// reads through the block table and copies nothing, which is where
+    /// page sharing pays.
+    ///
+    /// # Failure is checked before anything is written
+    ///
+    /// Every layer's blocks are reserved up front, so a store too small
+    /// for the batch refuses with `PagedStoreExhausted` having mutated
+    /// no layer. A partial append would leave some layers longer than
+    /// others, and no caller can recover from that.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_batch_last_paged(
+        &self,
+        tokens: &[usize],
+        start_pos: usize,
+        kv_caches: &mut [PagedKvCache],
+        stores: &SharedPagedKv,
+    ) -> Result<Vec<f32>, PagedStoreExhausted> {
+        par::on_workers(move || {
+            self.forward_batch_last_paged_on_worker(tokens, start_pos, kv_caches, stores)
+        })
+    }
+
+    /// Like [`Self::forward_batch`], but returns final RMS-normed hidden
+    /// states (pre-`output_head`) — one `hidden_dim` vector per input
+    /// token. Used by `/v1/embeddings` pooling (mean / last).
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_hidden_batch(
+        &self,
+        tokens: &[usize],
+        start_pos: usize,
+        kv_caches: &mut [KvCache],
+    ) -> Vec<Vec<f32>> {
+        par::on_workers(move || {
+            self.forward_hidden_batch_inner(tokens, start_pos, kv_caches, false)
+        })
+    }
+
+    /// Continuous-batching primitive: one decode step across N
+    /// independent *sequences*, each contributing exactly one new
+    /// token at its own current position, sharing every layer's
+    /// projection/router matmuls the same way `forward_batch` shares
+    /// them across positions of a single sequence -- but each
+    /// sequence keeps its own `KvCache`, independent `seq_len`, and
+    /// independent position, so sequences admitted/evicted at
+    /// different times can still share one batched matmul per step
+    /// (this is what "continuous" batching means: the batch
+    /// membership can change every step, unlike `forward_batch`'s
+    /// fixed-size prompt-processing batch). `kv_caches[s][l]` is
+    /// sequence `s`'s layer-`l` cache; `tokens[s]`/`positions[s]` is
+    /// that sequence's next token and its position within its own
+    /// history. Returns one logits vector per sequence, same order as
+    /// `tokens`.
+    ///
+    /// Must produce bit-identical output to calling `forward_token`
+    /// once per sequence with that sequence's own cache/position --
+    /// batching independent sequences together is a scheduling detail,
+    /// not a math change (no sequence's attention ever reads another
+    /// sequence's cache).
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_multi_seq(
+        &self,
+        tokens: &[usize],
+        positions: &[usize],
+        kv_caches: &mut [Vec<KvCache>],
+    ) -> Vec<Vec<f32>> {
+        par::on_workers(move || {
+            self.forward_multi_seq_kv(tokens, positions, &mut MultiSeqKv::Contiguous(kv_caches))
+        })
+    }
+
+    /// [`Self::forward_multi_seq`] over either KV backing.
+    ///
+    /// One body for both: the batched projections are identical, and
+    /// the per-sequence attention step is the only place the backing
+    /// shows through.
+    ///
+    /// Enters the CPU worker pool once for the whole call; see the
+    /// module docs for what that is worth.
+    pub fn forward_multi_seq_kv(
+        &self,
+        tokens: &[usize],
+        positions: &[usize],
+        kv: &mut MultiSeqKv<'_>,
+    ) -> Vec<Vec<f32>> {
+        par::on_workers(move || self.forward_multi_seq_kv_on_worker(tokens, positions, kv))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Every public forward entry point belongs in this file, because
+    /// this file is where the pool is entered. One declared next door
+    /// would open a parallel region per matvec again, and nothing but
+    /// a throughput measurement on a quiet host would notice.
+    ///
+    /// Sabotage: move any wrapper below back into `decoder.rs` with its
+    /// `pub` intact and this goes red naming it.
+    #[test]
+    fn a_public_forward_may_not_be_declared_outside_this_file() {
+        let body = include_str!("../decoder.rs");
+        let stray: Vec<&str> = body
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with("pub fn forward"))
+            .collect();
+        assert!(
+            stray.is_empty(),
+            "these forward entry points bypass the pool wrapper in entry.rs: {stray:?}"
+        );
+    }
+}

--- a/crates/ferrox-models/tests/forward_enters_the_pool_once.rs
+++ b/crates/ferrox-models/tests/forward_enters_the_pool_once.rs
@@ -1,0 +1,218 @@
+//! A forward pass enters the CPU worker pool ONCE, whatever its shape.
+//!
+//! # What shipped, and what this catches
+//!
+//! `ferrox_core::par`'s helpers funnel into `rayon::join` and the
+//! `par_iter` bridges, and both of those cost very different things
+//! depending on who calls them. From a rayon worker the caller runs one
+//! half of the split itself and waits on a spin latch. From any other
+//! thread the job is injected and the caller blocks on a pthread mutex
+//! and condvar, doing no arithmetic at all while it sleeps.
+//!
+//! Every forward pass used to be driven from a thread rayon did not own,
+//! so it paid the second kind once per parallel region: roughly five per
+//! layer, so ~150 per token on a 30-layer model. Sampled on an M2 Pro
+//! over SmolLM2-135M Q8_0 `tg128`, the driving thread spent 74% of the
+//! token parked in `__psynch_cvwait` under rayon's `LockLatch`, while
+//! the matvec kernel accounted for about a tenth of that window across
+//! every thread in the process. The wait was mostly the round trip, not
+//! the work.
+//!
+//! `decoder::entry` fixes that by wrapping each entry point in
+//! `par::on_workers`, and this suite is the guard. It is an OPERATION
+//! COUNT, not a throughput: `par::cold_regions` is a per-thread counter
+//! of regions opened from outside the pool, so the assertion needs no
+//! quiet host and no stopwatch, and it fails by a factor of a hundred
+//! rather than by a few percent if the wrapper is removed.
+//!
+//! # Why every entry point and not just `forward_token`
+//!
+//! Because the failure mode is a NEW entry point, or an old one quietly
+//! bypassing the wrapper. `decoder/entry.rs` carries the structural half
+//! of that check (nothing outside it may declare `pub fn forward_*`);
+//! this is the behavioural half, and it names each function so a
+//! regression says which one.
+
+use ferrox_core::cache::KvCache;
+use ferrox_core::par;
+use ferrox_models::config::ModelConfig;
+use ferrox_models::decoder::Decoder;
+
+/// A committed 2-layer synthetic checkpoint. Any of them would do: the
+/// claim is about the number of pool entries, which does not depend on
+/// the weights.
+const FIXTURE: &str = "tests/fixtures/ferrox_real_test.gguf";
+
+fn load() -> Decoder {
+    let file = ferrox_gguf::GgufFile::open(FIXTURE).expect("fixture opens");
+    let config = ModelConfig::from_gguf(&file).expect("fixture config parses");
+    Decoder::from_gguf(FIXTURE, config).expect("fixture loads")
+}
+
+fn caches(decoder: &Decoder) -> Vec<KvCache> {
+    decoder
+        .layers
+        .iter()
+        .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
+        .collect()
+}
+
+/// The two cases `par::on_workers` declines to promote, and so the two
+/// cases where there is nothing here to assert.
+///
+/// `FERROX_CPU_POOL=spin` deliberately keeps the rayon pool unbuilt, and
+/// a GPU backend keeps the step on its own thread because the Metal
+/// stack carries thread-local state across it. Skip rather than assert
+/// something the configuration makes untrue.
+fn the_promotion_applies_here() -> bool {
+    let pinned_to_spin = matches!(
+        std::env::var("FERROX_CPU_POOL")
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .as_deref(),
+        Some("spin" | "persistent" | "1" | "on" | "true")
+    );
+    !pinned_to_spin
+        && ferrox_core::weight_matrix::active_backend()
+            == ferrox_core::kernel_registry::Backend::Cpu
+}
+
+/// Runs `f` and reports how many parallel regions it opened from
+/// outside the pool.
+fn cold_entries(f: impl FnOnce()) -> u64 {
+    let before = par::cold_regions();
+    f();
+    par::cold_regions() - before
+}
+
+/// The headline: one decode step, one entry into the pool.
+///
+/// Sabotage: drop the `par::on_workers` from `Decoder::forward_token`
+/// in `decoder/entry.rs` and this reads dozens instead of one.
+#[test]
+fn one_decode_step_enters_the_pool_exactly_once() {
+    if !the_promotion_applies_here() {
+        return;
+    }
+    let decoder = load();
+    let mut kv = caches(&decoder);
+    // Warm up outside the measurement: the first call through a weight
+    // matrix builds its repack cache, which opens regions of its own.
+    let _ = decoder.forward_token(1, 0, &mut kv);
+
+    let entries = cold_entries(|| {
+        let _ = decoder.forward_token(2, 1, &mut kv);
+    });
+    assert_eq!(
+        entries, 1,
+        "a decode step must enter the pool once, not once per matvec"
+    );
+}
+
+/// Every public forward entry point, one at a time, so a regression
+/// names the one that broke.
+///
+/// Prefill and multi-sequence decode are wrapped for the same reason
+/// single-token decode is; they are only cheaper to get wrong because
+/// their regions are larger.
+#[test]
+fn every_forward_entry_point_enters_the_pool_exactly_once() {
+    if !the_promotion_applies_here() {
+        return;
+    }
+    let decoder = load();
+    let prompt: Vec<usize> = vec![1, 2, 3, 4];
+
+    // One untimed pass so no measurement below pays for a cold repack
+    // cache or a first-touch allocation.
+    let mut warm = caches(&decoder);
+    let _ = decoder.forward_batch(&prompt, 0, &mut warm);
+    let _ = decoder.forward_token(1, prompt.len(), &mut warm);
+
+    let mut kv = caches(&decoder);
+    assert_eq!(
+        cold_entries(|| {
+            let _ = decoder.forward_batch(&prompt, 0, &mut kv);
+        }),
+        1,
+        "forward_batch"
+    );
+
+    let mut kv = caches(&decoder);
+    assert_eq!(
+        cold_entries(|| {
+            let _ = decoder.forward_batch_with_hidden(&prompt, 0, &mut kv);
+        }),
+        1,
+        "forward_batch_with_hidden"
+    );
+
+    let mut kv = caches(&decoder);
+    assert_eq!(
+        cold_entries(|| {
+            let _ = decoder.forward_batch_last(&prompt, 0, &mut kv);
+        }),
+        1,
+        "forward_batch_last"
+    );
+
+    let mut kv = caches(&decoder);
+    assert_eq!(
+        cold_entries(|| {
+            let _ = decoder.forward_batch_last_host_kv(&prompt, 0, &mut kv);
+        }),
+        1,
+        "forward_batch_last_host_kv"
+    );
+
+    let mut kv = caches(&decoder);
+    assert_eq!(
+        cold_entries(|| {
+            let _ = decoder.forward_hidden_batch(&prompt, 0, &mut kv);
+        }),
+        1,
+        "forward_hidden_batch"
+    );
+
+    let mut seqs = vec![caches(&decoder), caches(&decoder)];
+    assert_eq!(
+        cold_entries(|| {
+            let _ = decoder.forward_multi_seq(&[1, 2], &[0, 0], &mut seqs);
+        }),
+        1,
+        "forward_multi_seq"
+    );
+}
+
+/// Without the wrapper a forward pass opens a region per matvec, so the
+/// count scales with the model. This is the same measurement taken
+/// against an unwrapped baseline: driving the private body directly is
+/// not possible from a test, so instead assert the property that makes
+/// the count meaningful at all -- that it does NOT grow when the same
+/// step is taken twice in a row.
+///
+/// A wrapper that fired only on the first call, or a cache that opened
+/// regions of its own on every token, would both show up here.
+#[test]
+fn the_pool_entry_count_does_not_grow_with_the_number_of_steps() {
+    if !the_promotion_applies_here() {
+        return;
+    }
+    let decoder = load();
+    let mut kv = caches(&decoder);
+    let _ = decoder.forward_token(1, 0, &mut kv);
+
+    let one = cold_entries(|| {
+        let _ = decoder.forward_token(2, 1, &mut kv);
+    });
+    let four = cold_entries(|| {
+        for step in 2..6 {
+            let _ = decoder.forward_token(2, step, &mut kv);
+        }
+    });
+    assert_eq!(one, 1);
+    assert_eq!(
+        four, 4,
+        "four steps must cost four entries, not four times N"
+    );
+}

--- a/docs/plans/cpu-cuda-parity.md
+++ b/docs/plans/cpu-cuda-parity.md
@@ -260,16 +260,84 @@ the pool per operation.
 measured on both aarch64 and x86 rather than guessed. `spin` stops
 being a user-visible knob.
 
-### 4. Find the 60 ms (#128)
+### 4. Find the 60 ms (#128)  [NAMED 2026-09-10: rayon's cold submit]
 
-Flat in thread count and model size, so it is not fork-join and not
-arithmetic. At 8B it is 27% of the token; at 135M it is 93%.
+**The premise of this step was wrong twice, and both corrections are
+recorded because each one cost work.**
 
-It also caps speculative decoding, which runs a small model as the
-drafter and pays the constant on every draft token.
+The first framing, "a fixed ~60 ms per token, flat in model size", was
+corrected by #155: the cost was proportional to gate and up projection
+BYTES and fired only on Q8_0 and Q4_0, because the int-dot matvec
+repacked the whole weight matrix on every call. That was 89% to 90% of
+decode and it is fixed.
 
-**Exit:** the constant named and removed, and 135M decode within 2x of
-llama.cpp on a quiet host.
+The second framing, in a comment on #128, measured 5.48 us per
+fork-join region, multiplied by ~210 regions per token, got 6.7% of the
+token, and concluded scheduling could not be what remained. **The
+arithmetic was right and the denominator was stale.** It was taken
+against a 17.23 ms token, i.e. WITH the repack bug still inflating the
+work. Once #155 removed that work the token fell to about 5 ms and the
+same fixed dispatch became a much larger share of it.
+
+#### What it actually is
+
+`rayon::join` and the `par_iter` bridges both funnel into
+`Registry::in_worker`, which has two arms with very different costs.
+From a rayon worker: run one half inline, post the other for stealing,
+wait on a `SpinLatch`, no syscall. From any other thread: inject the
+job and block on a `LockLatch`, which is a pthread mutex and condvar.
+Every forward pass was driven from a thread rayon did not own, so it
+paid the second arm once per region, roughly five per layer.
+
+Sampled with `sample` on an M2 Pro over SmolLM2-135M Q8_0 `tg128`,
+CPU-only, `-t 6`:
+
+| | share of the driving thread's wall time |
+|---|---|
+| `__psynch_cvwait` under rayon's `LockLatch` | **74%** |
+| attention (`causal_gqa_attention_softcap`) | 10% |
+| the one matvec that ran inline (`o_proj`) | 5% |
+
+Across all twelve threads in that process, the NEON `q8_0x4` matvec
+kernel held 6.6% of the samples and `__psynch_cvwait` 63.7%. During the
+74% the driving thread spent asleep, the six workers it was waiting for
+held about an eighth as many kernel samples between them: most of the
+wait was the round trip, not the work.
+
+#### The fix, and what it measured
+
+`ferrox_core::par::on_workers` wraps a whole forward pass in one
+`rayon::scope`, so the step runs on a worker and every nested region
+takes the hot arm. `~150` cold entries per token become **one**.
+`decoder/entry.rs` is the one place every public `Decoder::forward_*`
+does this, and `par::cold_regions` is a per-thread operation counter so
+the property is a test rather than a stopwatch.
+
+Interleaved `main, branch, main, branch` on the M2 Pro, CPU only, which
+is NOT a benchmark host, so these are ratios and not ledger rows:
+
+| model | decode | prefill |
+|---|---|---|
+| SmolLM2-135M Q8_0 | **+29%** (4 of 4 rounds) | flat |
+| Llama-3.2-3B Q4_K_M | **+9%** (4 of 4 rounds) | flat |
+| Llama-3.1-8B Q4_K_M | +3%, swap-bound on this host | not run |
+
+Against `llama-bench` on the same host and file, best-of-3 at `tg64`,
+the gap moved from about 1.9x to about 1.5x. The host was too noisy for
+that number to be worth more than its order of magnitude; the
+main-versus-branch ratio is the reliable half.
+
+Metal and CUDA are deliberately NOT promoted. Moving the step off the
+main thread changes Metal's output (`Llama-3.2-3B Q4_K_M --ngl 99`,
+greedy, diverges around the tenth token, deterministically on both
+sides), because the Metal stack carries thread-local state across a
+step. `on_workers` asks `weight_matrix::active_backend` first, and with
+that gate the Metal answer is byte-identical to `main` over three runs.
+
+**Exit:** 135M decode within 2x of llama.cpp on a QUIET host. Still
+owed: the numbers above are from a laptop, so the ledger row in
+`benchmarks/RESULTS.md` has not moved and must be re-measured on the
+rented aarch64 box it was taken on.
 
 ### 5. x86 CPU  [DONE for decode, 2026-09-04]
 


### PR DESCRIPTION
## The measured shape

**The 8.2x row is stale, but the gap is real and it is not the same gap.**

`benchmarks/RESULTS.md` carries `SmolLM2-135M Q8_0 tg128` at 14.73 tok/s
against llama.cpp's 120.56, an 8.2x gap on a rented Cortex-A725. That
row predates #155, which fixed the int-dot matvec repacking the whole
weight matrix on every call (Q8_0 and Q4_0 only, and SmolLM2-135M is
Q8_0). On an M2 Pro today, `main` reads about 1.9x behind `llama-bench`
at `tg64` rather than 8.2x. **That row still needs re-measuring on the
box it came from, and this PR does not touch it.**

What is left is a different cost, and it is the one #128's comment
thread ruled out.

### Where the token actually goes

`rayon::join` and the `par_iter` bridges both funnel into
`Registry::in_worker`, which has two arms that do not cost the same:

- **From a rayon worker** (`in_worker_hot`): the caller runs one half
  inline, posts the other for stealing, waits on a `SpinLatch`. No
  syscall.
- **From any other thread** (`in_worker_cold`): the job is injected and
  the caller blocks on a `LockLatch`, a pthread mutex and condvar, doing
  no arithmetic at all while it sleeps.

Every forward pass was driven from a thread rayon did not own. A decode
step opens roughly five parallel regions per layer, so a 30-layer model
paid ~150 of the second arm per token.

`sample`, M2 Pro, SmolLM2-135M Q8_0 `tg128`, CPU only, `-t 6`, 10 s:

| driving thread | share of wall |
|---|---|
| `__psynch_cvwait` under rayon's `LockLatch` | **74%** |
| attention (`causal_gqa_attention_softcap`) | 10% |
| the one matvec that ran inline (`o_proj`) | 5% |

Across all twelve threads, top of stack: `__psynch_cvwait` **63.7%**,
`swtch_pri` 21.3%, and the NEON `q8_0x4` matvec kernel **6.6%**. Over
the window the driving thread was asleep, the six workers it was waiting
for held about an eighth as many kernel samples between them. Most of
the wait was the round trip, not the work.

### Correcting #128's own correction

A comment on #128 measured 5.48 us per fork-join region, multiplied by
~210 regions per token, got **6.7% of the token**, and concluded
scheduling could not be what remained. **The arithmetic was right and
the denominator was stale.** It was taken against a 17.23 ms token, i.e.
with #155's per-matvec repack still inflating the work. Once that landed
the token fell to about 5 ms and the same fixed dispatch became a much
larger share of it. The lesson is the one already in `CLAUDE.md`: a
share is only as good as what it is a share of, and fixing something
else moves it.

## What changed

**`ferrox_core::par::on_workers`** runs a closure inside one
`rayon::scope`, so the step executes on a worker and every nested region
takes the hot arm. **~150 cold entries per token become one.** Nesting
short-circuits, so an entry point can wrap unconditionally.

**`crates/ferrox-models/src/decoder/entry.rs`** is the single place every
public `Decoder::forward_*` does that. Moving the ten entry points there
also takes them and their docs out of `decoder.rs`, which goes **6780 to
6562 lines** rather than growing again.

**Rayon workers get an explicit 8 MiB stack**, matching the main thread
whose job they took over.

### The lever was checked before it was pulled

The arithmetic was written down first, as `CLAUDE.md` asks. Useful
arithmetic across all threads was ~7.7% of process thread-time; if
dispatch were free the token could in principle be several times faster,
which is more than enough to cover a 1.9x gap. The lever could reach the
target. (It did not reach all of it: see "still owed".)

## Measured

Interleaved `main, branch, main, branch`, M2 Pro, CPU only
(`FERROX_METAL=0 FERROX_CUDA=0`), `backend_active` read from the bench
row as `CPU`. **This host is not a benchmark host** (load average 5 to
14, and a 98%-of-a-core system process had to be waited out mid-session),
so these are ratios within one interleaved sequence and no absolute
number here belongs in the ledger.

| model | test | main | branch | |
|---|---|---|---|---|
| SmolLM2-135M Q8_0 | tg128 | 158.9 / 155.4 / 157.0 / 156.2 | 201.1 / 205.4 / 201.9 / 204.8 | **+29%, 4 of 4** |
| Llama-3.2-3B Q4_K_M | tg32 | 35.1 / 35.9 / 36.7 / 31.4 | 40.0 / 39.7 / 38.9 / 34.0 | **+9%, 4 of 4** |
| Llama-3.1-8B Q4_K_M | tg16 | 0.71 / 0.73 / 0.71 | 0.74 / 0.73 / 0.74 | +3%, swap-bound |
| SmolLM2-135M Q8_0 | pp512 | 2250 / 2253 / 2410 | 2461 / 2290 / 2320 | flat |
| Llama-3.2-3B Q4_K_M | pp256 | 155.5 / 150.7 / 143.2 | 152.9 / 152.6 / 140.3 | flat |

**3B and 8B currently win against llama.cpp and both improve here**, so
the row this PR targets is not being bought with a regression elsewhere.
8B on this laptop is swap-bound at under 1 tok/s and its number means
only "not worse".

Against `llama-bench` (build 7650, `-ngl 0`) interleaved on the same
host and file, the gap moved from about **1.9x to about 1.5x** at
`tg64`. llama.cpp's own numbers swung 158 to 371 across three rounds
here, so treat that as an order of magnitude, not a measurement.

Re-profiled after the change: the driving thread's whole 10 s sample
collapses to a single `forward_token -> in_worker_cold ->
LockLatch::wait_and_reset` frame, one wait per token instead of ~150.
Matvec kernel share across all threads went **6.6% to 8.2%**, consistent
with the +29%.

## Correctness

Decode output is **token-identical to `main`**, greedy, `--temp 0`:

- SmolLM2-135M Q8_0 (CPU)
- Llama-3.2-3B Q4_K_M (CPU)
- Llama-3.1-8B Q4_K_M (CPU)
- Llama-3.2-3B Q4_K_M `--ngl 99` (Metal), byte-identical over three runs

## What was ruled out

- **Not the persistent spin pool.** `FERROX_CPU_POOL=spin` was already
  known to make this row worse (9.16 against 14.73) and is untouched.
- **Not a per-token fixed cost.** #128's original "~60 ms flat" framing
  was already corrected by #155; what remains scales with region count,
  which scales with layers.
- **Not `MIN_TASK_MACS` or `SPIN_MIN_OP_MACS`.** Neither is read on the
  path this changes, and neither moved.
- **Not the repack cache.** It is hit, not rebuilt; `get_or_repack_q8x4`
  and `Cache::take_hit` appear in the profile only as cache lookups.

## A finding this PR gates around rather than fixes

**Moving a decode step off the main thread changes Metal's output.**
`Llama-3.2-3B Q4_K_M --ngl 99`, greedy: `main` and an ungated branch
build each answer deterministically, and they diverge from each other
around the tenth token. The Metal stack carries thread-local state
across a step (the resident-activation hand-off from the dense stack to
`output_head`, plus thread-local mirrors of the pipeline and weight
caches), so which thread runs the step is not the free choice it is on
CPU.

That is an undeclared thread-affinity assumption and it deserves its own
investigation, not a CPU scheduling PR. So `on_workers` asks
`weight_matrix::active_backend()` first and promotes only on CPU: the
same cached predicate dispatch itself uses, rather than a second opinion
about which backend is live. With that gate Metal is byte-identical to
`main`. Filed as #166.

## Guards

Both are **operation counts, not throughputs**, so neither needs a quiet
host and both fail by a factor rather than by a few percent.

- `par::cold_regions()` counts regions opened from outside the pool, per
  thread. `crates/ferrox-models/tests/forward_enters_the_pool_once.rs`
  asserts every public forward entry point costs **exactly one**.
- `decoder::entry`'s own test refuses any `pub fn forward` declared in
  `decoder.rs`, so a new entry point cannot silently bypass the seam.
- `par`'s test walks all eight helpers and asserts each reports the
  region it opens, so the counter cannot read low.

Every new test was sabotaged once, with the mutation grep-confirmed in
the file before believing the run:

| sabotage | result |
|---|---|
| `on_workers` calls `f()` without the scope | 17 entries against 1, red |
| drop `note_rayon_region()` from `chunks_mut2` | red, naming `chunks_mut2` |
| drop `on_workers` from `Decoder::forward_token` | 9 entries against 1, red |
| re-`pub` a forward body in `decoder.rs` | red, naming it |

## Gates

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets -- -D warnings` green, debug
  **and** `--release`
- `cargo clippy --features metal` green on the Metal crates
- `cargo fmt --all`

## Still owed, and unverified

1. **The ledger row has not moved.** `benchmarks/RESULTS.md` is
   untouched, deliberately: every number above is from a loaded laptop.
   `SmolLM2-135M Q8_0` needs re-running on the quiet Cortex-A725 it came
   from, where both #155 and this change should show up at once.
2. **Whether this closes #128's exit criterion** ("135M decode within 2x
   of llama.cpp on a quiet host") is not settled from here. On this host
   it looks close; on the A725 it is unmeasured.
3. **The other engines are not wrapped.** `Gemma4Engine` and the Kimi /
   GLM / DS4 stacks have their own forwards and still pay the cold arm.
   Only `Decoder` (the 26 audited architectures) is covered.
4. **A second, smaller lever is visible and untested properly.**
   `FERROX_CPU_POOL=rayon` on top of this branch reads a further ~3% at
   135M (best-of-3: 234 against 224). At 135M the only operation above
   `SPIN_MIN_OP_MACS` is `lm_head` (49152 x 576 = 28M MACs), so the
   process runs a 6-worker rayon pool and a 5-worker spin pool on six
   performance cores, and `swtch_pri` holds 21% to 24% of all thread
   samples. That is a `SPIN_MIN_OP_MACS` question and its doc comment
   already says the crossover is bracketed rather than swept, so it
   wants the quiet-host sweep, not a guess from here.
5. **The main thread is now idle for the whole step.** That costs
   nothing measured (the workers already occupied every performance
   core), but on a host where `-t N` equals the core count it means N
   workers plus one sleeper rather than N-1 workers plus a participant.
   Not investigated.

Refs #27, #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
