### PR TITLE
fix(par): carry the greedy-fold setting onto the worker, and let Metal promote

### DIFF
--- a/crates/ferrox-core/src/par.rs
+++ b/crates/ferrox-core/src/par.rs
@@ -49,6 +49,7 @@ use rayon::prelude::*;
 
 use crate::cpu_pool::CpuPool;
 
+mod carry;
 pub mod policy;
 
 pub use policy::{backend, macs_per_row, with_op_work};
@@ -129,22 +130,26 @@ fn note_rayon_region() {
 /// `f()` directly), so an entry point may wrap unconditionally without
 /// having to know whether its caller already did.
 ///
+/// # What crosses with the work
+///
+/// A step that reads a thread-local *setting* would read the worker's
+/// default instead of its caller's choice, which is exactly what
+/// GitHub issue #166 was: a Metal decode moved to a worker silently took
+/// the other `lm_head` path and answered differently from the tenth
+/// token. So the settings are captured on this thread and adopted on the
+/// worker for the length of the job. [`carry::Carry`] is the single list
+/// of them and its `adopt` destructures exhaustively, so a new one that
+/// is not carried does not compile.
+///
 /// # Two cases this deliberately does NOT promote
 ///
-/// **A GPU backend.** Measured on an M2 Pro, moving the decode step off
-/// the process's main thread CHANGES METAL'S OUTPUT: `Llama-3.2-3B
-/// Q4_K_M --ngl 99`, greedy, diverges from the same build's main-thread
-/// answer at around the tenth token, deterministically on both sides.
-/// The Metal stack carries thread-local state across a step (the
-/// resident-activation hand-off from the dense stack to `output_head`,
-/// and the two thread-local mirrors of the pipeline and weight caches),
-/// so which thread runs the step is not the free choice it is on CPU.
-/// That is worth its own investigation and is not worth risking on a CPU
-/// scheduling change, so promotion asks
-/// [`crate::weight_matrix::active_backend`] first: the same cached
-/// predicate dispatch itself uses, not a second opinion about it. Under
-/// Metal or CUDA there is also almost nothing to win, because the
-/// parallel regions this saves are the ones the GPU is not running.
+/// **A backend whose thread-affine state is not proven carried.**
+/// Promotion asks [`crate::weight_matrix::active_backend`] -- the same
+/// cached predicate dispatch itself uses, not a second opinion about it
+/// -- and puts the answer to [`carry::promotable`], which holds the
+/// per-backend verdict and the evidence behind each one. CPU and Metal
+/// promote; CUDA and Vulkan do not, for want of hardware to check them
+/// on rather than for a known defect.
 ///
 /// **The pinned spin pool.** Under `FERROX_CPU_POOL=spin` the rayon
 /// global pool is never used for work, and `rayon::scope` would BUILD
@@ -156,7 +161,7 @@ where
     F: FnOnce() -> R + Send,
     R: Send,
 {
-    if crate::weight_matrix::active_backend() != crate::kernel_registry::Backend::Cpu {
+    if !carry::promotable(crate::weight_matrix::active_backend()) {
         return f();
     }
     if policy::pinned() == Some(Backend::Spin) {
@@ -165,11 +170,18 @@ where
     if rayon::current_thread_index().is_some() {
         return f();
     }
+    // Captured HERE, on the thread whose caller made the decision, and
+    // before anything is submitted. Reading it on the worker would read
+    // the worker's default, which is the defect.
+    let carried = carry::Carry::capture();
     // The one cold entry this whole design is willing to pay. Counted
     // like any other, so [`cold_regions`] reports the true total and a
     // test can assert it is exactly one.
     note_rayon_region();
-    rayon::scope(move |_| f())
+    rayon::scope(move |_| {
+        let _adopted = carried.adopt();
+        f()
+    })
 }
 
 /// Which scheduler CPU parallel regions use.
@@ -578,9 +590,13 @@ mod tests {
     /// The two configurations `on_workers` declines to promote in, and
     /// so the two it cannot be asserted in. One predicate, shared by
     /// every test below, rather than three spellings of it.
+    ///
+    /// The backend half asks [`carry::promotable`] rather than naming a
+    /// backend: the rule used to be "the backend is CPU", and writing
+    /// that here a second time is how a test comes to assert the rule
+    /// the code used to have.
     fn the_promotion_applies_here() -> bool {
-        policy::pinned().is_none()
-            && crate::weight_matrix::active_backend() == crate::kernel_registry::Backend::Cpu
+        policy::pinned().is_none() && carry::promotable(crate::weight_matrix::active_backend())
     }
 
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -875,6 +891,41 @@ mod tests {
             inside, 1,
             "the whole batch should enter the pool exactly once"
         );
+    }
+
+    /// A promoted step runs with the setting its SUBMITTER announced,
+    /// not with the worker's default.
+    ///
+    /// This is GitHub issue #166's whole mechanism at the seam that
+    /// caused it. `on_workers` moves the step to a thread the caller
+    /// never configured; before the carry, a Metal decode read the
+    /// default there and took the other `lm_head` path, changing the
+    /// completion from the tenth token. The test asserts on the thread
+    /// id first, so it cannot pass by not having moved.
+    ///
+    /// Sabotage: delete the `carried.adopt()` line from `on_workers`.
+    #[cfg(feature = "metal")]
+    #[test]
+    fn a_promoted_step_runs_with_the_setting_its_submitter_announced() {
+        use ferrox_metal::greedy_fold::{greedy_fold_setting, set_metal_greedy_argmax, GreedyFold};
+        if !the_promotion_applies_here() {
+            return;
+        }
+        set_metal_greedy_argmax(true);
+        let submitter = std::thread::current().id();
+
+        let (ran_on, seen) = on_workers(|| (std::thread::current().id(), greedy_fold_setting()));
+
+        assert_ne!(
+            ran_on, submitter,
+            "nothing is being tested unless the step actually moved"
+        );
+        assert_eq!(
+            seen,
+            GreedyFold::On,
+            "the worker must run the fold the caller asked for"
+        );
+        set_metal_greedy_argmax(false);
     }
 
     /// A nested call must not open a second entry, so an entry point can

--- a/crates/ferrox-core/src/par/carry.rs
+++ b/crates/ferrox-core/src/par/carry.rs
@@ -1,0 +1,261 @@
+//! What a promoted parallel region carries from the thread that
+//! submitted it, and which backends may be promoted at all.
+//!
+//! # The problem this exists for (GitHub issue #166)
+//!
+//! [`super::on_workers`] moves a whole forward pass onto a rayon worker
+//! so its ~150 cold pool entries collapse into one. Moving work between
+//! threads is free only for work that reads nothing off the thread it
+//! runs on, and a Metal decode step is not that: `ferrox-cli` and
+//! `ferrox-server` each decide per request whether the stack may fold
+//! `final_norm + lm_head + argmax` into its own command buffer, and
+//! they announce that decision into a THREAD-LOCAL.
+//!
+//! Measured on an M2 Pro, `Llama-3.2-3B-Instruct-Q4_K_M --ngl 99`,
+//! `--temp 0 --no-cnv`: a step driven on a worker read the default
+//! instead of the announcement and silently took the other `lm_head`
+//! path, giving a different completion from the tenth token. The
+//! workaround was to decline promotion under any GPU backend, which
+//! cost Metal the whole scheduling win.
+//!
+//! # The shape of the fix
+//!
+//! [`Carry`] is the ONE list of thread-local *settings* a moved step
+//! reads. It is captured by value on the submitting thread and adopted
+//! on the worker for exactly the length of the job.
+//!
+//! [`Carry::adopt`] destructures `self` exhaustively, with no `..`, so a
+//! field added to `Carry` and not adopted does not compile. That is the
+//! enforcement, and it is the point: this repo's dominant defect is two
+//! structures that must agree with nothing making them.
+//!
+//! # Settings, not caches
+//!
+//! Only state a CALLER configured belongs here. `ferrox-metal`'s other
+//! thread-locals -- `TL_PIPELINE_CACHE`, `TL_WEIGHT_CACHE`,
+//! `TL_F32_CACHE`, `TL_MOE_PACKED`, `TL_MOE_LAYER_RESIDENT` -- are
+//! per-thread mirrors of process-wide `Mutex` caches holding `Arc`s of
+//! the same GPU buffers, and `TL_MOE_PREFILL` / `MOE_SCRATCH` are
+//! per-thread scratch. A fresh thread rebuilds a mirror or allocates
+//! scratch; neither changes a value, and the mirrors clone `Arc`s
+//! rather than GPU memory, so a worker does not duplicate weights. The
+//! one hand-off that used to carry a value across a step, the resident
+//! activation, no longer lives on a thread at all: it is a host address
+//! recorded inside `DecodeScratch`, under the process mutex that owns
+//! the buffer it describes (`ferrox_metal::resident_act`).
+//!
+//! So `Carry` has exactly one field, and the reason there is only one
+//! is written down rather than assumed.
+//!
+//! # What losing the setting costs TODAY, which is not what it cost then
+//!
+//! Worth stating, because the before/after evidence for relaxing the
+//! gate is "bit-identical" and issue #166's evidence was "different from
+//! the tenth token", and those look contradictory.
+//!
+//! Issue #170 landed in between. It split the permission to fold into
+//! two predicates and made the device argmax legal only where the host
+//! sampler would have chosen the same id anyway, so the folded and
+//! unfolded paths now agree by construction WHENEVER the fold is
+//! permitted. A worker that loses the setting therefore falls back to a
+//! correct answer computed the slow way -- it downloads a whole
+//! vocabulary and argmaxes on the host instead of downloading four
+//! bytes.
+//!
+//! Measured with the carry deleted from [`super::on_workers`] and
+//! nothing else changed: on `Llama-3.2-3B-Instruct-Q4_K_M --ngl 99
+//! --temp 0 --repeat-penalty 1.0` the step still ran on a worker and the
+//! completion was byte-for-byte the same, but the fold went from `On` to
+//! `Unset` and stopped firing. That is the whole of what this module
+//! buys now, and it is why the enforcement above matters more than the
+//! one field it currently guards: the NEXT setting to be added has no
+//! guarantee of degrading so kindly.
+
+use crate::kernel_registry::Backend;
+
+/// The thread-local settings a moved forward pass reads.
+///
+/// Captured with [`Self::capture`] on the thread whose caller made the
+/// decisions, adopted with [`Self::adopt`] on the thread that runs the
+/// work.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct Carry {
+    /// Whether this request's Metal decode steps fold
+    /// `final_norm + lm_head + argmax` into the stack.
+    ///
+    /// Three-state on purpose (`Unset` / `Off` / `On`): a thread nobody
+    /// configured has not said "no fold", it has said nothing, and
+    /// resolving one into the other is what would let a sampling
+    /// request inherit a greedy request's precomputed token id. See
+    /// `ferrox_metal::greedy_fold`.
+    #[cfg(feature = "metal")]
+    greedy_fold: ferrox_metal::greedy_fold::GreedyFold,
+}
+
+impl Carry {
+    /// This thread's settings, as a value that can cross to another
+    /// thread.
+    pub(crate) fn capture() -> Self {
+        Self {
+            #[cfg(feature = "metal")]
+            greedy_fold: ferrox_metal::greedy_fold::greedy_fold_setting(),
+        }
+    }
+
+    /// Installs these settings on the calling thread until the returned
+    /// guard drops.
+    ///
+    /// A rayon worker is reused, so every setting installed here has to
+    /// be restored: leaving one behind would make the NEXT job on this
+    /// worker inherit a stranger's request, which is issue #166 again
+    /// one level down. Each field's guard restores what it replaced.
+    #[must_use = "the settings are restored when the guard drops"]
+    pub(crate) fn adopt(self) -> Adopted {
+        // Exhaustive, and deliberately without `..`: a new field must be
+        // adopted here or this stops compiling. That is the only thing
+        // standing between a future thread-local setting and a silent
+        // repeat of issue #166.
+        let Self {
+            #[cfg(feature = "metal")]
+            greedy_fold,
+        } = self;
+        Adopted {
+            #[cfg(feature = "metal")]
+            _greedy_fold: ferrox_metal::greedy_fold::adopt_greedy_fold(greedy_fold),
+        }
+    }
+}
+
+/// Restores every setting [`Carry::adopt`] installed, on drop.
+pub(crate) struct Adopted {
+    #[cfg(feature = "metal")]
+    _greedy_fold: ferrox_metal::greedy_fold::GreedyFoldGuard,
+}
+
+/// Whether [`super::on_workers`] may move a step running on `backend`
+/// onto a rayon worker.
+///
+/// Exhaustive with no `_` arm, so a new backend cannot be added without
+/// stating its verdict, and the only honest way to write `true` is to
+/// have made [`Carry`] reproduce everything that backend reads off the
+/// submitting thread AND to have checked on hardware that its output is
+/// unchanged.
+///
+/// The verdicts, and what each rests on:
+///
+/// - **`Cpu`** -- nothing thread-affine. Token-identical under the move
+///   at 135M, 3B and 8B (issue #167).
+/// - **`Metal`** -- the one setting is carried by [`Carry`], and the
+///   remaining `ferrox-metal` thread-locals are caches, mirrors and
+///   scratch (this module's header lists them). Verified bit-identical
+///   before and after with `ferrox verify` and `ferrox parity` on a
+///   dense Llama, a sandwich-norm Gemma-2 and an OLMoE MoE. On a build
+///   without the `metal` feature `active_backend` cannot return this,
+///   so the arm is unreachable rather than wrong there.
+/// - **`Cuda`** -- audited clean and NOT promoted. `ferrox-cuda` has no
+///   thread-locals at all: the device handle, the loaded-module set and
+///   the weight cache are process-wide `Mutex`es, and cudarc binds the
+///   primary context to whichever thread calls it. The audit is not the
+///   evidence this repo asks for, though; a GPU behaviour change merges
+///   after it has been RUN on that GPU, and this development machine
+///   has none. Flipping this row is a one-line change for whoever has
+///   the hardware, plus the same before/after check Metal got.
+/// - **`Vulkan`** -- one kernel, reached through MoltenVK, never
+///   measured under promotion. Same rule as CUDA.
+pub(crate) fn promotable(backend: Backend) -> bool {
+    match backend {
+        Backend::Cpu => true,
+        Backend::Metal => true,
+        Backend::Cuda => false,
+        Backend::Vulkan => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A captured setting reproduces itself on the thread that adopts
+    /// it, which is the whole of the fix for issue #166.
+    ///
+    /// The `ferrox-metal` half of this is tested at its source; what is
+    /// tested HERE is that `par`'s own capture/adopt pair is wired to
+    /// it, because the defect was never in `greedy_fold` -- it was in
+    /// nobody calling it.
+    ///
+    /// Sabotage: make `Carry::capture` return `Self::default()`.
+    #[cfg(feature = "metal")]
+    #[test]
+    fn a_captured_setting_crosses_to_the_thread_that_adopts_it() {
+        use ferrox_metal::greedy_fold::{
+            greedy_fold_setting, metal_greedy_argmax_active, set_metal_greedy_argmax, GreedyFold,
+        };
+
+        for (announced, expected) in [(true, GreedyFold::On), (false, GreedyFold::Off)] {
+            set_metal_greedy_argmax(announced);
+            let carried = Carry::capture();
+
+            let seen = std::thread::spawn(move || {
+                let _adopted = carried.adopt();
+                (greedy_fold_setting(), metal_greedy_argmax_active())
+            })
+            .join()
+            .expect("worker thread");
+
+            assert_eq!(
+                seen,
+                (expected, announced),
+                "the worker must run with the setting its submitter chose"
+            );
+        }
+    }
+
+    /// And the adopting thread gets its own setting back, so the next
+    /// job on a reused worker does not inherit this one's request.
+    ///
+    /// Sabotage: `drop` the `GreedyFoldGuard` inside `Carry::adopt`
+    /// instead of storing it in `Adopted` (the field then holds `()`),
+    /// and the setting is already gone at the first assertion.
+    #[cfg(feature = "metal")]
+    #[test]
+    fn an_adopted_setting_does_not_outlive_its_job() {
+        use ferrox_metal::greedy_fold::{greedy_fold_setting, set_metal_greedy_argmax, GreedyFold};
+
+        set_metal_greedy_argmax(false);
+        let mut carry = Carry::capture();
+        carry.greedy_fold = GreedyFold::On;
+        {
+            let _adopted = carry.adopt();
+            assert_eq!(greedy_fold_setting(), GreedyFold::On);
+        }
+        assert_eq!(
+            greedy_fold_setting(),
+            GreedyFold::Off,
+            "a worker is reused, so the borrowed setting must be given back"
+        );
+    }
+
+    /// The verdict table covers every backend this build knows about.
+    ///
+    /// `Backend::ALL` is generated from the same one table the enum is,
+    /// so this walks the real set rather than a restatement of it. The
+    /// match in [`promotable`] has no `_` arm, which is what makes a new
+    /// row a compile error; this asserts the other half, that the two
+    /// backends promotion is claimed for are the two that were checked.
+    ///
+    /// Sabotage: add `Backend::Cuda` to the expected set.
+    #[test]
+    fn only_the_backends_whose_thread_affine_state_is_carried_are_promoted() {
+        let promoted: Vec<Backend> = Backend::ALL
+            .iter()
+            .copied()
+            .filter(|&b| promotable(b))
+            .collect();
+        assert_eq!(
+            promoted,
+            vec![Backend::Cpu, Backend::Metal],
+            "promotion is claimed only where it was proven; see this \
+             module's verdict table"
+        );
+    }
+}

--- a/crates/ferrox-metal/src/greedy_fold.rs
+++ b/crates/ferrox-metal/src/greedy_fold.rs
@@ -82,10 +82,19 @@
 //! explicitly is the only sound answer, and the carrying has to be done
 //! by whoever moves the work.
 //!
-//! That is why `ferrox_core::par::on_workers` still declines to promote
-//! a decode step under a GPU backend. Relaxing that gate is a separate,
-//! measurable change, and it should pass [`greedy_fold_setting`] through
-//! [`adopt_greedy_fold`] when it does.
+//! # Who does the carrying
+//!
+//! `ferrox_core::par::carry`, which is the one thing in the workspace
+//! that moves a forward pass between threads. It captures with
+//! [`greedy_fold_setting`] on the submitting thread and installs with
+//! [`adopt_greedy_fold`] on the worker, for the length of the job, and
+//! its `Carry` struct is destructured exhaustively so a second setting
+//! added here and not carried there does not compile.
+//!
+//! With that in place `on_workers` no longer declines to promote under
+//! Metal. CUDA and Vulkan still decline, for want of hardware to check
+//! them on rather than for a known defect; the verdict per backend and
+//! its evidence live on `par::carry::promotable`.
 
 use std::cell::Cell;
 

--- a/crates/ferrox-models/src/engine/entry.rs
+++ b/crates/ferrox-models/src/engine/entry.rs
@@ -88,8 +88,8 @@ pub trait Engine: Sync {
     /// parallel region the step opens takes rayon's in-worker path. See
     /// the module docs for what that is worth, and
     /// [`ferrox_core::par::on_workers`] for the three cases it declines
-    /// to promote (a non-CPU active backend, a pinned spin pool, and a
-    /// caller already on a worker).
+    /// to promote (a backend whose thread-affine state `par::carry` does
+    /// not carry, a pinned spin pool, and a caller already on a worker).
     ///
     /// Do not override this. The body is one line, and the only reason
     /// it is a provided method rather than a free function is that a

--- a/crates/ferrox-models/tests/forward_enters_the_pool_once.rs
+++ b/crates/ferrox-models/tests/forward_enters_the_pool_once.rs
@@ -61,9 +61,10 @@ fn caches(decoder: &Decoder) -> Vec<KvCache> {
 /// where there is nothing here to assert.
 ///
 /// `FERROX_CPU_POOL=spin` deliberately keeps the rayon pool unbuilt, a
-/// GPU backend keeps the step on its own thread because the Metal stack
-/// carries thread-local state across it, and a caller already on a
-/// worker needs no promotion. Skip rather than assert something the
+/// backend whose thread-affine state `par::carry` does not carry keeps
+/// the step on its own thread (CUDA and Vulkan today; Metal's one
+/// setting is carried, so it promotes), and a caller already on a worker
+/// needs no promotion. Skip rather than assert something the
 /// configuration makes untrue.
 ///
 /// **Probed, not restated.** This used to spell out "not pinned to spin,


### PR DESCRIPTION
Closes #166. Its first half landed in PR #171; this is the second.

## What was missing

#171 named the cause -- `GREEDY_ARGMAX`, a thread-local *configuration*
flag set by the caller on one thread and read by the model layer on
whichever thread ran the step -- and turned it into a three-state
`GreedyFold` with `greedy_fold_setting` / `adopt_greedy_fold` as a
capture-and-adopt seam. Nothing called that seam, so
`ferrox_core::par::on_workers` still declined to promote a decode step
whenever the active backend was not CPU, and Metal forwent the whole
scheduling win #167 measured on CPU: ~150 cold rayon entries per token
collapsing to one, worth +29% at 135M, +9% at 3B, +3% at 8B.
`ferrox-server` runs generation on `spawn_blocking`, so the server is
exactly the case that crosses threads.

## What this adds

`crates/ferrox-core/src/par/carry.rs`, a new module rather than a new
section in the 900-line `par.rs`:

- **`Carry`** is the ONE list of thread-local *settings* a moved forward
  pass reads. Captured by value on the submitting thread, adopted on the
  worker for exactly the length of the job, restored by RAII so a reused
  worker does not inherit a stranger's request.
- **`Carry::adopt` destructures `self` exhaustively, with no `..`**, so a
  field added to `Carry` and not adopted does not compile. That is the
  enforcement, and it is the reason the module exists as a type rather
  than as two lines inline.
- **`promotable`** is the per-backend verdict: an exhaustive match with
  no `_` arm, each row carrying the evidence behind it. `on_workers` asks
  it instead of comparing against `Backend::Cpu`, and `par`'s own test
  helper -- which was asking the same question a second way -- asks it
  too.
- The header records the audit of everything else thread-affine a
  promoted step touches: `TL_PIPELINE_CACHE`, `TL_WEIGHT_CACHE`,
  `TL_F32_CACHE`, `TL_MOE_PACKED` and `TL_MOE_LAYER_RESIDENT` are
  per-thread mirrors of process-wide `Mutex` caches holding `Arc`s of the
  same GPU buffers (so a worker rebuilds a mirror, not GPU memory);
  `TL_MOE_PREFILL` and `MOE_SCRATCH` are per-thread scratch. The one
  hand-off that used to carry a value across a step, the resident
  activation, no longer lives on a thread at all.

## Is the gate relaxed? Yes, for Metal

CPU and Metal promote. **CUDA and Vulkan still decline**, and the row
says why: `ferrox-cuda` has no thread-locals at all -- device handle,
loaded-module set and weight cache are process-wide `Mutex`es, and
cudarc binds the primary context to whichever thread calls it -- so it
audits clean, but an audit is not the evidence this repo asks for. A GPU
behaviour change merges after it has been RUN on that GPU and this
machine has none. Flipping that row is one line plus the same
before/after check Metal got.

## Evidence

M2 Pro, release, `--ngl 99 --temp 0 --no-cnv`, 48 tokens, against a
binary built from the merge-base. Run at both the default
`--repeat-penalty 1.1` (fold off) and `1.0` (fold on), because only the
second exercises the carried setting:

| model | verdict |
|---|---|
| `Llama-3.2-3B-Instruct-Q4_K_M` | completions **bit-identical**, both penalties |
| `gemma-2-2b-it-Q4_K_M` (sandwich norm) | completions **bit-identical**, both penalties |
| `olmoe-1b-7b-0924-q4_0` (MoE) | completions **bit-identical**, both penalties |

- `ferrox verify --backend metal --prompt-tokens 32`: OK on all three,
  before and after, prefill covered.
- `ferrox parity --prompt-tokens 32`: MATCH on all three, before and
  after, with `KL(llama||ferrox)` identical to every printed digit
  (3.638e-5 / 2.065e-4 / 1.445e-6).
- `cargo test -p ferrox-metal --features metal -- --ignored`: 58 passed.
- `ferrox-server` on port 8391, Metal: a greedy request is byte-identical
  alone, while a concurrent `temperature 0.8` request runs, and again
  afterwards. The sampling request gets prose, not a token id.

Measured effect, `FERROX_METAL_GPU_TIMING=1` only, interleaved
main/branch/main/branch on the 3B: `dense-decode/tok` 15.215, 15.204,
15.369, 15.693 ms, and the **same** dispatch and barrier counts (362.2
dispatches, 278.6 barriers) on every run. That is the expected result --
the GPU work is unchanged and the saving is host-side. No tok/s figure
is claimed: the host is shared and not quiet, and `benchmarks/RESULTS.md`
is untouched.

## Two findings worth reading

**The gate really was reaching Metal.** Instrumented one-shot: the step
runs on `ThreadId(2)`, a rayon worker, with `backend=Metal
promotable=true`, and the fold reads `setting=On`. With `carried.adopt()`
deleted and nothing else changed, the same run reads `setting=Unset` and
the fold stops firing. So the promotion is live and the carry is what
keeps it.

**Losing the setting no longer changes the ANSWER**, which is why the
before/after above is bit-identical where #166's evidence was "different
from the tenth token". #170 landed in between: it split the permission to
fold into two predicates and made the device argmax legal only where the
host sampler would have chosen the same id anyway, so the two lm_head
paths now agree by construction wherever the fold is permitted. A worker
that loses the setting falls back to a correct answer computed the slow
way -- a whole vocabulary downloaded where four bytes would do. The next
setting has no guarantee of degrading that kindly, which is why the
exhaustive-destructure enforcement is worth more than the one field it
currently guards. Both are in the module docs.

## Gates

`cargo test --workspace` (62 suites green), `cargo test -p ferrox-models
--features metal`, clippy `-D warnings` in debug, release, and both with
`--features metal`, `cargo fmt --all`. Each of the four new tests was
sabotaged once with the mutation grep-confirmed in the file first, and
each went red; the sabotage is named in each test's doc comment.
