### PR TITLE
ui: one model selector, a URL-addressed chat, and a status control that reads as one

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -38,13 +38,20 @@ npm run check       # typecheck + lint + test
 
 `npm test` runs `node --test` over `src/lib/*.test.ts`, node strips the
 types itself, so there is no test framework in the dependency tree and
-nothing for the licence check to weigh. It covers the stream recovery
-paths in `lib/api.ts`, which are the half of SSE hardening that cannot
-be proven from the server: that a reconnect resumes from the last `id:`
-without repeating a token, that a lost replay window surfaces as a
-truncation error instead of a partial answer shown as a whole one, and
-that a non-resumable stream never tries to reconnect into a buffer that
-does not exist.
+nothing for the licence check to weigh. It covers three things a browser
+cannot show you:
+
+- the stream recovery paths in `lib/api.ts`, the half of SSE hardening
+  that cannot be proven from the server: that a reconnect resumes from
+  the last `id:` without repeating a token, that a lost replay window
+  surfaces as a truncation error instead of a partial answer shown as a
+  whole one, and that a non-resumable stream never tries to reconnect
+  into a buffer that does not exist;
+- the transcript sync's pure half in `lib/conversations.ts`, where
+  getting "which nodes are new" wrong duplicates or drops a message;
+- the entry rule in `lib/entry-state.ts` (below), where being too eager
+  throws away the conversation you were in and being too lazy resurrects
+  one for ever. Both failures are silent.
 
 CI runs `npm run licenses`, `npm run typecheck`, `npm run lint` and
 `npm run build`. It does not run `npm test`, so run `npm run check`
@@ -94,11 +101,64 @@ src/
                         one prefers-color-scheme block, nothing else)
   lib/api.ts            the ONLY place that talks HTTP
   lib/api.test.ts       stream recovery, against a stubbed fetch
+  lib/entry-state.ts    what Chat opens with, and why
+  lib/use-tab-activity  the heartbeat that measures "away"
   lib/format.ts         "unknown" is an em dash, never a zero
