### PR TITLE
perf(engines): enter the rayon pool once per forward for every engine, not just Decoder

### DIFF
--- a/crates/ferrox-models/src/bert_encoder.rs
+++ b/crates/ferrox-models/src/bert_encoder.rs
@@ -274,7 +274,11 @@ impl TextEncoder for BertEncoder {
         Some(PairSequence { tokens, segments })
     }
 
-    fn encode(&self, tokens: &[u32], segments: Option<&[u32]>) -> Result<Vec<f32>, EncodeError> {
+    fn encode_on_worker(
+        &self,
+        tokens: &[u32],
+        segments: Option<&[u32]>,
+    ) -> Result<Vec<f32>, EncodeError> {
         let n = tokens.len();
         if n == 0 {
             return Err(EncodeError::EmptySequence);

--- a/crates/ferrox-models/src/deepseek_v4_decoder.rs
+++ b/crates/ferrox-models/src/deepseek_v4_decoder.rs
@@ -758,6 +758,29 @@ mod tests {
         decoder_cfg_for(LayerCompressor::Hca)
     }
 
+    /// One DeepSeek-V4 decode step enters the CPU worker pool once.
+    ///
+    /// DeepSeek-V4 Pro has no checkpoint this machine can load -- the
+    /// `deepseek_v4_pro` preset is a sketch, not proof of
+    /// real-checkpoint support -- so the instance is the same synthetic
+    /// stack the tests below use. The count does not depend on the
+    /// weights: it is how many times the driving thread crossed rayon's
+    /// cold submission path, which before `engine/entry.rs` was once
+    /// per parallel region and is now once per step.
+    ///
+    /// Sabotage: drop the `par::on_workers` from
+    /// `Engine::forward_token` and this goes red with the region count.
+    #[test]
+    fn one_deepseek_v4_decode_step_enters_the_pool_once() {
+        crate::engine::assert_one_pool_entry_per_step(
+            &crate::DeepseekV4Engine {
+                weights: make_weights(),
+                cfg: decoder_cfg(),
+            },
+            0,
+        );
+    }
+
     /// All three arms of the schedule run and stay finite. The point of
     /// the dispatch is that these are three different mechanisms, so
     /// each has to be exercised as itself rather than one standing in

--- a/crates/ferrox-models/src/encoder.rs
+++ b/crates/ferrox-models/src/encoder.rs
@@ -94,7 +94,10 @@ pub struct PairSequence {
 
 /// A model that turns a whole token sequence into hidden states in one
 /// pass, with no carried state and no logits.
-pub trait TextEncoder {
+///
+/// `Sync` because [`TextEncoder::encode`] hands `&self` to a rayon
+/// worker for the duration of the pass; see its doc comment.
+pub trait TextEncoder: Sync {
     /// Width of one hidden-state row, and of the pooled embedding.
     fn n_embd(&self) -> usize;
 
@@ -159,7 +162,35 @@ pub trait TextEncoder {
     /// copied forward pass it has ever had, and the pair path is
     /// exercised far less often than the embedding path, so a copy is
     /// exactly where a fix would fail to land.
-    fn encode(&self, tokens: &[u32], segments: Option<&[u32]>) -> Result<Vec<f32>, EncodeError>;
+    ///
+    /// This is the body an encoder writes; callers want
+    /// [`Self::encode`], which is the same computation with the CPU
+    /// worker pool entered once for the whole pass.
+    fn encode_on_worker(
+        &self,
+        tokens: &[u32],
+        segments: Option<&[u32]>,
+    ) -> Result<Vec<f32>, EncodeError>;
+
+    /// [`Self::encode_on_worker`], with the CPU worker pool entered once
+    /// for the whole pass.
+    ///
+    /// Same rule, and the same reason, as
+    /// [`crate::engine::Engine::forward_token`]: a forward pass through
+    /// a stack of quantized projections opens a parallel region per
+    /// matmul, and every one of them costs a pthread park and wake when
+    /// the driving thread is not a rayon worker. An encoder pass is one
+    /// pass over the whole sequence rather than one per token, so the
+    /// saving is smaller than a decode loop's -- but it is the same
+    /// saving, and an encoder that had to remember to ask for it would
+    /// be one more place for the rule to be forgotten.
+    ///
+    /// Do not override. See
+    /// [`ferrox_core::par::on_workers`] for the three cases it declines
+    /// to promote.
+    fn encode(&self, tokens: &[u32], segments: Option<&[u32]>) -> Result<Vec<f32>, EncodeError> {
+        ferrox_core::par::on_workers(move || self.encode_on_worker(tokens, segments))
+    }
 
     /// [`Self::encode`] for a single sequence: every position is
     /// segment 0.

--- a/crates/ferrox-models/src/engine.rs
+++ b/crates/ferrox-models/src/engine.rs
@@ -39,18 +39,15 @@ use crate::kimi_tokenizer::KimiTokenizer;
 use ferrox_core::cache::KvCache;
 use ferrox_core::weight_matrix::WeightMatrix;
 
-/// A decoder that can run one incremental forward step given a token id
-/// and position, updating its own per-layer state in place.
-pub trait Engine {
-    type State;
+mod entry;
 
-    /// Builds fresh (empty) per-layer state for a new request.
-    fn new_state(&self) -> Self::State;
+pub use entry::Engine;
 
-    fn vocab_size(&self) -> usize;
-
-    fn forward_token(&self, token_id: usize, pos: usize, state: &mut Self::State) -> Vec<f32>;
-}
+/// The shared pool-entry assertion each engine's own tests call, and the
+/// probe for whether promotion happens in this process at all. See
+/// `entry.rs` for why each is one function and not one copy per engine.
+#[cfg(test)]
+pub(crate) use entry::{assert_one_pool_entry_per_step, on_workers_promotes_here};
 
 impl Engine for Decoder {
     type State = Vec<KvCache>;
@@ -66,7 +63,17 @@ impl Engine for Decoder {
         self.config.vocab_size
     }
 
-    fn forward_token(&self, token_id: usize, pos: usize, state: &mut Self::State) -> Vec<f32> {
+    /// Delegates to the inherent [`Decoder::forward_token`], which is
+    /// itself promoted in `decoder/entry.rs`. The two wrappers nest, and
+    /// nesting is free -- the inner one sees a rayon worker and returns
+    /// the body directly -- so this stays a delegation rather than
+    /// reaching past the entry module for a private body.
+    fn forward_token_on_worker(
+        &self,
+        token_id: usize,
+        pos: usize,
+        state: &mut Self::State,
+    ) -> Vec<f32> {
         Decoder::forward_token(self, token_id, pos, state)
     }
 }
@@ -93,7 +100,12 @@ impl Engine for KimiEngine {
         self.weights.output_head.rows()
     }
 
-    fn forward_token(&self, token_id: usize, _pos: usize, state: &mut Self::State) -> Vec<f32> {
+    fn forward_token_on_worker(
+        &self,
+        token_id: usize,
+        _pos: usize,
+        state: &mut Self::State,
+    ) -> Vec<f32> {
         kimi_forward_token(
             &self.weights,
             &self.cfg,
@@ -125,7 +137,12 @@ impl Engine for Glm52Engine {
         self.weights.output_head.rows()
     }
 
-    fn forward_token(&self, token_id: usize, _pos: usize, state: &mut Self::State) -> Vec<f32> {
+    fn forward_token_on_worker(
+        &self,
+        token_id: usize,
+        _pos: usize,
+        state: &mut Self::State,
+    ) -> Vec<f32> {
         glm52_forward_token(&self.weights, &self.cfg, token_id, state)
     }
 }
@@ -252,7 +269,12 @@ impl Engine for MlaEngine {
         self.output_head.rows()
     }
 
-    fn forward_token(&self, token_id: usize, _pos: usize, state: &mut Self::State) -> Vec<f32> {
+    fn forward_token_on_worker(
+        &self,
+        token_id: usize,
+        _pos: usize,
+        state: &mut Self::State,
+    ) -> Vec<f32> {
         use ferrox_core::matmul::{rms_norm, swiglu};
         let mut hidden = self.embedding.dequant_row(token_id);
         for (layer, (k_cache, v_cache)) in self.layers.iter().zip(state.layers.iter_mut()) {
@@ -304,7 +326,12 @@ impl Engine for DeepseekV4Engine {
         self.weights.output_head.rows()
     }
 
-    fn forward_token(&self, token_id: usize, _pos: usize, state: &mut Self::State) -> Vec<f32> {
+    fn forward_token_on_worker(
+        &self,
+        token_id: usize,
+        _pos: usize,
+        state: &mut Self::State,
+    ) -> Vec<f32> {
         deepseek_v4_forward_token(&self.weights, &self.cfg, token_id, state)
     }
 }

--- a/crates/ferrox-models/src/engine/entry.rs
+++ b/crates/ferrox-models/src/engine/entry.rs
@@ -1,0 +1,318 @@
+//! The [`Engine`] seam, and the one place every engine behind it enters
+//! the CPU worker pool.
+//!
+//! # Why this trait lives in its own file
+//!
+//! `decoder/entry.rs` holds the same rule for [`crate::decoder::Decoder`]:
+//! **a forward pass enters the pool once, at its outermost boundary.**
+//! #167 applied it to the generic decoder's ten entry points and stopped
+//! there, so every dedicated engine -- Gemma-4, Kimi K3, GLM-5.2,
+//! DeepSeek-V4 Pro, the MLA stack -- still paid the cold arm once per
+//! parallel region.
+//!
+//! Those five engines have exactly one thing in common, and it is this
+//! trait. So the wrapper is written ONCE, as [`Engine::forward_token`]'s
+//! provided body, and an engine supplies only
+//! [`Engine::forward_token_on_worker`]. There is no per-engine copy of
+//! the wrapper to drift, and an engine added later is promoted without
+//! its author having to know the rule exists.
+//!
+//! # What the wrapper buys
+//!
+//! `rayon::join` and the `par_iter` bridges cost very different things
+//! depending on who calls them. From a rayon worker the caller runs one
+//! half itself and waits on a spin latch; from any other thread the job
+//! is injected and the caller blocks on a pthread condvar, contributing
+//! no arithmetic while it sleeps. A decode step opens roughly five
+//! parallel regions per layer, so a 30-layer model was paying ~150 of
+//! the second kind per token, and the driving thread was measured
+//! holding 74% of the token inside `__psynch_cvwait`.
+//!
+//! [`ferrox_core::par::on_workers`] turns those ~150 cold entries into
+//! one, and [`ferrox_core::par::cold_regions`] is how a test says so
+//! without a stopwatch. Nesting is free -- a call from inside another
+//! `on_workers` returns directly -- so an engine whose body already
+//! promotes ([`crate::decoder::Decoder`]) costs one extra branch and
+//! nothing else.
+//!
+//! # The invariant this file exists to hold
+//!
+//! Nothing outside this file may declare `fn forward_token(`, because an
+//! `impl Engine for _` that overrode the provided body would bypass the
+//! wrapper for that engine alone while every other one still read as
+//! fixed. `no_engine_may_override_the_promoted_forward_token` walks the
+//! crate's sources and says so.
+
+use ferrox_core::par;
+
+/// A decoder that can run one incremental forward step given a token id
+/// and position, updating its own per-layer state in place.
+///
+/// # What an implementor writes
+///
+/// [`Engine::forward_token_on_worker`], never [`Engine::forward_token`].
+/// The second is provided, and providing it again is the one way to lose
+/// the pool promotion silently; see the module docs.
+///
+/// # Why `Sync` and `State: Send`
+///
+/// [`Engine::forward_token`] hands `&self` and `&mut Self::State` to a
+/// rayon worker for the duration of the step, which is exactly what
+/// those two bounds say. They are stated on the trait rather than as a
+/// `where` clause on the method so that an engine which cannot satisfy
+/// them fails to compile at its `impl`, where the author can see why,
+/// instead of at every call site of a method it silently would not have.
+pub trait Engine: Sync {
+    type State: Send;
+
+    /// Builds fresh (empty) per-layer state for a new request.
+    fn new_state(&self) -> Self::State;
+
+    fn vocab_size(&self) -> usize;
+
+    /// One decode step, already running on a rayon worker.
+    ///
+    /// This is the body an engine writes. Callers want
+    /// [`Engine::forward_token`] instead: same computation, with the
+    /// pool entered once for the whole step.
+    fn forward_token_on_worker(
+        &self,
+        token_id: usize,
+        pos: usize,
+        state: &mut Self::State,
+    ) -> Vec<f32>;
+
+    /// One decode step for `token_id` at position `pos`.
+    ///
+    /// Enters the CPU worker pool once for the whole call, so every
+    /// parallel region the step opens takes rayon's in-worker path. See
+    /// the module docs for what that is worth, and
+    /// [`ferrox_core::par::on_workers`] for the three cases it declines
+    /// to promote (a non-CPU active backend, a pinned spin pool, and a
+    /// caller already on a worker).
+    ///
+    /// Do not override this. The body is one line, and the only reason
+    /// it is a provided method rather than a free function is that a
+    /// free function could not be spelled `engine.forward_token(..)` by
+    /// the generation loops that already spell it that way.
+    fn forward_token(&self, token_id: usize, pos: usize, state: &mut Self::State) -> Vec<f32> {
+        par::on_workers(move || self.forward_token_on_worker(token_id, pos, state))
+    }
+}
+
+/// Whether [`par::on_workers`] promotes in this process at all.
+///
+/// Probed rather than restated: an empty step through
+/// [`par::on_workers`] costs exactly one cold region when it promotes
+/// and zero when it declines, so this asks the same predicate the
+/// wrapper itself asks instead of keeping a second copy of "not pinned
+/// to spin, and the active backend is CPU" beside it. `par::policy::
+/// pinned` is `pub(crate)` to `ferrox-core` and cannot be asked
+/// directly; a hand-written copy of its env-var spellings is how this
+/// repo has repeatedly ended up with a gate that could not fire.
+#[cfg(test)]
+pub(crate) fn on_workers_promotes_here() -> bool {
+    let before = par::cold_regions();
+    par::on_workers(|| {});
+    par::cold_regions() - before == 1
+}
+
+/// One decode step through `engine` costs exactly ONE entry into the CPU
+/// worker pool, where the same step run as its raw body costs many.
+///
+/// The shared assertion behind every engine's own pool-entry test. It is
+/// one function rather than one copy per engine for the reason this repo
+/// keeps relearning: a copied check drifts, and a check that drifted
+/// into asserting nothing still passes. Each engine supplies only the
+/// instance, which is the only part that differs.
+///
+/// Both halves matter. `promoted == 1` is the claim; `raw > promoted` is
+/// what makes the 1 mean anything, because a step that opened no regions
+/// at all would also read as one.
+#[cfg(test)]
+pub(crate) fn assert_one_pool_entry_per_step<E: Engine>(engine: &E, token_id: usize) {
+    if !on_workers_promotes_here() {
+        return;
+    }
+    let mut state = engine.new_state();
+    // Warm up outside the measurement: a weight matrix builds its repack
+    // cache on first use, and that opens regions of its own.
+    let _ = engine.forward_token_on_worker(token_id, 0, &mut state);
+
+    let before = par::cold_regions();
+    let _ = engine.forward_token_on_worker(token_id, 1, &mut state);
+    let raw = par::cold_regions() - before;
+
+    let before = par::cold_regions();
+    let _ = Engine::forward_token(engine, token_id, 2, &mut state);
+    let promoted = par::cold_regions() - before;
+
+    assert_eq!(
+        promoted, 1,
+        "a decode step must enter the pool once, not once per matvec"
+    );
+    assert!(
+        raw > promoted,
+        "the unpromoted body must open a region per parallel section \
+         ({raw} vs {promoted}); equal counts mean this engine's step is \
+         too small to be measuring the promotion at all"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{assert_one_pool_entry_per_step, on_workers_promotes_here, Engine};
+    use ferrox_core::par;
+    use std::path::{Path, PathBuf};
+
+    /// Every `.rs` file under this crate's `src/`, found rather than
+    /// listed. A restated list is the shape this repo keeps being bitten
+    /// by: an engine added in a file nobody added to the list would be
+    /// checked by nothing while the test still passed.
+    fn crate_sources() -> Vec<PathBuf> {
+        fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+            for entry in std::fs::read_dir(dir).expect("src/ is readable") {
+                let path = entry.expect("dir entry").path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut out = Vec::new();
+        walk(&src, &mut out);
+        assert!(!out.is_empty(), "walked src/ and found no Rust at all");
+        out
+    }
+
+    /// No engine may declare its own `forward_token`.
+    ///
+    /// The promoted entry point is provided by the trait, so an `impl
+    /// Engine for _` that writes `fn forward_token` overrides it and
+    /// opens a parallel region per matvec again -- for that engine
+    /// alone, while every other one still reads as fixed. Nothing but a
+    /// throughput measurement on a quiet host would notice.
+    ///
+    /// `decoder/entry.rs` is the one exemption: `Decoder::forward_token`
+    /// there is an inherent method that does its own promotion, and the
+    /// `Decoder` engine impl delegates to it.
+    ///
+    /// Sabotage: give any `impl Engine for _` a `fn forward_token` and
+    /// this goes red naming the file and line.
+    #[test]
+    fn no_engine_may_override_the_promoted_forward_token() {
+        let decoder_entry = Path::new("decoder").join("entry.rs");
+        let engine_entry = Path::new("engine").join("entry.rs");
+        let mut stray: Vec<String> = Vec::new();
+        for path in crate_sources() {
+            if path.ends_with(&decoder_entry) || path.ends_with(&engine_entry) {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).expect("source reads");
+            for (i, line) in body.lines().enumerate() {
+                let t = line.trim_start();
+                if t.starts_with("fn forward_token(") || t.starts_with("pub fn forward_token(") {
+                    stray.push(format!("{}:{}", path.display(), i + 1));
+                }
+            }
+        }
+        assert!(
+            stray.is_empty(),
+            "these declarations bypass the pool wrapper on Engine::forward_token: {stray:?}"
+        );
+    }
+
+    /// Three regions per "layer" over four "layers": twelve parallel
+    /// regions if nothing promotes, one if the trait does. The shape
+    /// every real engine has, without needing a checkpoint to build one.
+    struct TwelveRegions;
+
+    impl Engine for TwelveRegions {
+        type State = Vec<f32>;
+
+        fn new_state(&self) -> Vec<f32> {
+            vec![0.0; 4096]
+        }
+
+        fn vocab_size(&self) -> usize {
+            1
+        }
+
+        fn forward_token_on_worker(
+            &self,
+            _token_id: usize,
+            _pos: usize,
+            state: &mut Vec<f32>,
+        ) -> Vec<f32> {
+            for _ in 0..4 {
+                for _ in 0..3 {
+                    par::items_mut(state, 1, |_, x| *x += 1.0);
+                }
+            }
+            vec![0.0]
+        }
+    }
+
+    /// The provided body promotes, and promotes ONCE.
+    ///
+    /// Both halves matter. `promoted == 1` is the claim; `raw > promoted`
+    /// is what makes the 1 mean anything, because a step that opened no
+    /// regions at all would also read as one. This is the same
+    /// before/after the dedicated engines could not be measured on
+    /// directly: several of them have no checkpoint this machine can
+    /// load, and the wrapper they share is this one.
+    ///
+    /// Sabotage: replace `par::on_workers(..)` in
+    /// `Engine::forward_token` with a direct call to
+    /// `forward_token_on_worker` and the promoted count becomes twelve.
+    #[test]
+    fn a_step_through_the_trait_enters_the_pool_once_and_the_raw_body_does_not() {
+        assert_one_pool_entry_per_step(&TwelveRegions, 0);
+    }
+
+    /// The shared helper the engines' own tests call must be able to
+    /// fail, or every one of those tests is decoration.
+    ///
+    /// An engine whose step opens ONE region is indistinguishable from a
+    /// promoted one by the count alone, which is exactly the case
+    /// `assert_one_pool_entry_per_step`'s second assertion exists to
+    /// reject. Without it, an engine that stopped doing parallel work at
+    /// all would still read as fixed.
+    #[test]
+    fn the_shared_assertion_rejects_a_step_too_small_to_measure() {
+        struct OneRegion;
+
+        impl Engine for OneRegion {
+            type State = Vec<f32>;
+
+            fn new_state(&self) -> Vec<f32> {
+                vec![0.0; 64]
+            }
+
+            fn vocab_size(&self) -> usize {
+                1
+            }
+
+            fn forward_token_on_worker(
+                &self,
+                _token_id: usize,
+                _pos: usize,
+                state: &mut Vec<f32>,
+            ) -> Vec<f32> {
+                par::items_mut(state, 1, |_, x| *x += 1.0);
+                vec![0.0]
+            }
+        }
+
+        if !on_workers_promotes_here() {
+            return;
+        }
+        let caught = std::panic::catch_unwind(|| assert_one_pool_entry_per_step(&OneRegion, 0));
+        assert!(
+            caught.is_err(),
+            "a one-region step must be refused as unmeasurable, not accepted as promoted"
+        );
+    }
+}

--- a/crates/ferrox-models/src/gemma4_engine.rs
+++ b/crates/ferrox-models/src/gemma4_engine.rs
@@ -247,7 +247,12 @@ impl Engine for Gemma4Engine {
         self.weights.output_head.rows()
     }
 
-    fn forward_token(&self, token_id: usize, pos: usize, state: &mut Self::State) -> Vec<f32> {
+    fn forward_token_on_worker(
+        &self,
+        token_id: usize,
+        pos: usize,
+        state: &mut Self::State,
+    ) -> Vec<f32> {
         let hp = &self.hp;
         let mut hidden = self.weights.token_embd.dequant_row(token_id);
         let emb_scale = (hp.hidden_dim as f32).sqrt();

--- a/crates/ferrox-models/src/glm52_decoder.rs
+++ b/crates/ferrox-models/src/glm52_decoder.rs
@@ -394,6 +394,29 @@ mod tests {
         }
     }
 
+    /// One GLM-5.2 decode step enters the CPU worker pool once.
+    ///
+    /// GLM-5.2 has no checkpoint this machine can load -- the `glm_5_2`
+    /// preset is a sketch, not proof of real-checkpoint support -- so
+    /// the instance is the same synthetic two-layer stack the tests
+    /// above use. The count does not depend on the weights: it is how
+    /// many times the driving thread crossed rayon's cold submission
+    /// path, which before `engine/entry.rs` was once per parallel
+    /// region and is now once per step.
+    ///
+    /// Sabotage: drop the `par::on_workers` from
+    /// `Engine::forward_token` and this goes red with the region count.
+    #[test]
+    fn one_glm52_decode_step_enters_the_pool_once() {
+        crate::engine::assert_one_pool_entry_per_step(
+            &crate::Glm52Engine {
+                weights: make_weights(),
+                cfg: decoder_cfg(),
+            },
+            0,
+        );
+    }
+
     #[test]
     fn two_mixed_layers_run_end_to_end_across_three_tokens() {
         let weights = make_weights();

--- a/crates/ferrox-models/src/kimi_decoder.rs
+++ b/crates/ferrox-models/src/kimi_decoder.rs
@@ -1020,6 +1020,30 @@ mod tests {
         }
     }
 
+    /// One Kimi K3 decode step enters the CPU worker pool once.
+    ///
+    /// Kimi has no checkpoint this machine can load, so the instance is
+    /// the same synthetic two-layer stack every other test in this file
+    /// uses. The count being asserted does not depend on the weights:
+    /// it is how many times the driving thread crossed rayon's cold
+    /// submission path, which before `engine/entry.rs` was once per
+    /// parallel region and is now once per step.
+    ///
+    /// Sabotage: drop the `par::on_workers` from
+    /// `Engine::forward_token` and this goes red with the region count.
+    #[test]
+    fn one_kimi_decode_step_enters_the_pool_once() {
+        crate::engine::assert_one_pool_entry_per_step(
+            &crate::KimiEngine {
+                weights: make_weights(),
+                cfg: decoder_cfg(),
+                mla_cfg: mla_cfg(),
+                kda_cfg: kda_cfg(),
+            },
+            0,
+        );
+    }
+
     #[test]
     fn two_mixed_layers_match_independent_python_reference() {
         let weights = make_weights();

--- a/crates/ferrox-models/src/kimi_generate.rs
+++ b/crates/ferrox-models/src/kimi_generate.rs
@@ -37,6 +37,49 @@ pub fn kimi_generate(
     eos_id: Option<u32>,
     seed: u64,
 ) -> (String, Vec<u32>) {
+    ferrox_core::par::on_workers(move || {
+        generate_on_workers(
+            weights,
+            cfg,
+            mla_cfg,
+            kda_cfg,
+            tokenizer,
+            prompt,
+            max_new_tokens,
+            sampling,
+            eos_id,
+            seed,
+        )
+    })
+}
+
+/// [`kimi_generate`]'s body, running on a rayon worker.
+///
+/// The promotion is placed around the WHOLE loop rather than around each
+/// `kimi_forward_token`, because this is the outermost public entry
+/// point of this path: `ferrox run-kimi` calls `kimi_generate` and
+/// nothing else. One `rayon::scope` for the generation makes every
+/// parallel region inside it -- every layer of every token, plus the
+/// sampler's -- take rayon's in-worker path, where wrapping each forward
+/// call instead would still pay one cold entry per token and would put a
+/// second spelling of the rule in this file.
+///
+/// This path does not reach [`crate::engine::Engine`]: it is handed
+/// borrowed weights and configs rather than an owned [`crate::KimiEngine`],
+/// so `Engine::forward_token`'s promotion cannot cover it.
+#[allow(clippy::too_many_arguments)]
+fn generate_on_workers(
+    weights: &KimiDecoderWeights,
+    cfg: &KimiDecoderConfig,
+    mla_cfg: &MlaConfig,
+    kda_cfg: &KdaConfig,
+    tokenizer: &KimiTokenizer,
+    prompt: &str,
+    max_new_tokens: usize,
+    sampling: &SamplingParams,
+    eos_id: Option<u32>,
+    seed: u64,
+) -> (String, Vec<u32>) {
     let prompt_ids = tokenizer.encode(prompt);
     let mut state = KimiDecodeState::new(weights, kda_cfg);
     let mut sampler = Sampler::new(seed);
@@ -95,8 +138,25 @@ mod tests {
         lines.join("\n")
     }
 
-    #[test]
-    fn kimi_generate_produces_a_finite_length_bounded_token_sequence() {
+    /// The smallest thing `kimi_generate` will actually run: a
+    /// one-layer dense+KDA stack over the tiny byte vocab, with every
+    /// config it needs.
+    ///
+    /// Extracted rather than written out twice. Two tests drive this
+    /// loop for different reasons -- one checks the token sequence it
+    /// produces, one counts how many times it enters the worker pool --
+    /// and a second copy of a ninety-line builder is exactly where the
+    /// two would drift into exercising different graphs while both
+    /// still passed.
+    #[allow(clippy::type_complexity)]
+    fn tiny_kda_stack() -> (
+        KimiDecoderWeights,
+        KimiDecoderConfig,
+        MlaConfig,
+        KdaConfig,
+        KimiTokenizer,
+        usize,
+    ) {
         let hidden_dim = 8;
         let kda_num_heads = 2;
         let kda_head_dim = 3;
@@ -194,6 +254,20 @@ mod tests {
             use_full_rank_gate: true,
         };
 
+        (
+            weights,
+            decoder_cfg,
+            mla_cfg,
+            kda_cfg,
+            tokenizer,
+            vocab_size,
+        )
+    }
+
+    #[test]
+    fn kimi_generate_produces_a_finite_length_bounded_token_sequence() {
+        let (weights, decoder_cfg, mla_cfg, kda_cfg, tokenizer, vocab_size) = tiny_kda_stack();
+
         let (text, ids) = kimi_generate(
             &weights,
             &decoder_cfg,
@@ -220,6 +294,75 @@ mod tests {
         // confirms decode() ran without panicking, not a byte-count
         // equivalence.
         let _ = text;
+    }
+
+    /// A whole `kimi_generate` run enters the CPU worker pool ONCE.
+    ///
+    /// This path never reaches [`crate::engine::Engine`] -- it is handed
+    /// borrowed weights rather than an owned `KimiEngine` -- so the
+    /// promotion every other engine gets from `engine/entry.rs` cannot
+    /// cover it, and before this it paid rayon's cold submission arm
+    /// once per parallel region of every token. `ferrox run-kimi` is
+    /// the caller.
+    ///
+    /// Measured against the unpromoted body, because a count of one
+    /// means nothing on its own: a loop that opened no regions would
+    /// read the same.
+    ///
+    /// Sabotage: drop the `par::on_workers` from `kimi_generate` and
+    /// the two counts become equal.
+    #[test]
+    fn a_whole_kimi_generation_enters_the_pool_once() {
+        let (weights, decoder_cfg, mla_cfg, kda_cfg, tokenizer, _) = tiny_kda_stack();
+        if !crate::engine::on_workers_promotes_here() {
+            return;
+        }
+        // `generate_on_workers` is the same loop with the wrapper NOT
+        // applied, so this compares the shipped entry point against its
+        // own body rather than against a hand-wrapped stand-in.
+        let count = |f: &dyn Fn()| {
+            let before = ferrox_core::par::cold_regions();
+            f();
+            ferrox_core::par::cold_regions() - before
+        };
+        let raw = count(&|| {
+            generate_on_workers(
+                &weights,
+                &decoder_cfg,
+                &mla_cfg,
+                &kda_cfg,
+                &tokenizer,
+                "hi",
+                5,
+                &SamplingParams::default(),
+                None,
+                42,
+            );
+        });
+        let promoted = count(&|| {
+            kimi_generate(
+                &weights,
+                &decoder_cfg,
+                &mla_cfg,
+                &kda_cfg,
+                &tokenizer,
+                "hi",
+                5,
+                &SamplingParams::default(),
+                None,
+                42,
+            );
+        });
+        assert_eq!(
+            promoted, 1,
+            "a whole generation must enter the pool once, not once per region"
+        );
+        assert!(
+            raw > promoted,
+            "the unpromoted loop must open a region per parallel section \
+             ({raw} vs {promoted}); equal counts mean this is not measuring \
+             the promotion at all"
+        );
     }
 
     #[test]

--- a/crates/ferrox-models/tests/forward_enters_the_pool_once.rs
+++ b/crates/ferrox-models/tests/forward_enters_the_pool_once.rs
@@ -57,24 +57,27 @@ fn caches(decoder: &Decoder) -> Vec<KvCache> {
         .collect()
 }
 
-/// The two cases `par::on_workers` declines to promote, and so the two
-/// cases where there is nothing here to assert.
+/// The cases `par::on_workers` declines to promote, and so the cases
+/// where there is nothing here to assert.
 ///
-/// `FERROX_CPU_POOL=spin` deliberately keeps the rayon pool unbuilt, and
-/// a GPU backend keeps the step on its own thread because the Metal
-/// stack carries thread-local state across it. Skip rather than assert
-/// something the configuration makes untrue.
+/// `FERROX_CPU_POOL=spin` deliberately keeps the rayon pool unbuilt, a
+/// GPU backend keeps the step on its own thread because the Metal stack
+/// carries thread-local state across it, and a caller already on a
+/// worker needs no promotion. Skip rather than assert something the
+/// configuration makes untrue.
+///
+/// **Probed, not restated.** This used to spell out "not pinned to spin,
+/// and the active backend is CPU" -- a second copy of `par::policy`'s
+/// own rule, including its list of accepted env-var spellings, with
+/// nothing making the two agree. `par::policy::pinned` is `pub(crate)`
+/// to `ferrox-core`, so the copy was the only way to ask. It is not: an
+/// EMPTY step through `on_workers` costs exactly one cold region when it
+/// promotes and zero when it declines, which asks the real predicate and
+/// cannot drift from it.
 fn the_promotion_applies_here() -> bool {
-    let pinned_to_spin = matches!(
-        std::env::var("FERROX_CPU_POOL")
-            .ok()
-            .map(|v| v.trim().to_ascii_lowercase())
-            .as_deref(),
-        Some("spin" | "persistent" | "1" | "on" | "true")
-    );
-    !pinned_to_spin
-        && ferrox_core::weight_matrix::active_backend()
-            == ferrox_core::kernel_registry::Backend::Cpu
+    let before = par::cold_regions();
+    par::on_workers(|| {});
+    par::cold_regions() - before == 1
 }
 
 /// Runs `f` and reports how many parallel regions it opened from
@@ -214,5 +217,95 @@ fn the_pool_entry_count_does_not_grow_with_the_number_of_steps() {
     assert_eq!(
         four, 4,
         "four steps must cost four entries, not four times N"
+    );
+}
+
+/// The same property for a DEDICATED engine, on a real checkpoint.
+///
+/// #167 promoted `Decoder` alone, so every engine behind
+/// `engine::Engine` -- Gemma-4, Kimi K3, GLM-5.2, DeepSeek-V4 Pro, the
+/// MLA stack -- still opened a parallel region per matvec. Gemma-4 is
+/// the one of them a real GGUF exists for on this machine, so it is the
+/// one that can be asserted against weights rather than against a
+/// synthetic stand-in; `engine/entry.rs` carries the checkpoint-free
+/// half for the rest, which all share this one wrapper.
+///
+/// Sabotage: drop the `par::on_workers` from `Engine::forward_token` in
+/// `engine/entry.rs` and this reads dozens instead of one.
+#[test]
+#[ignore = "needs models/gemma-4-E2B-it-Q4_K_M.gguf (or FERROX_TEST_GEMMA4_GGUF)"]
+fn a_gemma4_decode_step_enters_the_pool_exactly_once() {
+    use ferrox_models::engine::Engine;
+
+    if !the_promotion_applies_here() {
+        return;
+    }
+    let path = std::env::var("FERROX_TEST_GEMMA4_GGUF").unwrap_or_else(|_| {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../models/gemma-4-E2B-it-Q4_K_M.gguf")
+            .to_string_lossy()
+            .into_owned()
+    });
+    if !std::path::Path::new(&path).exists() {
+        eprintln!("skip: Gemma-4 GGUF missing at {path}");
+        return;
+    }
+    let file = ferrox_gguf::GgufFile::open(&path).expect("open GGUF");
+    let engine = ferrox_models::gemma4_gguf_loader::load_gemma4_engine(&file).expect("load");
+    let mut state = Engine::new_state(&engine);
+
+    // Warm up outside the measurement, for the same reason the generic
+    // cases above do: the first pass through a weight matrix builds its
+    // repack cache, which opens regions of its own.
+    let _ = engine.forward_token(1, 0, &mut state);
+
+    let entries = cold_entries(|| {
+        let _ = engine.forward_token(2, 1, &mut state);
+    });
+    assert_eq!(
+        entries, 1,
+        "a Gemma-4 decode step must enter the pool once, not once per matvec"
+    );
+}
+
+/// The encoder seam pays the same rule.
+///
+/// `TextEncoder::encode` is a forward pass through the same quantized
+/// projections, just over a whole sequence at once instead of one token,
+/// so it opened the same per-matmul cold region and nothing wrapped it.
+/// One pass per request rather than one per token makes it a smaller
+/// win, not a different rule.
+///
+/// Sabotage: drop the `par::on_workers` from `TextEncoder::encode` in
+/// `encoder.rs` and this reads dozens instead of one.
+#[test]
+#[ignore = "needs models/bge-small-en-v1.5-q8_0.gguf (or FERROX_TEST_BERT_GGUF)"]
+fn one_encoder_pass_enters_the_pool_exactly_once() {
+    use ferrox_models::TextEncoder;
+
+    if !the_promotion_applies_here() {
+        return;
+    }
+    let path = std::env::var("FERROX_TEST_BERT_GGUF").unwrap_or_else(|_| {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../models/bge-small-en-v1.5-q8_0.gguf")
+            .to_string_lossy()
+            .into_owned()
+    });
+    if !std::path::Path::new(&path).exists() {
+        eprintln!("skip: BERT GGUF missing at {path}");
+        return;
+    }
+    let encoder = ferrox_models::load_bert_encoder_from_path(&path).expect("load");
+    let tokens: Vec<u32> = encoder.wrap_special(&[100, 200, 300, 400]);
+
+    let _ = encoder.encode(&tokens, None).expect("warm-up pass");
+
+    let entries = cold_entries(|| {
+        let _ = encoder.encode(&tokens, None).expect("measured pass");
+    });
+    assert_eq!(
+        entries, 1,
+        "an encoder pass must enter the pool once, not once per matmul"
     );
 }


### PR DESCRIPTION
Finishes #167, which measured the cost and fixed one caller.

Every forward pass was driven from a thread rayon does not own, so each
parallel region took `Registry::in_worker`'s cold arm: the job is
injected and the caller blocks on a pthread mutex and condvar,
contributing no arithmetic while it sleeps. `par::on_workers` wraps a
whole forward in one `rayon::scope` so ~150 cold entries become one.
#167 applied it in `decoder/entry.rs` and nowhere else, so every
dedicated engine still paid the cold arm per region.

## Engines promoted

| Seam | Engines | Where the wrapper lives |
|---|---|---|
| `engine::Engine` | `Decoder`, `Gemma4Engine`, `KimiEngine`, `Glm52Engine`, `MlaEngine`, `DeepseekV4Engine` | `engine/entry.rs`, one provided body |
| `encoder::TextEncoder` | `BertEncoder` | `encoder.rs` |
| `kimi_generate` | Kimi K3 CLI generation loop | `kimi_generate.rs` |

The five dedicated engines have exactly one thing in common and it is
`Engine`, so the wrapper is written **once** as `Engine::forward_token`'s
provided body and an engine supplies only `forward_token_on_worker`.
There is no per-engine copy to drift, and an engine added later is
promoted without its author knowing the rule exists.
`TextEncoder::encode` gets the same shape for the same reason.

`kimi_generate` is the one live path that cannot reach the trait: it is
handed borrowed weights rather than an owned `KimiEngine`, so its own
outermost public entry point wraps instead. `ferrox run-kimi` is the
caller.

**Not promoted, deliberately:** `vision::encoder_forward`. Nothing calls
it outside its own tests (every VL engine is a refusal stub), and it
lives in a 2571-line file that the file-size rule says to split before
adding to. Said here rather than left to be rediscovered.

`Llama4Engine`, `MinimaxEngine`, `RecurrentEngine`, `T5Engine`,
`VlEngine` and `HybridEngine` are refusal stubs with no forward pass at
all; there is nothing in them to promote.

## Cold-region counts, before and after

`par::cold_regions()` is an operation count, not a stopwatch: it is
load-immune and needs no quiet host. One decode step, measured by
removing the wrapper and putting it back:

| Engine | Before | After |
|---|---|---|
| Gemma-4 E2B Q4_K_M (**real checkpoint**) | 100 | 1 |
| bge-small-en-v1.5 Q8_0, one encoder pass (**real checkpoint**) | 72 | 1 |
| Kimi K3 (synthetic 2-layer) | 30 | 1 |
| GLM-5.2 (synthetic 2-layer) | 30 | 1 |
| DeepSeek-V4 Pro (synthetic) | 16 | 1 |
| `kimi_generate`, 5 tokens (synthetic 1-layer) | 84 | 1 |

The synthetic rows are small stacks; the 100 on a real 30-layer Gemma-4
is what the shape looks like at model scale.

No tok/s is published and `benchmarks/RESULTS.md` is untouched. This is
an M2 Pro laptop with another agent's Metal server running on it, which
is not a benchmark host.

## What I could and could not execute

**Executed on real checkpoints:**

* **Gemma-4 E2B Q4_K_M.** `gemma4_real_contract -- --ignored` still
  decodes `Paris`. A 64-token greedy A/B of `main` against this branch
  is byte-identical output (only the timing lines differ).
* **SmolLM2-135M Q8_0** through the generic `Decoder`: `ferrox verify`
  reports OK on both builds, and a 48-token greedy A/B is identical.
* **bge-small-en-v1.5 Q8_0** and **ms-marco-MiniLM-L6-v2 Q8_0** through
  the encoder seam: `bert_llama_cpp_parity` still matches llama.cpp's
  embeddings, and all seven `rerank_cross_encoder_ordering` /
  `rerank_pooler_present` cases still match the numpy reference scores.

**NOT executed on a real checkpoint:** Kimi K3, GLM-5.2, DeepSeek-V4 Pro
and the MLA stack. No checkpoint for any of them exists on this machine,
and `CLAUDE.md` is explicit that the `kimi_k3`, `glm_5_2` and
`deepseek_v4_pro` presets are sketches rather than proof of
real-checkpoint support. For those four the evidence is the cold-region
count on their own synthetic stacks plus the structural test below; no
claim of real-checkpoint output identity is made for them.

## What the tests hold

* `no_engine_may_override_the_promoted_forward_token` walks `src/`
  (found, not listed) and refuses any `fn forward_token(` outside the
  two entry modules. An override would bypass the wrapper for one engine
  while every other one read as fixed.
* `assert_one_pool_entry_per_step` is **one** shared assertion, called by
  Kimi, GLM-5.2 and DeepSeek-V4's own tests with their synthetic stacks
  and by a synthetic engine in `engine/entry.rs`. It asserts both that
  the promoted step costs one region **and** that the unpromoted body
  costs more, because a count of one means nothing if the step opened
  none. `the_shared_assertion_rejects_a_step_too_small_to_measure`
  proves that second half can fail.
* Gemma-4 and the BERT encoder are asserted against real checkpoints, as
  `#[ignore]`d cases in `forward_enters_the_pool_once.rs`.

Every new assertion was sabotaged once, with the mutation grep-confirmed
in the file before the red run was believed:

| Sabotage | Result |
|---|---|
| drop `on_workers` from `Engine::forward_token` | Gemma-4 reads 100, Kimi/GLM 30, DS4 16, synthetic 12 |
| give `Gemma4Engine` its own `fn forward_token` | structural test names `gemma4_engine.rs:250` |
| drop `on_workers` from `TextEncoder::encode` | encoder reads 72 |
| drop `on_workers` from `kimi_generate` | reads 84 |
| an engine whose step opens one region | shared assertion refuses it as unmeasurable |

## Not touched

None of `par::on_workers`'s three refusals is relaxed: a non-CPU active
backend (Metal decode is thread-affine, #166, another agent's), a pinned
Spin pool, and a caller already on a worker. `crates/ferrox-metal/`,
`crates/ferrox-core/src/par.rs`, `ferrox-quant`, `ferrox-cuda` and
`benchmarks/` are untouched.

## One thing removed while here

`forward_enters_the_pool_once.rs`'s skip predicate used to restate
`par::policy`'s own rule, including its list of accepted
`FERROX_CPU_POOL` spellings, with nothing making the two agree --
`par::policy::pinned` is `pub(crate)` to `ferrox-core`, so a copy was the
only way to ask. It is not: an EMPTY step through `on_workers` costs
exactly one cold region when it promotes and zero when it declines, so
the predicate is now probed rather than restated and cannot drift from
it.

## Gates

`cargo fmt --all`, `cargo test --workspace` (all green), and
`cargo clippy --workspace --all-targets -- -D warnings` in **both** debug
and release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
