### PR TITLE
fix(parity): correct an inverted quant claim that made IQ4_XS unreadable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,14 @@ On `Q8_0` and `IQ4_NL`, ferrox's logits match llama.cpp's. On K-quants
 they drift, for a
 [known reason](docs/plans/llama-cpp-gap-inventory.md) that is not a
 ferrox bug: llama.cpp quantizes activations to `Q8_K` before the dot
-product and ferrox keeps them in f32. Use whichever quant you would
+product and ferrox keeps them in f32.
+
+**`IQ4_XS` is on the drifting side, not the matching one**, which the
+pair of names above makes easy to misread. ggml declares
+`vec_dot_type = Q8_K` for `IQ4_XS` and `Q8_0` for `IQ4_NL`, so they
+behave oppositely here despite the spelling. `ferrox parity` on an
+`IQ4_XS` checkpoint reads `DRIFT` by design and says so in its own
+output. Use whichever quant you would
 use with llama.cpp; if you are comparing the two, `Q8_0` is the one
 that answers the question without that variable in it.
 [docs/MODELS.md](docs/MODELS.md) lists what runs today, and which

--- a/crates/ferrox-cli/src/parity/quant.rs
+++ b/crates/ferrox-cli/src/parity/quant.rs
@@ -47,12 +47,30 @@ pub(super) fn llama_dots_this_against_q8k(kind: &str) -> bool {
 
 /// The most common quantization among a checkpoint's PER-LAYER tensors.
 ///
-/// The FILENAME is not this. `Llama-3.2-1B-Instruct-IQ4_XS.gguf`
-/// contains no IQ4_XS tensors at all -- 96 of its per-layer weights are
-/// `IQ4_NL` -- because the name is the quantization RECIPE and the
-/// recipe falls back. Reading the tensor table is the only way to know,
-/// and mistaking the two is what made that file look like a
-/// counterexample.
+/// The FILENAME is not this, because the name is the quantization
+/// RECIPE and a recipe falls back per tensor. Reading the tensor table
+/// is the only way to know.
+///
+/// `Llama-3.2-1B-Instruct-IQ4_XS.gguf`, counted from its own header, is
+/// **147 tensors: 96 IQ4_XS, 16 Q5_K (every `attn_v`), 1 Q6_K
+/// (`token_embd`, which is also the tied head), 34 F32 norms**. So the
+/// name gets the body right and says nothing about the other 17
+/// quantized tensors, and this function answers `IQ4_XS`.
+///
+/// That census replaces a claim this comment used to make -- that the
+/// same file "contains no IQ4_XS tensors at all" and is 96x `IQ4_NL` --
+/// which was inverted. The count was right and the type was wrong, and
+/// it mattered in the one direction that changes a verdict:
+/// [`llama_dots_this_against_q8k`] lists `IQ4XS` and does NOT list
+/// `IQ4NL`, so the comment described a file whose drift would be
+/// unexplained while the real file's drift is the expected §10 one. A
+/// reader who checked the claim against the file would have found the
+/// opposite and had no reason to trust the rule it was illustrating.
+///
+/// Re-checkable in one line, which is why the numbers are here rather
+/// than an assertion that it "falls back":
+/// `ferrox inspect models/Llama-3.2-1B-Instruct-IQ4_XS.gguf`
+/// (it truncates; the full census is a header parse).
 ///
 /// The output head and the embedding table are EXCLUDED, so "body" here
 /// means the body and cannot be outvoted into meaning the head on a
@@ -315,5 +333,39 @@ pub(super) mod tests {
         for q8_0_dotted in Q8_0_DOTTED {
             assert!(!llama_dots_this_against_q8k(q8_0_dotted));
         }
+    }
+
+    /// `IQ4XS` and `IQ4NL` are one character apart and land on OPPOSITE
+    /// sides of this predicate. Named as a pair, because the tests above
+    /// cannot catch them being swapped.
+    ///
+    /// `the_q8k_predicate_uses_the_dtype_debug_spelling` walks whatever
+    /// [`Q8K_DOTTED`] and [`Q8_0_DOTTED`] happen to contain, so moving
+    /// `IQ4NL` from one list to the other keeps every assertion above
+    /// green while inverting what the tool says about a real
+    /// checkpoint. This pins the two to their ggml facts directly.
+    ///
+    /// It is worth its runtime because the swap has already happened in
+    /// prose: `body_quant`'s doc claimed
+    /// `Llama-3.2-1B-Instruct-IQ4_XS.gguf` was 96x `IQ4_NL` and contained
+    /// no `IQ4_XS` at all. Counted from the file's own header it is 96x
+    /// `IQ4_XS` and zero `IQ4_NL` -- the count right, the type inverted,
+    /// and inverted across exactly this line, so the comment described a
+    /// file whose DRIFT would be unexplained while the real one's is the
+    /// expected §10 case.
+    ///
+    /// Sabotage: move `"IQ4XS"` out of the `matches!` in
+    /// [`llama_dots_this_against_q8k`], or add `"IQ4NL"` to it.
+    #[test]
+    fn iq4_xs_is_q8k_dotted_and_iq4_nl_is_not() {
+        assert!(
+            llama_dots_this_against_q8k("IQ4XS"),
+            "ggml declares vec_dot_type = Q8_K for IQ4_XS, so its drift is expected"
+        );
+        assert!(
+            !llama_dots_this_against_q8k("IQ4NL"),
+            "ggml declares vec_dot_type = Q8_0 for IQ4_NL, so a drift there is NOT \
+             excused by §10 and would be a real finding"
+        );
     }
 }


