### PR TITLE
fix(metal): name the thread-affine state, and give the resident activation an identity a caller cannot get wrong

### DIFF
--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -75,7 +75,7 @@ use objc2_metal::{
     MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue, MTLComputeCommandEncoder,
     MTLDevice, MTLResourceOptions, MTLSize,
 };
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::ptr::NonNull;
 use std::sync::{Mutex, OnceLock};
@@ -180,24 +180,14 @@ pub fn metal_attn_enabled() -> bool {
     })
 }
 
-thread_local! {
-    /// Per-request flag set by `ferrox-server::generate` when
-    /// `temperature<=0`. Thread-local so concurrent requests sharing one
-    /// `Arc<Decoder>` do not race.
-    static GREEDY_ARGMAX: Cell<bool> = const { Cell::new(false) };
-}
-
-/// Enable/disable greedy GPU argmax for the current thread's decode steps.
-pub fn set_metal_greedy_argmax(on: bool) {
-    GREEDY_ARGMAX.with(|c| c.set(on));
-}
-
-/// True when this thread should fold final_norm+lm_head+argmax into the
-/// dense/MoE stack and return a 1-element `[token_id as f32]` instead of
-/// hidden or full vocab logits.
-pub fn metal_greedy_argmax_active() -> bool {
-    GREEDY_ARGMAX.with(|c| c.get())
-}
+// The greedy GPU argmax fold's setting lives in `crate::greedy_fold`,
+// which states what it is and why running a decode step on the wrong
+// thread used to change the answer (GitHub issue #166). Re-exported
+// here because `ferrox-models` reads it at `ferrox_metal::attn::`.
+pub use crate::greedy_fold::{
+    adopt_greedy_fold, greedy_fold_setting, metal_greedy_argmax_active, set_metal_greedy_argmax,
+    GreedyFold, GreedyFoldGuard,
+};
 
 // Norm (interleaved) and NeoX (split-half) kernels share the same buffer
 // layout so `encode_rope` only swaps the entry point. Math mirrors
@@ -2564,6 +2554,12 @@ pub(crate) struct DecodeScratch {
     pub(crate) logits: Option<Retained<ProtocolObject<dyn MTLBuffer>>>,
     /// Single u32 slot for greedy argmax-in-stack (always resident; 4 bytes).
     pub(crate) argmax_idx: Retained<ProtocolObject<dyn MTLBuffer>>,
+    /// What `x` currently holds, when the dense stack has said so.
+    ///
+    /// Lives HERE, inside the thing the mutex protects, so the claim
+    /// and the buffer it describes cannot be read apart. See
+    /// [`crate::resident_act`] for what happened when it did not.
+    pub(crate) resident: Option<crate::resident_act::ResidentPublication>,
     hidden_cap: usize,
     max_q_cap: usize,
     max_kv_cap: usize,
@@ -2854,11 +2850,30 @@ struct PrefillScratchCaps {
     max_gate: usize,
 }
 
+/// The decode scratch, if no one else is using it right now.
+///
+/// `try_lock` and not `lock`: the only caller outside the decode stack
+/// is [`crate::resident_act`], whose whole contract is that a busy
+/// scratch means "upload normally". Blocking there would mean waiting
+/// out another thread's entire decode step, and it would invert a lock
+/// order. Poisoning is treated as busy for the same reason.
+pub(crate) fn try_lock_decode_scratch(
+) -> Option<std::sync::MutexGuard<'static, Option<DecodeScratch>>> {
+    DECODE_SCRATCH.try_lock().ok()
+}
+
 pub(crate) fn borrow_decode_scratch(
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
     caps: ScratchCaps,
 ) -> Result<std::sync::MutexGuard<'static, Option<DecodeScratch>>, MetalError> {
     let mut guard = DECODE_SCRATCH.lock().unwrap();