-  components/           app shell, health pill, shadcn-style primitives
+  components/           app shell, server status, shadcn-style primitives
   screens/chat/         assistant-ui runtime, markdown, thread
   screens/{models,activity,connect}.tsx
 ```
+
+## Where you land, and what it opens
+
+**The URL says which conversation you are in.** `/ui/chat` is a new
+chat, `/ui/chat/<id>` is that conversation, and `/` and `/ui` redirect to
+the first of those. That is what every chat UI of this shape does, and it
+is what makes the base URL a predictable entry point instead of "whatever
+was open last" — which is what this app used to do, from any path, after
+any amount of time, by opening the newest conversation it could find.
+
+The id is stamped into the URL by the first message, with `replace`, so
+Back leaves Chat rather than walking into the empty version of the
+conversation you are looking at. Opening one from the picker and starting
+a new chat are pushes, so Back undoes them.
+
+**A tab that has been away comes back to a new chat.** The window is
+`RESUME_WINDOW_MS` in `lib/entry-state.ts`, thirty minutes, and it is
+measured rather than assumed: a heartbeat stamps `sessionStorage` only
+while the document is visible, so a hidden tab, a closed lid and a
+sleeping machine accumulate away-time and a tab you are sitting in front
+of never does. `sessionStorage`, not `localStorage`, is the whole trick —
+it is per tab and dies with the tab, so a reload of a tab that was away
+all night still reads as away, while a fresh tab opened on a deep link
+has no record at all and the link is simply honoured.
+
+Two things keep this from being a rule that loses work. It never fires
+over a running generation or a half-typed message. And when it does fire
+it says so, in the number, and offers the conversation back in one click.
+No other chat UI does this at all — the research behind it found not one
+product with a staleness rule — so it is deliberately narrow, announced
+and undoable rather than silent.
+
+Local mode (a server with no `/v1/conversations`) has no ids to put in a
+URL, so it asks the same function with the one slot it has and its own
+saved-at stamp. One rule, two callers.
+
+## One model selector
+
+Choosing which model answers happens in **one** place: the menu in the
+Chat header. **Models** is the library — what is on disk, downloads, and
+`Unload`, which is the one verb the menu cannot express. It used to carry
+a second selector (a `Load` button per row, the same `POST
+/admin/models/load` for the same server-wide effect), a second `Unload`,
+and an `active:` badge restating the row's own `state` column.
+
+The sidebar's bottom control is **server status**, not a model picker. It
+used to render the loaded model id under a chevron, in the slot an
+account or settings control normally occupies, which made it read as a
+third selector; the model id belongs where the model is chosen. It never
+names a backend, either: `/health` says which backends are *available*,
+never which one is running, so "on Metal" there would be invented.
 
 ## Streams that survive a proxy
 

--- a/ui/src/components/health-pill.tsx
+++ b/ui/src/components/health-pill.tsx
@@ -4,15 +4,30 @@ import { cn } from "@/lib/utils";
 import { fmtDuration } from "@/lib/format";
 import type { HealthState } from "@/lib/use-health";
 
+// The bottom of the sidebar, which is where an app of this shape puts
+// "how is my connection" and nothing else. This one used to put the
+// LOADED MODEL ID there, under a chevron, in the slot an account or a
+// settings control normally occupies. It read as a third model picker
+// beside the two real ones, it was the widest thing in the sidebar, and
+// the one word that would have explained it ("Backend status") was in a
+// `title` attribute nobody hovers. The model id belongs where the model
+// is chosen. This belongs to the server.
+//
 // Three states, and the third one is the point: while the server is
 // still probing backends it answers `detecting`, and this shows a
 // probing pill rather than a verdict. Rendering "CPU only" from a guess
 // is pixel-identical to rendering it from a measurement, and the user
-// cannot tell which they were shown.
+// cannot tell which they were shown. The line beside the state is the
+// server's VERSION, which it states, and never a backend name: `/health`
+// says which backends are *available*, never which one is running, so an
+// "on Metal" here would be invented.
 type Visual = {
   dot: string;
   ring: string;
+  /** The state, in the server's own words wherever it has any. */
   label: string;
+  /** What is worth knowing beside it, or nothing. */
+  detail: string | null;
 };
 
 function visual({ health, error }: HealthState): Visual {
@@ -21,29 +36,34 @@ function visual({ health, error }: HealthState): Visual {
       dot: "bg-err",
       ring: "bg-err/25",
       label: error.status === 503 ? "unavailable" : "unreachable",
+      detail: error.status === 503 ? "answered, not serving" : "no answer",
     };
   }
   if (!health) {
-    return { dot: "bg-faint", ring: "bg-faint/25", label: "connecting…" };
+    return {
+      dot: "bg-faint",
+      ring: "bg-faint/25",
+      label: "connecting…",
+      detail: null,
+    };
   }
+  const version = health.version ? `v${health.version}` : null;
   switch (health.state) {
     case "ready":
-      return {
-        dot: "bg-ok",
-        ring: "bg-ok/25",
-        label: health.model?.id || "ready",
-      };
+      return { dot: "bg-ok", ring: "bg-ok/25", label: "ready", detail: version };
     case "detecting":
       return {
         dot: "bg-warn",
         ring: "bg-warn/30",
         label: "detecting backends…",
+        detail: version,
       };
     default:
       return {
         dot: "bg-err",
         ring: "bg-err/25",
         label: health.reason || "unavailable",
+        detail: version,
       };
   }
 }
@@ -55,11 +75,11 @@ export function HealthPill({ state, className }: { state: HealthState; className
   return (
     <Popover.Root>
       <Popover.Trigger
+        aria-label="Server status — open for backend and capability detail"
         className={cn(
-          "group flex w-full items-center gap-2 rounded-lg border border-line bg-raised px-2.5 py-2 text-left text-xs transition-colors hover:border-line-strong hover:bg-inset",
+          "group flex w-full items-center gap-2.5 rounded-lg border border-line bg-raised px-2.5 py-2 text-left text-xs transition-colors hover:border-line-strong hover:bg-inset",
           className,
         )}
-        title="Backend status — open for capability detail"
       >
         <span className="relative grid size-2.5 shrink-0 place-items-center">
           {state.health?.state === "detecting" ? (
@@ -72,8 +92,21 @@ export function HealthPill({ state, className }: { state: HealthState; className
           ) : null}
           <span className={cn("size-2 rounded-full", v.dot)} />
         </span>
-        <span className="min-w-0 flex-1 truncate font-medium" aria-live="polite">
-          {v.label}
+        {/* The word first. A status control you have to click to find out
+            is a status control is the thing being fixed here. */}
+        <span className="min-w-0 flex-1">
+          <span className="block text-[0.6875rem] leading-tight text-faint">
+            Server
+          </span>
+          <span
+            className="block truncate leading-tight font-medium"
+            aria-live="polite"
+          >
+            {v.label}
+            {v.detail ? (
+              <span className="font-normal text-faint"> · {v.detail}</span>
+            ) : null}
+          </span>
         </span>
         <ChevronDown className="size-3.5 shrink-0 text-faint transition-transform group-data-[state=open]:rotate-180" />
       </Popover.Trigger>

--- a/ui/src/lib/entry-state.test.ts
+++ b/ui/src/lib/entry-state.test.ts
@@ -1,0 +1,111 @@
+// Tests for the entry rule: what Chat opens with, and why.
+//
+// This is worth pinning without a browser because every failure mode is
+// silent. A rule that is too eager throws away the conversation someone
+// was in the middle of; a rule that is too lazy is the bug this replaces,
+// where every entry into the app resurrected the newest conversation for
+// ever. Neither shows up as an error anywhere.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  decideEntry,
+  describeAway,
+  RESUME_WINDOW_MS,
+  type EntryDecision,
+} from "./entry-state.ts";
+
+const NOW = 1_700_000_000_000;
+
+test("the base URL is always a new chat, however recently the tab was active", () => {
+  const decision = decideEntry({
+    conversationId: null,
+    lastActiveAt: NOW - 1000,
+    now: NOW,
+  });
+  assert.deepEqual(decision, { kind: "fresh", awayMs: null, resumable: null });
+});
+
+test("a deep link with no activity record is honoured", () => {
+  // A bookmark, a shared link, a brand-new tab: `sessionStorage` is
+  // empty, and an absent record must not read as "away for ever".
+  const decision = decideEntry({
+    conversationId: "conv_1",
+    lastActiveAt: null,
+    now: NOW,
+  });
+  assert.deepEqual(decision, { kind: "resume", conversationId: "conv_1" });
+});
+
+test("a tab that was active a moment ago keeps its conversation", () => {
+  const decision = decideEntry({
+    conversationId: "conv_1",
+    lastActiveAt: NOW - RESUME_WINDOW_MS + 1,
+    now: NOW,
+  });
+  assert.deepEqual(decision, { kind: "resume", conversationId: "conv_1" });
+});
+
+test("exactly at the window is still inside it", () => {
+  // The boundary is a strict `>` on purpose: a rule that fires at
+  // exactly the window would fire a heartbeat early on a tab that has
+  // been away for precisely the allowed time.
+  const decision = decideEntry({
+    conversationId: "conv_1",
+    lastActiveAt: NOW - RESUME_WINDOW_MS,
+    now: NOW,
+  });
+  assert.deepEqual(decision, { kind: "resume", conversationId: "conv_1" });
+});
+
+test("past the window is a new chat that still names what it declined", () => {
+  const awayMs = RESUME_WINDOW_MS + 60_000;
+  const decision = decideEntry({
+    conversationId: "conv_1",
+    lastActiveAt: NOW - awayMs,
+    now: NOW,
+  });
+  assert.deepEqual(decision, {
+    kind: "fresh",
+    awayMs,
+    resumable: "conv_1",
+  } satisfies EntryDecision);
+});
+
+test("a clock that went backwards keeps the conversation", () => {
+  // Machine slept, NTP corrected, timestamp is in the future. The safe
+  // side of this comparison is "not away": a bad clock must not delete
+  // somebody's place.
+  const decision = decideEntry({
+    conversationId: "conv_1",
+    lastActiveAt: NOW + 86_400_000,
+    now: NOW,
+  });
+  assert.deepEqual(decision, { kind: "resume", conversationId: "conv_1" });
+});
+
+test("the window is a parameter, so local mode and tab mode share one rule", () => {
+  const input = {
+    conversationId: "local",
+    lastActiveAt: NOW - 5_000,
+    now: NOW,
+  };
+  assert.deepEqual(decideEntry({ ...input, windowMs: 10_000 }), {
+    kind: "resume",
+    conversationId: "local",
+  });
+  assert.deepEqual(decideEntry({ ...input, windowMs: 1_000 }), {
+    kind: "fresh",
+    awayMs: 5_000,
+    resumable: "local",
+  });
+});
+
+test("the away time reads as a sentence, and never as zero", () => {
+  assert.equal(describeAway(null), "a while");
+  assert.equal(describeAway(30_000), "1 minutes");
+  assert.equal(describeAway(42 * 60_000), "42 minutes");
+  assert.equal(describeAway(3 * 3_600_000), "3 hours");
+  assert.equal(describeAway(3 * 86_400_000), "3 days");
+});

--- a/ui/src/lib/entry-state.ts
+++ b/ui/src/lib/entry-state.ts
@@ -1,0 +1,148 @@
+// Where Chat lands when you arrive, and why.
+//
+// Two facts decide it, and nothing else: **what the URL points at**, and
+// **how long this tab has been away**. Keeping both in one pure function
+// is the point of this module — the rule used to be a single line buried
+// in the sync effect (`else if (list.length) await open(list[0].id)`),
+// which meant every entry into the app, from any path, after any amount
+// of time, resurrected whatever conversation happened to be newest. That
+// is not a rule anybody chose; it is what "load the list, show
+// something" turns into.
+//
+// The rule, in one sentence:
+//
+//   `/ui/chat` is always a new chat, `/ui/chat/<id>` is that
+//   conversation, and a tab that has been away longer than the resume
+//   window drops back to a new chat when you return to it.
+//
+// The window is the only number here, it is named once, and when it
+// fires the screen says so out loud and offers the conversation back.
+// A rule that silently moves the user is indistinguishable from a bug.
+
+/**
+ * How long a tab may be away before Chat stops calling the conversation
+ * it was in "the one you are in".
+ *
+ * Thirty minutes, which is the usual definition of a session boundary
+ * everywhere else that has to draw this line. Short enough that coming
+ * back the next morning is a fresh start, long enough that lunch, a
+ * meeting, or a long read of an answer is not.
+ *
+ * "Away" is measured, not assumed: the timestamp is refreshed on a
+ * heartbeat only while the document is visible, so a hidden tab, a
+ * closed lid and a sleeping machine all accumulate away-time, and a tab
+ * you are sitting in front of never does.
+ */
+export const RESUME_WINDOW_MS = 30 * 60 * 1000;
+
+/** How often the "this tab is awake" timestamp is refreshed. */
+export const ACTIVITY_HEARTBEAT_MS = 30 * 1000;
+
+/**
+ * The local-mode stand-in for a conversation id.
+ *
+ * A server without `/v1/conversations` has exactly one transcript and no
+ * ids to put in a URL, so the same decision is asked with this sentinel
+ * and the stored transcript's own save time. One rule, two callers,
+ * rather than two rules that drift.
+ */
+export const LOCAL_SLOT = "local";
+
+export type EntryDecision =
+  /** Open this conversation. */
+  | { kind: "resume"; conversationId: string }
+  /**
+   * Start empty. `awayMs` is how long the tab had been away when that is
+   * the reason, and `resumable` is the conversation that was declined,
+   * so the screen can offer it back instead of losing it.
+   */
+  | { kind: "fresh"; awayMs: number | null; resumable: string | null };
+
+export type EntryInput = {
+  /** What the URL (or, in local mode, the store) points at. `null` is
+   * the bare base URL: a new chat, with nothing to decide. */
+  conversationId: string | null;
+  /** When this tab was last known to be awake, or `null` if there is no
+   * record — a fresh tab, a deep link from a bookmark, a browser that
+   * refused the storage. No record is not evidence of being away. */
+  lastActiveAt: number | null;
+  now: number;
+  windowMs?: number;
+};
+
+/**
+ * Decide what Chat opens with.
+ *
+ * Ordered, and the order is the argument:
+ *
+ *  1. **No conversation is pointed at** — the base URL. A new chat, and
+ *     nothing was declined, so nothing is offered back.
+ *  2. **The tab has been away longer than the window.** A new chat, with
+ *     the declined conversation named so it is one click away.
+ *  3. **Otherwise** the conversation is opened. A deep link with no
+ *     activity record (a bookmark, a shared link, a new tab) lands here:
+ *     an explicit navigation is explicit, whatever the clock says.
+ */
+export function decideEntry({
+  conversationId,
+  lastActiveAt,
+  now,
+  windowMs = RESUME_WINDOW_MS,
+}: EntryInput): EntryDecision {
+  if (!conversationId) return { kind: "fresh", awayMs: null, resumable: null };
+
+  if (lastActiveAt !== null) {
+    const awayMs = now - lastActiveAt;
+    // A clock that went backwards reads as "not away", which is the safe
+    // side of this comparison: it keeps the conversation rather than
+    // throwing it away on the strength of a bad timestamp.
+    if (awayMs > windowMs)
+      return { kind: "fresh", awayMs, resumable: conversationId };
+  }
+
+  return { kind: "resume", conversationId };
+}
+
+/** The away time as a sentence fragment: "42 minutes", "3 hours". */
+export function describeAway(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms)) return "a while";
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 90) return `${Math.max(1, minutes)} minutes`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 36) return `${hours} hours`;
+  return `${Math.round(hours / 24)} days`;
+}
+
+// ---------------------------------------------------------------------
+// The activity record.
+//
+// `sessionStorage`, not `localStorage`, and that is the whole design: it
+// is per tab and it dies with the tab. So a reload of a tab that has
+// been away all night still reads as away, while a brand-new tab opened
+// on a deep link has no record at all and the link is honoured. One
+// storage choice, and the two cases that used to need special-casing
+// fall out of it.
+// ---------------------------------------------------------------------
+
+const ACTIVE_AT_KEY = "ferrox.studio.tabActiveAt";
+
+export function readTabActiveAt(): number | null {
+  try {
+    const raw = sessionStorage.getItem(ACTIVE_AT_KEY);
+    if (raw === null) return null;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    // Private browsing, or storage disabled. No record means "honour the
+    // URL", which is the same answer a fresh tab gets.
+    return null;
+  }
+}
+
+export function markTabActive(now = Date.now()): void {
+  try {
+    sessionStorage.setItem(ACTIVE_AT_KEY, String(now));
+  } catch {
+    /* nothing is recorded, so nothing is ever considered stale */
+  }
+}

--- a/ui/src/lib/use-tab-activity.ts
+++ b/ui/src/lib/use-tab-activity.ts
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import {
+  ACTIVITY_HEARTBEAT_MS,
+  markTabActive,
+  readTabActiveAt,
+  RESUME_WINDOW_MS,
+} from "@/lib/entry-state";
+import { useLatest } from "@/lib/use-latest";
+
+/**
+ * Keep the tab's "last awake" stamp current, and say when it comes back.
+ *
+ * The stamp is refreshed on a heartbeat **only while the document is
+ * visible**, which is what makes the gap it leaves behind mean something:
+ * a hidden tab, a closed lid and a suspended machine all stop the
+ * heartbeat, so the gap is time the user was away rather than time that
+ * merely passed. A tab someone is sitting in front of never accumulates
+ * any.
+ *
+ * `onReturn` fires once per return, with how long the gap was, and only
+ * when the gap is longer than the window. It is a report, not a
+ * decision: what to do about it belongs to the caller, which is also the
+ * only thing that knows whether a generation is in flight.
+ */
+export function useTabActivity(
+  onReturn: (awayMs: number) => void,
+  windowMs: number = RESUME_WINDOW_MS,
+) {
+  const onReturnRef = useLatest(onReturn);
+
+  useEffect(() => {
+    const visible = () =>
+      typeof document === "undefined" || document.visibilityState === "visible";
+
+    markTabActive();
+
+    /**
+     * One tick, and both triggers run it.
+     *
+     * A heartbeat that only stamped, and a visibility handler that only
+     * compared, would be two halves of one rule that could disagree —
+     * and they did: a machine that slept with this tab in front of the
+     * user never fires `visibilitychange` at all, so only the heartbeat
+     * can see that gap, and only if the heartbeat is the thing that
+     * measures it.
+     */
+    const tick = () => {
+      if (!visible()) {
+        // Stamp the moment of leaving, so the gap starts now rather than
+        // at the last heartbeat up to `ACTIVITY_HEARTBEAT_MS` earlier.
+        markTabActive();
+        return;
+      }
+      // Read before writing: the stamp is the evidence, and overwriting
+      // it first would destroy the only record of how long this was.
+      const last = readTabActiveAt();
+      markTabActive();
+      if (last === null) return;
+      const awayMs = Date.now() - last;
+      if (awayMs > windowMs) onReturnRef.current(awayMs);
+    };
+
+    const beat = setInterval(tick, ACTIVITY_HEARTBEAT_MS);
+    document.addEventListener("visibilitychange", tick);
+    return () => {
+      clearInterval(beat);
+      document.removeEventListener("visibilitychange", tick);
+    };
+  }, [windowMs, onReturnRef]);
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -13,9 +13,17 @@ import { ConnectScreen } from "@/screens/connect";
 import "@/index.css";
 
 // `/` and `/ui` both land on Chat; `/ui/<screen>` deep links resolve
-// directly. The server answers every one of these paths with the same
-// shell (see `crates/ferrox-server/src/ui.rs`), so a reload or a
-// bookmark lands on the right screen instead of a 404.
+// directly. A static host answers every one of these paths with the same
+// `index.html`, so a reload or a bookmark lands on the right screen
+// instead of a 404.
+//
+// **The conversation is in the URL.** `/ui/chat` is a new chat and
+// `/ui/chat/<id>` is that conversation, which is what makes the base URL
+// a predictable entry point rather than "whatever was open last" — see
+// `lib/entry-state.ts` for the whole rule. The optional segment is one
+// route, not two, on purpose: two route objects would remount
+// `ChatScreen` on every switch between a new chat and a saved one, and
+// remounting it throws away the runtime holding the thread.
 const router = createBrowserRouter([
   {
     path: "/",
@@ -23,7 +31,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <Navigate to="/ui/chat" replace /> },
       { path: "ui", element: <Navigate to="/ui/chat" replace /> },
-      { path: "ui/chat", element: <ChatScreen /> },
+      { path: "ui/chat/:conversationId?", element: <ChatScreen /> },
       { path: "ui/models", element: <ModelsScreen /> },
       { path: "ui/activity", element: <ActivityScreen /> },
       { path: "ui/connect", element: <ConnectScreen /> },

--- a/ui/src/screens/chat.tsx
+++ b/ui/src/screens/chat.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import * as Popover from "@radix-ui/react-popover";
-import { Link, useOutletContext } from "react-router";
+import { Link, useNavigate, useOutletContext, useParams } from "react-router";
 import {
   Check,
   ChevronDown,
+  History,
   Loader2,
   MessagesSquare,
   SlidersHorizontal,
@@ -37,6 +38,8 @@ import {
   type Transcript,
 } from "@/screens/chat/persistence";
 import { conversationLabel } from "@/lib/conversations";
+import { describeAway, RESUME_WINDOW_MS } from "@/lib/entry-state";
+import { useTabActivity } from "@/lib/use-tab-activity";
 
 const SETTINGS_KEY = "ferrox.studio.sampling.v1";
 
@@ -428,7 +431,7 @@ function ChatInner({
     ? null
     : serving.error
       ? `Could not read ${routes.models}: ${serving.error}`
-      : "No model is loaded — load one on the Models screen before sending.";
+      : "No model is loaded — pick one from the model menu above before sending.";
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -456,8 +459,38 @@ function ChatInner({
       transport ||
       serving.synthetic ||
       disabledReason ||
+      transcript.stale ||
       transcript.error ? (
         <div className="shrink-0 space-y-2 border-b border-line bg-raised/40 px-4 py-2.5">
+          {transcript.stale ? (
+            <Notice>
+              <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <span>
+                  You were away for {describeAway(transcript.stale.awayMs)}, so
+                  this is a new chat. Anything idle for over{" "}
+                  {Math.round(RESUME_WINDOW_MS / 60_000)} minutes is not picked
+                  back up on its own.
+                </span>
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={transcript.resumeStale}
+                >
+                  <History />
+                  <span className="max-w-[14rem] truncate">
+                    Reopen {transcript.stale.label}
+                  </span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={transcript.dismissStale}
+                >
+                  Dismiss
+                </Button>
+              </span>
+            </Notice>
+          ) : null}
           {transcript.error ? (
             <Notice tone="err">
               This conversation is not being saved: {transcript.error} The
@@ -468,7 +501,7 @@ function ChatInner({
             <Notice tone="warn">
               {disabledReason}{" "}
               <Link to="/ui/models" className="underline underline-offset-2">
-                Open Models
+                Or download one
               </Link>
             </Notice>
           ) : null}
@@ -504,6 +537,11 @@ function ChatInner({
 
 export function ChatScreen() {
   const health = useOutletContext<HealthState>();
+  const navigate = useNavigate();
+  // `/ui/chat` is a new chat and `/ui/chat/<id>` is that conversation.
+  // The URL is the only place that says which one is open, so the
+  // address bar cannot disagree with the screen — see `lib/entry-state`.
+  const { conversationId } = useParams();
   const [sampling, setSamplingState] = useState<Sampling>(loadSampling);
   const [serving, refreshServing] = useServingModel(
     health?.health?.model?.id ?? null,
@@ -550,12 +588,44 @@ export function ChatScreen() {
       ),
   });
 
+  // A push moves you somewhere you asked to go; a replace corrects an
+  // address that was never a place. Opening a conversation and starting
+  // a new chat are the first kind, so Back undoes them. The URL a
+  // just-created conversation gets, and the URL a declined entry is put
+  // back to, are the second.
+  const onRoute = useCallback(
+    (id: string | null, opts?: { replace?: boolean }) => {
+      navigate(id ? `/ui/chat/${encodeURIComponent(id)}` : "/ui/chat", {
+        replace: opts?.replace ?? false,
+      });
+    },
+    [navigate],
+  );
+
   // Above the provider on purpose: the sync loop needs the runtime
   // object itself (export/import/subscribe), not the React context a
   // component under the provider would read.
   const transcript = useTranscript(runtime, {
     model: () => servingRef.current.modelId,
+    routeId: conversationId ?? null,
+    onRoute,
   });
+
+  // Coming back to a tab that has been away long enough drops to a new
+  // chat — but never over the top of work in progress. A running
+  // generation or a half-typed message means the tab was left mid-task,
+  // and "you were away" is not a reason to throw that out.
+  const transcriptRef = useLatest(transcript);
+  useTabActivity(
+    useCallback(
+      (awayMs: number) => {
+        if (runtime.thread.getState().isRunning) return;
+        if (runtime.thread.composer.getState().text.trim()) return;
+        transcriptRef.current.onReturnedAfterAway(awayMs);
+      },
+      [runtime, transcriptRef],
+    ),
+  );
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/ui/src/screens/chat/persistence.ts
+++ b/ui/src/screens/chat/persistence.ts
@@ -17,6 +17,12 @@ import {
   type ConversationSummary,
   type ExportedRepository,
 } from "@/lib/conversations";
+import {
+  decideEntry,
+  LOCAL_SLOT,
+  readTabActiveAt,
+  type EntryDecision,
+} from "@/lib/entry-state";
 import { useLatest } from "@/lib/use-latest";
 
 // Where the transcript lives.
@@ -36,14 +42,48 @@ import { useLatest } from "@/lib/use-latest";
 // The one thing neither mode does is guess. When the store cannot be
 // reached, nothing is silently dropped and nothing is silently kept
 // somewhere else: the mode is reported and the reason with it.
+//
+// **Which conversation is open is not decided here.** In server mode the
+// URL decides it and this module follows; the whole rule, including what
+// "after a while" means, lives in `lib/entry-state.ts` and is applied in
+// exactly one place below. Local mode has no ids to put in a URL, so it
+// asks the same function with the one slot it has.
 
-const LOCAL_KEY = "ferrox.studio.thread.v2";
+const LOCAL_KEY = "ferrox.studio.thread.v3";
+/** The shape before the transcript carried its own save time. */
+const LEGACY_LOCAL_KEY = "ferrox.studio.thread.v2";
+
+type LocalTranscript = {
+  /** When this was written. The entry rule needs an age, and a blob that
+   * cannot say how old it is cannot be aged out. */
+  savedAt: number | null;
+  exported: { messages: unknown[] };
+};
 
 /** Anything unparseable is dropped: a corrupt blob must not wedge Chat. */
-function readLocal(): { messages?: unknown[] } | null {
+function readLocal(): LocalTranscript | null {
   try {
     const raw = localStorage.getItem(LOCAL_KEY);
-    return raw ? JSON.parse(raw) : null;
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<LocalTranscript>;
+      const messages = parsed?.exported?.messages;
+      if (!Array.isArray(messages) || !messages.length) return null;
+      return {
+        savedAt:
+          typeof parsed.savedAt === "number" && Number.isFinite(parsed.savedAt)
+            ? parsed.savedAt
+            : null,
+        exported: { messages },
+      };
+    }
+    // A transcript written before this key carried a timestamp. It has no
+    // age, and `decideEntry` reads a missing age as "no evidence of being
+    // away", so it is restored once and rewritten in the new shape.
+    const legacy = localStorage.getItem(LEGACY_LOCAL_KEY);
+    if (!legacy) return null;
+    const parsed = JSON.parse(legacy) as { messages?: unknown[] };
+    if (!Array.isArray(parsed?.messages) || !parsed.messages.length) return null;
+    return { savedAt: null, exported: { messages: parsed.messages } };
   } catch {
     return null;
   }
@@ -51,8 +91,16 @@ function readLocal(): { messages?: unknown[] } | null {
 
 function writeLocal(exported: { messages: unknown[] }) {
   try {
-    if (!exported.messages.length) clearLocalTranscript();
-    else localStorage.setItem(LOCAL_KEY, JSON.stringify(exported));
+    // An empty transcript is never written, and never clears a stored
+    // one. A new chat starts empty while the previous transcript is
+    // still being offered back, and a write here would delete the thing
+    // the offer points at. Clearing is an explicit act: `newChat`.
+    if (!exported.messages.length) return;
+    localStorage.setItem(
+      LOCAL_KEY,
+      JSON.stringify({ savedAt: Date.now(), exported } satisfies LocalTranscript),
+    );
+    localStorage.removeItem(LEGACY_LOCAL_KEY);
   } catch {
     /* quota or private browsing — the in-memory thread still works */
   }
@@ -61,6 +109,7 @@ function writeLocal(exported: { messages: unknown[] }) {
 export function clearLocalTranscript() {
   try {
     localStorage.removeItem(LOCAL_KEY);
+    localStorage.removeItem(LEGACY_LOCAL_KEY);
   } catch {
     /* private browsing: nothing was persisted to begin with */
   }
@@ -73,6 +122,20 @@ const DEBOUNCE_MS = 500;
 
 export type TranscriptMode = "checking" | "server" | "local";
 
+/**
+ * A conversation that was NOT opened, and could be.
+ *
+ * Set only when the entry rule declined one — the tab had been away
+ * longer than the resume window. It is what turns "you have been moved"
+ * into "you have been moved, here is the way back".
+ */
+export type StaleOffer = {
+  /** A conversation id, or `LOCAL_SLOT` in local mode. */
+  id: string;
+  label: string;
+  awayMs: number | null;
+};
+
 export type Transcript = {
   mode: TranscriptMode;
   /** Why the transcript is browser-local, when it is. */
@@ -83,10 +146,20 @@ export type Transcript = {
   error: string | null;
   current: { id: string; title: string | null } | null;
   summaries: ConversationSummary[];
+  /** The conversation the entry rule declined to reopen, if any. */
+  stale: StaleOffer | null;
   refresh: () => void;
   open: (id: string) => void;
   newChat: () => void;
   remove: (id: string) => void;
+  /** Take up the declined conversation after all. */
+  resumeStale: () => void;
+  /** Drop the offer without taking it. */
+  dismissStale: () => void;
+  /** The tab came back after being away. Applied here rather than in the
+   * screen so there is one implementation of "go fresh, offer the way
+   * back", shared with the one that runs at load. */
+  onReturnedAfterAway: (awayMs: number) => void;
 };
 
 type SyncState = {
@@ -104,6 +177,18 @@ type SyncState = {
    * back as if the user had typed it. */
   suspended: boolean;
   migrating: boolean;
+  /**
+   * The conversation the entry rule DECLINED to open.
+   *
+   * The URL cannot be corrected synchronously — asking the router to
+   * replace it is a state update, and the route effect runs once more on
+   * the old id before the new one arrives. Without this the effect
+   * loaded exactly the conversation the rule had just declined, which is
+   * how the rule came to fire, print its banner, and then be undone by
+   * the very next effect. Cleared the moment the route points anywhere
+   * else.
+   */
+  declined: string | null;
 };
 
 function sentence(cause: unknown): string {
@@ -120,10 +205,19 @@ function sentence(cause: unknown): string {
  * append. Nothing is ever pulled back into a live thread, because two
  * writers on one transcript is how a message gets lost, and this server
  * serves one person's Chat screen.
+ *
+ * `routeId` is the conversation the URL points at, and `onRoute` is how
+ * this asks for a different one. Opening a conversation is therefore a
+ * navigation, never a direct load: one path in, so the address bar
+ * cannot disagree with what is on screen.
  */
 export function useTranscript(
   runtime: AssistantRuntime,
-  deps: { model: () => string | null },
+  deps: {
+    model: () => string | null;
+    routeId: string | null;
+    onRoute: (id: string | null, opts?: { replace?: boolean }) => void;
+  },
 ): Transcript {
   const [mode, setMode] = useState<TranscriptMode>("checking");
   const [reason, setReason] = useState<string | null>(null);
@@ -134,6 +228,19 @@ export function useTranscript(
     title: string | null;
   } | null>(null);
   const [summaries, setSummaries] = useState<ConversationSummary[]>([]);
+  const [stale, setStale] = useState<StaleOffer | null>(null);
+
+  // Read during the FIRST RENDER, before any effect has run.
+  //
+  // The heartbeat in `useTabActivity` stamps the tab as awake from its
+  // own mount effect, and the probe below reads this from inside a
+  // promise — so by the time the probe asks, the heartbeat has already
+  // overwritten the only evidence that the tab was away. Capturing it
+  // here, synchronously, is what makes the load-time half of the entry
+  // rule reachable at all. It was not, when this was a call inside the
+  // probe: the tab always looked freshly active and the rule never
+  // fired once.
+  const [entryActiveAt] = useState<number | null>(readTabActiveAt);
 
   const depsRef = useLatest(deps);
   const sync = useRef<SyncState>({
@@ -145,6 +252,7 @@ export function useTranscript(
     dirty: false,
     suspended: true,
     migrating: false,
+    declined: null,
   });
 
   const setBoth = useCallback((next: TranscriptMode) => {
@@ -188,6 +296,7 @@ export function useTranscript(
     setSaving(true);
     try {
       const head = pending.headId ? { head_id: pending.headId } : {};
+      const created = !s.conversationId;
       const conversation = s.conversationId
         ? await updateConversation(s.conversationId, {
             append: pending.messages,
@@ -206,6 +315,13 @@ export function useTranscript(
       s.storedHead = conversation.head_id;
       setCurrent({ id: conversation.id, title: conversation.title });
       setError(null);
+      if (created) {
+        // The first send is what turns a new chat into a conversation,
+        // so it is also what puts it in the address bar. `replace`, not
+        // `push`: Back should leave Chat, not walk backwards into the
+        // empty version of the conversation you are looking at.
+        depsRef.current.onRoute(conversation.id, { replace: true });
+      }
       if (s.migrating) {
         // The browser copy is dropped only once the server has echoed
         // the messages back. Clearing it on the way out would lose the
@@ -229,7 +345,26 @@ export function useTranscript(
     }
   }, [runtime, depsRef, refresh]);
 
-  const open = useCallback(
+  /** Empty the thread and forget which conversation it was. Does not
+   * navigate and does not delete anything: the callers decide both. */
+  const resetThread = useCallback(() => {
+    const s = sync.current;
+    s.suspended = true;
+    runtime.thread.cancelRun();
+    runtime.thread.reset();
+    s.conversationId = null;
+    s.stored = new Set();
+    s.storedHead = null;
+    s.migrating = false;
+    setCurrent(null);
+    setError(null);
+    s.suspended = false;
+  }, [runtime]);
+
+  /** Pull a conversation out of the store and into the thread. Called
+   * only from the route effect and the first landing, so there is one
+   * way for a conversation to become the open one. */
+  const load = useCallback(
     async (id: string) => {
       const s = sync.current;
       s.suspended = true;
@@ -255,25 +390,19 @@ export function useTranscript(
   );
 
   const newChat = useCallback(() => {
-    const s = sync.current;
-    s.suspended = true;
-    runtime.thread.cancelRun();
-    runtime.thread.reset();
-    s.conversationId = null;
-    s.stored = new Set();
-    s.storedHead = null;
-    s.migrating = false;
-    setCurrent(null);
-    setError(null);
-    if (s.mode === "local") clearLocalTranscript();
-    s.suspended = false;
-  }, [runtime]);
+    resetThread();
+    setStale(null);
+    sync.current.declined = null;
+    if (sync.current.mode === "local") clearLocalTranscript();
+    depsRef.current.onRoute(null);
+  }, [resetThread, depsRef]);
 
   const remove = useCallback(
     async (id: string) => {
       try {
         await deleteConversation(id);
         if (sync.current.conversationId === id) newChat();
+        setStale((offer) => (offer?.id === id ? null : offer));
         refresh();
       } catch (cause) {
         setError(sentence(cause));
@@ -282,30 +411,127 @@ export function useTranscript(
     [newChat, refresh],
   );
 
-  // Probe once: does this server keep conversations at all?
+  /**
+   * Apply an entry decision.
+   *
+   * One implementation, three callers: the first landing in server mode,
+   * the first landing in local mode, and the tab coming back after being
+   * away. A second copy of "reset, navigate, remember what was declined"
+   * is exactly the shape that drifts.
+   */
+  const applyEntry = useCallback(
+    (decision: EntryDecision, label: (id: string) => string) => {
+      if (decision.kind === "resume") return decision.conversationId;
+      sync.current.declined = decision.resumable;
+      if (decision.resumable) {
+        setStale({
+          id: decision.resumable,
+          label: label(decision.resumable),
+          awayMs: decision.awayMs,
+        });
+      }
+      return null;
+    },
+    [],
+  );
+
+  const resumeStale = useCallback(() => {
+    const offer = stale;
+    if (!offer) return;
+    setStale(null);
+    // Explicitly asked for, so it is no longer declined -- and the route
+    // effect below would otherwise skip the very navigation this makes.
+    sync.current.declined = null;
+    if (offer.id === LOCAL_SLOT) {
+      const local = readLocal();
+      if (!local) return;
+      const s = sync.current;
+      s.suspended = true;
+      try {
+        runtime.thread.import(local.exported as never);
+      } catch {
+        clearLocalTranscript();
+      } finally {
+        s.suspended = false;
+      }
+      return;
+    }
+    depsRef.current.onRoute(offer.id);
+  }, [stale, runtime, depsRef]);
+
+  const dismissStale = useCallback(() => setStale(null), []);
+
+  const onReturnedAfterAway = useCallback(
+    (awayMs: number) => {
+      const s = sync.current;
+      if (s.mode === "checking") return;
+      const openId =
+        s.mode === "local"
+          ? readLocal()
+            ? LOCAL_SLOT
+            : null
+          : s.conversationId;
+      if (!openId) return;
+      const label =
+        openId === LOCAL_SLOT
+          ? "your last chat"
+          : (current?.title?.trim() || "the last conversation");
+      resetThread();
+      // Same call the first landing makes, so "go fresh and offer the way
+      // back" has one implementation and the two triggers cannot drift.
+      applyEntry({ kind: "fresh", awayMs, resumable: openId }, () => label);
+      if (s.mode === "server") depsRef.current.onRoute(null, { replace: true });
+    },
+    [current, resetThread, applyEntry, depsRef],
+  );
+
+  // Probe once: does this server keep conversations at all? The answer
+  // decides the mode, and the mode decides which half of the entry rule
+  // applies.
   useEffect(() => {
     let cancelled = false;
     const s = sync.current;
+    const entryRouteId = depsRef.current.routeId;
 
     listConversations()
       .then(async (list) => {
         if (cancelled) return;
         setBoth("server");
         setSummaries(list);
+
+        const titleOf = (id: string) =>
+          list.find((entry) => entry.id === id)?.title?.trim() ||
+          "the last conversation";
+        const open = applyEntry(
+          decideEntry({
+            conversationId: entryRouteId,
+            lastActiveAt: entryActiveAt,
+            now: Date.now(),
+          }),
+          titleOf,
+        );
+
+        if (open) {
+          await load(open);
+          return;
+        }
+        // A new chat. The URL is put back to the bare `/ui/chat` so the
+        // address bar and the screen agree; without this a reload would
+        // walk straight back into the conversation just declined.
+        if (entryRouteId) depsRef.current.onRoute(null, { replace: true });
+
         const local = readLocal();
-        if (local?.messages?.length) {
+        if (local) {
           // A transcript from before this server had a store. It is
           // imported into the thread and then written through the
           // normal sync path, so there is one code path that creates a
           // conversation rather than two.
           try {
-            runtime.thread.import(local as never);
+            runtime.thread.import(local.exported as never);
             s.migrating = true;
           } catch {
             clearLocalTranscript();
           }
-        } else if (list.length) {
-          await open(list[0].id);
         }
       })
       .catch((cause) => {
@@ -316,10 +542,23 @@ export function useTranscript(
             ? "This server has no conversation API, so the transcript is kept in this browser only."
             : `The conversation store could not be reached (${sentence(cause)}), so the transcript is kept in this browser only.`,
         );
+        // No ids exist in this mode, so a conversation id in the URL
+        // cannot mean anything: the address bar is put back to the bare
+        // path rather than left pointing at something unreachable.
+        if (entryRouteId) depsRef.current.onRoute(null, { replace: true });
+
         const local = readLocal();
-        if (local?.messages?.length) {
+        const open = applyEntry(
+          decideEntry({
+            conversationId: local ? LOCAL_SLOT : null,
+            lastActiveAt: local?.savedAt ?? null,
+            now: Date.now(),
+          }),
+          () => "your last chat",
+        );
+        if (open && local) {
           try {
-            runtime.thread.import(local as never);
+            runtime.thread.import(local.exported as never);
           } catch {
             clearLocalTranscript();
           }
@@ -336,6 +575,27 @@ export function useTranscript(
     // thread the user is in the middle of.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runtime]);
+
+  // The URL is the single source of truth for which conversation is
+  // open. Every other path -- the picker, New chat, a created
+  // conversation, the Back button -- moves the URL and lands here.
+  //
+  // The lint rule below is about effects that write state React already
+  // knows; this one drives an EXTERNAL system, the assistant-ui runtime
+  // holding the thread, and the state it touches is the label describing
+  // what that runtime now contains. It fires only when the route id
+  // actually changes, so there is no cascade.
+  const routeId = deps.routeId;
+  useEffect(() => {
+    const s = sync.current;
+    if (s.mode !== "server") return;
+    if (routeId !== null && routeId === s.declined) return;
+    s.declined = null;
+    if (routeId === s.conversationId) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (routeId === null) resetThread();
+    else void load(routeId);
+  }, [routeId, mode, load, resetThread]);
 
   // Coalesced writes. The thread notifies once per decoded token, and a
   // request per token would stutter the stream it is recording.
@@ -358,9 +618,13 @@ export function useTranscript(
     error,
     current,
     summaries,
+    stale,
     refresh,
-    open: (id) => void open(id),
+    open: (id) => depsRef.current.onRoute(id),
     newChat,
     remove: (id) => void remove(id),
+    resumeStale,
+    dismissStale,
+    onReturnedAfterAway,
   };
 }

--- a/ui/src/screens/models.tsx
+++ b/ui/src/screens/models.tsx
@@ -1,6 +1,21 @@
-// Models: the inventory, the swap, and the download job.
+// Models: the library. What is on disk, how to get more, and how to give
+// the memory back.
 //
-// Two rules this screen exists to respect.
+// **Choosing which model answers is not done here.** It is done in the
+// picker in the Chat header, which is the only model selector in this
+// app. This screen used to carry a second one — a `Load` button on every
+// row, posting the same `/admin/models/load` to the same server for the
+// same effect — plus an `Unload` in the header AND an `Unload` in the
+// loaded row, and an `active:` badge restating what the row's own state
+// column already said. Four controls and two badges for two verbs.
+//
+// The split it now follows is the one every UI of this shape converged
+// on: a management screen installs, removes and reports; a picker beside
+// the conversation selects. `Unload` stays because it is the one verb
+// the picker cannot express — give the memory back without putting
+// something else in it — and it exists exactly once.
+//
+// Two more rules this screen exists to respect.
 //
 // **A rate is shown only when the server calls the task `stable`.** The
 // backend runs a rolling-window estimator that refuses to divide until
@@ -14,13 +29,8 @@
 // explanation rather than as a broken table.
 
 import { useCallback, useEffect, useState } from "react";
-import {
-  Boxes,
-  CloudDownload,
-  HardDriveDownload,
-  RefreshCw,
-  Search,
-} from "lucide-react";
+import { Boxes, CloudDownload, RefreshCw, Search } from "lucide-react";
+import { Link } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -209,8 +219,6 @@ export function ModelsScreen() {
     await refresh();
   };
 
-  const loadModel = (id: string) =>
-    act(`Loading ${id}`, () => postJson(routes.adminModelsLoad, { id }));
   const unloadModel = () =>
     act("Unload", () => postJson(routes.adminModelsUnload));
   const cancelTask = (taskId: string) =>
@@ -262,9 +270,6 @@ export function ModelsScreen() {
   }
 
   const active = inventory?.active ?? null;
-  const anyLoading = (inventory?.models ?? []).some(
-    (m) => m.state === "loading",
-  );
   const needle = filter.trim().toLowerCase();
   const visible = (inventory?.models ?? []).filter(
     (m) =>
@@ -281,7 +286,7 @@ export function ModelsScreen() {
         description={
           inventory?.model_dir
             ? `Scanning ${inventory.model_dir}`
-            : "Inventory, load / unload, and Hugging Face downloads."
+            : "What is on disk, Hugging Face downloads, and giving the memory back."
         }
         actions={
           <>
@@ -303,11 +308,12 @@ export function ModelsScreen() {
       <Card>
         <CardHeader>
           <CardTitle>Inventory</CardTitle>
-          {active ? (
-            <Badge tone="ok">active: {active}</Badge>
-          ) : (
-            <Badge tone="neutral">nothing loaded</Badge>
-          )}
+          {/* The active checkpoint is stated once on this screen. When
+              there is one it is on the `Unload …` button, which names it
+              and does something about it; only the empty case needs a
+              badge of its own. The `state` column says the same thing
+              per row and is where the eye goes anyway. */}
+          {active ? null : <Badge tone="neutral">nothing loaded</Badge>}
           <span className="flex-1" />
           <div className="relative">
             <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-faint" />
@@ -361,12 +367,10 @@ export function ModelsScreen() {
                   <Th numeric>on disk</Th>
                   <Th numeric>resident</Th>
                   <Th>state</Th>
-                  <Th />
                 </Tr>
               </thead>
               <tbody>
                 {visible.map((entry) => {
-                  const loaded = entry.id === active;
                   return (
                     <Tr key={entry.id}>
                       <Td mono className="max-w-[22rem]">
@@ -395,32 +399,6 @@ export function ModelsScreen() {
                       <Td>
                         <StateBadge entry={entry} activeId={active} />
                       </Td>
-                      <Td className="text-right">
-                        {loaded ? (
-                          <Button
-                            variant="default"
-                            size="sm"
-                            onClick={unloadModel}
-                          >
-                            Unload
-                          </Button>
-                        ) : (
-                          <Button
-                            variant="primary"
-                            size="sm"
-                            disabled={anyLoading}
-                            title={
-                              anyLoading
-                                ? "a load is already in progress"
-                                : undefined
-                            }
-                            onClick={() => loadModel(entry.id)}
-                          >
-                            <HardDriveDownload />
-                            Load
-                          </Button>
-                        )}
-                      </Td>
                     </Tr>
                   );
                 })}
@@ -430,7 +408,11 @@ export function ModelsScreen() {
         )}
 
         <CardFooter>
-          A load swaps the checkpoint for every client of this server; an
+          Pick which of these answers in the model menu at the top of{" "}
+          <Link to="/ui/chat" className="text-accent underline">
+            Chat
+          </Link>
+          . A swap loads the checkpoint for every client of this server; an
           in-flight request finishes on the weights it started on.
         </CardFooter>
       </Card>


### PR DESCRIPTION
Three complaints — a duplicate model selector, entry state that resurrects
old chats, and a bottom-of-sidebar control that is not intuitive — turned
out to share one cause. No fact in this app had a single owner, so
"which model", "which conversation" and "what is this control" were each
stated by two or three surfaces with nothing keeping them in agreement.

## What I found

**Three surfaces claimed to be a model selector; two of them were.**

| Surface | What it did | Verdict |
|---|---|---|
| Chat header menu (`chat.tsx` `ModelSwitcher`) | `POST /admin/models/load` | **kept** |
| Models table `Load` button per row | `POST /admin/models/load` — same call, same server-wide effect | **removed** |
| Sidebar bottom pill (`HealthPill`) | rendered the loaded model id under a chevron; opened a `/health` panel | **not a selector, made to look like one** |

They are not different scopes. `ferrox-server` serves one checkpoint,
`/v1/chat/completions` has no per-request model override, and the Chat
menu's own footnote already said so: "Loading a checkpoint swaps it for
every client of this server." A per-conversation override would have been
a real feature worth keeping; there is no such thing here to keep.

The Models screen was also duplicating itself: an `Unload {active}` in
the page header **and** an `Unload` in the loaded row, plus an
`active: <id>` badge restating what that row's own `state` column already
said. Four controls and two badges for two verbs.

**Entry state had no rule, only a fallthrough.** `persistence.ts` ended
its probe with `else if (list.length) await open(list[0].id)`. Every
entry into the app — `/`, `/ui`, `/ui/chat`, a reload, a bookmark, after
five seconds or five weeks — reopened whatever conversation was newest.
Nobody chose that; it is what "load the list, show something" becomes.

**The sidebar's bottom control** put the loaded model id under a chevron
in the slot an account/settings control normally occupies. The one word
that would have explained it, "Backend status", was in a `title`
attribute. It read as a third model picker and was the widest thing in
the sidebar.

## What the Ollama-style UIs actually do

Researched from source and docs: the Ollama app (v0.34.0), Open WebUI
(v0.11.3), LM Studio, ChatGPT web, Claude web, llama.cpp's own WebUI, HF
chat-ui, LibreChat, Hollama, Page Assist, Enchanted, Msty, Chatbot
Ollama.

**Adopted:**

1. **Root `/` is a new chat; an existing chat is `/<something>/<id>`.**
   Universal — ChatGPT `/c/<uuid>`, Open WebUI `/c/<uuid>`, Ollama
   `/c/<id>`, llama.cpp `/chat/<id>`, HF chat-ui `/conversation/<id>`,
   LibreChat `/c/:id`, Claude `/new` + `/chat/<uuid>`. Not one of them
   restores the last conversation from the root URL. Here: `/ui/chat` and
   `/ui/chat/<id>`.
2. **The id appears at the first message and swaps in place**
   (`replace`, no history entry). Open WebUI, Ollama and ChatGPT all do
   this. So Back leaves Chat rather than walking into the empty version
   of the conversation you are looking at.
3. **Selection and management are separated by verb.** Where both exist
   — Msty ("the administrative center" vs the in-conversation selector),
   Page Assist, Open WebUI — the management screen installs, removes and
   reports, and a picker beside the conversation selects. That settles
   which of our two selectors survives, and why `Unload` stays on Models:
   it is the one verb the picker cannot express, giving the memory back
   without putting something else in it.
4. **Bottom-of-sidebar is status/account, never selection.** Nobody puts
   a model picker there.

**Rejected, with reasons:**

- **A staleness rule.** The research found **no product anywhere** with
  one — its explicit advice was "do not invent one". But you asked for
  it, and once the routing is fixed it only bites in one case: a tab left
  open for a long time. So it is implemented as narrowly as it can be:
  it fires only for a tab that has actually been away, never over a
  running generation or a half-typed message, it announces itself with
  the real number, and it offers the conversation back in one click. I
  would not defend it as a silent rule; I do defend it as this one.
- **Reopening a conversation reseeds the model picker from that
  conversation's model** (Ollama and llama.cpp implement this
  identically). Wrong here: on `ferrox-server` that is a real multi-GB
  `POST /admin/models/load` affecting every client of the server, not a
  cheap per-request field. Opening an old chat must not silently start a
  checkpoint load.
- **Moving the model picker into the composer.** The single biggest
  recent shift in this space — Ollama, Open WebUI (since v0.11.0),
  ChatGPT, Claude and llama.cpp's WebUI all moved it from the header into
  the input box within about a year. I did not do it: it is a layout
  change to `thread.tsx` rather than a duplicate to delete, and the
  header position is still what LibreChat, Page Assist, Enchanted and
  Cherry Studio ship. Proposing it separately.
- **Conversation list in the sidebar, "New chat" as its top row.** Also
  near-universal (Open WebUI, LibreChat, ChatGPT, Claude, HF chat-ui,
  llama.cpp, Hollama), and "a dropdown conversation list is used by
  nobody serious" is a fair hit on our header `ConversationPicker`. Same
  reasoning: that is a redesign of the shell, not a cleanup. Proposing it
  separately, along with `Cmd/Ctrl+Shift+O` for new chat, which is now a
  de facto standard.
- **Suppressing browser semantics** (Ollama's webview disables Cmd+R and
  blocks back/forward). Actively wrong for a real web UI.
- **Empty-state content.** Genuinely contested — nothing at all (Ollama),
  one line (Hollama, llama.cpp), greeting (ChatGPT, Claude), suggestions
  (Enchanted, LibreChat). No consensus to copy, so ours is untouched.

## What changed

**One selector.** Models loses the per-row `Load`, the duplicate row-level
`Unload`, and the `active:` badge; its action column is gone and the table
is now purely facts. Its footer points at where selection happens. The
Chat header menu is the only model selector in the app.

**Server status reads as server status.** The sidebar pill says `Server`
and then the state (`ready · v<server version>`), with an `aria-label` rather than a
`title`. The model id, capabilities, version, pid and last-request age
are all still one click away in the same popover. It still never names a
backend: `/health` reports which backends are *available*, never which
one is running, so an "on Metal" there would be invented — the same rule
the file already held for `detecting`.

**The URL owns the conversation.** One route with an optional segment
(`ui/chat/:conversationId?`), deliberately one route object and not two,
because two would remount `ChatScreen` on every switch and throw away the
runtime holding the thread. Opening a conversation is now a navigation
rather than a direct load, so the address bar cannot disagree with the
screen. Pushes for what you asked for (picker, New chat), replaces for
corrections (a created id, a declined entry).

**The away rule, in one place.** `lib/entry-state.ts` holds
`RESUME_WINDOW_MS` (30 minutes) and one pure `decideEntry`. "Away" is
measured, not assumed: `use-tab-activity.ts` stamps `sessionStorage` on a
heartbeat **only while the document is visible**, so a hidden tab, a
closed lid and a sleeping machine accumulate away-time and a tab you are
sitting in front of never does. `sessionStorage` rather than
`localStorage` is the whole trick — per tab, dies with the tab — so a
reload of a night-old tab still reads as away while a fresh tab opened on
a deep link has no record at all and the link is simply honoured. Local
mode (a server with no `/v1/conversations`) has no ids for a URL, so it
asks the same function with the one slot it has and the transcript's own
saved-at stamp. One rule, two callers.

The number is not buried: it is one exported constant with its reasoning,
it is printed in the banner when the rule fires ("You were away for 3
hours, so this is a new chat. Anything idle for over 30 minutes is not
picked back up on its own."), and it is in `ui/README.md`.

## Two defects found while building it

Both are this repo's dominant shape — two things that must agree, with
nothing enforcing it — and both were found by using the thing, not by
reading it.

1. **The load-time half of the rule could never fire.** `useTabActivity`
   stamps the tab as awake from its mount effect; the entry check read
   that stamp from inside a promise, so by the time it asked, the
   evidence was always already overwritten. It looked like it worked
   because the resume branch is also the branch that does nothing
   visible. The stamp is now captured during the first render, before any
   effect runs.
2. **The route effect re-loaded exactly the conversation the rule had
   just declined.** Asking the router to correct the URL is a state
   update, so the effect runs once more on the old id before the new one
   arrives — it fired, printed its banner, and was then silently undone
   by the very next effect, with the old transcript back on screen under
   a banner saying it was a new chat. The declined id is now held until
   the route points elsewhere.

## Tests

`ui/src/lib/entry-state.test.ts`, seven cases: base URL always fresh, a
deep link with no activity record honoured, inside the window resumes,
**exactly at** the window is still inside it, past it goes fresh and
names what it declined, a clock that went backwards keeps the
conversation, and the window as a parameter so local mode and tab mode
share one rule.

Sabotaged once to confirm it can fail: `>` to `>=` in `decideEntry`,
grepped the file to confirm the mutation had landed, ran the suite —
"exactly at the window is still inside it" went red, 30 pass / 1 fail —
then reverted and confirmed 31 pass.

## Verified in a browser vs only in tests

Against a real `ferrox-server` (`-ngl 99`, Metal, a 14-model inventory
and 7 stored conversations), Vite pointed at it with no mock:

- `/` lands on an empty new chat with the empty state — previously it
  reopened the newest conversation.
- Picking a conversation moves the URL to `/ui/chat/<id>` and loads it.
- Reload at `/ui/chat/<id>` in the same tab keeps the conversation.
- Deep link in a **brand-new tab** (no `sessionStorage`) loads it.
- With the tab stamp rewound 3 hours: the URL goes back to `/ui/chat`,
  the thread is empty, and the banner reads "You were away for 3 hours…"
  with "Reopen Explain KV caching in three …". Clicking Reopen returns to
  `/ui/chat/<id>` with the transcript. This is where both defects above
  were caught — the first run showed the banner *over the old transcript*
  and the second showed no banner at all.
- Sending a message from a new chat created the conversation and stamped
  `/ui/chat/conv_…04` in with no extra history entry.
- New chat → `/ui/chat` + empty state; Back returns to the conversation.
- The surviving selector really swaps: clicked `Llama-3.2-1B-Instruct-Q4_K_M`,
  `/admin/models` `active` changed and the header label followed, then
  restored the original checkpoint.
- Models screen renders facts-only with one `Unload <id>` in its header.
- Sidebar bottom reads `● Server / ready · v0.17.1`; its popover still
  carries the model, all five capabilities, version, pid and last-request
  age.

**Only in tests, not in a browser:** local (`localStorage`) mode, which
needs a server without `/v1/conversations`; the mid-generation and
half-typed-composer guards on the away rule; and the sleep-with-tab-visible
path through the heartbeat.

One caveat on the setup: a sibling session already held ports 5173 and
5174, so my dev server ran on **5180** against the same backend on 8383.
Same code, same proxy config, different port only.

## Gates

`npm run check` (typecheck + lint + 31 tests), `npm run build` and
`npm run licenses` all pass. **No new dependencies.** Nothing outside
`ui/` is touched; no `docs/` change was needed, since nothing there
documented the behaviour that moved.

## Proposed separately, not done here

1. Model picker into the composer, next to Send.
2. Conversation list into the sidebar with "New chat" as its top row,
   time-grouped, replacing the header dropdown — plus `Cmd/Ctrl+Shift+O`.
3. Record the model per message rather than only per conversation, which
   is what makes a mid-conversation switch legible afterwards.
