### PR TITLE
fix(metal): a resident buffer must prove it still holds the caller's bytes (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ Entries name what changed and, where it matters, what was wrong
 before. A fix that closed a silent-wrong-answer class says so — those
 are the ones worth reading twice.
 
+## [Unreleased]
+
+### Fixed
+
+- **Swapping the model through `POST /admin/models/load` could leave
+  generation fluent and wrong** (#180). Silent-wrong-answer class, so
+  read it twice. Two Metal caches map `(host pointer, host length)` to
+  an uploaded `MTLBuffer`, and an address is not an identity: the
+  outgoing model's allocations are freed with it and the incoming
+  model's land on the same addresses. `resident_weight_buffer` knew
+  that and checked; `resident_f32_buffer`, seventy lines below it in the
+  same file, did not, and what it caches are the RMSNorm gammas a
+  `Decoder` owns. Measured, not assumed: instrumenting every hit to
+  compare it against the host bytes reported **49 stale hits in a
+  24-token decode** of Llama-3.2-1B-Q6_K loaded after
+  Llama-3.2-1B-Q4_K_M. The MoE stack had a third cache in front of both,
+  keyed on a bare pointer with no length at all. Every resident cache
+  now goes through one lookup that will not serve an entry unless the
+  entry can still prove it holds the caller's bytes, and the Studio
+  model selector is that endpoint. The repack cache named as the likely
+  cause in the issue was NOT it: the same swap sequence under
+  `FERROX_METAL=0` answers identically on every pair.
+
 ## [0.19.1] - 2026-09-10
 
 Ferrox Studio only. No crate in the workspace changed, so an engine

--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -4837,7 +4837,6 @@ pub struct MoeLayerMetal<'a> {
 
 /// Pre-bound MTLBuffers for one MoE layer (llama: bind weights once).
 struct MoeLayerResident {
-    attn_key: usize,
     attn_nw: std::sync::Arc<ResidentF32Buffer>,
     ffn_nw: std::sync::Arc<ResidentF32Buffer>,
     q_w: std::sync::Arc<ResidentWeightBuffer>,
@@ -4847,38 +4846,22 @@ struct MoeLayerResident {
     r_w: std::sync::Arc<ResidentWeightBuffer>,
 }
 
-thread_local! {
-    /// Hoisted per-layer QKV/router/norm buffers for the MoE stack.
-    static TL_MOE_LAYER_RESIDENT: RefCell<Vec<Option<MoeLayerResident>>> =
-        const { RefCell::new(Vec::new()) };
-}
-
+/// Seven cache lookups, exactly as the dense stack does per layer per
+/// token.
+///
+/// This used to memoise the seven behind a thread-local keyed on
+/// `attn_norm_w.as_ptr()` -- an address, with no length beside it and
+/// no check that the bytes were still that layer's. It was a second,
+/// weaker copy of a decision [`crate::resident_cache`] already makes,
+/// in front of the caches that make it, so a recycled address served a
+/// whole layer of another model's weights past two caches that would
+/// have caught it. Two structures deciding one thing, and only one of
+/// them checking.
 fn moe_layer_resident(
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
-    layer_idx: usize,
     layer: &MoeLayerMetal<'_>,
 ) -> Result<MoeLayerResident, MetalError> {
-    let attn_key = layer.attn_norm_w.as_ptr() as usize;
-    if let Some(hit) = TL_MOE_LAYER_RESIDENT.with(|c| {
-        c.borrow().get(layer_idx).and_then(|slot| {
-            slot.as_ref()
-                .filter(|r| r.attn_key == attn_key)
-                .map(|r| MoeLayerResident {
-                    attn_key: r.attn_key,
-                    attn_nw: r.attn_nw.clone(),
-                    ffn_nw: r.ffn_nw.clone(),
-                    q_w: r.q_w.clone(),
-                    k_w: r.k_w.clone(),
-                    v_w: r.v_w.clone(),
-                    o_w: r.o_w.clone(),
-                    r_w: r.r_w.clone(),
-                })
-        })
-    }) {
-        return Ok(hit);
-    }
-    let bound = MoeLayerResident {
-        attn_key,
+    Ok(MoeLayerResident {
         attn_nw: resident_f32_buffer(device, layer.attn_norm_w)?,
         ffn_nw: resident_f32_buffer(device, layer.ffn_norm_w)?,
         q_w: resident_weight_buffer(device, layer.q.weights)?,
@@ -4886,24 +4869,7 @@ fn moe_layer_resident(
         v_w: resident_weight_buffer(device, layer.v.weights)?,
         o_w: resident_weight_buffer(device, layer.o.weights)?,
         r_w: resident_weight_buffer(device, layer.router.weights)?,
-    };
-    TL_MOE_LAYER_RESIDENT.with(|c| {
-        let mut v = c.borrow_mut();
-        if v.len() <= layer_idx {
-            v.resize_with(layer_idx + 1, || None);
-        }
-        v[layer_idx] = Some(MoeLayerResident {
-            attn_key: bound.attn_key,
-            attn_nw: bound.attn_nw.clone(),
-            ffn_nw: bound.ffn_nw.clone(),
-            q_w: bound.q_w.clone(),
-            k_w: bound.k_w.clone(),
-            v_w: bound.v_w.clone(),
-            o_w: bound.o_w.clone(),
-            r_w: bound.r_w.clone(),
-        });
-    });
-    Ok(bound)
+    })
 }
 
 /// One MoE layer into a Concurrent encoder using llama-style [`MemRanges`]
@@ -4932,7 +4898,7 @@ fn encode_moe_layer_fused(
     pos: usize,
     rms_eps: f32,
 ) -> Result<(), MetalError> {
-    let bound = moe_layer_resident(device, layer_idx, layer)?;
+    let bound = moe_layer_resident(device, layer)?;
     let attn_nw = &bound.attn_nw;
     let ffn_nw = &bound.ffn_nw;
     let q_w = &bound.q_w;

--- a/crates/ferrox-metal/src/gpu.rs
+++ b/crates/ferrox-metal/src/gpu.rs
@@ -53,6 +53,7 @@
 
 use crate::dispatch::dispatch_counted;
 use crate::moe_ids::IdsBinding;
+use crate::resident_cache::{get_or_build, HostKey, Resident};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSString;
@@ -5208,9 +5209,10 @@ pub(crate) fn warm_mul_mm_sg_pipeline(
     ensure_pipeline(device, K_QUANT_MUL_MM_SG_KERNEL_SRC, fn_name)
 }
 
-/// Process-wide cache of quantized weight `MTLBuffer`s, keyed by the
-/// host slice's base pointer and length. Stable for mmap-backed and
-/// owned `WeightBytes` after load (weights are not mutated in place).
+/// Process-wide cache of quantized weight `MTLBuffer`s, looked up by
+/// the host slice's base pointer and length and served only when the
+/// entry can still prove it holds those bytes -- see
+/// [`crate::resident_cache`] for why a lookup key is not an identity.
 pub(crate) struct ResidentWeightBuffer {
     pub(crate) buffer: Retained<ProtocolObject<dyn MTLBuffer>>,
     /// Byte offset of the weight bytes within `buffer`. Non-zero only on
@@ -5266,78 +5268,46 @@ fn weight_fingerprint(weights: &[u8]) -> u64 {
 unsafe impl Send for ResidentWeightBuffer {}
 unsafe impl Sync for ResidentWeightBuffer {}
 
-type WeightCacheKey = (usize, usize);
-type WeightCacheMap = HashMap<WeightCacheKey, Arc<ResidentWeightBuffer>>;
+impl Resident for ResidentWeightBuffer {
+    /// One proof per way this entry can have been built.
+    ///
+    /// A `BytesNoCopy` alias holds an `Arc<ResidentMmapFile>`, and that
+    /// keepalive is what makes its address an identity: the mapping
+    /// cannot be unmapped while the entry lives, so the kernel cannot
+    /// reissue the range to a second file. There is also nothing to
+    /// compare, because the device bytes ARE the host bytes.
+    ///
+    /// A copied entry owns its bytes, and the host allocation behind
+    /// the address can be freed and reissued, so it carries a
+    /// fingerprint of what it was built from. Sampled rather than
+    /// exhaustive: the copy path is what an expert-streaming lease
+    /// takes, where comparing a whole matrix per matvec would cost what
+    /// the upload it skips costs. That is a weaker proof than
+    /// [`ResidentF32Buffer`]'s, and saying so is the honest version.
+    fn still_holds(&self, host: &[u8]) -> bool {
+        self.mmap_backed || self.fingerprint == weight_fingerprint(host)
+    }
+
+    fn resident_bytes(&self) -> usize {
+        self.nbytes
+    }
+}
+
+type WeightCacheMap = HashMap<HostKey, Arc<ResidentWeightBuffer>>;
 
 static WEIGHT_CACHE: Mutex<Option<WeightCacheMap>> = Mutex::new(None);
 
 thread_local! {
-    static TL_WEIGHT_CACHE: RefCell<HashMap<(usize, usize), Arc<ResidentWeightBuffer>>> =
-        RefCell::new(HashMap::new());
-}
-
-fn weight_cache_budget_bytes() -> usize {
-    match std::env::var("FERROX_METAL_WEIGHT_CACHE_BYTES") {
-        Ok(v) => v.parse().unwrap_or(usize::MAX),
-        // Default: effectively unlimited on unified memory; callers can
-        // cap with FERROX_METAL_WEIGHT_CACHE_BYTES for smaller machines.
-        Err(_) => usize::MAX,
-    }
+    static TL_WEIGHT_CACHE: RefCell<WeightCacheMap> = RefCell::new(HashMap::new());
 }
 
 pub(crate) fn resident_weight_buffer(
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
     weights: &[u8],
 ) -> Result<Arc<ResidentWeightBuffer>, MetalError> {
-    let key = (weights.as_ptr() as usize, weights.len());
-    // The fingerprint guards against an address being freed and reused
-    // by different bytes. That cannot happen to a registered mmap: the
-    // cached entry holds an `Arc<ResidentMmapFile>` keeping the mapping
-    // alive, so the range stays valid and unchanged for as long as the
-    // entry does. Every real GGUF weight takes that path, and computing
-    // the fingerprint touches 64 pages -- per weight, per call, on the
-    // hot side of the cache lookup. So compute it lazily, only for the
-    // owned/unregistered slices that can actually alias.
-    let fingerprint_of = |c: &ResidentWeightBuffer| -> bool {
-        c.mmap_backed || c.fingerprint == weight_fingerprint(weights)
-    };
-    if let Some(cached) = TL_WEIGHT_CACHE.with(|c| c.borrow().get(&key).cloned()) {
-        if fingerprint_of(&cached) {
-            return Ok(cached);
-        }
-        // Address reused by different bytes: drop the stale alias and
-        // fall through to rebuild.
-        TL_WEIGHT_CACHE.with(|c| {
-            c.borrow_mut().remove(&key);
-        });
-    }
-    let cached = {
-        let mut guard = WEIGHT_CACHE.lock().unwrap();
-        let cache = guard.get_or_insert_with(HashMap::new);
-        if let Some(cached) = cache.get(&key).filter(|c| fingerprint_of(c)) {
-            cached.clone()
-        } else {
-            let budget = weight_cache_budget_bytes();
-            let used: usize = cache.values().map(|b| b.nbytes).sum();
-            if used.saturating_add(weights.len()) > budget {
-                // Drop everything and retry with a clean slate for this matrix.
-                // Better than silently re-uploading forever under a tight budget.
-                cache.clear();
-                TL_WEIGHT_CACHE.with(|c| c.borrow_mut().clear());
-            }
-            if weights.len() > budget {
-                // Matrix alone exceeds budget: one-shot upload, do not cache.
-                return Ok(Arc::new(build_resident_weight_buffer(device, weights)?));
-            }
-            let cached = Arc::new(build_resident_weight_buffer(device, weights)?);
-            cache.insert(key, cached.clone());
-            cached
-        }
-    };
-    TL_WEIGHT_CACHE.with(|c| {
-        c.borrow_mut().insert(key, cached.clone());
-    });
-    Ok(cached)
+    get_or_build(&WEIGHT_CACHE, &TL_WEIGHT_CACHE, weights, || {
+        build_resident_weight_buffer(device, weights)
+    })
 }
 
 /// VM page size used for `BytesNoCopy` alignment. Apple Silicon uses
@@ -5483,77 +5453,74 @@ pub(crate) struct ResidentF32Buffer {
     nbytes: usize,
 }
 
+impl Resident for ResidentF32Buffer {
+    /// An exhaustive compare, because this entry can prove nothing
+    /// else: it always copies, so it neither aliases the host bytes nor
+    /// keeps their allocation alive, and what it caches are the RMSNorm
+    /// gammas and RoPE frequency factors owned by a `Decoder` that
+    /// `/admin/models/load` drops.
+    ///
+    /// Exact rather than sampled, and affordable for the same reason it
+    /// is needed: these are `hidden_dim` floats, single-digit KB, so
+    /// the compare costs a fraction of the upload it avoids. That
+    /// leaves no residual probability of serving one model's norms to
+    /// another (GitHub issue #180).
+    fn still_holds(&self, host: &[u8]) -> bool {
+        if self.nbytes != host.len() {
+            return false;
+        }
+        // SAFETY: `buffer` is a `StorageModeShared` buffer this process
+        // allocated with exactly `nbytes` bytes and only ever reads on
+        // the GPU, so its contents pointer is valid and readable for
+        // that length for as long as this entry lives.
+        let device = unsafe {
+            std::slice::from_raw_parts(self.buffer.contents().as_ptr() as *const u8, self.nbytes)
+        };
+        device == host
+    }
+
+    fn resident_bytes(&self) -> usize {
+        self.nbytes
+    }
+}
+
 // SAFETY: same justification as `SharedMetal` -- `MTLBuffer` created
 // once and only read by compute kernels is safe to share across threads
 // that each build their own command buffer/encoder.
 unsafe impl Send for ResidentF32Buffer {}
 unsafe impl Sync for ResidentF32Buffer {}
 
-type F32CacheKey = (usize, usize);
-type F32CacheMap = HashMap<F32CacheKey, Arc<ResidentF32Buffer>>;
+type F32CacheMap = HashMap<HostKey, Arc<ResidentF32Buffer>>;
 
 static F32_CACHE: Mutex<Option<F32CacheMap>> = Mutex::new(None);
 
 thread_local! {
-    static TL_F32_CACHE: RefCell<HashMap<(usize, usize), Arc<ResidentF32Buffer>>> =
-        RefCell::new(HashMap::new());
+    static TL_F32_CACHE: RefCell<F32CacheMap> = RefCell::new(HashMap::new());
 }
 
 pub(crate) fn resident_f32_buffer(
     device: &Retained<ProtocolObject<dyn MTLDevice>>,
     data: &[f32],
 ) -> Result<Arc<ResidentF32Buffer>, MetalError> {
-    let key = (data.as_ptr() as usize, data.len());
-    if let Some(cached) = TL_F32_CACHE.with(|c| c.borrow().get(&key).cloned()) {
-        return Ok(cached);
-    }
     let nbytes = std::mem::size_of_val(data);
-    let cached = {
-        let mut guard = F32_CACHE.lock().unwrap();
-        let cache = guard.get_or_insert_with(HashMap::new);
-        if let Some(cached) = cache.get(&key) {
-            cached.clone()
-        } else {
-            let budget = weight_cache_budget_bytes();
-            let used: usize = cache.values().map(|b| b.nbytes).sum();
-            if used.saturating_add(nbytes) > budget {
-                // Drop everything and retry with a clean slate for this matrix.
-                // Better than silently re-uploading forever under a tight budget.
-                cache.clear();
-                TL_F32_CACHE.with(|c| c.borrow_mut().clear());
-            }
-            if nbytes > budget {
-                // Matrix alone exceeds budget: one-shot upload, do not cache.
-                let mut data_owned = data.to_vec();
-                let buffer = unsafe {
-                    device.newBufferWithBytes_length_options(
-                        NonNull::new(data_owned.as_mut_ptr() as *mut _).unwrap(),
-                        nbytes,
-                        MTLResourceOptions::StorageModeShared,
-                    )
-                }
-                .ok_or(MetalError::BufferAllocFailed)?;
-                return Ok(Arc::new(ResidentF32Buffer { buffer, nbytes }));
-            }
-
-            let mut data_owned = data.to_vec();
-            let buffer = unsafe {
-                device.newBufferWithBytes_length_options(
-                    NonNull::new(data_owned.as_mut_ptr() as *mut _).unwrap(),
-                    nbytes,
-                    MTLResourceOptions::StorageModeShared,
-                )
-            }
-            .ok_or(MetalError::BufferAllocFailed)?;
-            let cached = Arc::new(ResidentF32Buffer { buffer, nbytes });
-            cache.insert(key, cached.clone());
-            cached
+    // SAFETY: an initialised `[f32]` is `nbytes` initialised bytes, and
+    // `u8` has no alignment requirement. Read-only, and the borrow of
+    // `data` outlives the view.
+    let host = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, nbytes) };
+    get_or_build(&F32_CACHE, &TL_F32_CACHE, host, || {
+        let mut data_owned = data.to_vec();
+        // SAFETY: `data_owned` holds `nbytes` initialised bytes and is
+        // alive across the call, which copies them into the buffer.
+        let buffer = unsafe {
+            device.newBufferWithBytes_length_options(
+                NonNull::new(data_owned.as_mut_ptr() as *mut _).unwrap(),
+                nbytes,
+                MTLResourceOptions::StorageModeShared,
+            )
         }
-    };
-    TL_F32_CACHE.with(|c| {
-        c.borrow_mut().insert(key, cached.clone());
-    });
-    Ok(cached)
+        .ok_or(MetalError::BufferAllocFailed)?;
+        Ok(ResidentF32Buffer { buffer, nbytes })
+    })
 }
 
 /// One quantized matvec to encode into a fused Metal command buffer

--- a/crates/ferrox-metal/src/lib.rs
+++ b/crates/ferrox-metal/src/lib.rs
@@ -27,6 +27,9 @@ pub mod decode_dense;
 pub mod resident_act;
 
 #[cfg(feature = "metal")]
+mod resident_cache;
+
+#[cfg(feature = "metal")]
 pub mod greedy_fold;
 
 #[cfg(feature = "metal")]

--- a/crates/ferrox-metal/src/resident_cache.rs
+++ b/crates/ferrox-metal/src/resident_cache.rs
@@ -1,0 +1,259 @@
+//! The one lookup path every address-keyed resident-buffer cache takes,
+//! and the proof each entry has to give before it may be served.
+//!
+//! # What went wrong (GitHub issue #180)
+//!
+//! Two caches in `gpu.rs` mapped `(host pointer, host length)` to an
+//! `MTLBuffer` built from those bytes. A host address is not an
+//! identity: free the allocation and the next one of the same size gets
+//! the address back, and the cache then serves the new tensor the old
+//! tensor's uploaded bytes.
+//!
+//! `resident_weight_buffer` knew that and defended itself twice -- a
+//! mmap keepalive on the zero-copy path, a sampled fingerprint on the
+//! copy path. `resident_f32_buffer`, sitting seventy lines below it in
+//! the same file with the same key type, defended itself not at all.
+//! That is this repo's dominant bug shape: two structures that must
+//! agree about one thing with nothing enforcing it.
+//!
+//! What it cost: `POST /admin/models/load` swaps checkpoints in one
+//! process, and a `Decoder`'s RMSNorm gammas are owned `Vec<f32>`s that
+//! are freed with it. Loading Llama-3.2-1B-Q4_K_M and then
+//! Llama-3.2-1B-Q6_K put the second model's gammas at the first
+//! model's freed addresses -- 49 stale hits in a 24-token decode,
+//! measured -- and the answer came back fluent and wrong. The Studio
+//! model selector is that endpoint.
+//!
+//! # The rule now
+//!
+//! An entry may be served only if it can still prove it holds the
+//! caller's bytes ([`Resident::still_holds`]), and [`get_or_build`] is
+//! the only way to read one of these caches. A new cache added here
+//! inherits the check by construction: it cannot be looked up without
+//! an entry type that answers the question, and answering it `true`
+//! unconditionally is a thing a reviewer can see, unlike an absent
+//! check nobody wrote.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::thread::LocalKey;
+
+use crate::gpu::MetalError;
+
+/// Where a cached upload came from: a host address and a length.
+///
+/// Deliberately NOT called an identity. It is the lookup key and
+/// nothing more -- what makes a hit legitimate is
+/// [`Resident::still_holds`], not this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct HostKey {
+    addr: usize,
+    len: usize,
+}
+
+impl HostKey {
+    pub(crate) fn of(bytes: &[u8]) -> Self {
+        HostKey {
+            addr: bytes.as_ptr() as usize,
+            len: bytes.len(),
+        }
+    }
+}
+
+/// What a cached device buffer must be able to say about itself.
+pub(crate) trait Resident {
+    /// True when this entry still holds exactly `host`.
+    ///
+    /// Called on EVERY hit, including thread-local ones, because the
+    /// window this closes is "the allocation moved on and the address
+    /// did not". An implementation that cannot answer cheaply and
+    /// exactly must answer conservatively (`false`) rather than
+    /// optimistically.
+    fn still_holds(&self, host: &[u8]) -> bool;
+
+    /// Bytes this entry retains, for the cache budget. Zero for an
+    /// entry that aliases host memory it does not own.
+    fn resident_bytes(&self) -> usize;
+}
+
+/// A process-wide cache and its per-thread mirror.
+type Global<V> = Mutex<Option<HashMap<HostKey, Arc<V>>>>;
+type Mirror<V> = LocalKey<std::cell::RefCell<HashMap<HostKey, Arc<V>>>>;
+
+/// Byte budget shared by every resident cache.
+///
+/// One budget, because on unified memory two budgets are the same RAM
+/// counted twice. `usize::MAX` by default: on Apple Silicon the weights
+/// are already resident and the aliasing path retains nothing.
+pub(crate) fn budget_bytes() -> usize {
+    match std::env::var("FERROX_METAL_WEIGHT_CACHE_BYTES") {
+        Ok(v) => v.parse().unwrap_or(usize::MAX),
+        Err(_) => usize::MAX,
+    }
+}
+
+/// Look `host` up, building and caching an entry when there is no valid
+/// one.
+///
+/// The single reader of every resident cache: the thread-local mirror,
+/// the process map, the freshness check, the budget and the insert are
+/// written once here rather than once per cache, which is what stopped
+/// one of them from having a check the other lacked.
+pub(crate) fn get_or_build<V: Resident>(
+    global: &Global<V>,
+    mirror: &'static Mirror<V>,
+    host: &[u8],
+    build: impl FnOnce() -> Result<V, MetalError>,
+) -> Result<Arc<V>, MetalError> {
+    get_or_build_within(global, mirror, host, budget_bytes(), build)
+}
+
+/// [`get_or_build`] with the budget stated rather than read from the
+/// environment, so a test can exercise a tight budget without a
+/// process-wide variable two tests would race over.
+fn get_or_build_within<V: Resident>(
+    global: &Global<V>,
+    mirror: &'static Mirror<V>,
+    host: &[u8],
+    budget: usize,
+    build: impl FnOnce() -> Result<V, MetalError>,
+) -> Result<Arc<V>, MetalError> {
+    let key = HostKey::of(host);
+
+    if let Some(cached) = mirror.with(|c| c.borrow().get(&key).cloned()) {
+        if cached.still_holds(host) {
+            return Ok(cached);
+        }
+        // The address was recycled under us. Drop the alias here and in
+        // the process map, then rebuild: a stale entry is a miss, never
+        // a hit.
+        mirror.with(|c| {
+            c.borrow_mut().remove(&key);
+        });
+    }
+
+    let cached = {
+        let mut guard = global.lock().unwrap();
+        let cache = guard.get_or_insert_with(HashMap::new);
+        match cache.get(&key).filter(|c| c.still_holds(host)) {
+            Some(cached) => cached.clone(),
+            None => {
+                let used: usize = cache.values().map(|b| b.resident_bytes()).sum();
+                if used.saturating_add(host.len()) > budget {
+                    // Drop everything and retry with a clean slate for
+                    // this buffer. Better than silently re-uploading
+                    // forever under a tight budget.
+                    cache.clear();
+                    mirror.with(|c| c.borrow_mut().clear());
+                }
+                let built = Arc::new(build()?);
+                if built.resident_bytes() > budget {
+                    // This buffer alone exceeds the budget: one-shot
+                    // upload, do not cache.
+                    return Ok(built);
+                }
+                cache.insert(key, built.clone());
+                built
+            }
+        }
+    };
+    mirror.with(|c| {
+        c.borrow_mut().insert(key, cached.clone());
+    });
+    Ok(cached)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// A stand-in for a device buffer: it remembers the bytes it was
+    /// built from, which is exactly what a real `MTLBuffer` holds.
+    struct FakeBuffer {
+        bytes: Vec<u8>,
+        /// Distinguishes two entries built from equal-length host
+        /// buffers, so a test can tell WHICH one came back.
+        tag: u32,
+    }
+
+    impl Resident for FakeBuffer {
+        fn still_holds(&self, host: &[u8]) -> bool {
+            self.bytes == host
+        }
+        fn resident_bytes(&self) -> usize {
+            self.bytes.len()
+        }
+    }
+
+    /// The whole bug: one allocation is freed, the next one lands on
+    /// its address with different contents, and the cache must not
+    /// serve the first one's upload.
+    ///
+    /// The recycled address is FORCED rather than hoped for: the bytes
+    /// under one address are overwritten in place, which is exactly
+    /// what an allocator handing that address to a second tensor looks
+    /// like to a cache that keys on the address.
+    ///
+    /// Sabotage: make `still_holds` return `true` unconditionally and
+    /// this goes red with `tag` 1 where 2 is expected.
+    #[test]
+    fn an_address_reused_by_different_bytes_is_a_miss_not_a_hit() {
+        static CACHE: Global<FakeBuffer> = Mutex::new(None);
+        thread_local! {
+            static TL: RefCell<HashMap<HostKey, Arc<FakeBuffer>>> = RefCell::new(HashMap::new());
+        }
+        let fetch = |host: &[u8], tag: u32| {
+            get_or_build_within(&CACHE, &TL, host, usize::MAX, || {
+                Ok(FakeBuffer {
+                    bytes: host.to_vec(),
+                    tag,
+                })
+            })
+            .expect("build")
+        };
+
+        let mut region = vec![0xAAu8; 64];
+        assert_eq!(fetch(&region, 1).tag, 1);
+        assert_eq!(
+            fetch(&region, 99).tag,
+            1,
+            "unchanged bytes at one address must still hit"
+        );
+
+        region.iter_mut().for_each(|b| *b = 0x55);
+        let second = fetch(&region, 2);
+        assert_eq!(
+            second.tag, 2,
+            "the address was recycled by different bytes, so the old upload must not be served"
+        );
+        assert_eq!(second.bytes, region);
+    }
+
+    /// A budget of zero means nothing is retained, which is the
+    /// behaviour before any of these caches existed.
+    #[test]
+    fn a_zero_budget_retains_nothing() {
+        static CACHE: Global<FakeBuffer> = Mutex::new(None);
+        thread_local! {
+            static TL: RefCell<HashMap<HostKey, Arc<FakeBuffer>>> = RefCell::new(HashMap::new());
+        }
+        let fetch = |host: &[u8], tag: u32| {
+            get_or_build_within(&CACHE, &TL, host, 0, || {
+                Ok(FakeBuffer {
+                    bytes: host.to_vec(),
+                    tag,
+                })
+            })
+            .expect("build")
+        };
+
+        let region = vec![0x11u8; 32];
+        assert_eq!(fetch(&region, 7).tag, 7);
+        assert_eq!(
+            fetch(&region, 8).tag,
+            8,
+            "nothing may be retained under a zero budget"
+        );
+    }
+}

--- a/crates/ferrox-models/tests/common/mod.rs
+++ b/crates/ferrox-models/tests/common/mod.rs
@@ -176,3 +176,91 @@ pub fn worst_vs(got: &[f32], golden: &[f32]) -> f32 {
         .map(|(a, b)| (a - b).abs())
         .fold(0f32, f32::max)
 }
+
+// ---------------------------------------------------------------------
+// Real-checkpoint sweeps
+//
+// Shared by `paged_metal_parity` and `model_swap_isolation`, which both
+// greedy-decode one prompt on a real GGUF and compare the token ids two
+// runs produce. Each had grown its own copy of the tokenize/stretch
+// pair, and a prompt or a BOS rule that drifted between them would have
+// made one suite quietly measure something else.
+// ---------------------------------------------------------------------
+
+/// Root the real-GGUF suites scan.
+///
+/// `FERROX_TEST_MODELS_DIR` because a git worktree has no `models/` of
+/// its own, and these checks are worth running from one.
+pub fn model_dir() -> PathBuf {
+    if let Ok(d) = std::env::var("FERROX_TEST_MODELS_DIR") {
+        return PathBuf::from(d);
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../models")
+}
+
+/// The greedy pick, which is what makes two runs comparable at all.
+pub fn argmax(logits: &[f32]) -> usize {
+    logits
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(i, _)| i)
+        .unwrap()
+}
+
+/// Repeat until exactly `want` tokens, keeping at most one leading BOS
+/// -- the same stretch `ferrox verify --prompt-tokens` performs, down
+/// to only treating the first token as BOS when it really is one. A
+/// checkpoint without BOS otherwise loses its first word, which makes a
+/// suite run a different prompt from the one `verify` reports on.
+fn stretch(mut tokens: Vec<usize>, want: usize, bos: Option<usize>) -> Vec<usize> {
+    if tokens.len() >= want {
+        tokens.truncate(want);
+        return tokens;
+    }
+    let leading_bos = (bos.is_some() && tokens.first().copied() == bos).then(|| tokens[0]);
+    let body: Vec<usize> = tokens[leading_bos.iter().count()..].to_vec();
+    tokens.truncate(leading_bos.iter().count());
+    while tokens.len() < want {
+        let take = (want - tokens.len()).min(body.len());
+        tokens.extend_from_slice(&body[..take]);
+    }
+    tokens
+}
+
+/// `prompt` under this checkpoint's own tokenizer, with its BOS policy
+/// applied, stretched to exactly `want` tokens.
+///
+/// Panics rather than skipping for a tokenizer family it does not
+/// cover: a suite that silently ran a different prompt would report a
+/// pass it had not earned.
+pub fn prompt_tokens(file: &ferrox_gguf::ShardedGguf, prompt: &str, want: usize) -> Vec<usize> {
+    use ferrox_models::tokenizer::{GgufBpeTokenizer, GgufSpmTokenizer};
+    let raw: Vec<usize> = match file.metadata_str("tokenizer.ggml.model") {
+        Some("gpt2" | "gemma4") => GgufBpeTokenizer::from_gguf(file)
+            .expect("bpe tokenizer")
+            .encode(prompt)
+            .into_iter()
+            .map(|i| i as usize)
+            .collect(),
+        Some("llama") => GgufSpmTokenizer::from_gguf(file)
+            .expect("spm tokenizer")
+            .encode(prompt)
+            .into_iter()
+            .map(|i| i as usize)
+            .collect(),
+        other => panic!("this suite does not cover tokenizer {other:?}"),
+    };
+    let bos = file
+        .metadata_u64("tokenizer.ggml.bos_token_id")
+        .map(|v| v as usize);
+    let mut tokens = raw;
+    if ferrox_models::tokenizer::should_add_bos_token(file) {
+        if let Some(b) = bos {
+            if tokens.first() != Some(&b) {
+                tokens.insert(0, b);
+            }
+        }
+    }
+    stretch(tokens, want, bos)
+}

--- a/crates/ferrox-models/tests/model_swap_isolation.rs
+++ b/crates/ferrox-models/tests/model_swap_isolation.rs
@@ -1,0 +1,210 @@
+//! A checkpoint must answer the same whether or not another checkpoint
+//! was loaded and dropped before it in the same process.
+//!
+//! `POST /admin/models/load` hot-swaps the served checkpoint, so the
+//! second load in a process is what a Studio user gets when they pick a
+//! different model from the selector. It came back wrong: on an M2 Pro
+//! with `-ngl 99`, Llama-3.2-3B-Q4_K_M answered `'Tokyo'` on a fresh
+//! server, `'Question\nI\n\nThe\n\n is\n\n'` after a swap through
+//! Llama-3.2-1B-Q8_0, and the same corrupt string byte for byte on
+//! every repeat (GitHub issue #180).
+//!
+//! The shape is process-global GPU state that outlives the `Decoder`
+//! that filled it and is keyed by something a second model can
+//! reproduce -- a host address plus a length. `paged_metal_parity`
+//! already had to run one model per child process because of this, and
+//! says so in its own docs.
+//!
+//! The check is a swapped run against a fresh run of the same
+//! checkpoint, both as children of this process, so "fresh" means a
+//! process that has loaded nothing else.
+//!
+//! Requires:
+//! - `cargo test -p ferrox-models --features metal --test model_swap_isolation -- --ignored --nocapture`
+//! - Apple Silicon + Metal (`FERROX_METAL=0` ablates it to the CPU path)
+//! - the GGUFs under `models/` (`FERROX_TEST_MODELS_DIR` to point elsewhere)
+
+#![cfg(feature = "metal")]
+
+use std::path::{Path, PathBuf};
+
+use ferrox_core::cache::KvCache;
+use ferrox_gguf::ShardedGguf;
+use ferrox_models::config::ModelConfig;
+use ferrox_models::decoder::Decoder;
+
+mod common;
+use common::{argmax, model_dir, prompt_tokens};
+
+const PROMPT: &str = "The capital of France is";
+/// Long enough that prefill runs the batched Metal kernels rather than
+/// degenerating to a handful of single-token steps.
+const PROMPT_TOKENS: usize = 64;
+const MAX_NEW_TOKENS: usize = 24;
+
+/// The pairs to run, as `(loaded first, then checked)`.
+///
+/// Both orders of the pair from the issue, because Q8_0 survived the
+/// swap there and Q4_K_M did not: a fix that only helps one direction
+/// is not a fix. The third pair is a different size class again, so a
+/// pass is not an accident of two files that happen not to collide.
+const PAIRS: &[(&str, &str)] = &[
+    (
+        "Llama-3.2-1B-Instruct-Q8_0.gguf",
+        "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+    ),
+    (
+        "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+        "Llama-3.2-1B-Instruct-Q8_0.gguf",
+    ),
+    (
+        "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+        "Llama-3.2-1B-Instruct-Q6_K.gguf",
+    ),
+    // The MoE decode stack, which had a per-layer cache of its own
+    // keyed on a bare pointer. This is the pair `paged_metal_parity`
+    // names in its docs as the one that made it run a child process
+    // per model.
+    (
+        "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+        "olmoe-1b-7b-0924-q4_0.gguf",
+    ),
+];
+
+/// Load `path`, greedy-decode `MAX_NEW_TOKENS`, drop everything.
+///
+/// The drop is the point: it is what `/admin/models/load` does to the
+/// outgoing model before the next one is mapped.
+fn greedy_once(path: &Path) -> Vec<usize> {
+    let file = ShardedGguf::open(path).expect("open gguf");
+    let config = ModelConfig::from_gguf(&file).expect("model config");
+    let eos = file
+        .metadata_u64("tokenizer.ggml.eos_token_id")
+        .map(|v| v as usize);
+    let prompt = prompt_tokens(&file, PROMPT, PROMPT_TOKENS);
+    let decoder = Decoder::from_gguf(path, config).expect("decoder");
+
+    let mut caches: Vec<KvCache> = (0..decoder.layers.len())
+        .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
+        .collect();
+    let mut logits = decoder.forward_batch_last(&prompt, 0, &mut caches);
+    let mut out = Vec::with_capacity(MAX_NEW_TOKENS);
+    for pos in (prompt.len()..).take(MAX_NEW_TOKENS) {
+        let next = argmax(&logits);
+        out.push(next);
+        if Some(next) == eos {
+            break;
+        }
+        logits = decoder.forward_token(next, pos, &mut caches);
+    }
+    out
+}
+
+/// Env var carrying the `;`-separated checkpoint sequence a child runs.
+const SEQUENCE_VAR: &str = "FERROX_TEST_SWAP_SEQUENCE";
+
+/// Run `paths` in order in one process, returning each one's answer.
+fn run_sequence_in_child(paths: &[PathBuf]) -> Vec<Vec<usize>> {
+    let exe = std::env::current_exe().expect("test binary path");
+    let joined = paths
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(";");
+    let out = std::process::Command::new(&exe)
+        .args([
+            "--ignored",
+            "--exact",
+            "--nocapture",
+            "a_checkpoint_answers_the_same_after_another_checkpoint_was_loaded_first",
+        ])
+        .env(SEQUENCE_VAR, &joined)
+        .output()
+        .expect("spawning the sequence child");
+    let text =
+        String::from_utf8_lossy(&out.stderr).into_owned() + &String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "child running [{joined}] failed:\n{text}"
+    );
+    let answers: Vec<Vec<usize>> = text
+        .lines()
+        .filter_map(|l| l.strip_prefix("SWAP-ANSWER "))
+        .map(|l| {
+            l.split_whitespace()
+                .map(|t| t.parse::<usize>().expect("token id"))
+                .collect()
+        })
+        .collect();
+    assert_eq!(
+        answers.len(),
+        paths.len(),
+        "child ran {} of {} checkpoints:\n{text}",
+        answers.len(),
+        paths.len()
+    );
+    answers
+}
+
+/// Loading a checkpoint may not change what the NEXT checkpoint says.
+///
+/// A model whose answer depends on what the process loaded before it is
+/// serving one model's weights through another model's cached buffers,
+/// and it does it at full speed and full fluency.
+#[test]
+#[ignore = "needs Apple Metal GPU + the GGUFs under models/ (FERROX_TEST_MODELS_DIR to relocate)"]
+fn a_checkpoint_answers_the_same_after_another_checkpoint_was_loaded_first() {
+    // Honour a pre-set value so `FERROX_METAL=0 cargo test …` ablates to
+    // the CPU path, which is how a GPU-cache cause is told apart from a
+    // host-side one.
+    for (k, v) in [("FERROX_METAL", "1"), ("FERROX_METAL_ATTN", "1")] {
+        if std::env::var(k).is_err() {
+            std::env::set_var(k, v);
+        }
+    }
+
+    // Child mode: run the sequence this process was handed and report.
+    if let Ok(seq) = std::env::var(SEQUENCE_VAR) {
+        for path in seq.split(';') {
+            let answer = greedy_once(Path::new(path));
+            let ids = answer
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            println!("SWAP-ANSWER {ids}");
+        }
+        return;
+    }
+
+    if ferrox_metal::gpu::probe().is_none() && std::env::var("FERROX_METAL").as_deref() != Ok("0") {
+        eprintln!("skip: no Metal GPU detected");
+        return;
+    }
+
+    let mut ran = 0usize;
+    let mut broken: Vec<String> = Vec::new();
+    for (first, second) in PAIRS {
+        let first_path = model_dir().join(first);
+        let second_path = model_dir().join(second);
+        if !first_path.exists() || !second_path.exists() {
+            eprintln!("skip: {first} or {second} missing");
+            continue;
+        }
+        let alone = run_sequence_in_child(std::slice::from_ref(&second_path));
+        let swapped = run_sequence_in_child(&[first_path, second_path]);
+        let want = &alone[0];
+        let got = &swapped[1];
+        eprintln!("{second} alone:        {want:?}");
+        eprintln!("{second} after {first}: {got:?}");
+        if want != got {
+            broken.push(format!("{second} after {first}"));
+        }
+        ran += 1;
+    }
+    assert!(ran > 0, "no model pair available to check");
+    assert!(
+        broken.is_empty(),
+        "a checkpoint answered differently because another was loaded first: {broken:?}"
+    );
+}

--- a/crates/ferrox-models/tests/model_swap_isolation.rs
+++ b/crates/ferrox-models/tests/model_swap_isolation.rs
@@ -1,0 +1,272 @@
+//! A checkpoint must answer the same whether or not another checkpoint
+//! was loaded and dropped before it in the same process.
+//!
+//! `POST /admin/models/load` hot-swaps the served checkpoint, so the
+//! second load in a process is what a Studio user gets when they pick a
+//! different model from the selector. It came back wrong: on an M2 Pro
+//! with `-ngl 99`, Llama-3.2-3B-Q4_K_M answered `'Tokyo'` on a fresh
+//! server, `'Question\nI\n\nThe\n\n is\n\n'` after a swap through
+//! Llama-3.2-1B-Q8_0, and the same corrupt string byte for byte on
+//! every repeat (GitHub issue #180).
+//!
+//! The shape is process-global GPU state that outlives the `Decoder`
+//! that filled it and is keyed by something a second model can
+//! reproduce -- a host address plus a length. `paged_metal_parity`
+//! already had to run one model per child process because of this, and
+//! says so in its own docs.
+//!
+//! The check is a swapped run against a fresh run of the same
+//! checkpoint, both as children of this process, so "fresh" means a
+//! process that has loaded nothing else.
+//!
+//! Requires:
+//! - `cargo test -p ferrox-models --features metal --test model_swap_isolation -- --ignored --nocapture`
+//! - Apple Silicon + Metal (`FERROX_METAL=0` ablates it to the CPU path)
+//! - the GGUFs under `models/` (`FERROX_TEST_MODELS_DIR` to point elsewhere)
+
+#![cfg(feature = "metal")]
+
+use std::path::{Path, PathBuf};
+
+use ferrox_core::cache::KvCache;
+use ferrox_gguf::ShardedGguf;
+use ferrox_models::config::ModelConfig;
+use ferrox_models::decoder::Decoder;
+use ferrox_models::tokenizer::{GgufBpeTokenizer, GgufSpmTokenizer};
+
+const PROMPT: &str = "The capital of France is";
+/// Long enough that prefill runs the batched Metal kernels rather than
+/// degenerating to a handful of single-token steps.
+const PROMPT_TOKENS: usize = 64;
+const MAX_NEW_TOKENS: usize = 24;
+
+/// The pairs to run, as `(loaded first, then checked)`.
+///
+/// Both orders of the pair from the issue, because Q8_0 survived the
+/// swap there and Q4_K_M did not: a fix that only helps one direction
+/// is not a fix. The third pair is a different size class again, so a
+/// pass is not an accident of two files that happen not to collide.
+const PAIRS: &[(&str, &str)] = &[
+    (
+        "Llama-3.2-1B-Instruct-Q8_0.gguf",
+        "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+    ),
+    (
+        "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+        "Llama-3.2-1B-Instruct-Q8_0.gguf",
+    ),
+    (
+        "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+        "Llama-3.2-1B-Instruct-Q6_K.gguf",
+    ),
+    // The MoE decode stack, which had a per-layer cache of its own
+    // keyed on a bare pointer. This is the pair `paged_metal_parity`
+    // names in its docs as the one that made it run a child process
+    // per model.
+    (
+        "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+        "olmoe-1b-7b-0924-q4_0.gguf",
+    ),
+];
+
+fn model_dir() -> PathBuf {
+    // `FERROX_TEST_MODELS_DIR` because a git worktree has no `models/` of
+    // its own, and this check is worth running from one.
+    if let Ok(d) = std::env::var("FERROX_TEST_MODELS_DIR") {
+        return PathBuf::from(d);
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../models")
+}
+
+fn argmax(logits: &[f32]) -> usize {
+    logits
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(i, _)| i)
+        .unwrap()
+}
+
+/// Repeat until exactly `want` tokens, keeping at most one leading BOS.
+fn stretch(mut tokens: Vec<usize>, want: usize, bos: Option<usize>) -> Vec<usize> {
+    if tokens.len() >= want {
+        tokens.truncate(want);
+        return tokens;
+    }
+    let leading_bos = (bos.is_some() && tokens.first().copied() == bos).then(|| tokens[0]);
+    let body: Vec<usize> = tokens[leading_bos.iter().count()..].to_vec();
+    tokens.truncate(leading_bos.iter().count());
+    while tokens.len() < want {
+        let take = (want - tokens.len()).min(body.len());
+        tokens.extend_from_slice(&body[..take]);
+    }
+    tokens
+}
+
+fn tokenize(file: &ShardedGguf) -> Vec<usize> {
+    let raw: Vec<usize> = match file.metadata_str("tokenizer.ggml.model") {
+        Some("gpt2" | "gemma4") => GgufBpeTokenizer::from_gguf(file)
+            .expect("bpe tokenizer")
+            .encode(PROMPT)
+            .into_iter()
+            .map(|i| i as usize)
+            .collect(),
+        Some("llama") => GgufSpmTokenizer::from_gguf(file)
+            .expect("spm tokenizer")
+            .encode(PROMPT)
+            .into_iter()
+            .map(|i| i as usize)
+            .collect(),
+        other => panic!("model-swap isolation does not cover tokenizer {other:?}"),
+    };
+    let bos = file
+        .metadata_u64("tokenizer.ggml.bos_token_id")
+        .map(|v| v as usize);
+    let mut tokens = raw;
+    if ferrox_models::tokenizer::should_add_bos_token(file) {
+        if let Some(b) = bos {
+            if tokens.first() != Some(&b) {
+                tokens.insert(0, b);
+            }
+        }
+    }
+    stretch(tokens, PROMPT_TOKENS, bos)
+}
+
+/// Load `path`, greedy-decode `MAX_NEW_TOKENS`, drop everything.
+///
+/// The drop is the point: it is what `/admin/models/load` does to the
+/// outgoing model before the next one is mapped.
+fn greedy_once(path: &Path) -> Vec<usize> {
+    let file = ShardedGguf::open(path).expect("open gguf");
+    let config = ModelConfig::from_gguf(&file).expect("model config");
+    let eos = file
+        .metadata_u64("tokenizer.ggml.eos_token_id")
+        .map(|v| v as usize);
+    let prompt = tokenize(&file);
+    let decoder = Decoder::from_gguf(path, config).expect("decoder");
+
+    let mut caches: Vec<KvCache> = (0..decoder.layers.len())
+        .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
+        .collect();
+    let mut logits = decoder.forward_batch_last(&prompt, 0, &mut caches);
+    let mut out = Vec::with_capacity(MAX_NEW_TOKENS);
+    for pos in (prompt.len()..).take(MAX_NEW_TOKENS) {
+        let next = argmax(&logits);
+        out.push(next);
+        if Some(next) == eos {
+            break;
+        }
+        logits = decoder.forward_token(next, pos, &mut caches);
+    }
+    out
+}
+
+/// Env var carrying the `;`-separated checkpoint sequence a child runs.
+const SEQUENCE_VAR: &str = "FERROX_TEST_SWAP_SEQUENCE";
+
+/// Run `paths` in order in one process, returning each one's answer.
+fn run_sequence_in_child(paths: &[PathBuf]) -> Vec<Vec<usize>> {
+    let exe = std::env::current_exe().expect("test binary path");
+    let joined = paths
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(";");
+    let out = std::process::Command::new(&exe)
+        .args([
+            "--ignored",
+            "--exact",
+            "--nocapture",
+            "a_checkpoint_answers_the_same_after_another_checkpoint_was_loaded_first",
+        ])
+        .env(SEQUENCE_VAR, &joined)
+        .output()
+        .expect("spawning the sequence child");
+    let text =
+        String::from_utf8_lossy(&out.stderr).into_owned() + &String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "child running [{joined}] failed:\n{text}"
+    );
+    let answers: Vec<Vec<usize>> = text
+        .lines()
+        .filter_map(|l| l.strip_prefix("SWAP-ANSWER "))
+        .map(|l| {
+            l.split_whitespace()
+                .map(|t| t.parse::<usize>().expect("token id"))
+                .collect()
+        })
+        .collect();
+    assert_eq!(
+        answers.len(),
+        paths.len(),
+        "child ran {} of {} checkpoints:\n{text}",
+        answers.len(),
+        paths.len()
+    );
+    answers
+}
+
+/// Loading a checkpoint may not change what the NEXT checkpoint says.
+///
+/// A model whose answer depends on what the process loaded before it is
+/// serving one model's weights through another model's cached buffers,
+/// and it does it at full speed and full fluency.
+#[test]
+#[ignore = "needs Apple Metal GPU + the GGUFs under models/ (FERROX_TEST_MODELS_DIR to relocate)"]
+fn a_checkpoint_answers_the_same_after_another_checkpoint_was_loaded_first() {
+    // Honour a pre-set value so `FERROX_METAL=0 cargo test …` ablates to
+    // the CPU path, which is how a GPU-cache cause is told apart from a
+    // host-side one.
+    for (k, v) in [("FERROX_METAL", "1"), ("FERROX_METAL_ATTN", "1")] {
+        if std::env::var(k).is_err() {
+            std::env::set_var(k, v);
+        }
+    }
+
+    // Child mode: run the sequence this process was handed and report.
+    if let Ok(seq) = std::env::var(SEQUENCE_VAR) {
+        for path in seq.split(';') {
+            let answer = greedy_once(Path::new(path));
+            let ids = answer
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            println!("SWAP-ANSWER {ids}");
+        }
+        return;
+    }
+
+    if ferrox_metal::gpu::probe().is_none() && std::env::var("FERROX_METAL").as_deref() != Ok("0") {
+        eprintln!("skip: no Metal GPU detected");
+        return;
+    }
+
+    let mut ran = 0usize;
+    let mut broken: Vec<String> = Vec::new();
+    for (first, second) in PAIRS {
+        let first_path = model_dir().join(first);
+        let second_path = model_dir().join(second);
+        if !first_path.exists() || !second_path.exists() {
+            eprintln!("skip: {first} or {second} missing");
+            continue;
+        }
+        let alone = run_sequence_in_child(std::slice::from_ref(&second_path));
+        let swapped = run_sequence_in_child(&[first_path, second_path]);
+        let want = &alone[0];
+        let got = &swapped[1];
+        eprintln!("{second} alone:        {want:?}");
+        eprintln!("{second} after {first}: {got:?}");
+        if want != got {
+            broken.push(format!("{second} after {first}"));
+        }
+        ran += 1;
+    }
+    assert!(ran > 0, "no model pair available to check");
+    assert!(
+        broken.is_empty(),
+        "a checkpoint answered differently because another was loaded first: {broken:?}"
+    );
+}

--- a/crates/ferrox-models/tests/paged_metal_parity.rs
+++ b/crates/ferrox-models/tests/paged_metal_parity.rs
@@ -22,13 +22,15 @@
 
 #![cfg(feature = "metal")]
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use ferrox_core::cache::{KvCache, PagedKvCache, SharedPagedKv};
 use ferrox_gguf::ShardedGguf;
 use ferrox_models::config::ModelConfig;
 use ferrox_models::decoder::Decoder;
-use ferrox_models::tokenizer::{GgufBpeTokenizer, GgufSpmTokenizer};
+
+mod common;
+use common::{argmax, model_dir, prompt_tokens};
 
 const PROMPT: &str = "The capital of France is";
 /// Long enough that prefill runs the batched Metal kernels rather than
@@ -46,74 +48,6 @@ const MODELS: &[&str] = &[
     "olmoe-1b-7b-0924-q4_0.gguf",
     "gemma-2-2b-it-Q4_K_M.gguf",
 ];
-
-fn model_dir() -> PathBuf {
-    // `FERROX_TEST_MODELS_DIR` because a git worktree has no `models/` of its
-    // own, and this check is worth running from one.
-    if let Ok(d) = std::env::var("FERROX_TEST_MODELS_DIR") {
-        return PathBuf::from(d);
-    }
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../models")
-}
-
-fn argmax(logits: &[f32]) -> usize {
-    logits
-        .iter()
-        .enumerate()
-        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
-        .map(|(i, _)| i)
-        .unwrap()
-}
-
-/// Repeat until exactly `want` tokens, keeping at most one leading BOS
-/// -- the same stretch `ferrox verify --prompt-tokens` performs, down
-/// to only treating the first token as BOS when it really is one. A
-/// checkpoint without BOS otherwise loses its first word, which makes
-/// this run a different prompt from the one `verify` reports on.
-fn stretch(mut tokens: Vec<usize>, want: usize, bos: Option<usize>) -> Vec<usize> {
-    if tokens.len() >= want {
-        tokens.truncate(want);
-        return tokens;
-    }
-    let leading_bos = (bos.is_some() && tokens.first().copied() == bos).then(|| tokens[0]);
-    let body: Vec<usize> = tokens[leading_bos.iter().count()..].to_vec();
-    tokens.truncate(leading_bos.iter().count());
-    while tokens.len() < want {
-        let take = (want - tokens.len()).min(body.len());
-        tokens.extend_from_slice(&body[..take]);
-    }
-    tokens
-}
-
-fn tokenize(file: &ShardedGguf) -> Vec<usize> {
-    let raw: Vec<usize> = match file.metadata_str("tokenizer.ggml.model") {
-        Some("gpt2" | "gemma4") => GgufBpeTokenizer::from_gguf(file)
-            .expect("bpe tokenizer")
-            .encode(PROMPT)
-            .into_iter()
-            .map(|i| i as usize)
-            .collect(),
-        Some("llama") => GgufSpmTokenizer::from_gguf(file)
-            .expect("spm tokenizer")
-            .encode(PROMPT)
-            .into_iter()
-            .map(|i| i as usize)
-            .collect(),
-        other => panic!("paged parity does not cover tokenizer {other:?}"),
-    };
-    let mut tokens = raw;
-    let bos = file
-        .metadata_u64("tokenizer.ggml.bos_token_id")
-        .map(|v| v as usize);
-    if ferrox_models::tokenizer::should_add_bos_token(file) {
-        if let Some(b) = bos {
-            if tokens.first() != Some(&b) {
-                tokens.insert(0, b);
-            }
-        }
-    }
-    stretch(tokens, PROMPT_TOKENS, bos)
-}
 
 fn greedy_contiguous(decoder: &Decoder, prompt: &[usize], eos: Option<usize>) -> Vec<usize> {
     let mut caches: Vec<KvCache> = (0..decoder.layers.len())
@@ -187,13 +121,17 @@ fn paged_kv_answers_exactly_what_contiguous_kv_answers_on_metal() {
 
 /// One model per process, run as children of this one.
 ///
-/// Not fussiness: two checkpoints loaded into a single process do NOT
+/// Not fussiness: two checkpoints loaded into a single process did NOT
 /// come out the same as either alone on Metal. Loading Llama-3.2-1B and
 /// then OLMoE in one run produced three different OLMoE continuations
 /// across three runs, none of them the stable answer OLMoE gives on its
 /// own, while paged and contiguous agreed with each other every time.
-/// That is process-global Metal state surviving a dropped `Decoder` --
-/// a separate bug, and one this check must not be at the mercy of.
+/// That was process-global Metal state surviving a dropped `Decoder`:
+/// resident-buffer caches keyed on a host address the dropped model's
+/// allocator had already handed to the next one (GitHub issue #180),
+/// now fixed and held by `model_swap_isolation`. The isolation stays,
+/// because what this suite measures should not depend on that fix
+/// holding.
 ///
 /// The re-invocation is the shape `ferrox verify` already uses for the
 /// same reason: some state is per process, so isolate per process.
@@ -233,7 +171,7 @@ fn check_one(path: &Path) {
     let eos = file
         .metadata_u64("tokenizer.ggml.eos_token_id")
         .map(|v| v as usize);
-    let prompt = tokenize(&file);
+    let prompt = prompt_tokens(&file, PROMPT, PROMPT_TOKENS);
     let decoder = Decoder::from_gguf(path, config).expect("decoder");
 
     let want = greedy_contiguous(&decoder, &prompt, eos);

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -135,9 +135,12 @@ Held by `cargo test -p ferrox-models --features metal --test
 paged_metal_parity -- --ignored`, which greedy-decodes the same prompt
 twice in one process, once through each cache, on a dense model, an MoE
 model and a sliding-window model. It runs one model per process on
-purpose: two checkpoints loaded into a single process do not answer the
-same as either alone on Metal, which is a separate bug and not one this
-check should be at the mercy of.
+purpose: two checkpoints in one process used not to answer the same as
+either alone on Metal, because the resident-buffer caches keyed on a
+host address a dropped model's allocator had already handed on. That
+was GitHub issue #180 and is fixed; `model_swap_isolation` is the check
+that holds it, and the per-process isolation here stays because this
+suite should not be at the mercy of it either way.
 
 `FERROX_PREFIX_CACHE_ENTRIES` had the same bug and no refusal in front
 of it. A stored snapshot is the host rows, so on Metal it was all zeros,
@@ -223,7 +226,7 @@ tests that read them skip instead.
 
 | Variable | Purpose |
 |---|---|
-| `FERROX_TEST_MODELS_DIR` | Root the real-GGUF sweeps scan (default `models`). Read by `bos_policy`, `chat_template_real_gguf` and `paged_metal_parity` -- a git worktree has no `models/` of its own, which is what this is for. Unrelated to `FERROX_MODEL_DIR`, which is server config |
+| `FERROX_TEST_MODELS_DIR` | Root the real-GGUF sweeps scan (default `models`). Read by `bos_policy`, `chat_template_real_gguf`, `paged_metal_parity` and `model_swap_isolation` -- a git worktree has no `models/` of its own, which is what this is for. Unrelated to `FERROX_MODEL_DIR`, which is server config |
 | `FERROX_TEST_GEMMA2_GGUF` | Gemma-2 GGUF for the Metal quality gate |
 | `FERROX_TEST_QWEN2MOE_GGUF` | Qwen2-MoE GGUF for the "capital of France" check |
 | `FERROX_TEST_SMOLLM2_GGUF` | SmolLM2 GGUF for the same check on Metal |


### PR DESCRIPTION
Closes #180.

## What the cause is, proved

`resident_f32_buffer` (`ferrox-metal/src/gpu.rs`) keys a process-wide
cache, and a thread-local mirror of it, of uploaded `MTLBuffer`s on
**`(host pointer, host length)`** and checks nothing else. What it
caches are a `Decoder`'s **RMSNorm gammas** and RoPE frequency factors:
owned `Vec<f32>`s that are freed when `/admin/models/load` drops the
outgoing model. The incoming model's allocations of the same size land
on those addresses and are served the outgoing model's uploads.

Not inferred from reading. I instrumented every cache hit to compare the
device buffer against the host slice it claimed to hold and ran the swap:

```
STALE-HIT f32/tl len=2048 at 0xb61000000: cached[0]=2.453125   host[0]=0.15429688   (x25)
STALE-HIT f32/tl len=2048 at 0xb60378000: cached[0]=0.15429688 host[0]=2.453125     (x24)
```

49 stale hits in a 24-token decode of Llama-3.2-1B-Q6_K loaded after
Llama-3.2-1B-Q4_K_M — two layers' gammas swapped for each other's, at
`hidden_dim` = 2048.

Seventy lines above it in the same file, `resident_weight_buffer` has
the same key type and defends itself twice (an mmap keepalive on the
zero-copy path, a sampled fingerprint on the copy path). Two structures
that must agree about one thing with nothing enforcing it. The MoE
decode stack had a third cache in front of both, memoising a whole
layer's bindings on `attn_norm_w.as_ptr()` — an address with no length
beside it and no check at all.

## What I ruled out

- **The repack cache the issue names as the likely cause is innocent.**
  Its `MapId` already holds a `Weak<Mmap>`, and the same swap sequence
  with `FERROX_METAL=0` (the CPU path, which is where that cache lives)
  answers identically on every pair. Nothing on the host side is stale.
- **The Metal weight cache.** The same instrumentation reported no stale
  weight hit: mmap-backed entries keep their mapping alive, which is
  what makes their address an identity, and copied entries carry a
  fingerprint.
- **The neighbours:** the `resident_act` activation publication (the
  #171 shape) is invalidated by any scratch borrow and lives under the
  mutex that owns the buffer; `greedy_fold`'s thread-local carries
  environment config, not model state; the KV cache is per request; the
  tokenizer and chat template are rebuilt by `activate_loaded_model` on
  every load, which is one function shared with startup.

## The fix

One new module, `ferrox-metal/src/resident_cache.rs`, holding the only
lookup path an address-keyed resident cache has. A key is a lookup key
and explicitly not an identity; an entry may be served only if it can
still prove it holds the caller's bytes (`Resident::still_holds`), and a
stale entry is a miss in the thread-local mirror as well as in the
process map.

- `ResidentWeightBuffer` answers with the keepalive or the fingerprint
  it already had — no behaviour change, but the check now lives on the
  entry where the other cache can see it.
- `ResidentF32Buffer` answers with an **exhaustive** compare of the
  device bytes. Exact rather than probable, and it costs a fraction of
  the upload it skips: these vectors are `hidden_dim` floats, single
  digit KB.
- The MoE per-layer memo is **deleted** rather than fixed. It was a
  second, weaker copy of a decision the caches make; the MoE stack now
  takes the same validated lookups per layer that the dense stack
  already took.
- Budget, eviction and the mirror are written once instead of once per
  cache, so a cache added here later inherits the check instead of
  having to remember it.

## The test that settles it

`crates/ferrox-models/tests/model_swap_isolation.rs` runs a checkpoint
alone in a child process, then again after another checkpoint was loaded
and dropped in the same process, and asserts the token ids match.

**On this PR's parent it fails**, on two of the four pairs, and it fails
as a wrong-answer assertion rather than a panic:

```
a checkpoint answered differently because another was loaded first:
["Llama-3.2-1B-Instruct-Q6_K.gguf after Llama-3.2-1B-Instruct-Q4_K_M.gguf",
 "olmoe-1b-7b-0924-q4_0.gguf after Llama-3.2-1B-Instruct-Q4_K_M.gguf"]
```

Q6_K after Q4_K_M answered `[11, 94330, 118219, 127084, …]` where alone
it answers `[9822, 374, 791, 6864, …]`. With this branch all four pairs
match. Its helpers moved into `tests/common` rather than being copied
out of `paged_metal_parity`, which had the only other copy.

## Verified

On an M2 Pro with Metal:

- `cargo test -p ferrox-metal --features metal -- --ignored` — 58 pass.
- `model_swap_isolation` and `paged_metal_parity` (dense, MoE and
  sliding-window), release, `--ignored`.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets`
  with and without `--features metal`, and again `--release`.
- The `resident_cache` unit test sabotaged once (`still_holds` forced to
  `true`), grep-confirmed in the file, and it went red on the assertion
  it is there for.
- By hand through the endpoint, on `-ngl 99` at temperature 0: seven
  swaps across `3B-Q4_K_M → 1B-Q8_0 → 3B-Q4_K_M → 1B-Q4_K_M → 1B-Q6_K →
  1B-Q4_K_M → OLMoE → 3B-Q4_K_M`, every answer correct.

## Two honest caveats

- **I could not reproduce the issue's exact server-level symptom on this
  box**, on either build. The same seven-swap sequence and an
  alternating 1B-Q4_K_M/1B-Q6_K sequence answer correctly on a *pre-fix*
  server here. Which addresses an allocator recycles is
  allocation-history dependent, and the server's history differs from a
  test binary's. What is reproducible here is the same defect, in the
  same cache, deterministically, in-process — and the mechanism the
  instrumentation names is exactly the reported behaviour (deterministic
  garbage, only after a swap, pair dependent).
- **No benchmark row.** The added work is bounded by arithmetic: two
  `hidden_dim`-float compares per layer per token, ~256 KB per token on
  a 1B, against a token that reads the whole weight set — under a
  percent. Interleaved smoke runs (main, branch, main, branch) read
  136.3 / 144.3 / 145.8 / 143.3 tok/s, no separation, but this host was
  at load average 34 with another `ferrox-server` holding a model, and
  `ferrox bench` refuses to time under exactly that condition. A real
  row needs a quiet box.

## Flagged, not fixed here (out of scope)

`/admin/models/load` reuses the startup model's `SharedPagedKv`
(`state.paged_kv`), which is sized from the startup model's `n_layers`,
`n_kv_heads` and `head_dim`. Swapping to a model with a different KV
geometry while paged KV is configured (`FERROX_PAGED_KV_BLOCKS` +
`FERROX_PAGED_KV_BLOCK_SIZE`, off by default, which is why nothing here
hit it) decodes against a store shaped for the other model. The step
assert in `cache.rs` suggests it panics rather than answering wrong, but
nothing in the swap path checks the geometry.