### PR DESCRIPTION
## What was wrong

`body_quant`'s doc comment used `Llama-3.2-1B-Instruct-IQ4_XS.gguf` to
teach that a filename is not a quantization, and got the example
backwards:

> `Llama-3.2-1B-Instruct-IQ4_XS.gguf` contains no IQ4_XS tensors at all
> -- 96 of its per-layer weights are `IQ4_NL`

Counted from the file's own GGUF header:

| | count |
|---|---|
| IQ4_XS | **96** |
| Q5_K (every `attn_v`) | 16 |
| Q6_K (`token_embd`, tied head) | 1 |
| F32 norms | 34 |
| **IQ4_NL** | **0** |

The count was right and the type inverted.

## Why it mattered

It is inverted across the one line that decides a verdict.
`llama_dots_this_against_q8k` lists `IQ4XS` and does **not** list
`IQ4NL`, because ggml declares `vec_dot_type = Q8_K` for IQ4_XS and
`Q8_0` for IQ4_NL. So the comment described a file whose `DRIFT` would
be *unexplained*, while the real file's `DRIFT` is the expected §10
case.

That is how this was found. I ran `ferrox parity` on the file, got
`DRIFT`, isolated it with `FERROX_METAL=0` (still `DRIFT`), and went to
the comment to confirm the cause — where the comment said the file was
IQ4_NL-bodied, i.e. that it should have matched. Checking the claim
against the file gives the opposite answer, which destroys the
authority of the rule it was illustrating.

## No behaviour change

`body_quant` already returned `IQ4_XS` for that file and the verdict was
already correct. The comment was the whole defect. The rule it teaches
is kept, with better evidence: the same file carries **three**
quantizations, so the name gets the body right and says nothing about
the other 17 quantized tensors.

## The test the old ones could not be

`the_q8k_predicate_uses_the_dtype_debug_spelling` walks whatever
`Q8K_DOTTED` and `Q8_0_DOTTED` contain, so moving `IQ4NL` from one list
to the other keeps every assertion green while inverting what the tool
says about a real checkpoint. `iq4_xs_is_q8k_dotted_and_iq4_nl_is_not`
pins the two neighbours to their ggml facts directly.

Sabotaged with the mutation grep-confirmed in the file: removing
`"IQ4XS"` from the `matches!` turns it red (along with two others).

## README

Gains the same warning. The sentence "on `Q8_0` and `IQ4_NL` ferrox's
logits match llama.cpp's" sits in a repo whose only IQ4-family
checkpoint is IQ4_XS, so the obvious thing to try returns `DRIFT` and
reads as the docs lying.

## One thing I did not change, for you to decide

`CLAUDE.md` line 51 carries the same sentence ("MATCHES on
Q8_0/IQ4_NL"). I left it alone rather than edit the repo's constitution
mid-task. Worth knowing: **no checkpoint in `models/` has an IQ4_NL
body** — I censused all 19 — so the IQ4_NL half of that claim is not
reproducible on this machine. It is theoretically sound (IQ4_NL really
is Q8_0-dotted), so I have not called it wrong; it is unevidenced
locally.

`cargo test --workspace` green, `clippy --all-targets -D warnings`
clean, `cargo fmt --all`.

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
