### PR TITLE
fix(sampling): the Metal greedy argmax fold ignored the repetition penalties, which are on by default

### DIFF
--- a/crates/ferrox-cli/src/run.rs
+++ b/crates/ferrox-cli/src/run.rs
@@ -406,17 +406,25 @@ impl TokenStep {
     ///
     /// `sampling` is taken because the CHAIN can need the vocabulary
     /// too: `xtc` and `typ_p` remove candidates the argmax may be one
-    /// of, and `dry` moves logits, so at `temperature <= 0` the answer
-    /// is not the argmax of what the device would fold.
-    /// `SamplingParams::greedy_equals_argmax` is the one predicate that
-    /// decides it, shared with the sampler's own greedy fast path and
-    /// with `ferrox_server::generate`'s copy of this gate.
+    /// of, and `dry` and the repetition / presence / frequency
+    /// penalties move logits, so at `temperature <= 0` the answer is not
+    /// the argmax of what the device would fold.
+    /// `SamplingParams::greedy_equals_raw_argmax` is the one predicate
+    /// that decides it, shared with `ferrox_server::generate`'s copy of
+    /// this gate.
+    ///
+    /// RAW argmax, not `chain_keeps_the_argmax`: the fold argmaxes the
+    /// logits before anything on the host touches them, so the
+    /// penalties are skipped too. Reading the sampler's own
+    /// already-penalised predicate here was GitHub issue #170, and with
+    /// `--repeat-penalty` defaulting to 1.1 it was live on every plain
+    /// `--ngl 99 --temp 0` run.
     // Read only by the Metal greedy guard, so a CPU-only build has no
     // fold to refuse and this is genuinely dead there. Same shape and
     // same reason as `ferrox-models`'s `FoldedLmHead`.
     #[cfg_attr(not(feature = "metal"), allow(dead_code))]
     pub fn needs_vocab_logits(&self, sampling: &ferrox_models::sampling::SamplingParams) -> bool {
-        self.grammar.is_some() || !sampling.greedy_equals_argmax()
+        self.grammar.is_some() || !sampling.greedy_equals_raw_argmax()
     }
 
     /// `Ok(None)` means the grammar is SATISFIED and has no legal
@@ -2077,6 +2085,57 @@ mod tests {
         let mut full = vec!["ferrox"];
         full.extend_from_slice(argv);
         Cli::parse_from(full).infer
+    }
+
+    /// GitHub issue #170, at the flag rather than at the predicate: the
+    /// DEFAULT `ferrox run -m … --temp 0 --ngl 99` must not let Metal
+    /// fold `lm_head + argmax` onto the device.
+    ///
+    /// `--repeat-penalty` defaults to **1.1** here, deliberately unlike
+    /// llama.cpp's 1.0 (`docs/FEATURES.md` records the difference), and
+    /// a device argmax over raw logits never applies it. The fold gate
+    /// read a predicate that tested XTC, typical-p and DRY and not the
+    /// penalties, so a plain greedy Metal run returned a token the host
+    /// sampler would not have chosen -- and agreed instead, byte for
+    /// byte, with the same run at `--repeat-penalty 1.0`.
+    ///
+    /// This test is here and not only in `ferrox-models` because the
+    /// DEFAULT is the thing that made it live: the predicate and the
+    /// flag are two structures that have to agree, and `ferrox-models`
+    /// cannot see this crate's `default_value_t`.
+    ///
+    /// Sabotage: set `default_value_t = 1.0` on `--repeat-penalty`; the
+    /// first assertion goes red.
+    #[test]
+    fn the_default_flags_forbid_the_metal_greedy_argmax_fold() {
+        let step = super::TokenStep::new(ferrox_models::sampling::Sampler::new(1), None);
+        let sampling = |argv: &[&str]| {
+            args(argv)
+                .sampling(None, 4096)
+                .expect("no --dry-multiplier, so no vocabulary is needed")
+        };
+
+        let defaults = sampling(&["-m", "m.gguf", "--temp", "0"]);
+        assert_eq!(defaults.repetition_penalty, 1.1, "llama.cpp's is 1.0");
+        assert!(
+            step.needs_vocab_logits(&defaults),
+            "the default repetition penalty is applied on the host, so the \
+             device must hand back a vocabulary and not one token id"
+        );
+
+        // Both of llama.cpp's off switches restore the fold, which is
+        // what makes the assertion above about the penalty and not about
+        // `--top-k 40` or `--min-p 0.05`, which default on too.
+        for off in [
+            ["-m", "m.gguf", "--temp", "0", "--repeat-penalty", "1.0"],
+            ["-m", "m.gguf", "--temp", "0", "--repeat-last-n", "0"],
+        ] {
+            let s = sampling(&off);
+            assert!(
+                !step.needs_vocab_logits(&s),
+                "{off:?} switches the penalties off, so the fold is exact again"
+            );
+        }
     }
 
     /// The banner may not promise a KV dtype the run will not use.

--- a/crates/ferrox-metal/src/greedy_fold.rs
+++ b/crates/ferrox-metal/src/greedy_fold.rs
@@ -36,24 +36,33 @@
 //! So the resident-activation hand-off (`crate::resident_act`) is
 //! value-neutral and this flag is the whole of the difference.
 //!
-//! # Why the two paths do not agree, which is the deeper defect
+//! # Why the two paths did not agree, which was the deeper defect
 //!
-//! They should. Both compute `lm_head` with the same
+//! They should not differ at all. Both compute `lm_head` with the same
 //! `MatvecLaunch` through the same `encode_matvec`, over an activation
-//! that is bit-identical either way. What differs is what happens AFTER
+//! that is bit-identical either way. What differed is what happens AFTER
 //! the logits: the folded path takes a device argmax of the RAW logits,
 //! and the unfolded path hands the vocabulary to the host sampler, which
 //! applies the repetition penalties first.
 //!
 //! `--repeat-penalty` defaults to 1.1 in this project (llama.cpp's is
 //! 1.0), so on a default `--temp 0` run the penalty is live and the fold
-//! drops it. Re-run the same comparison with `--repeat-penalty 1.0` and
-//! the two paths agree exactly. The gate that permits the fold,
-//! `SamplingParams::greedy_equals_argmax`, tests XTC, typical-p and DRY
-//! and does NOT test the penalties: two structures that must agree about
-//! when an argmax is the answer, with nothing enforcing it. That gate
-//! lives in `ferrox-models` and is tracked separately; this module can
-//! only say which flag selects which path.
+//! dropped it. The gate that permits the fold,
+//! `SamplingParams::greedy_equals_argmax`, tested XTC, typical-p and DRY
+//! and did NOT test the penalties: two structures that must agree about
+//! when an argmax is the answer, with nothing enforcing it.
+//!
+//! Fixed in `ferrox-models` (GitHub issue #170), where that gate lives.
+//! It is now two predicates rather than one -- `chain_keeps_the_argmax`
+//! for a host that has already penalised, `greedy_equals_raw_argmax` for
+//! a device that has not -- built from an exhaustive classification of
+//! every chain step and every `SamplingParams` field. The consequence
+//! for THIS module is worth stating plainly, because it moves Metal
+//! decode numbers: **at the CLI's default `--repeat-penalty 1.1` the
+//! fold no longer fires**. `--repeat-penalty 1.0` or `--repeat-last-n 0`
+//! gets it back, and so would a fold that masked the penalty window on
+//! the device. This module can still only say which flag selects which
+//! path.
 //!
 //! # What is fixed here and what is not
 //!

--- a/crates/ferrox-models/src/sampling.rs
+++ b/crates/ferrox-models/src/sampling.rs
@@ -21,6 +21,7 @@
 //! dependency tree the same minimal, pure-Rust shape as the rest of
 //! this crate.
 
+mod greedy_equivalence;
 mod params;
 mod penalties;
 mod recommended;
@@ -63,17 +64,21 @@ pub(crate) fn spread_logits(vocab: usize) -> Vec<f32> {
 /// ferrox keeps its `argmax` fast path, because building and sorting a
 /// 128k-entry candidate list per token to reach an answer that cannot
 /// differ would be a decode-speed regression on the most common
-/// configuration there is. [`SamplingParams::greedy_equals_argmax`] is
-/// the one predicate that decides which path is exact, and it is read
-/// here and by the Metal `lm_head + argmax` fold's guard, so a chain
-/// that can move the argmax also stops the GPU from folding it away.
+/// configuration there is. [`SamplingParams::chain_keeps_the_argmax`]
+/// decides which path is exact.
+///
+/// That predicate and NOT [`SamplingParams::greedy_equals_raw_argmax`],
+/// which is the Metal `lm_head + argmax` fold's question: `scores` here
+/// has already been through [`apply_history_penalties`], and a device
+/// argmax over raw logits has not. Reading one predicate for both was
+/// GitHub issue #170 -- see [`greedy_equivalence`].
 fn greedy_choice(
     scores: Vec<f32>,
     params: &SamplingParams,
     history: PenaltyWindow<'_>,
     xtc_roll: Option<f32>,
 ) -> usize {
-    if params.greedy_equals_argmax() {
+    if params.chain_keeps_the_argmax() {
         return argmax(&scores);
     }
     argmax(&filtered_distribution(scores, params, history, xtc_roll))
@@ -798,8 +803,8 @@ mod tests {
     /// XTC removes the TOP candidates, so it can change greedy output --
     /// and ferrox's greedy fast path knows that.
     ///
-    /// `greedy_equals_argmax` is the predicate that decides whether the
-    /// `argmax` shortcut is exact. Make it return `true`
+    /// `chain_keeps_the_argmax` is the predicate that decides whether
+    /// the `argmax` shortcut is exact. Make it return `true`
     /// unconditionally and this goes red: the shortcut would return
     /// token 0 while llama.cpp's chain, which runs XTC before the
     /// temperature at every temperature, returns something else.
@@ -814,7 +819,7 @@ mod tests {
             xtc_threshold: 0.05,
             ..SamplingParams::default()
         };
-        assert!(!params.greedy_equals_argmax());
+        assert!(!params.chain_keeps_the_argmax());
         let mut sampler = Sampler::new(11);
         assert_eq!(
             sampler.sample(&logits, &params, PenaltyWindow::new(&[], &[])),
@@ -848,12 +853,12 @@ mod tests {
             typical_p: 0.5,
             ..SamplingParams::default()
         };
-        assert!(!params.greedy_equals_argmax());
+        assert!(!params.chain_keeps_the_argmax());
         assert!(SamplingParams {
             typical_p: 1.0,
             ..params.clone()
         }
-        .greedy_equals_argmax());
+        .chain_keeps_the_argmax());
 
         // logits ln(0.4), ln(0.2) x3: llama.cpp keeps the three 0.2
         // candidates and drops the 0.4 leader (`tests/test-sampling.cpp:346`),

--- a/crates/ferrox-models/src/sampling/greedy_equivalence.rs
+++ b/crates/ferrox-models/src/sampling/greedy_equivalence.rs
@@ -1,0 +1,569 @@
+//! When an argmax may stand in for the whole sampler chain, and over
+//! WHICH logits it may stand in.
+//!
+//! # The two questions, which are not the same question
+//!
+//! There are two callers, and they hand an argmax two different vectors:
+//!
+//! * [`super::greedy_choice`] argmaxes scores the penalties have
+//!   ALREADY been applied to ([`super::penalties::apply_history_penalties`]
+//!   runs first, on the greedy path as well as the sampled one). It
+//!   needs to know whether anything LEFT in the chain can move the
+//!   argmax.
+//! * A backend that folds `final_norm + lm_head + argmax` into its
+//!   decode stack argmaxes the **raw** logits on the device and returns
+//!   one token id. Nothing on the host ever sees the vocabulary, so the
+//!   penalties never happen at all. It needs to know whether the WHOLE
+//!   chain, penalties included, can move the argmax.
+//!
+//! Until GitHub issue #170 those were one predicate,
+//! `SamplingParams::greedy_equals_argmax`, whose body answered the first
+//! question and whose name and Metal callers asked the second. It tested
+//! XTC, typical-p and DRY and did not test the penalties, so on Metal at
+//! `--ngl 99 --temp 0` with this project's default `--repeat-penalty
+//! 1.1` the fold silently dropped the repetition penalty and returned a
+//! different token from the host path and from the CPU reference.
+//!
+//! Measured on an M2 Pro, `Llama-3.2-3B-Instruct-Q4_K_M --ngl 99
+//! --temp 0 --no-cnv`, 64 tokens, md5 of the completion:
+//!
+//! | path | `--repeat-penalty` | md5 |
+//! |---|---|---|
+//! | Metal, fold on | 1.1 (default) | `85ef7c43…` |
+//! | Metal, fold off | 1.1 (default) | `36c6ae0d…` |
+//! | CPU reference | 1.1 (default) | `36c6ae0d…` |
+//! | Metal, fold on | 1.0 | `85ef7c43…` |
+//! | Metal, fold off | 1.0 | `85ef7c43…` |
+//!
+//! The folded answer at 1.1 is bit-identical to the answer at 1.0, which
+//! is what "the penalty never ran" looks like, and the unfolded answer
+//! agrees with the CPU reference exactly.
+//!
+//! # Why this is a table and not two `&&` chains
+//!
+//! Because the thing that went wrong is the repo's dominant defect
+//! shape: a predicate hand-listing a SUBSET of the sampler, with nothing
+//! tying the list to the sampler. So the classification is one
+//! EXHAUSTIVE `match` over [`ChainStep`] and one EXHAUSTIVE destructure
+//! of [`SamplingParams`] with no `..`. A step added to the chain, or a
+//! knob added to the params, does not compile until somebody says what
+//! it does to an argmax.
+//!
+//! The two predicates then differ by exactly one clause -- whether
+//! [`ChainStep::Penalties`] is excused because the caller already ran it
+//! -- which is the whole of issue #170 written down in one line.
+
+use super::SamplingParams;
+use crate::sampler_order::ChainStep;
+
+/// What one chain step does to the argmax of the scores it is handed.
+///
+/// Three states rather than a `bool`, because "cannot change any score"
+/// and "changes scores but never which one is largest" are different
+/// facts, and only the first says the step is switched off. Reading them
+/// as one would make the default chain look live and the live chain look
+/// harmless, depending on which way the collapse went.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StepEffect {
+    /// Configured to its own no-op value: it cannot change any score.
+    Inert,
+    /// Live, and keeps the maximum by construction: it either filters
+    /// candidates by a threshold measured FROM the maximum, or scales
+    /// every score monotonically.
+    KeepsTheMaximum,
+    /// Live, and can change which token the argmax picks -- either by
+    /// removing the maximum from the candidate list or by moving a
+    /// logit past it.
+    MovesTheArgmax,
+}
+
+/// What `step` would do to an argmax, given `params`.
+///
+/// Chain MEMBERSHIP is the caller's question, not this function's: the
+/// callers walk `params.sampler_order.steps()`, and a step a caller left
+/// out of `--samplers` is a step llama.cpp does not run.
+pub(crate) fn step_effect(step: ChainStep, params: &SamplingParams) -> StepEffect {
+    // EXHAUSTIVE, with NO `..`. A knob added to `SamplingParams` stops
+    // this crate compiling here until someone states what it does to an
+    // argmax. That is the enforcement issue #170 was missing: the old
+    // predicate hand-listed three of the chain's nine steps and nothing
+    // noticed that the penalties were not among them.
+    //
+    // A field bound to `_` is one whose verdict is written in the arm
+    // that consumes it; binding it is what keeps the pattern exhaustive.
+    let SamplingParams {
+        temperature,
+        top_p,
+        min_p,
+        top_k,
+        typical_p,
+        top_n_sigma,
+        // Read together through `SamplingParams::xtc_can_fire`, which
+        // exists precisely so the two conditions are not restated. See
+        // the `Xtc` arm.
+        xtc_probability: _,
+        xtc_threshold: _,
+        dry,
+        repetition_penalty,
+        penalty_last_n,
+        presence_penalty,
+        frequency_penalty,
+        // Membership is the caller's loop; see this function's doc.
+        sampler_order: _,
+    } = params;
+
+    match step {
+        // The repetition / presence / frequency penalties move
+        // individual logits, so they can move which logit is the
+        // maximum. This is the arm the old predicate did not have.
+        //
+        // The switched-off conditions restate `apply_history_penalties`'s
+        // own early returns, and
+        // `tests::the_inert_verdict_matches_what_the_penalty_step_actually_does`
+        // walks a matrix asserting the two agree, rather than trusting
+        // this copy of them.
+        ChainStep::Penalties => {
+            let neutral =
+                *repetition_penalty == 1.0 && *presence_penalty == 0.0 && *frequency_penalty == 0.0;
+            if *penalty_last_n == 0 || neutral {
+                StepEffect::Inert
+            } else {
+                StepEffect::MovesTheArgmax
+            }
+        }
+        // DRY subtracts from the logits of tokens that would extend a
+        // repetition, so like the penalties it can move the maximum.
+        ChainStep::Dry => {
+            if dry.is_enabled() {
+                StepEffect::MovesTheArgmax
+            } else {
+                StepEffect::Inert
+            }
+        }
+        // Keeps candidates within `n` standard deviations BELOW the
+        // maximum, so the maximum is always one of them.
+        ChainStep::TopNSigma => {
+            if *top_n_sigma <= 0.0 {
+                StepEffect::Inert
+            } else {
+                StepEffect::KeepsTheMaximum
+            }
+        }
+        // Keeps the `k` most likely, which starts at the maximum.
+        ChainStep::TopK => {
+            if *top_k == 0 {
+                StepEffect::Inert
+            } else {
+                StepEffect::KeepsTheMaximum
+            }
+        }
+        // Selects OUTWARD from the distribution's entropy and can drop
+        // the most likely token -- llama.cpp's own test case
+        // `test_typical({0.4, 0.2, 0.2, 0.2}, {0.2, 0.2, 0.2}, 0.5)`
+        // (`tests/test-sampling.cpp:346`) drops it.
+        ChainStep::TypP => {
+            if *typical_p >= 1.0 {
+                StepEffect::Inert
+            } else {
+                StepEffect::MovesTheArgmax
+            }
+        }
+        // Accumulates probability from the most likely downward and
+        // keeps at least one candidate, so the maximum always survives.
+        ChainStep::TopP => {
+            if *top_p >= 1.0 {
+                StepEffect::Inert
+            } else {
+                StepEffect::KeepsTheMaximum
+            }
+        }
+        // A threshold expressed as a fraction OF the maximum, which the
+        // maximum meets by construction.
+        ChainStep::MinP => {
+            if *min_p <= 0.0 {
+                StepEffect::Inert
+            } else {
+                StepEffect::KeepsTheMaximum
+            }
+        }
+        // Removes the TOP candidates, by construction.
+        ChainStep::Xtc => {
+            if params.xtc_can_fire() {
+                StepEffect::MovesTheArgmax
+            } else {
+                StepEffect::Inert
+            }
+        }
+        // A positive temperature divides every logit by the same
+        // positive number, which is monotone. `temp <= 0` is
+        // llama.cpp's greedy collapse (`src/llama-sampler.cpp:271-286`),
+        // which sets every logit but the maximum to `-inf`. Neither can
+        // change WHICH index is maximal, so temperature is never a
+        // reason to refuse a fold -- and it is never `Inert` either,
+        // since there is no value at which it stops touching scores.
+        ChainStep::Temperature => {
+            debug_assert!(!temperature.is_nan(), "a NaN temperature is not a chain");
+            StepEffect::KeepsTheMaximum
+        }
+    }
+}
+
+impl SamplingParams {
+    /// True when no step LEFT in the chain can move the argmax of the
+    /// scores it is handed -- scores the penalties have ALREADY been
+    /// applied to.
+    ///
+    /// This is [`super::greedy_choice`]'s question and only its
+    /// question. It is called per token, so it is a walk over at most
+    /// [`crate::sampler_order::SamplerName::ALL`]`.len()` steps with no
+    /// allocation, not a candidate list.
+    ///
+    /// A device fold must ask [`Self::greedy_equals_raw_argmax`]
+    /// instead: this one excuses the penalties because its caller
+    /// already ran them, and a device that argmaxes raw logits has not.
+    pub fn chain_keeps_the_argmax(&self) -> bool {
+        self.sampler_order.steps().iter().all(|&step| {
+            step == ChainStep::Penalties || step_effect(step, self) != StepEffect::MovesTheArgmax
+        })
+    }
+
+    /// True when the argmax of the **raw** logits is the token the whole
+    /// sampler chain would choose, penalties included.
+    ///
+    /// This is the question a backend folding `lm_head + argmax` into
+    /// its decode stack has to ask, because the fold returns one token
+    /// id and the host never sees a vocabulary: every step of the chain
+    /// is skipped, not just the candidate-list filters.
+    ///
+    /// **Three readers**, because the alternative is this repo's
+    /// dominant defect: `ferrox_cli::run`'s `needs_vocab_logits`,
+    /// `ferrox_server::generate`'s, and through them the Metal fold's
+    /// own guard in `ferrox_metal::greedy_fold`.
+    ///
+    /// Note what this costs: with the CLI's default `--repeat-penalty
+    /// 1.1` the answer is `false`, so the Metal fold does not fire in
+    /// the default configuration. That is deliberate -- see issue #170
+    /// and this module's header for the numbers. `--repeat-penalty 1.0`
+    /// or `--repeat-last-n 0` gets it back.
+    pub fn greedy_equals_raw_argmax(&self) -> bool {
+        self.sampler_order
+            .steps()
+            .iter()
+            .all(|&step| step_effect(step, self) != StepEffect::MovesTheArgmax)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dry::{DryBreakers, DryParams};
+    use crate::penalty_window::PenaltyWindow;
+    use crate::sampler_order::SamplerOrder;
+    use crate::sampling::Sampler;
+
+    /// The CLI's defaults, which are the configuration the bug was live
+    /// in. Built here rather than imported because `ferrox-models` does
+    /// not depend on `ferrox-cli`. `ferrox_cli::run::tests::
+    /// the_default_flags_forbid_the_metal_greedy_argmax_fold` asserts
+    /// the real `default_value_t`s resolve to this.
+    fn cli_defaults() -> SamplingParams {
+        SamplingParams {
+            temperature: 0.0,
+            top_p: 0.95,
+            min_p: 0.05,
+            top_k: 40,
+            repetition_penalty: 1.1,
+            penalty_last_n: 64,
+            ..SamplingParams::default()
+        }
+    }
+
+    /// GitHub issue #170, at the predicate: the default repetition
+    /// penalty forbids a raw-logit argmax, and `1.0` permits it.
+    ///
+    /// This is what shipped broken. `--repeat-penalty` defaults to 1.1
+    /// in this project (llama.cpp's is 1.0), the Metal fold gate read a
+    /// predicate that did not test the penalties, and a greedy `--ngl
+    /// 99` run returned a token the host sampler would not have chosen.
+    ///
+    /// Sabotage: drop the `ChainStep::Penalties` arm's
+    /// `MovesTheArgmax` for `Inert`; the first assertion goes red, and
+    /// so does every gate test in `ferrox-cli` and `ferrox-server`.
+    #[test]
+    fn the_default_repetition_penalty_forbids_a_raw_argmax_fold() {
+        let defaults = cli_defaults();
+        assert!(
+            !defaults.greedy_equals_raw_argmax(),
+            "a device argmax over raw logits skips the repetition penalty"
+        );
+        // ... and the chain BEHIND the penalties is still argmax-safe,
+        // which is what makes this assertion about the penalties and not
+        // about top-k or min-p.
+        assert!(defaults.chain_keeps_the_argmax());
+
+        // The proof that the penalties are the whole difference: the
+        // same flags at `--repeat-penalty 1.0` fold again.
+        assert!(SamplingParams {
+            repetition_penalty: 1.0,
+            ..defaults.clone()
+        }
+        .greedy_equals_raw_argmax());
+        // And so does `--repeat-last-n 0`, llama.cpp's other off switch.
+        assert!(SamplingParams {
+            penalty_last_n: 0,
+            ..defaults.clone()
+        }
+        .greedy_equals_raw_argmax());
+        // The OpenAI-shaped penalties are the same statement.
+        for moved in [
+            SamplingParams {
+                repetition_penalty: 1.0,
+                presence_penalty: 0.5,
+                ..defaults.clone()
+            },
+            SamplingParams {
+                repetition_penalty: 1.0,
+                frequency_penalty: 0.5,
+                ..defaults.clone()
+            },
+        ] {
+            assert!(
+                !moved.greedy_equals_raw_argmax(),
+                "{moved:?} moves logits before the argmax"
+            );
+        }
+        // A chain that does not NAME `penalties` does not penalise, so
+        // the fold is sound however the knobs are set.
+        assert!(SamplingParams {
+            sampler_order: SamplerOrder::from_names(["top_k", "top_p", "min_p", "temperature"])
+                .expect("a chain without penalties"),
+            ..defaults
+        }
+        .greedy_equals_raw_argmax());
+    }
+
+    /// The predicate's actual contract, exercised through the sampler
+    /// rather than asserted about itself: when
+    /// [`SamplingParams::greedy_equals_raw_argmax`] says yes, the argmax
+    /// of the RAW logits is the token the chain chooses; when it says
+    /// no, this particular case proves it was right to.
+    ///
+    /// The penalty case is the reproduction: token 0 leads by 0.2, the
+    /// history contains token 0, and `1.1` divides it below token 1. A
+    /// device fold returns 0; the sampler returns 1; the CPU reference
+    /// returns 1.
+    ///
+    /// Sabotage: as above. With `Penalties => Inert` the predicate says
+    /// the fold is sound and the `assert_ne!` below shows it is not.
+    #[test]
+    fn a_penalty_that_moves_the_argmax_is_one_the_fold_must_not_skip() {
+        let logits = vec![4.0f32, 3.8, 1.0];
+        let history = || PenaltyWindow::new(&[], &[0]);
+        let params = SamplingParams {
+            repetition_penalty: 1.1,
+            ..cli_defaults()
+        };
+
+        // 4.0 / 1.1 = 3.636, which is below 3.8.
+        let chosen = Sampler::new(7).sample(&logits, &params, history());
+        assert_eq!(chosen, 1, "the penalty demotes the raw argmax");
+        assert_ne!(
+            chosen,
+            super::super::argmax(&logits),
+            "raw argmax and the chain's answer differ, so a fold is wrong here"
+        );
+        assert!(!params.greedy_equals_raw_argmax());
+
+        // Neutralise the penalty and the two agree, which is the same
+        // proof the `--repeat-penalty 1.0` row of the table in this
+        // module's header carries.
+        let neutral = SamplingParams {
+            repetition_penalty: 1.0,
+            ..params
+        };
+        assert!(neutral.greedy_equals_raw_argmax());
+        assert_eq!(
+            Sampler::new(7).sample(&logits, &neutral, history()),
+            super::super::argmax(&logits)
+        );
+    }
+
+    /// Params under which `step` is LIVE, one per step.
+    ///
+    /// EXHAUSTIVE, no `_` arm: a step added to [`ChainStep`] does not
+    /// compile until someone supplies a configuration that switches it
+    /// on, which is what stops the next sampler being forgotten the way
+    /// the penalties were.
+    fn live_exemplar(step: ChainStep) -> SamplingParams {
+        let base = SamplingParams::default();
+        match step {
+            ChainStep::Penalties => SamplingParams {
+                repetition_penalty: 1.1,
+                ..base
+            },
+            ChainStep::Dry => SamplingParams {
+                dry: DryParams::new(6.0, 1.1, 2, -1, 1024, DryBreakers::none()),
+                ..base
+            },
+            ChainStep::TopNSigma => SamplingParams {
+                top_n_sigma: 1.0,
+                ..base
+            },
+            ChainStep::TopK => SamplingParams { top_k: 40, ..base },
+            ChainStep::TypP => SamplingParams {
+                typical_p: 0.5,
+                ..base
+            },
+            ChainStep::TopP => SamplingParams { top_p: 0.9, ..base },
+            ChainStep::MinP => SamplingParams {
+                min_p: 0.05,
+                ..base
+            },
+            ChainStep::Xtc => SamplingParams {
+                xtc_probability: 1.0,
+                xtc_threshold: 0.1,
+                ..base
+            },
+            // Temperature has no off switch; see its arm in
+            // `step_effect`.
+            ChainStep::Temperature => SamplingParams {
+                temperature: 0.8,
+                ..base
+            },
+        }
+    }
+
+    /// Every step of the chain has a verdict, every step is `Inert` at
+    /// the struct's own defaults, and every exemplar switches its step
+    /// on.
+    ///
+    /// The three halves close the loop the old predicate left open. It
+    /// hand-listed three steps of nine, so a step could be added to the
+    /// chain and never appear in it; here `step_effect`'s `match` and
+    /// `live_exemplar`'s must both name every step, and this walks
+    /// `ChainStep::all()` -- which is derived from the name table -- to
+    /// prove neither list is a private one.
+    ///
+    /// Sabotage: add `top_k: 40` to `SamplingParams::default`; the
+    /// `Inert` half goes red. Or make the `TopK` arm of `step_effect`
+    /// return `Inert` unconditionally; the exemplar half does.
+    #[test]
+    fn every_chain_step_is_classified_and_neutral_at_the_struct_defaults() {
+        let neutral = SamplingParams::default();
+        let steps = ChainStep::all();
+        assert_eq!(steps.len(), 9, "the chain gained or lost a step");
+        for step in steps {
+            // Temperature is the one step with no neutral value: it
+            // always scales, and always monotonically.
+            let expected_at_rest = if step == ChainStep::Temperature {
+                StepEffect::KeepsTheMaximum
+            } else {
+                StepEffect::Inert
+            };
+            assert_eq!(
+                step_effect(step, &neutral),
+                expected_at_rest,
+                "{step:?} is not neutral at the struct's defaults"
+            );
+            assert_ne!(
+                step_effect(step, &live_exemplar(step)),
+                StepEffect::Inert,
+                "{step:?}'s exemplar does not switch it on, so its \
+                 classification is never exercised"
+            );
+        }
+        // A neutral chain folds, which is the statement the whole table
+        // exists to make safely.
+        assert!(neutral.greedy_equals_raw_argmax());
+        assert!(neutral.chain_keeps_the_argmax());
+    }
+
+    /// Every step classified `MovesTheArgmax` refuses the fold, and no
+    /// step classified otherwise refuses it.
+    ///
+    /// This is the join between the table and the two predicates. A
+    /// verdict nothing reads would be a gate that cannot fire.
+    ///
+    /// Sabotage: make `greedy_equals_raw_argmax` ignore
+    /// `ChainStep::Penalties`, i.e. restore the old body; the
+    /// `Penalties` row goes red.
+    #[test]
+    fn a_step_that_moves_the_argmax_is_a_step_that_refuses_the_fold() {
+        for step in ChainStep::all() {
+            let live = live_exemplar(step);
+            let moves = step_effect(step, &live) == StepEffect::MovesTheArgmax;
+            assert_eq!(
+                !live.greedy_equals_raw_argmax(),
+                moves,
+                "{step:?}: the classification and the fold gate disagree"
+            );
+            // And the post-penalty predicate is the same statement with
+            // exactly one step excused, which is the whole of #170.
+            let expected_after_penalties = if step == ChainStep::Penalties {
+                true
+            } else {
+                !moves
+            };
+            assert_eq!(
+                live.chain_keeps_the_argmax(),
+                expected_after_penalties,
+                "{step:?}: the post-penalty predicate excuses the wrong step"
+            );
+        }
+    }
+
+    /// The `Inert` verdict for the penalties is the SAME condition
+    /// `apply_history_penalties` short-circuits on.
+    ///
+    /// Two copies of "the penalties are switched off" is the defect this
+    /// module is a fix for, one level down: if the classification said
+    /// inert where the penalty step still moved a logit, the fold would
+    /// be permitted over scores the host would have changed. Rather than
+    /// derive one from the other -- the penalty step's early returns are
+    /// entangled with its window scan -- this walks a matrix and asserts
+    /// they agree, so a change to either goes red.
+    ///
+    /// Sabotage: drop `|| neutral` from the `Penalties` arm; the
+    /// all-neutral rows go red.
+    #[test]
+    fn the_inert_verdict_matches_what_the_penalty_step_actually_does() {
+        use crate::sampling::penalties::apply_history_penalties;
+
+        let logits = vec![4.0f32, 3.8, -1.0];
+        for &rep in &[1.0f32, 1.1] {
+            for &pres in &[0.0f32, 0.5] {
+                for &freq in &[0.0f32, 0.5] {
+                    for &last_n in &[0usize, 64] {
+                        let params = SamplingParams {
+                            repetition_penalty: rep,
+                            presence_penalty: pres,
+                            frequency_penalty: freq,
+                            penalty_last_n: last_n,
+                            ..SamplingParams::default()
+                        };
+                        let mut scores = logits.clone();
+                        apply_history_penalties(
+                            &mut scores,
+                            &params,
+                            PenaltyWindow::new(&[], &[0, 1]),
+                        );
+                        let untouched = scores == logits;
+                        let inert = step_effect(ChainStep::Penalties, &params) == StepEffect::Inert;
+                        assert_eq!(
+                            inert,
+                            untouched,
+                            "rep={rep} pres={pres} freq={freq} last_n={last_n}: the \
+                             classification says inert={inert} and the penalty step \
+                             {}",
+                            if untouched {
+                                "changed nothing"
+                            } else {
+                                "changed the scores"
+                            }
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/ferrox-models/src/sampling/params.rs
+++ b/crates/ferrox-models/src/sampling/params.rs
@@ -18,7 +18,7 @@
 //! resolves to.
 
 use crate::dry::DryParams;
-use crate::sampler_order::{ChainStep, SamplerOrder};
+use crate::sampler_order::SamplerOrder;
 
 /// Sampling parameters for one generation request. `temperature <= 0.0`
 /// means "sample nothing, take the greedy argmax" -- the same
@@ -145,45 +145,13 @@ impl SamplingParams {
         self.xtc_probability > 0.0 && self.xtc_threshold <= 0.5
     }
 
-    /// True when no step in this chain can move the argmax, so greedy
-    /// decoding may skip building the candidate list entirely -- and a
-    /// backend may fold `lm_head + argmax` into its decode stack.
-    ///
-    /// llama.cpp does not special-case `temp <= 0`: it runs the whole
-    /// chain and lets the temperature step set every logit but the
-    /// maximum to `-inf` (`src/llama-sampler.cpp:271-286`), so a filter
-    /// that removed the maximum changes greedy output. Exactly two do:
-    ///
-    /// * `xtc` removes the TOP candidates, by construction;
-    /// * `typ_p` selects outward from the distribution's entropy and can
-    ///   drop the most likely token -- llama.cpp's own test case
-    ///   `test_typical({0.4, 0.2, 0.2, 0.2}, {0.2, 0.2, 0.2}, 0.5)`
-    ///   (`tests/test-sampling.cpp:346`) drops it.
-    ///
-    /// `dry` changes logits rather than removing candidates, but it can
-    /// change WHICH logit is the maximum, so it counts too. `top_k`,
-    /// `top_p`, `min_p` and `top_n_sigma` all keep the maximum by
-    /// construction, and `penalties` is applied to the whole vocabulary
-    /// before the candidate list exists.
-    ///
-    /// **One predicate, three readers**, because the alternative is this
-    /// repo's dominant defect: the sampler's own greedy shortcut
-    /// ([`super::greedy_choice`]), the Metal `lm_head + argmax` fold in
-    /// `ferrox_server::generate` and the same fold in `ferrox_cli::run`
-    /// must agree about it. A fold that ran while `xtc` was configured
-    /// would hand the sampler a single precomputed id with no
-    /// vocabulary left to remove anything from, and XTC would silently
-    /// not run.
-    ///
-    /// Chain membership is checked, not just the knob: a caller who set
-    /// `xtc_probability` but left `xtc` out of `--samplers` asked for no
-    /// XTC, and must keep the fast path.
-    pub fn greedy_equals_argmax(&self) -> bool {
-        let runs = |step| self.sampler_order.steps().contains(&step);
-        !(runs(ChainStep::Xtc) && self.xtc_can_fire())
-            && !(runs(ChainStep::TypP) && self.typical_p < 1.0)
-            && !(runs(ChainStep::Dry) && self.dry.is_enabled())
-    }
+    // The two "may an argmax stand in for the chain" predicates --
+    // [`Self::chain_keeps_the_argmax`] and
+    // [`Self::greedy_equals_raw_argmax`] -- are in
+    // [`super::greedy_equivalence`], with the exhaustive destructure of
+    // THIS struct that a knob added below must satisfy before the crate
+    // compiles. They used to be one function here, and it hand-listed
+    // three of the chain's nine steps: GitHub issue #170.
 }
 
 #[cfg(test)]

--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -1163,11 +1163,20 @@ impl GenerationParams {
     /// the argmax of the raw logits. A device that folded the argmax
     /// away would hand the sampler one precomputed id with no
     /// vocabulary left for XTC to remove anything from, and XTC would
-    /// silently not run. `SamplingParams::greedy_equals_argmax` is the
-    /// single predicate deciding that, shared with the sampler's own
-    /// greedy fast path and with `ferrox_cli::run`'s copy of this gate.
+    /// silently not run. `SamplingParams::greedy_equals_raw_argmax` is
+    /// the single predicate deciding that, shared with
+    /// `ferrox_cli::run`'s copy of this gate.
+    ///
+    /// The repetition / presence / frequency penalties are the FOURTH,
+    /// and they were missing from that predicate until GitHub issue
+    /// #170. They move logits over the whole vocabulary before the
+    /// candidate list exists, so a device argmax over raw logits skips
+    /// them entirely -- a wrong token, not a wrong distribution. A
+    /// request carrying any of `repeat_penalty`, `presence_penalty` or
+    /// `frequency_penalty` therefore needs the vocabulary even at
+    /// `temperature: 0`.
     pub(crate) fn needs_vocab_logits(&self) -> bool {
-        self.json_object || self.grammar.is_some() || !self.sampling.greedy_equals_argmax()
+        self.json_object || self.grammar.is_some() || !self.sampling.greedy_equals_raw_argmax()
     }
 }
 

--- a/crates/ferrox-server/src/sample_step.rs
+++ b/crates/ferrox-server/src/sample_step.rs
@@ -555,6 +555,49 @@ mod tests {
                 p.sampling
             );
         }
+
+        // And the FOURTH: the repetition / presence / frequency
+        // penalties (GitHub issue #170). They are applied to the whole
+        // vocabulary on the HOST, so a device argmax over raw logits
+        // skips them and answers a chain the caller did not configure.
+        //
+        // This route defaults them off, so the bug was only reachable
+        // here for a client that sent one; `ferrox run` defaults
+        // `--repeat-penalty` to 1.1 and had it live on every greedy
+        // `--ngl 99` run.
+        //
+        // Sabotage: revert `needs_vocab_logits` to the old
+        // `greedy_equals_argmax`; all three rows go red.
+        for penalised in [
+            ferrox_models::SamplingParams {
+                repetition_penalty: 1.1,
+                ..ferrox_models::SamplingParams::default()
+            },
+            ferrox_models::SamplingParams {
+                presence_penalty: 0.5,
+                ..ferrox_models::SamplingParams::default()
+            },
+            ferrox_models::SamplingParams {
+                frequency_penalty: 0.5,
+                ..ferrox_models::SamplingParams::default()
+            },
+        ] {
+            let mut p = params(false, 0.0);
+            p.sampling = penalised;
+            assert!(
+                !greedy_gpu_fold_allowed(&p),
+                "a live penalty must stop the fold: {:?}",
+                p.sampling
+            );
+        }
+        // A penalty with no window is no penalty, so the fold stands.
+        let mut windowless = params(false, 0.0);
+        windowless.sampling = ferrox_models::SamplingParams {
+            repetition_penalty: 1.1,
+            penalty_last_n: 0,
+            ..ferrox_models::SamplingParams::default()
+        };
+        assert!(greedy_gpu_fold_allowed(&windowless));
     }
 
     /// A grammar that waits for a trigger, with the trigger MANDATORY --

--- a/crates/ferrox-server/src/sampling_knobs.rs
+++ b/crates/ferrox-server/src/sampling_knobs.rs
@@ -609,7 +609,7 @@ mod tests {
         assert_eq!(resolved.xtc_threshold, 0.1);
         assert!(!resolved.dry.is_enabled());
         assert!(!resolved.xtc_can_fire());
-        assert!(resolved.greedy_equals_argmax());
+        assert!(resolved.greedy_equals_raw_argmax());
     }
 
     /// DRY asked for against a checkpoint with no vocabulary is a

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -157,6 +157,18 @@ token-identical. `-e`/`--escape` is on by default as it is there, and a
 *partial* `-ngl N` is refused rather than silently offloading every
 layer.
 
+That non-default default has a **Metal decode cost**, and it is
+deliberate. At `--temp 0` the Metal stack can fold
+`final_norm + lm_head + argmax` into its own command buffer and hand
+back one token id instead of `vocab_size` floats. A device argmax over
+raw logits cannot apply the penalties, so the fold is now refused
+whenever any of `--repeat-penalty`, `--presence-penalty` or
+`--frequency-penalty` is live -- which, at `--repeat-penalty 1.1`, is
+every plain greedy run. It used to fire anyway and return a token the
+host sampler would not have chosen (GitHub issue #170).
+`--repeat-penalty 1.0` or `--repeat-last-n 0` gets the fold back and
+is also what makes a run token-identical to llama.cpp's defaults.
+
 `ferrox bench -m model.gguf` works like `llama-bench`: the same `pp512`
 and `tg128` workloads, reported as a median with a population stddev.
 Add `--compare` to run `llama-bench` alongside it and print the gap.


### PR DESCRIPTION
Closes #170.

## The reproduction, before anything was changed

M2 Pro, `Llama-3.2-3B-Instruct-Q4_K_M`, `-p "What is gravity?" -n 64
--temp 0 --no-cnv`, md5 of the completion. The fold is switched off
without a kill switch by `--typical 0.999999`, which makes the gate
refuse it while leaving the argmax where it was.

| path | `--repeat-penalty` | md5 |
|---|---|---|
| Metal `--ngl 99`, fold on | 1.1 (default) | `85ef7c43…` |
| Metal `--ngl 99`, fold off | 1.1 (default) | `36c6ae0d…` |
| **CPU `--ngl 0`** | 1.1 (default) | `36c6ae0d…` |
| Metal `--ngl 99`, fold on | 1.0 | `85ef7c43…` |
| Metal `--ngl 99`, fold off | 1.0 | `85ef7c43…` |

Two readings, both decisive:

1. The folded answer at 1.1 is **bit-identical to the answer at 1.0**.
   That is what "the penalty never ran" looks like.
2. The unfolded answer at 1.1 is **bit-identical to the CPU reference**.
   So the fold-off answer is the right one and the fold-on answer is
   wrong, which the issue could not say on its own.

After the fix, Metal `--ngl 99 --repeat-penalty 1.1` returns
`36c6ae0d…`: the CPU answer.

## What the predicate actually was

`SamplingParams::greedy_equals_argmax` was **one predicate answering two
questions**, and that is the whole defect rather than a missing `&&`.

* `sampling::greedy_choice` is called *after*
  `apply_history_penalties`. Its question is "given scores the penalties
  have ALREADY been applied to, can anything left in the chain move the
  argmax?" Excluding the penalties there is correct.
* The Metal fold argmaxes the **raw** logits on the device and returns
  one token id. Nothing on the host ever sees a vocabulary, so every
  step of the chain is skipped, penalties included. Its question is
  strictly stronger.

The body answered the first question; the name and the two Metal gates
asked the second. It hand-listed three of the chain's nine steps.

## The fix

Two predicates, in a new `crates/ferrox-models/src/sampling/greedy_equivalence.rs`:

* `chain_keeps_the_argmax()` — the post-penalty question, for
  `greedy_choice`. Semantically identical to the old function.
* `greedy_equals_raw_argmax()` — the fold question, for
  `ferrox_cli::run`'s `needs_vocab_logits` and
  `ferrox_server::generate`'s.

The old name is gone, so every call site had to pick one and the
compiler checked that it did.

Both are derived from one table, not from two `&&` chains:

* an **exhaustive `match` over `ChainStep`** classifying each step as
  `Inert`, `KeepsTheMaximum` or `MovesTheArgmax`, so a sampler added to
  the chain does not compile until somebody says what it does to an
  argmax;
* an **exhaustive destructure of `SamplingParams` with no `..`**, so a
  knob added to the struct does not compile either. That is the
  enforcement the issue asked for.

The two predicates then differ by exactly one clause — whether
`ChainStep::Penalties` is excused because the caller already ran it —
which is the whole of #170 written in one line.

## Which fix, and why

**The fold is refused whenever a penalty is live.** Not: apply the
penalties before the fold.

Teaching the device to penalise means a second implementation of
`apply_history_penalties` inside a Metal kernel that has to agree with
the host one about the sign convention, the once-per-candidate rule and
the `penalty_last_n` window. That is precisely the defect shape this fix
exists to close, put back one level down, inside the fix for it. There
is a sound middle option — have the fold mask the ≤`penalty_last_n`
window tokens on device and return the window's raw logits, so the host
picks between them with the penalties it already knows how to apply, and
no penalty math moves to the GPU — but it is a real Metal kernel change
and this PR is a correctness fix.

## What else the predicate was missing

Nothing else was *wrong*, but nothing else was *stated* either. The
audit of all nine steps and all fourteen fields found:

* **`penalties` — the bug.** Repetition, presence and frequency all move
  individual logits and so can move the maximum. `penalty_last_n == 0`
  and all-neutral knobs are the two off switches, and they are the same
  two conditions `apply_history_penalties` short-circuits on;
  `the_inert_verdict_matches_what_the_penalty_step_actually_does` walks a
  16-row matrix asserting the two copies agree rather than trusting one.
* `top_n_sigma`, `top_p`, `min_p`, `top_k` — all four keep the maximum
  by construction (three of them threshold *from* the maximum). Right
  answer in the old predicate, by omission rather than by argument; now
  `KeepsTheMaximum` with the reason written down.
* `temperature` — monotone at every value, including llama.cpp's
  `temp <= 0` collapse to `-inf`. It is the one step with **no neutral
  value**, which is why `StepEffect` has three states and not two.
* `xtc`, `typ_p`, `dry` — unchanged, and now reached through the same
  table as the rest.
* Chain membership is still honoured: a `--samplers` list without
  `penalties` does not penalise, so the fold stands.

## Tests, each sabotaged with the mutation grep-confirmed in the file

New, in `greedy_equivalence`:

* `the_default_repetition_penalty_forbids_a_raw_argmax_fold`
* `a_penalty_that_moves_the_argmax_is_one_the_fold_must_not_skip` — runs
  the real `Sampler`, asserts the chain's answer differs from the raw
  argmax, and that the predicate says so
* `every_chain_step_is_classified_and_neutral_at_the_struct_defaults` —
  walks `ChainStep::all()`, which is derived from the name table, so
  neither the classification nor the exemplar list can be a private one
* `a_step_that_moves_the_argmax_is_a_step_that_refuses_the_fold` — the
  join between the table and the two predicates
* `the_inert_verdict_matches_what_the_penalty_step_actually_does`

New, in `ferrox_cli::run`:
`the_default_flags_forbid_the_metal_greedy_argmax_fold`, which parses
the real clap defaults. It is here and not in `ferrox-models` because
the DEFAULT is what made the bug live and `ferrox-models` cannot see
this crate's `default_value_t`. (`run.rs` is already 2288 lines and this
adds 47 more; `ferrox-cli` has no lib target, so an integration test
cannot reach `InferArgs`. Splitting `run.rs` is a separate change.)

Extended, in `ferrox_server::sample_step`:
`a_constrained_request_may_never_fold_lm_head_into_a_gpu_argmax` gains
the three penalties and the `penalty_last_n: 0` counter-case.

Two sabotages, both grep-confirmed in the file before the run:

1. `ChainStep::Penalties => StepEffect::Inert` unconditionally — 6 of
   the 7 tests go red, across all three crates.
2. `greedy_equals_raw_argmax` restored to excusing `Penalties`, i.e. the
   old body — `a_step_that_moves_the_argmax_is_a_step_that_refuses_the_fold`
   goes red, which is the sabotage its doc comment names.

## Verification on the M2 Pro

* `cargo test --workspace`: 62 test binaries, all green.
* `cargo test -p ferrox-metal --features metal -- --ignored`: 58 passed.
* `cargo clippy --workspace --all-targets -- -D warnings` in debug and
  release, and again with `--features metal` in both: clean.
  `cargo fmt --all`.
* `ferrox verify -m Llama-3.2-3B-Instruct-Q4_K_M.gguf`: OK, and with
  `--prompt-tokens 16` so prefill is covered too.
* `ferrox verify -m olmoe-1b-7b-0924-q4_0.gguf`: OK.
* `ferrox parity -m Llama-3.2-1B-Instruct-Q8_0.gguf`: MATCH on both
  halves (tokenizer 19/19; KL 7.219e-4 against the 1.0e-2 threshold),
  the same KL `#171` reported.
* CPU output byte-identical to before the change.

## The cost, stated plainly because it will move Metal numbers

**At the default `--repeat-penalty 1.1` the greedy GPU fold no longer
fires.** `--repeat-penalty 1.0` or `--repeat-last-n 0` gets it back.
This is recorded in `docs/FEATURES.md` and in `ferrox-metal/src/greedy_fold.rs`
so the next suite run is not a mystery regression.

Interleaved within-process GPU clock, `FERROX_METAL_GPU_TIMING=1`, 64
decode tokens, 3B Q4_K_M, sequence `1.0, 1.1, 1.0, 1.1` — the same
binary, with the fold on at 1.0 and off at 1.1:

| `--repeat-penalty` | fold | GPU clock / decode token | dispatches |
|---|---|---|---|
| 1.0 | on | 15.151 ms | 362.2 |
| 1.1 | off | 13.309 ms | 361.3 |
| 1.0 | on | 15.162 ms | 362.2 |
| 1.1 | off | 13.377 ms | 361.3 |

Ratio 0.88 **in favour of the fixed path**, and the dispatch counts say
why: the fold is one extra kernel, a 128k-element device argmax
reduction, and on this GPU that reduction costs more GPU time than it
saves.

That is not the whole story and should not be read as "the fix is free".
What the fold buys is on the **host** side, which a GPU-clock timer
cannot see: instead of four bytes, the unfolded path copies
`128256 * 4 = 513 KB` per token out of the buffer and runs a
128256-element argmax on the CPU. Whether that is visible in tok/s is a
wall-clock question, and **this host is not quiet** (another
`ferrox-server` resident on the GPU throughout, load average high), so
**no tok/s is published here and `benchmarks/RESULTS.md` is untouched**.
Somebody should measure Metal `tg` on a quiet box before and after.

A correctness fix that costs speed is still correct; the sound way to
buy the speed back is the on-device window mask described above, not a
gate that lies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
