### PR TITLE
docs(benchmarks): record that bench never uses the Metal greedy fold

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -168,6 +168,17 @@ Four traps, each of which put a wrong number in this file before:
   fusion removing 5% of dispatches was worth ~1.4% of wall against a
   ~1.1% noise floor. "No difference" measured nothing either way.
 
+- **`ferrox bench` does not use the Metal greedy argmax fold, so the
+  fold's eligibility does not move these rows.** Worth stating because
+  [#172](https://github.com/antonellof/ferrox/pull/172) stopped the fold
+  firing in `ferrox run`'s default configuration, which looks like it
+  should have changed the `tg` numbers and did not. The bench path asks
+  the engine for full logits and argmaxes them on the host
+  (`bench_guard::greedy_pick`), because a row that cannot show which
+  token it produced cannot show it computed anything. The fold is opt-in
+  through `set_metal_greedy_argmax`, which only `ferrox run` calls, and
+  its thread-local setting defaults to unset.
+
 Do not compare this file to a pre-0.13 version: those receipts had no
 warmup, so their prefill numbers include cold mmap page faults.
 


### PR DESCRIPTION
PR #172 stopped the Metal greedy argmax fold firing in `ferrox run`'s default configuration, because the fold argmaxes raw logits while the repetition penalties, on by default at 1.1, are applied on the host path.

That looks like it should move the published Metal `tg` rows. It does not, and the reason is worth writing down rather than leaving for someone to re-derive or, worse, to chase with a re-measurement.

The bench path asks the engine for full logits and argmaxes them on the host in `bench_guard::greedy_pick`, because a row that cannot show which token it produced cannot show it computed anything. The fold is opt-in through `set_metal_greedy_argmax`, which only `ferrox run` calls, and its thread-local setting defaults to unset.

So the fold's eligibility cannot reach these numbers, and the 2026-09-09 Metal receipts stand as measured.

Docs only. `cargo test -p ferrox-cli` green, including the committed-receipt checks.

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