+    // Handing out the guard is handing out the right to WRITE `x`, so
+    // any standing claim about what `x` holds stops being true here.
+    // This is the invalidation the old thread-local publication had no
+    // way to express: it was not stored with the buffer.
+    if let Some(scratch) = guard.as_mut() {
+        scratch.resident = None;
+    }
     let fits = match guard.as_ref() {
         Some(s) => {
             s.hidden_cap >= caps.hidden
@@ -2891,6 +2906,7 @@ pub(crate) fn borrow_decode_scratch(
             down: alloc_f32_buffer(device, caps.hidden)?,
             logits,
             argmax_idx: alloc_u32_buffer(device, 1)?,
+            resident: None,
             hidden_cap: caps.hidden,
             max_q_cap: caps.max_q,
             max_kv_cap: caps.max_kv,

--- a/crates/ferrox-metal/src/decode_dense.rs
+++ b/crates/ferrox-metal/src/decode_dense.rs
@@ -160,7 +160,7 @@ pub fn launch_decode_dense_stack(
     let device = &shared.device;
     let queue = &shared.queue;
 
-    let scratch_guard = borrow_decode_scratch(
+    let mut scratch_guard = borrow_decode_scratch(
         device,
         ScratchCaps {
             hidden: hidden_dim,
@@ -570,12 +570,6 @@ pub fn launch_decode_dense_stack(
         kv.seq_len = pos + 1;
     }
 
-    // If final_norm ran but no lm_head, mark normalized hidden (x_buf)
-    // as resident so the next apply_gpu can skip re-upload.
-    if norm_resident {
-        crate::gpu::set_resident_activation(x_buf, hidden_dim);
-    }
-
     if argmax_only && download_n == 1 && output.is_some() {
         let ptr = argmax_idx_buf.contents();
         let idx = unsafe { *(ptr.as_ptr() as *const u32) as usize };
@@ -590,7 +584,24 @@ pub fn launch_decode_dense_stack(
         logits_buf.expect("logits buffer when downloading logits")
     };
     let out_ptr = src.contents();
-    Ok(unsafe { std::slice::from_raw_parts(out_ptr.as_ptr() as *const f32, download_n).to_vec() })
+    // SAFETY: `src` is a StorageModeShared buffer allocated for at least
+    // `download_n` f32 and written by the command buffer waited on above.
+    let out =
+        unsafe { std::slice::from_raw_parts(out_ptr.as_ptr() as *const f32, download_n).to_vec() };
+
+    // final_norm ran but no lm_head: `scratch.x` still holds exactly the
+    // vector being returned, so say so and let the caller's next matvec
+    // bind it instead of uploading a copy. Published UNDER THE GUARD, on
+    // the vector's own address, so nothing but that vector can claim it.
+    // See `crate::resident_act` for the version of this that used a raw
+    // pointer and a length.
+    if norm_resident {
+        let scratch = scratch_guard
+            .as_mut()
+            .expect("scratch ensured at entry and held throughout");
+        crate::resident_act::publish(scratch, &out);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/ferrox-metal/src/gpu.rs
+++ b/crates/ferrox-metal/src/gpu.rs
@@ -61,7 +61,7 @@ use objc2_metal::{
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCreateSystemDefaultDevice, MTLDevice,
     MTLDispatchType, MTLLibrary, MTLResource, MTLResourceOptions, MTLSize,
 };
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ptr::NonNull;
 use std::sync::{Arc, Mutex};
@@ -151,56 +151,12 @@ pub(crate) fn memory_barrier_resources(
     memory_barrier_resource_list(encoder, &mut resources);
 }
 
-/// Thread-local pointer + length for a Metal-resident activation buffer
-/// (normalized hidden after final_norm in the dense stack). When set,
-/// [`launch_matvec_fused`] can skip re-uploading if `x` matches.
-#[derive(Clone, Copy)]
-struct ResidentActivation {
-    /// Raw pointer to the MTLBuffer (not retained — caller owns).
-    buf_ptr: *const ProtocolObject<dyn MTLBuffer>,
-    /// Number of f32 elements.
-    len: usize,
-}
-
-thread_local! {
-    /// Holds a resident activation buffer from the dense stack (final_norm
-    /// output in `x_buf`) so the next `output_head.apply_gpu` can reuse it
-    /// without uploading. Cleared after first read.
-    static RESIDENT_ACT: Cell<Option<ResidentActivation>> = const { Cell::new(None) };
-}
-
-/// Stores a resident activation buffer pointer for the current thread.
-/// Used by [`crate::attn::launch_decode_dense_stack`] when writing
-/// final_norm output to scratch so the next matvec can skip upload.
-pub(crate) fn set_resident_activation(buf: &ProtocolObject<dyn MTLBuffer>, len: usize) {
-    RESIDENT_ACT.set(Some(ResidentActivation {
-        buf_ptr: buf as *const _,
-        len,
-    }));
-}
-
-/// Clears the resident activation buffer TLS. Used to ensure clean state
-/// after a decode that doesn't consume the resident buffer.
-pub fn clear_resident_activation() {
-    RESIDENT_ACT.set(None);
-}
-
-/// Checks if a resident activation buffer matches `x`, and if so, returns
-/// the buffer and clears the TLS. Used by [`launch_matvec_fused`].
-fn take_resident_activation_if_matches(
-    x: &[f32],
-) -> Option<Retained<ProtocolObject<dyn MTLBuffer>>> {
-    RESIDENT_ACT.take().and_then(|res| {
-        if res.len == x.len() {
-            // Safety: pointer came from a live buffer in the same thread's
-            // dense stack call (still in scope). We use Retained::retain
-            // to get a new strong reference.
-            unsafe { Retained::retain(res.buf_ptr as *mut _) }
-        } else {
-            None
-        }
-    })
-}
+/// The resident-activation hand-off from the dense stack to the next
+/// matvec used to live here, as a thread-local raw pointer into the
+/// process-wide decode scratch, matched on LENGTH alone. It is now
+/// [`crate::resident_act`], which states the identity it matches on and
+/// why a length was not one.
+pub use crate::resident_act::{clear_resident_activation, resident_activation_reuses};
 
 /// Returns the default Metal device's name, or `None` if this machine
 /// has no Metal-capable GPU (real check, not a compile-time guess).
@@ -5644,24 +5600,10 @@ pub fn launch_matvec_fused(
     let device = &shared.device;
     let queue = &shared.queue;
 
-    // Check if x is already resident from the dense stack (final_norm
-    // output). If so, skip upload and use the resident buffer. Always
-    // clear TLS afterward to prevent stale matches.
-    let x_buf = if let Some(resident) = take_resident_activation_if_matches(x) {
-        resident
-    } else {
-        // No match or no TLS set — clear any stale TLS and upload normally.
-        clear_resident_activation();
-        let mut x_owned = x.to_vec();
-        unsafe {
-            device.newBufferWithBytes_length_options(
-                NonNull::new(x_owned.as_mut_ptr() as *mut _).unwrap(),
-                x_owned.len() * 4,
-                MTLResourceOptions::StorageModeShared,
-            )
-        }
-        .ok_or(MetalError::BufferAllocFailed)?
-    };
+    // Reuses the dense stack's own `x` buffer when `x` IS the vector
+    // that stack just returned, and uploads otherwise. One helper, not
+    // one copy per consumer: see `crate::resident_act`.
+    let x_buf = crate::resident_act::upload_or_reuse(device, x)?;
 
     let mut weight_bufs = Vec::with_capacity(launches.len());
     let mut out_bufs = Vec::with_capacity(launches.len());
@@ -5739,20 +5681,7 @@ pub fn launch_dense_ffn_swiglu(
     let device = &shared.device;
     let queue = &shared.queue;
 
-    let x_buf = if let Some(resident) = take_resident_activation_if_matches(x) {
-        resident
-    } else {
-        clear_resident_activation();
-        let mut x_owned = x.to_vec();
-        unsafe {
-            device.newBufferWithBytes_length_options(
-                NonNull::new(x_owned.as_mut_ptr() as *mut _).unwrap(),
-                x_owned.len() * 4,
-                MTLResourceOptions::StorageModeShared,
-            )
-        }
-        .ok_or(MetalError::BufferAllocFailed)?
-    };
+    let x_buf = crate::resident_act::upload_or_reuse(device, x)?;
 
     let gate_w = resident_weight_buffer(device, gate.weights)?;
     let up_w = resident_weight_buffer(device, up.weights)?;
@@ -7087,20 +7016,7 @@ pub fn launch_moe_topk_swiglu(
     let device = &shared.device;
     let queue = &shared.queue;
 
-    let x_buf = if let Some(resident) = take_resident_activation_if_matches(x) {
-        resident
-    } else {
-        clear_resident_activation();
-        let mut x_owned = x.to_vec();
-        unsafe {
-            device.newBufferWithBytes_length_options(
-                NonNull::new(x_owned.as_mut_ptr() as *mut _).unwrap(),
-                x_owned.len() * 4,
-                MTLResourceOptions::StorageModeShared,
-            )
-        }
-        .ok_or(MetalError::BufferAllocFailed)?
-    };
+    let x_buf = crate::resident_act::upload_or_reuse(device, x)?;
 
     let q4_0_batched = experts.len() <= 8
         && experts.iter().all(|ex| {

--- a/crates/ferrox-metal/src/greedy_fold.rs
+++ b/crates/ferrox-metal/src/greedy_fold.rs
@@ -1,0 +1,258 @@
+//! Whether a Metal decode step folds `final_norm + lm_head + argmax`
+//! into its own command buffer and returns one token id, and WHERE that
+//! decision is kept.
+//!
+//! # The decision
+//!
+//! At `temperature <= 0`, with nothing in the chain that needs to see a
+//! vocabulary before a token is chosen, the argmax can be computed on
+//! the device. The stack then downloads four bytes instead of
+//! `vocab_size` floats. `ferrox-cli` and `ferrox-server` each decide
+//! this per request and announce it with [`set_metal_greedy_argmax`];
+//! `ferrox-models` reads it back with [`metal_greedy_argmax_active`] and
+//! turns it into the `argmax_only` parameter the stack actually takes.
+//!
+//! # Why this is its own module (GitHub issue #166)
+//!
+//! Because that announcement is THREAD-LOCAL, and the decode step it
+//! configures need not run on the announcing thread.
+//!
+//! Measured on an M2 Pro, `Llama-3.2-3B-Instruct-Q4_K_M`, `--ngl 99`,
+//! `--temp 0 --no-cnv`, 32 tokens: driving the same build's forward pass
+//! from a rayon worker instead of the process's main thread changes the
+//! completion, deterministically, from the tenth token or so. The flag
+//! is set on the main thread, read as `false` on the worker, and the
+//! stack silently takes its other path.
+//!
+//! Bisected with two temporary kill switches, one per suspect:
+//!
+//! | fold | resident activation | thread | answer |
+//! |---|---|---|---|
+//! | on | on | main | A |
+//! | on | on | worker | B |
+//! | off | on | either | B |
+//! | off | off | either | B |
+//!
+//! So the resident-activation hand-off (`crate::resident_act`) is
+//! value-neutral and this flag is the whole of the difference.
+//!
+//! # Why the two paths do not agree, which is the deeper defect
+//!
+//! They should. Both compute `lm_head` with the same
+//! `MatvecLaunch` through the same `encode_matvec`, over an activation
+//! that is bit-identical either way. What differs is what happens AFTER
+//! the logits: the folded path takes a device argmax of the RAW logits,
+//! and the unfolded path hands the vocabulary to the host sampler, which
+//! applies the repetition penalties first.
+//!
+//! `--repeat-penalty` defaults to 1.1 in this project (llama.cpp's is
+//! 1.0), so on a default `--temp 0` run the penalty is live and the fold
+//! drops it. Re-run the same comparison with `--repeat-penalty 1.0` and
+//! the two paths agree exactly. The gate that permits the fold,
+//! `SamplingParams::greedy_equals_argmax`, tests XTC, typical-p and DRY
+//! and does NOT test the penalties: two structures that must agree about
+//! when an argmax is the answer, with nothing enforcing it. That gate
+//! lives in `ferrox-models` and is tracked separately; this module can
+//! only say which flag selects which path.
+//!
+//! # What is fixed here and what is not
+//!
+//! Fixed: the setting is now [`GreedyFold`], a value with three states
+//! rather than a bare `bool`, so "no caller on this thread said
+//! anything" is no longer spelled the same way as "this caller wants no
+//! fold"; and it can be CAPTURED on the deciding thread and ADOPTED on
+//! the thread that runs the step ([`greedy_fold_setting`],
+//! [`adopt_greedy_fold`]).
+//!
+//! Not fixed, deliberately: this module does NOT resolve an unset thread
+//! by looking at what other threads chose. It cannot. `ferrox-server`'s
+//! non-greedy branch announces nothing at all, so a thread with no
+//! setting is indistinguishable from a thread that wants no fold, and
+//! adopting some other request's `On` would hand a sampling request one
+//! precomputed id where it expects a vocabulary. Carrying the setting
+//! explicitly is the only sound answer, and the carrying has to be done
+//! by whoever moves the work.
+//!
+//! That is why `ferrox_core::par::on_workers` still declines to promote
+//! a decode step under a GPU backend. Relaxing that gate is a separate,
+//! measurable change, and it should pass [`greedy_fold_setting`] through
+//! [`adopt_greedy_fold`] when it does.
+
+use std::cell::Cell;
+
+/// What the caller on some thread has said about the fold.
+///
+/// Three states and not a `bool`, because the two spellings of `false`
+/// are not the same claim, and collapsing them is what makes the
+/// setting impossible to carry safely.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum GreedyFold {
+    /// No caller on this thread has decided. Behaves as [`Self::Off`]
+    /// and is never resolved from another thread's choice.
+    #[default]
+    Unset,
+    /// This caller needs the vocabulary; the stack must not fold.
+    Off,
+    /// This caller is greedy and needs nothing but the chosen id.
+    On,
+}
+
+impl GreedyFold {
+    /// Whether a step configured this way folds.
+    pub fn folds(self) -> bool {
+        matches!(self, Self::On)
+    }
+}
+
+thread_local! {
+    /// Per-request setting, kept per thread so two concurrent requests
+    /// sharing one `Arc<Decoder>` cannot overwrite each other's.
+    ///
+    /// Per thread is right for isolation and wrong for hand-off; see
+    /// this module's header for the half that is not solved here.
+    static SETTING: Cell<GreedyFold> = const { Cell::new(GreedyFold::Unset) };
+}
+
+/// Enable/disable the greedy GPU argmax fold for THIS THREAD's decode
+/// steps.
+///
+/// `false` records [`GreedyFold::Off`], not "unset": a caller that has
+/// finished a greedy request has expressed something, and the
+/// distinction is what lets a carried setting be checked.
+pub fn set_metal_greedy_argmax(on: bool) {
+    SETTING.set(if on { GreedyFold::On } else { GreedyFold::Off });
+}
+
+/// True when this thread's decode steps should fold
+/// `final_norm + lm_head + argmax` into the stack and return a
+/// 1-element `[token_id as f32]` instead of hidden or full vocab logits.
+pub fn metal_greedy_argmax_active() -> bool {
+    greedy_fold_setting().folds()
+}
+
+/// This thread's setting, as a value that can be sent to another thread.
+///
+/// Capture it on the thread that decided, hand it to
+/// [`adopt_greedy_fold`] on the thread that will run the step. Anything
+/// that moves a Metal decode between threads has to do this, or the step
+/// silently runs with a different setting from the one its caller chose.
+pub fn greedy_fold_setting() -> GreedyFold {
+    SETTING.get()
+}
+
+/// Installs `setting` on this thread until the returned guard drops.
+///
+/// The seam a work-stealing scheduler needs: `ferrox_core::par`'s
+/// `on_workers` promotion is gated off GPU backends today precisely
+/// because a promoted step lost this setting, and relaxing that gate
+/// means capturing on the submitting thread and adopting here.
+#[must_use = "the setting is restored when the guard drops"]
+pub fn adopt_greedy_fold(setting: GreedyFold) -> GreedyFoldGuard {
+    let previous = SETTING.replace(setting);
+    GreedyFoldGuard { previous }
+}
+
+/// Restores the setting a thread had before [`adopt_greedy_fold`].
+///
+/// A worker is reused, so leaving a borrowed setting behind would make
+/// the NEXT job on this thread inherit it, which is the same defect one
+/// level down.
+pub struct GreedyFoldGuard {
+    previous: GreedyFold,
+}
+
+impl Drop for GreedyFoldGuard {
+    fn drop(&mut self) {
+        SETTING.set(self.previous);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// GitHub issue #166's mechanism, in one test: the decision does not
+    /// follow the work.
+    ///
+    /// This is a characterization test, not an aspiration. A Metal
+    /// decode step driven on a thread that was never told what the
+    /// caller wanted takes the other lm_head path, and on a default
+    /// `--temp 0` run the two paths give different tokens. Anything that
+    /// moves a decode step between threads must carry the setting.
+    ///
+    /// Sabotage: make `greedy_fold_setting` read a `static AtomicU8`
+    /// instead of the thread-local, which is the tempting "fix" that
+    /// would break two concurrent server requests at different
+    /// temperatures.
+    #[test]
+    fn the_fold_decision_does_not_follow_the_work_to_another_thread() {
+        set_metal_greedy_argmax(true);
+        assert!(metal_greedy_argmax_active());
+
+        let seen_elsewhere = std::thread::spawn(metal_greedy_argmax_active)
+            .join()
+            .expect("worker thread");
+        assert!(
+            !seen_elsewhere,
+            "a thread that was never told sees the default, so a decode \
+             step moved there silently changes lm_head path"
+        );
+    }
+
+    /// And the fix for anything that DOES move the work: capture, carry,
+    /// adopt.
+    ///
+    /// Sabotage: drop the `SETTING.replace` in `adopt_greedy_fold` for a
+    /// plain read.
+    #[test]
+    fn a_captured_setting_reproduces_itself_on_the_thread_that_adopts_it() {
+        for (announced, expected) in [(true, GreedyFold::On), (false, GreedyFold::Off)] {
+            set_metal_greedy_argmax(announced);
+            let carried = greedy_fold_setting();
+            assert_eq!(carried, expected);
+
+            let seen = std::thread::spawn(move || {
+                let _adopted = adopt_greedy_fold(carried);
+                (greedy_fold_setting(), metal_greedy_argmax_active())
+            })
+            .join()
+            .expect("worker thread");
+            assert_eq!(seen, (expected, announced));
+        }
+    }
+
+    /// A worker is reused, so an adopted setting must not outlive the
+    /// job that adopted it.
+    ///
+    /// Sabotage: make `GreedyFoldGuard::drop` a no-op.
+    #[test]
+    fn an_adopted_setting_is_gone_when_its_guard_drops() {
+        set_metal_greedy_argmax(false);
+        {
+            let _adopted = adopt_greedy_fold(GreedyFold::On);
+            assert!(metal_greedy_argmax_active());
+        }
+        assert_eq!(greedy_fold_setting(), GreedyFold::Off);
+        assert!(!metal_greedy_argmax_active());
+    }
+
+    /// The two spellings of "does not fold" are different claims, and
+    /// collapsing them is what makes a carried setting unsafe: an unset
+    /// thread must never be resolved from another thread's choice.
+    ///
+    /// Sabotage: give `GreedyFold` a `Default` of `Off` and delete
+    /// `Unset`; the first assertion goes red.
+    #[test]
+    fn unset_is_not_the_same_claim_as_off() {
+        let fresh = std::thread::spawn(greedy_fold_setting)
+            .join()
+            .expect("worker thread");
+        assert_eq!(
+            fresh,
+            GreedyFold::Unset,
+            "a thread nobody configured must say so"
+        );
+        assert!(!fresh.folds(), "and it must still behave as no fold");
+        assert_ne!(GreedyFold::Unset, GreedyFold::Off);
+    }
+}

--- a/crates/ferrox-metal/src/lib.rs
+++ b/crates/ferrox-metal/src/lib.rs
@@ -24,6 +24,12 @@ pub mod attn;
 pub mod decode_dense;
 
 #[cfg(feature = "metal")]
+pub mod resident_act;
+
+#[cfg(feature = "metal")]
+pub mod greedy_fold;
+
+#[cfg(feature = "metal")]
 mod dispatch;
 
 #[cfg(feature = "metal")]

--- a/crates/ferrox-metal/src/resident_act.rs
+++ b/crates/ferrox-metal/src/resident_act.rs
@@ -1,0 +1,484 @@
+//! The one hand-off that lets a decode step skip re-uploading its own
+//! activation, and the identity that decides whether the hand-off is
+//! valid.
+//!
+//! # What the hand-off is
+//!
+//! When [`crate::decode_dense::launch_decode_dense_stack`] runs
+//! `final_norm` but no `lm_head` (the caller wants hidden state, not
+//! logits), the normalized hidden already sits in the decode scratch's
+//! `x` buffer on the GPU. The stack downloads it and returns it, and the
+//! caller's very next act is to hand that same vector straight back to
+//! a matvec. Uploading it again would allocate a fresh `MTLBuffer` and
+//! memcpy `hidden_dim` floats for data the device already has, so the
+//! stack PUBLISHES the fact instead and the next matvec REUSES the
+//! buffer.
+//!
+//! # Why it needed rewriting (GitHub issue #166)
+//!
+//! The published fact used to be a thread-local raw
+//! `*const MTLBuffer` plus a LENGTH, matched by comparing that length
+//! against the incoming activation's. Both halves of that were wrong:
+//!
+//! - **The pointer aimed into shared, mutable state with no lock.**
+//!   `DECODE_SCRATCH` is a process-wide `Mutex`, and the publication
+//!   escaped it: the pointer outlived the guard. Two concurrent decodes
+//!   in one process (`ferrox-server` serves each request on its own
+//!   `spawn_blocking` thread over one `Arc<Decoder>`) meant thread A
+//!   could publish `&scratch.x`, thread B's dense stack could overwrite
+//!   `scratch.x`, and thread A's `lm_head` would then read B's
+//!   activation. Same model, so the lengths always agreed and nothing
+//!   would have noticed.
+//! - **Length is not an identity.** Every consumer of a published
+//!   activation ([`crate::gpu::launch_matvec_fused`],
+//!   `launch_dense_ffn_swiglu`, `launch_moe_topk_swiglu`) is routinely
+//!   handed a `hidden_dim`-long activation that is NOT the published
+//!   one. Nothing but call-order discipline in another crate stood
+//!   between that and a silently wrong answer.
+//!
+//! # The identity now
+//!
+//! A publication records the HOST ADDRESS and length of the exact
+//! `Vec<f32>` the dense stack returned, and it lives INSIDE
+//! `DecodeScratch`, under the mutex that owns the buffer it describes.
+//! That gives three properties the length comparison did not:
+//!
+//! 1. Only the exact slice the stack returned can match. A different
+//!    activation of the same length has a different address and misses.
+//! 2. [`crate::attn::borrow_decode_scratch`] drops any publication when
+//!    it hands out the guard, so anything that may WRITE `scratch.x`
+//!    invalidates the claim that `scratch.x` holds a known activation.
+//! 3. A reuse holds the scratch guard for as long as it uses the buffer,
+//!    so no other thread can be writing `scratch.x` underneath it.
+//!
+//! The lock is taken with `try_lock`: a busy scratch is a miss and an
+//! ordinary upload, never a wait and never a deadlock. That also makes
+//! the optimisation self-disabling under concurrency, which is the
+//! correct direction to fail in.
+//!
+//! What this does NOT promise: a publication whose `Vec` is freed and
+//! whose address is then reused by another same-length allocation
+//! before the next scratch borrow would still match. That window is
+//! within one decode step, and closing it would cost a content compare
+//! as expensive as the upload being avoided. It is stated rather than
+//! hidden.
+
+use std::ops::Deref;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2_metal::{MTLBuffer, MTLDevice, MTLResourceOptions};
+
+use crate::attn::DecodeScratch;
+use crate::gpu::MetalError;
+
+/// A claim that the decode scratch's `x` buffer holds the activation
+/// whose host copy is `len` floats at `host_addr`.
+///
+/// Stored in [`DecodeScratch`] rather than beside it, so the claim and
+/// the buffer it describes are behind one lock and cannot drift.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ResidentPublication {
+    host_addr: usize,
+    len: usize,
+}
+
+impl ResidentPublication {
+    /// The publication a dense stack makes for the vector it is about
+    /// to return.
+    pub(crate) fn of(host: &[f32]) -> Self {
+        Self {
+            host_addr: host.as_ptr() as usize,
+            len: host.len(),
+        }
+    }
+
+    /// Whether `x` is the very slice this publication was made for.
+    ///
+    /// The whole point of the rewrite: a caller cannot get this right by
+    /// accident the way it could get a length right by accident.
+    pub(crate) fn describes(&self, x: &[f32]) -> bool {
+        self.host_addr == x.as_ptr() as usize && self.len == x.len()
+    }
+}
+
+/// How many times a matvec reused a published activation instead of
+/// uploading it.
+///
+/// Read by the hardware tests: an optimisation whose fast path never
+/// fires reads as coverage while doing nothing, which is the same
+/// defect shape as a gate that cannot fire.
+static REUSES: AtomicU64 = AtomicU64::new(0);
+
+/// Reuses of a resident activation since process start.
+pub fn resident_activation_reuses() -> u64 {
+    REUSES.load(Ordering::Relaxed)
+}
+
+/// Publishes `host` as the contents of the decode scratch's `x` buffer.
+///
+/// `scratch` is the caller's live guard, which is what makes this safe:
+/// the publication is written under the same lock that protects the
+/// buffer, by the code that just filled it.
+pub(crate) fn publish(scratch: &mut DecodeScratch, host: &[f32]) {
+    scratch.resident = Some(ResidentPublication::of(host));
+}
+
+/// Drops any published activation.
+///
+/// Best effort: a busy scratch is left alone, because a publication is
+/// already invalidated by the next borrow of the scratch and can only
+/// be consumed by the exact slice it was made for. Blocking here would
+/// mean waiting on another thread's whole decode step.
+///
+/// `ferrox-models` calls this at the boundaries of a forward pass, where
+/// it is belt-and-braces rather than the thing correctness rests on.
+pub fn clear_resident_activation() {
+    if let Some(mut guard) = crate::attn::try_lock_decode_scratch() {
+        if let Some(scratch) = guard.as_mut() {
+            scratch.resident = None;
+        }
+    }
+}
+
+/// The activation buffer a matvec binds, however it was obtained.
+///
+/// Derefs to the buffer, so call sites read exactly as they did when
+/// this was a bare `Retained`. When the buffer is the decode scratch's
+/// own `x`, the scratch guard rides along and is released only when the
+/// matvec is done with it.
+pub(crate) struct ActivationBuffer {
+    buf: Retained<ProtocolObject<dyn MTLBuffer>>,
+    /// Held to keep another thread's dense stack out of `scratch.x`
+    /// while this buffer is bound. `None` for a freshly uploaded copy,
+    /// which nothing else can reach.
+    _scratch: Option<std::sync::MutexGuard<'static, Option<DecodeScratch>>>,
+}
+
+impl Deref for ActivationBuffer {
+    type Target = ProtocolObject<dyn MTLBuffer>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf
+    }
+}
+
+/// The single way a matvec gets its activation onto the GPU: reuse the
+/// published buffer when `x` IS the published activation, upload
+/// otherwise.
+///
+/// This was three copies of the same fourteen lines in `gpu.rs`, one per
+/// consumer, which is the shape that loses a fix in two of three places.
+pub(crate) fn upload_or_reuse(
+    device: &Retained<ProtocolObject<dyn MTLDevice>>,
+    x: &[f32],
+) -> Result<ActivationBuffer, MetalError> {
+    if let Some(mut guard) = crate::attn::try_lock_decode_scratch() {
+        let hit = guard
+            .as_ref()
+            .and_then(|s| s.resident)
+            .is_some_and(|p| p.describes(x));
+        if hit {
+            let buf = {
+                let scratch = guard.as_mut().expect("hit implies a live scratch");
+                // Consumed: a publication answers exactly one matvec.
+                scratch.resident = None;
+                scratch.x.clone()
+            };
+            REUSES.fetch_add(1, Ordering::Relaxed);
+            return Ok(ActivationBuffer {
+                buf,
+                _scratch: Some(guard),
+            });
+        }
+    }
+    let mut x_owned = x.to_vec();
+    // SAFETY: `x_owned` is a live, non-empty-capacity `Vec<f32>` of
+    // exactly `x_owned.len() * 4` bytes, and `newBufferWithBytes` COPIES
+    // those bytes into the new buffer, so the allocation may be dropped
+    // at the end of this call.
+    let buf = unsafe {
+        device.newBufferWithBytes_length_options(
+            NonNull::new(x_owned.as_mut_ptr() as *mut _).ok_or(MetalError::BufferAllocFailed)?,
+            std::mem::size_of_val(x_owned.as_slice()),
+            MTLResourceOptions::StorageModeShared,
+        )
+    }
+    .ok_or(MetalError::BufferAllocFailed)?;
+    Ok(ActivationBuffer {
+        buf,
+        _scratch: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug this module was rewritten for: the old publication
+    /// matched on LENGTH, so any same-length activation consumed it.
+    ///
+    /// Sabotage: make `describes` compare `self.len == x.len()` only,
+    /// which is verbatim what `take_resident_activation_if_matches`
+    /// did before issue #166.
+    #[test]
+    fn a_same_length_activation_is_not_the_published_one() {
+        let published = vec![1.0f32, 2.0, 3.0, 4.0];
+        let other = vec![9.0f32, 9.0, 9.0, 9.0];
+        assert_eq!(published.len(), other.len(), "the trap needs equal lengths");
+        let p = ResidentPublication::of(&published);
+        assert!(p.describes(&published), "the published slice must match");
+        assert!(
+            !p.describes(&other),
+            "a different activation of the same length must NOT be \
+             mistaken for the published one"
+        );
+    }
+
+    /// A sub-slice starting at the same address is a different vector
+    /// and must miss too: the buffer holds `len` floats and binding it
+    /// for a shorter matvec would feed the kernel the wrong columns.
+    #[test]
+    fn a_prefix_of_the_published_activation_is_not_the_published_one() {
+        let published = vec![1.0f32, 2.0, 3.0, 4.0];
+        let p = ResidentPublication::of(&published);
+        assert!(!p.describes(&published[..2]));
+    }
+
+    const COLS: usize = 64;
+    const ROWS: usize = 8;
+
+    /// The decode scratch, the publication in it and the reuse counter
+    /// are all process-wide, and `cargo test` runs tests in parallel.
+    /// Two of these at once read each other's publications and each
+    /// other's counter deltas, which is a flake, not a finding.
+    static SERIALIZE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn one_at_a_time() -> std::sync::MutexGuard<'static, ()> {
+        SERIALIZE.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// `rows x COLS` of f32 weights, row `r` scaled by `r + 1`, so a
+    /// wrong activation cannot accidentally give the right answer.
+    fn f32_weights() -> Vec<u8> {
+        let mut w = Vec::with_capacity(ROWS * COLS * 4);
+        for r in 0..ROWS {
+            for c in 0..COLS {
+                let v = (r + 1) as f32 * (1.0 + c as f32 * 0.01);
+                w.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        w
+    }
+
+    fn f32_matvec(weights: &[u8], x: &[f32]) -> Vec<f32> {
+        let launch = crate::gpu::MatvecLaunch {
+            kernel_src: crate::gpu::F32_MATVEC_KERNEL_SRC,
+            fn_name: "f32_matvec",
+            block_bytes: 4,
+            block_elems: 1,
+            weights,
+            rows: ROWS,
+            row_bytes: COLS * 4,
+            rows_per_tg: 1,
+        };
+        crate::gpu::launch_matvec_fused(x, std::slice::from_ref(&launch))
+            .expect("matvec launch")
+            .pop()
+            .expect("one launch, one output")
+    }
+
+    /// Puts `act` into the decode scratch's `x` buffer and publishes it,
+    /// exactly as `launch_decode_dense_stack` does when `final_norm` ran
+    /// without `lm_head`.
+    fn publish_into_scratch(act: &[f32]) {
+        let shared = crate::gpu::shared_metal().expect("Metal device");
+        let mut guard = crate::attn::borrow_decode_scratch(
+            &shared.device,
+            crate::attn::ScratchCaps {
+                hidden: COLS,
+                max_q: COLS,
+                max_kv: COLS,
+                attn: COLS,
+                max_gate: COLS,
+                logits: 0,
+            },
+        )
+        .expect("scratch");
+        let scratch = guard.as_mut().expect("scratch just ensured");
+        crate::attn::copy_f32_into(&scratch.x, act);
+        publish(scratch, act);
+    }
+
+    /// The reuse must be a pure optimisation: the same activation gives
+    /// the same bits whether it was uploaded or found already resident.
+    ///
+    /// The reuse COUNTER is asserted as well, because a fast path that
+    /// silently stopped firing would leave this test green while proving
+    /// nothing -- the same shape as a refusal whose condition is
+    /// unreachable.
+    #[test]
+    #[ignore = "needs a real Metal-capable GPU; run manually with --ignored on Apple Silicon"]
+    fn reusing_a_published_activation_is_bit_identical_to_uploading_it() {
+        let _serialized = one_at_a_time();
+        let weights = f32_weights();
+        let act: Vec<f32> = (0..COLS).map(|i| (i as f32 * 0.37).sin()).collect();
+
+        clear_resident_activation();
+        let uploaded = f32_matvec(&weights, &act);
+
+        publish_into_scratch(&act);
+        let before = resident_activation_reuses();
+        let reused = f32_matvec(&weights, &act);
+        assert_eq!(
+            resident_activation_reuses(),
+            before + 1,
+            "the resident fast path never fired, so this test proves nothing"
+        );
+
+        let a: Vec<u32> = uploaded.iter().map(|v| v.to_bits()).collect();
+        let b: Vec<u32> = reused.iter().map(|v| v.to_bits()).collect();
+        assert_eq!(a, b, "reuse must not change a single bit of the result");
+    }
+
+    /// GitHub issue #166's aliasing half: the old publication matched on
+    /// LENGTH, and every consumer of one is routinely handed a
+    /// `hidden_dim`-long activation that is not the published one.
+    ///
+    /// `published` is all zeros and `other` is all ones, so consuming
+    /// the wrong buffer is not a rounding difference: it is an all-zero
+    /// answer where the row sums belong.
+    ///
+    /// Sabotage: make `ResidentPublication::describes` compare
+    /// `self.len == x.len()` only, which is verbatim the rule
+    /// `take_resident_activation_if_matches` used before this change.
+    #[test]
+    #[ignore = "needs a real Metal-capable GPU; run manually with --ignored on Apple Silicon"]
+    fn a_same_length_activation_never_consumes_a_published_one_on_the_gpu() {
+        let _serialized = one_at_a_time();
+        let weights = f32_weights();
+        let published = vec![0.0f32; COLS];
+        let other = vec![1.0f32; COLS];
+
+        clear_resident_activation();
+        let want = f32_matvec(&weights, &other);
+        assert!(
+            want.iter().any(|v| v.abs() > 1.0),
+            "the reference answer must be far from the zero one"
+        );
+
+        publish_into_scratch(&published);
+        let got = f32_matvec(&weights, &other);
+
+        assert_eq!(
+            got.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            want.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            "a same-length activation consumed the published one: the \
+             matvec answered for the resident vector, not for its own"
+        );
+    }
+
+    /// Anything that may WRITE `scratch.x` must drop the claim about
+    /// what `scratch.x` holds, and taking the guard IS that permission.
+    ///
+    /// Without this, a publication would outlive the next decode step
+    /// that overwrote the buffer, which is precisely how a second
+    /// concurrent request used to be able to answer the first one's
+    /// `lm_head` with its own activation.
+    ///
+    /// Sabotage: delete the `scratch.resident = None` that
+    /// `crate::attn::borrow_decode_scratch` does before it hands out the
+    /// guard.
+    #[test]
+    #[ignore = "needs a real Metal-capable GPU; run manually with --ignored on Apple Silicon"]
+    fn borrowing_the_scratch_invalidates_a_publication() {
+        let _serialized = one_at_a_time();
+        let weights = f32_weights();
+        let act: Vec<f32> = (0..COLS).map(|i| (i as f32 * 0.23).sin()).collect();
+
+        publish_into_scratch(&act);
+        clear_resident_activation();
+        let before = resident_activation_reuses();
+        let _ = f32_matvec(&weights, &act);
+        assert_eq!(
+            resident_activation_reuses(),
+            before,
+            "an explicitly cleared publication was still consumed"
+        );
+
+        // What the NEXT decode step does first: borrow the scratch.
+        publish_into_scratch(&act);
+        let shared = crate::gpu::shared_metal().expect("Metal device");
+        drop(
+            crate::attn::borrow_decode_scratch(
+                &shared.device,
+                crate::attn::ScratchCaps {
+                    hidden: COLS,
+                    max_q: COLS,
+                    max_kv: COLS,
+                    attn: COLS,
+                    max_gate: COLS,
+                    logits: 0,
+                },
+            )
+            .expect("scratch"),
+        );
+        let before = resident_activation_reuses();
+        let _ = f32_matvec(&weights, &act);
+        assert_eq!(
+            resident_activation_reuses(),
+            before,
+            "a publication survived a borrow of the buffer it describes"
+        );
+    }
+
+    /// Issue #166 proper: the same matvec, driven from the calling
+    /// thread and from another thread, must give the same bits.
+    ///
+    /// The publication is process-wide now rather than thread-local, so
+    /// the hand-off survives the step moving threads instead of being
+    /// silently skipped on one side and taken on the other.
+    #[test]
+    #[ignore = "needs a real Metal-capable GPU; run manually with --ignored on Apple Silicon"]
+    fn the_same_matvec_gives_the_same_bits_on_any_thread() {
+        let _serialized = one_at_a_time();
+        let weights = f32_weights();
+        let act: Vec<f32> = (0..COLS).map(|i| (i as f32 * 0.11).cos()).collect();
+
+        clear_resident_activation();
+        let here = f32_matvec(&weights, &act);
+        let there = std::thread::scope(|s| {
+            s.spawn(|| f32_matvec(&weights, &act))
+                .join()
+                .expect("worker thread")
+        });
+        assert_eq!(
+            here.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            there.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            "the Metal matvec path is not thread-agnostic"
+        );
+
+        // And the hand-off itself crosses the thread boundary: published
+        // here, consumed there.
+        publish_into_scratch(&act);
+        let before = resident_activation_reuses();
+        let on_worker = std::thread::scope(|s| {
+            s.spawn(|| f32_matvec(&weights, &act))
+                .join()
+                .expect("worker thread")
+        });
+        assert_eq!(
+            resident_activation_reuses(),
+            before + 1,
+            "a publication made on one thread must still be visible on \
+             another; a thread-local one was not"
+        );
+        assert_eq!(
+            on_worker.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            here.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            "consuming the publication on another thread changed the answer"
+        );
+    }
+}

--- a/docs/plans/cpu-cuda-parity.md
+++ b/docs/plans/cpu-cuda-parity.md
@@ -238,13 +238,22 @@ could never have worked even had the diagnosis been right.
 **Exit:** tok/s against llama.cpp on the same GPU and model, with
 utilization already high on both sides. Not a utilization target.
 
-**The hazard to design around first.** Metal's equivalent
-(`take_resident_activation_if_matches`) matches on LENGTH alone, which
-is safe there only because exactly one site sets it and it is cleared
-aggressively. Copied to CUDA without that discipline, two same-length
-activations alias and the model silently answers wrong, which is worse
-than being slow. Whatever carries residency needs an identity the
-caller cannot get wrong, not a length comparison.
+**The hazard to design around first, and it was real.** Metal's
+equivalent used to match on LENGTH alone, which this note called safe
+"only because exactly one site sets it and it is cleared aggressively".
+It was not safe. There is one publisher but THREE consumers, each
+routinely handed a `hidden_dim`-long activation that is not the
+published one, and the publication was a thread-local raw pointer into
+`DECODE_SCRATCH` -- a process-wide `Mutex` the pointer escaped, so two
+concurrent `ferrox-server` requests could have one answer the other's
+`lm_head` with its own activation, lengths agreeing by construction.
+Fixed in `ferrox-metal/src/resident_act.rs` (issue #166): the
+publication lives inside the thing the mutex protects, records the host
+address and length of the exact vector the stack returned, is dropped by
+any borrow of the buffer it describes, and holds the guard while the
+buffer is bound. Read that module before writing the CUDA twin.
+Whatever carries residency needs an identity the caller cannot get
+wrong, not a length comparison.
 
 ### 3. Decide the CPU pool by work size, not by environment variable
 


### PR DESCRIPTION
Closes nothing on its own; #166 stays open for its remaining half, and
this PR says exactly which half.

## The mechanism, established rather than guessed

Bisected on the M2 Pro with two temporary kill switches, one per
suspect, `Llama-3.2-3B-Instruct-Q4_K_M --ngl 99 --temp 0 --no-cnv`:

| greedy fold | resident activation | driving thread | answer |
|---|---|---|---|
| on | on | main | A |
| on | on | rayon worker | B |
| off | on | either | B |
| off | off | either | B |

Two readings, both decisive:

1. **The resident-activation hand-off is value-neutral.** Turning it
   off changes nothing. The issue's first suspect is not the cause: the
   dense stack downloads `x_buf` with an exact f32 copy, so reusing the
   buffer and re-uploading the copy are the same bits.
2. **The whole divergence is `GREEDY_ARGMAX`**, the thread-local flag
   that says whether the stack folds `final_norm + lm_head + argmax`.
   `ferrox-cli` sets it on the main thread, `ferrox-models` reads it on
   whichever thread runs the step, and a worker reads the default. The
   worker's completion is byte-identical to the main thread's with the
   fold switched off, which is what a lost flag looks like.

With the fold flag neutralised, main-thread and worker completions are
**byte identical** on `Llama-3.2-3B-Instruct-Q4_K_M` (dense) and
`olmoe-1b-7b-0924-q4_0` (MoE), 48 tokens each. So no other thread-local
in `ferrox-metal` decides output by thread identity. The rest
(`TL_PIPELINE_CACHE`, `TL_WEIGHT_CACHE`, `TL_F32_CACHE`,
`TL_MOE_PREFILL`, `TL_MOE_PACKED`, `MOE_SCRATCH`,
`TL_MOE_LAYER_RESIDENT`) are per-thread mirrors of process-wide caches
or scratch buffers: a miss re-creates the same bytes, at the cost of
holding a second copy per thread.

## The bigger finding, filed as #170

The two lm_head paths should not differ at all, and the reason they do
is not a Metal bug. Both compute lm_head with the same `MatvecLaunch`
through the same `encode_matvec` over a bit-identical activation. The
fold then takes a device argmax of the **raw** logits; the unfolded
path hands the vocabulary to the host sampler, which applies the
**repetition penalties** first. `--repeat-penalty` defaults to 1.1
here, so the fold silently drops it, and re-running the same comparison
at `--repeat-penalty 1.0` makes the two paths agree exactly.

`SamplingParams::greedy_equals_argmax` tests XTC, typical-p and DRY and
does not test the penalties. That is a wrong answer on the **main**
thread in the default configuration; #166 only made it visible. It
lives in `ferrox-models`, so it is #170 rather than this PR.

## Is the length-only aliasing hazard real? Yes, and worse than recorded

`docs/plans/cpu-cuda-parity.md` called the length-only match "safe
there only because exactly one site sets it and it is cleared
aggressively". Both halves of that are wrong:

- One site sets it and **three** consume it
  (`launch_matvec_fused`, `launch_dense_ffn_swiglu`,
  `launch_moe_topk_swiglu`), and every one of them is routinely handed
  a `hidden_dim`-long activation that is not the published one. Only
  call-order discipline in another crate stood between that and a
  silently wrong answer.
- The publication was a thread-local raw `*const MTLBuffer` aimed into
  `DECODE_SCRATCH`, which is a **process-wide `Mutex`** the pointer
  escaped. Thread A publishes `&scratch.x`; thread B's dense stack
  overwrites `scratch.x`; thread A's lm_head reads B's activation.
  Same model, so the lengths always agree and nothing notices. Two
  concurrent `ferrox-server` requests over one `Arc<Decoder>` is
  exactly that shape, so this one is live rather than latent.

The `// SAFETY: scratch is gated by DECODE_SCRATCH mutex; only one
encode at a time` comment on `DecodeScratch` was exactly wrong for the
one pointer that left the lock.

## What changed

Two new modules, because `gpu.rs` is 9018 lines and `attn.rs` 8715 and
neither may grow.

**`resident_act.rs`** -- the hand-off, with an identity a caller cannot
get wrong. The publication now lives **inside** `DecodeScratch`, under
the mutex that owns the buffer it describes, and records the host
address and length of the exact `Vec<f32>` the dense stack returned.
`borrow_decode_scratch` drops it when it hands out the guard, because
handing out the guard is handing out the right to write `x`. A reuse
keeps the guard while the buffer is bound, taken with `try_lock`, so a
busy scratch is a miss and an ordinary upload rather than a wait or a
lock-order inversion. The optimisation is preserved and now also works
**across** threads, where the thread-local one silently did not. The
three copies of the upload block in `gpu.rs` collapse into one
`upload_or_reuse`.

The residual window is stated in the module rather than hidden: a
publication whose `Vec` is freed and whose address is reused by another
same-length allocation before the next scratch borrow would still
match. Closing that costs a content compare as expensive as the upload
being avoided.

**`greedy_fold.rs`** -- the decision. `GreedyFold` has three states, so
"nobody on this thread said" is no longer spelled the same way as "this
caller wants no fold", and the setting can be captured on the deciding
thread and adopted on the running one.

It deliberately does **not** resolve an unset thread from another
thread's choice, and the module says why: `ferrox-server`'s non-greedy
branch announces nothing at all, so an unset thread is indistinguishable
from one that wants no fold, and adopting some other request's `On`
would hand a sampling request one precomputed id where it expects a
vocabulary. Carrying it explicitly is the only sound answer, and the
carrying belongs to whoever moves the work.

**`ferrox_core::par::on_workers` is untouched.** Relaxing its backend
gate is a separate, measurable change; when it happens it should
capture `greedy_fold_setting()` on the submitting thread and install it
with `adopt_greedy_fold()` on the worker. That is what #166's remaining
half is.

## Tests

Each new test sabotaged once, with the mutation grep-confirmed in the
file before believing the red run:

- `a_same_length_activation_is_not_the_published_one` (unit) and
  `a_same_length_activation_never_consumes_a_published_one_on_the_gpu`
  (hardware). The GPU one publishes an all-zero activation and runs a
  matvec for an all-one one: under the old length-only rule it goes red
  with `left: [0, 0, ...]` against the row sums.
- `borrowing_the_scratch_invalidates_a_publication`.
- `reusing_a_published_activation_is_bit_identical_to_uploading_it`,
  which asserts the reuse **counter** moved, so a fast path that quietly
  stopped firing cannot leave the test green.
- `the_same_matvec_gives_the_same_bits_on_any_thread`, which also
  proves a publication made on one thread is consumable on another.
- `the_fold_decision_does_not_follow_the_work_to_another_thread`,
  `a_captured_setting_reproduces_itself_on_the_thread_that_adopts_it`,
  `an_adopted_setting_is_gone_when_its_guard_drops`,
  `unset_is_not_the_same_claim_as_off`.

The hardware tests serialise on a test-local mutex: the scratch, the
publication and the counter are process-wide, and `cargo test` runs
tests in parallel, which is a flake rather than a finding.

## Verification on the M2 Pro

- `cargo test -p ferrox-metal --features metal -- --ignored`: 58 passed.
- `cargo test --workspace`: green.
- `cargo clippy --workspace --all-targets -- -D warnings` in debug and
  release, with and without `--features metal`: clean. `cargo fmt --all`.
- Output **token-identical to main** on `Llama-3.2-3B-Instruct-Q4_K_M
  --ngl 99 --temp 0`, same md5.
- `ferrox parity -m Llama-3.2-1B-Instruct-Q8_0.gguf`: MATCH on both
  halves (tokenizer 19/19; KL 7.219e-4 against a 1.0e-2 threshold).
- `ferrox verify -m Llama-3.2-3B-Instruct-Q4_K_M.gguf`: OK, decode and
  with `--prompt-tokens 16` prefill too.
- `ferrox verify -m olmoe-1b-7b-0924-q4_0.gguf`: OK.

## Cost

None measurable. The command buffers are unchanged, which the encode
counters confirm exactly: 362.2 dispatches / 278.6 barriers / 279.6
hazard checks per decode token on both builds.

Interleaved base/branch/base/branch GPU-clock time per decode token
(`FERROX_METAL_GPU_TIMING=1`, 64 tokens, 3B Q4_K_M): base 15.175 and
15.267 ms, branch 15.249 and 15.104 ms. Ratio 0.997, inside the spread
of the pairs themselves. This host is not quiet (load average 5.8,
another `ferrox-server` resident, Chrome at 50% of a core), so **no
tok/s is published and `benchmarks/RESULTS.md` is untouched** -- the
GPU-clock figure is here only to show the change is not paying for
itself with GPU work.

One behavioural cost that is not a number: when a reuse fires, the
scratch lock is held across that matvec's `waitUntilCompleted`, so a
second concurrent request waits one extra matvec. Concurrent requests
already serialise on the same scratch for the dense stack itself, and
the `try_lock` means a busy scratch degrades to an upload rather than
to a wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
