### PR TITLE
ui: a mark instead of two letters, and a palette with no brand hue

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -109,6 +109,34 @@ src/
   screens/{models,activity,connect}.tsx
 ```
 
+## The look, in four rules
+
+They are written at the top of `src/index.css`, because a rule nobody can
+quote is a rule that drifts. Three of them are asserted by
+`lib/theme.test.ts` rather than promised.
+
+- **Colour.** There is **no brand hue**. The neutral ramp is zero-chroma
+  and the only chromatic tokens in the app are `ok`, `warn` and `err`, so
+  chroma means exactly one thing: a state. The test fails if any other
+  token grows chroma, or if a semantic one loses it.
+- **Emphasis**, since no hue carries it. Four levers, loudest first: a
+  solid **ink** fill (`--ink`, near-black in light and near-white in
+  dark) for the one primary action in a view; **weight** for a selected
+  row or a label; **surface** behind a hairline for grouping; and the
+  **contrast** ramp `fg` / `muted` / `faint` for rank inside a block.
+- **Type.** One six-step scale — `2xs` 11, `xs` 12, `sm` 14, `base` 15,
+  `lg` 17, `xl` 20, plus `code` 13 — and no arbitrary sizes in
+  components.
+- **Elevation.** Borders separate; shadows only float. One shadow token,
+  `--shadow-pop`, for popovers and the mobile drawer.
+
+The mark is a body-centred cubic cell, which is the structure of α-iron.
+Its geometry lives in `lib/logo-geometry.ts` and is drawn twice — by
+`components/logo.tsx` in `currentColor`, and by `public/favicon.svg`,
+which needs a colour of its own because a favicon cannot inherit one.
+`lib/logo-geometry.test.ts` reads the favicon off disk and holds the two
+to the same path strings.
+
 ## Where you land, and what it opens
 
 **The URL says which conversation you are in.** `/ui/chat` is a new

--- a/ui/index.html
+++ b/ui/index.html
@@ -9,10 +9,13 @@
       name="description"
       content="Chat, model manager and live request log for a local ferrox-server."
     />
-    <link
-      rel="icon"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23c2410c'/%3E%3Cpath d='M11 8h12v4h-8v4h7v4h-7v8h-4z' fill='%23fff'/%3E%3C/svg%3E"
-    />
+    <!-- The mark, drawn from the geometry in src/lib/logo-geometry.ts and
+         held to it by src/lib/logo-geometry.test.ts. It is a file rather
+         than a data: URI because it needs a `prefers-color-scheme` rule
+         of its own: a favicon cannot inherit `currentColor` from the
+         page, and one fixed colour disappears into one of the two
+         browser chromes. -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <!-- The Ferrox mark. Geometry is owned by src/lib/logo-geometry.ts and
+       asserted against this file by src/lib/logo-geometry.test.ts, because
+       nothing else links a static favicon to the React component.
+       A favicon cannot inherit currentColor from the page, so the colour is
+       set here and flipped by prefers-color-scheme; there is no tile, so the
+       mark reads on light and dark browser chrome alike. -->
+  <style>
+    :root { color: #18181b }
+    @media (prefers-color-scheme: dark) { :root { color: #fafafa } }
+  </style>
+  <g transform="translate(12 12) scale(1.3) translate(-12 -12)"
+     fill="none" stroke="currentColor" stroke-width="1.6"
+     stroke-linejoin="round" stroke-linecap="round">
+    <path d="M12 3 19.79 7.5 19.79 16.5 12 21 4.21 16.5 4.21 7.5Z"/>
+    <path d="M12 12 12 3M12 12 19.79 16.5M12 12 4.21 16.5"/>
+    <circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none"/>
+  </g>
+</svg>

--- a/ui/src/components/app-shell.tsx
+++ b/ui/src/components/app-shell.tsx
@@ -3,24 +3,9 @@ import { NavLink, Outlet } from "react-router";
 import { PanelLeft, X } from "lucide-react";
 import { SCREENS } from "@/lib/screens";
 import { HealthPill } from "@/components/health-pill";
+import { FerroxWordmark } from "@/components/logo";
 import { useHealth } from "@/lib/use-health";
 import { cn } from "@/lib/utils";
-
-function Brand() {
-  return (
-    <div className="flex items-center gap-2.5">
-      <span
-        aria-hidden
-        className="grid size-7 shrink-0 place-items-center rounded-[0.4375rem] bg-accent text-[0.8125rem] font-bold text-accent-fg"
-      >
-        Fe
-      </span>
-      <span className="text-sm font-semibold tracking-tight">
-        Ferrox Studio
-      </span>
-    </div>
-  );
-}
 
 function Nav({ onNavigate }: { onNavigate?: () => void }) {
   return (
@@ -30,12 +15,15 @@ function Nav({ onNavigate }: { onNavigate?: () => void }) {
           key={to}
           to={to}
           onClick={onNavigate}
+          // Where you are is not news: you clicked it. A neutral fill
+          // plus a weight bump says it without making the loudest thing
+          // on a screen where nothing is wrong be "which tab am I on".
           className={({ isActive }) =>
             cn(
               "group flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm transition-colors",
               isActive
-                ? "bg-accent-soft font-medium text-accent"
-                : "text-muted hover:bg-inset hover:text-fg",
+                ? "bg-inset font-medium text-fg"
+                : "text-muted hover:bg-inset/60 hover:text-fg",
             )
           }
         >
@@ -44,11 +32,11 @@ function Nav({ onNavigate }: { onNavigate?: () => void }) {
               <Icon
                 className={cn(
                   "size-4 shrink-0",
-                  isActive ? "text-accent" : "text-faint group-hover:text-muted",
+                  isActive ? "text-fg" : "text-faint group-hover:text-muted",
                 )}
               />
               <span className="min-w-0 flex-1 truncate">{label}</span>
-              <span className="hidden text-[0.6875rem] text-faint lg:group-hover:inline">
+              <span className="hidden text-2xs text-faint lg:group-hover:inline">
                 {blurb}
               </span>
             </>
@@ -66,7 +54,7 @@ export function AppShell() {
   const sidebar = (
     <div className="flex h-full flex-col gap-4 p-3">
       <div className="flex items-center justify-between px-1 pt-1">
-        <Brand />
+        <FerroxWordmark />
         <button
           type="button"
           onClick={() => setDrawer(false)}
@@ -122,7 +110,7 @@ export function AppShell() {
           >
             <PanelLeft className="size-4" />
           </button>
-          <Brand />
+          <FerroxWordmark />
         </header>
 
         <main id="main" tabIndex={-1} className="min-h-0 flex-1 overflow-hidden">

--- a/ui/src/components/health-pill.tsx
+++ b/ui/src/components/health-pill.tsx
@@ -95,7 +95,7 @@ export function HealthPill({ state, className }: { state: HealthState; className
         {/* The word first. A status control you have to click to find out
             is a status control is the thing being fixed here. */}
         <span className="min-w-0 flex-1">
-          <span className="block text-[0.6875rem] leading-tight text-faint">
+          <span className="block text-2xs leading-tight text-faint">
             Server
           </span>
           <span
@@ -117,7 +117,7 @@ export function HealthPill({ state, className }: { state: HealthState; className
           align="start"
           sideOffset={8}
           collisionPadding={12}
-          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-card border border-line bg-raised p-3 text-xs shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-xl border border-line bg-raised p-3 text-xs shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           {health ? (
             <div className="space-y-3">

--- a/ui/src/components/logo.tsx
+++ b/ui/src/components/logo.tsx
@@ -1,0 +1,56 @@
+import {
+  CELL_PATH,
+  CORE_R,
+  SPOKES_PATH,
+  STROKE_WIDTH,
+  VIEWBOX,
+} from "@/lib/logo-geometry";
+import { cn } from "@/lib/utils";
+
+/**
+ * The Ferrox mark. See `lib/logo-geometry.ts` for what it draws and why.
+ *
+ * It is inline SVG on `currentColor` rather than an image, so one file
+ * serves the sidebar, the assistant avatar, the empty state and the
+ * favicon, in both themes, with no second asset to keep in step.
+ */
+export function FerroxMark({
+  className,
+  title,
+}: {
+  className?: string;
+  /** Give it one only where the mark is the sole naming of something. */
+  title?: string;
+}) {
+  return (
+    <svg
+      viewBox={VIEWBOX}
+      className={cn("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={STROKE_WIDTH}
+      strokeLinejoin="round"
+      strokeLinecap="round"
+      role={title ? "img" : undefined}
+      aria-hidden={title ? undefined : true}
+    >
+      {title ? <title>{title}</title> : null}
+      <path d={CELL_PATH} />
+      <path d={SPOKES_PATH} />
+      <circle cx="12" cy="12" r={CORE_R} fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+/** Mark plus name. The weight split is the whole lockup: no hue does it. */
+export function FerroxWordmark({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex min-w-0 items-center gap-2", className)}>
+      <FerroxMark className="size-5 text-fg" />
+      <span className="truncate text-sm tracking-tight">
+        <span className="font-semibold">Ferrox</span>{" "}
+        <span className="text-faint">Studio</span>
+      </span>
+    </div>
+  );
+}

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -3,12 +3,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[0.6875rem] font-medium leading-4 whitespace-nowrap",
+  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-medium leading-4 whitespace-nowrap",
   {
     variants: {
+      // `ok`/`warn`/`err` are the only tones carrying a hue, and the hue
+      // is the whole reason they exist. "In progress" is not a verdict,
+      // so it gets contrast rather than a colour — a running download in
+      // a brand hue reads as an alarm in a column of them.
       tone: {
         neutral: "border-line bg-inset text-muted",
-        accent: "border-accent/35 bg-accent-soft text-accent",
+        strong: "border-line-strong bg-inset text-fg",
         ok: "border-ok/35 bg-ok-soft text-ok",
         warn: "border-warn/35 bg-warn-soft text-warn",
         err: "border-err/35 bg-err-soft text-err",

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -3,26 +3,33 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+// The radius lives on the SIZE, not on the base, because `round` is a
+// size whose whole point is a different radius. Two radius utilities on
+// one element resolve by stylesheet order rather than class order, so
+// "the later class wins" would be a coin flip; only one is ever emitted.
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg font-medium transition-[background,color,border-color,box-shadow] disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap font-medium transition-[background,color,border-color] disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        primary:
-          "bg-accent text-accent-fg hover:bg-accent-hover shadow-sm shadow-black/5",
+        // Ink. With no brand hue this is the loudest thing the app can
+        // draw, so it is spent on ONE action per view and nothing else.
+        primary: "bg-ink text-on-ink hover:bg-ink-hover",
         default:
           "border border-line bg-raised text-fg hover:bg-inset hover:border-line-strong",
         ghost: "text-muted hover:bg-inset hover:text-fg",
-        danger:
-          "border border-err/40 bg-err-soft text-err hover:border-err/70",
-        link: "text-accent underline-offset-4 hover:underline",
+        danger: "border border-err/40 bg-err-soft text-err hover:border-err/70",
+        // A link has no hue either; the underline is what marks it.
+        link: "text-fg underline decoration-line-strong underline-offset-4 hover:decoration-fg",
       },
       size: {
-        sm: "h-7 px-2.5 text-xs [&_svg]:size-3.5",
-        md: "h-9 px-3.5 text-sm [&_svg]:size-4",
-        lg: "h-10 px-4 text-sm [&_svg]:size-4",
-        icon: "size-9 [&_svg]:size-4",
-        iconSm: "size-7 [&_svg]:size-3.5",
+        sm: "h-7 rounded-md px-2.5 text-xs [&_svg]:size-3.5",
+        md: "h-9 rounded-lg px-3.5 text-sm [&_svg]:size-4",
+        lg: "h-10 rounded-lg px-4 text-sm [&_svg]:size-4",
+        icon: "size-9 rounded-lg [&_svg]:size-4",
+        /** The composer's send / stop. A circle, and the only one. */
+        round: "size-9 rounded-full [&_svg]:size-4",
+        iconSm: "size-7 rounded-md [&_svg]:size-3.5",
       },
     },
     defaultVariants: { variant: "default", size: "md" },

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -5,7 +5,7 @@ export function Card({ className, ...props }: React.ComponentProps<"section">) {
   return (
     <section
       className={cn(
-        "rounded-card border border-line bg-raised shadow-panel",
+        "rounded-xl border border-line bg-raised",
         className,
       )}
       {...props}

--- a/ui/src/components/ui/field.tsx
+++ b/ui/src/components/ui/field.tsx
@@ -3,7 +3,7 @@ import * as LabelPrimitive from "@radix-ui/react-label";
 import { cn } from "@/lib/utils";
 
 const control =
-  "w-full rounded-lg border border-line bg-raised px-2.5 py-1.5 text-sm text-fg placeholder:text-faint transition-colors hover:border-line-strong focus:border-accent focus:outline-none focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1 disabled:opacity-50";
+  "w-full rounded-lg border border-line bg-raised px-2.5 py-1.5 text-sm text-fg placeholder:text-faint transition-colors hover:border-line-strong focus:border-ink focus:outline-none focus-visible:outline-2 focus-visible:outline-ink focus-visible:outline-offset-1 disabled:opacity-50";
 
 export function Input({ className, ...props }: React.ComponentProps<"input">) {
   return <input className={cn(control, "h-9", className)} {...props} />;
@@ -49,7 +49,7 @@ export function Field({
     <div className={cn("flex min-w-0 flex-col gap-1.5", className)}>
       <Label htmlFor={htmlFor}>{label}</Label>
       {children}
-      {hint ? <p className="text-[0.6875rem] text-faint">{hint}</p> : null}
+      {hint ? <p className="text-2xs text-faint">{hint}</p> : null}
     </div>
   );
 }

--- a/ui/src/components/ui/progress.tsx
+++ b/ui/src/components/ui/progress.tsx
@@ -28,10 +28,10 @@ export function Progress({
       )}
     >
       {pct === null ? (
-        <div className="h-full w-1/3 animate-[indeterminate_1.4s_ease-in-out_infinite] rounded-full bg-accent/70" />
+        <div className="h-full w-1/3 animate-[indeterminate_1.4s_ease-in-out_infinite] rounded-full bg-ink/70" />
       ) : (
         <div
-          className="h-full rounded-full bg-accent transition-[width] duration-500 ease-out"
+          className="h-full rounded-full bg-ink transition-[width] duration-500 ease-out"
           style={{ width: `${pct.toFixed(1)}%` }}
         />
       )}

--- a/ui/src/components/ui/sparkline.tsx
+++ b/ui/src/components/ui/sparkline.tsx
@@ -51,25 +51,25 @@ export function Sparkline({
       preserveAspectRatio="none"
       role="img"
       aria-label={`${label}: ${points.length} samples, ${min.toFixed(1)} to ${max.toFixed(1)}`}
-      className={cn("h-8 w-full overflow-visible", className)}
+      className={cn("h-8 w-full overflow-visible text-fg", className)}
     >
       <defs>
         <linearGradient id={id} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.25" />
-          <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.25" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
         </linearGradient>
       </defs>
       <path d={area} fill={`url(#${id})`} />
       <path
         d={path}
         fill="none"
-        stroke="var(--accent)"
+        stroke="currentColor"
         strokeWidth="1.5"
         strokeLinejoin="round"
         strokeLinecap="round"
         vectorEffect="non-scaling-stroke"
       />
-      <circle cx={last[0]} cy={last[1]} r="2" fill="var(--accent)" />
+      <circle cx={last[0]} cy={last[1]} r="2" fill="currentColor" />
     </svg>
   );
 }

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -1,7 +1,15 @@
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 
-/** Wide tables scroll inside their own box; the page never scrolls sideways. */
+/**
+ * Wide tables scroll inside their own box; the page never scrolls sideways.
+ *
+ * Every cell below is `whitespace-nowrap`, and that is what makes this box
+ * work at all. A `w-full` table with auto layout does not overflow when it
+ * is too wide — it WRAPS, so at 430px `708.7 MB` broke across two lines
+ * and every row in the inventory was 57px instead of 35px, with nothing to
+ * scroll. Let the cells refuse to wrap and the overflow lands here.
+ */
 export function TableScroll({
   className,
   ...props
@@ -32,7 +40,7 @@ export function Th({
     <th
       scope="col"
       className={cn(
-        "sticky top-0 z-10 border-b border-line bg-raised px-3 py-2 text-left text-[0.6875rem] font-semibold tracking-wide text-faint uppercase",
+        "sticky top-0 z-10 border-b border-line bg-raised px-3 py-2 text-left text-2xs font-semibold tracking-wide whitespace-nowrap text-faint uppercase",
         numeric && "text-right tabular-nums",
         className,
       )}
@@ -50,9 +58,9 @@ export function Td({
   return (
     <td
       className={cn(
-        "border-b border-line/70 px-3 py-2 align-middle",
+        "border-b border-line/70 px-3 py-2 align-middle whitespace-nowrap",
         numeric && "text-right tabular-nums",
-        mono && "font-mono text-[0.8125rem]",
+        mono && "font-mono text-code",
         className,
       )}
       {...props}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -3,70 +3,112 @@
 
 /* Ferrox Studio theme.
  *
- * The discipline the previous hand-written stylesheet had is kept: every
- * colour is declared exactly once on `:root`, and the dark theme is one
- * `prefers-color-scheme` block that redefines the SAME names and nothing
- * else. No component below hard-codes a colour, so the two themes cannot
- * drift apart — adding a token to one and forgetting the other is a
- * missing-variable error, not a silently wrong shade.
- *
- * The accent is ferrox's burnt orange, carried over unchanged from the
- * old stylesheet and from the favicon. No new brand was invented here.
+ * Every colour is declared exactly once on `:root`, and the dark theme is
+ * one `prefers-color-scheme` block that redefines the SAME names and
+ * nothing else. No component below hard-codes a colour, so the two themes
+ * cannot drift apart. `lib/theme.test.ts` asserts that: the two blocks
+ * must define the same key set, every `--color-*` must point at a token
+ * that exists, and the neutral ramp must be provably hueless.
  *
  * No web fonts: the binary carries the UI, and a font file is 40-100 KB
- * of it. The system stack is also the only stack that needs no network
- * at all, which is the point of a locally-served studio.
+ * of it. The system stack is also the only stack that needs no network at
+ * all, which is the point of a locally-served studio.
+ *
+ * Four rules the rest of the app is built on. They are written down
+ * because a rule nobody can quote is a rule that drifts:
+ *
+ *   COLOUR. There is no brand hue. The neutral ramp is zero-chroma and
+ *     the ONLY chromatic tokens in the file are `ok`, `warn` and `err`.
+ *     That is deliberate: chroma now means one thing, "something is
+ *     wrong or something finished", so a red badge cannot be mistaken
+ *     for decoration. Nothing may add a fourth hue without answering
+ *     what state it names.
+ *
+ *   EMPHASIS, since no hue carries it. Four levers, in order of volume:
+ *     INK (`--ink`, a solid near-black fill in light and near-white in
+ *     dark) for the one primary action in a view; WEIGHT (500 for a
+ *     selected row or a label, 600 for a title, never bold) for "you are
+ *     here"; SURFACE (raised / inset / sunken behind a hairline) for
+ *     grouping and selection; CONTRAST (`fg` / `muted` / `faint`) for
+ *     rank inside a block. `--ink` IS `--fg`; the separate name exists so
+ *     that "this is the loudest thing on the screen" is a decision a
+ *     component states rather than one it borrows from a text colour.
+ *
+ *   TYPE. One scale, six steps, no arbitrary sizes in components.
+ *     2xs 11 · xs 12 · sm 14 (the UI default) · base 15 (prose) ·
+ *     lg 17 (titles) · xl 20. Plus `code` 13 for monospace blocks.
+ *     Before this, `text-[0.6875rem]` appeared 23 times in the app — one
+ *     magic number restated 23 times, which is this repo's dominant
+ *     defect shape wearing a stylesheet.
+ *
+ *   ELEVATION. Borders separate; shadows only FLOAT. A hairline is the
+ *     boundary between two surfaces that both sit on the page — cards,
+ *     tables, inputs, the sidebar — and it never gets a shadow. Exactly
+ *     one shadow token exists, `--shadow-pop`, for things genuinely
+ *     above the page: popovers and the mobile drawer.
  */
 
 :root {
-  --bg: oklch(0.976 0.001 286);
+  /* The neutral ramp. Zero chroma, by rule and by test. */
+  --bg: oklch(0.985 0 0);
   --bg-raised: oklch(1 0 0);
-  --bg-sunken: oklch(0.949 0.002 286);
-  --bg-inset: oklch(0.962 0.003 286);
-  --border: oklch(0.898 0.003 286);
-  --border-strong: oklch(0.808 0.005 286);
-  --fg: oklch(0.187 0.004 286);
-  --fg-muted: oklch(0.492 0.006 286);
-  --fg-faint: oklch(0.634 0.007 286);
-  --accent: oklch(0.518 0.164 39.5);
-  --accent-hover: oklch(0.463 0.155 39.5);
-  --accent-fg: oklch(1 0 0);
-  --accent-soft: oklch(0.958 0.019 47);
-  --accent-ring: oklch(0.518 0.164 39.5 / 0.45);
-  --ok: oklch(0.556 0.121 154);
+  --bg-sunken: oklch(0.971 0 0);
+  --bg-inset: oklch(0.949 0 0);
+  --border: oklch(0.909 0 0);
+  --border-strong: oklch(0.833 0 0);
+  --fg: oklch(0.205 0 0);
+  --fg-muted: oklch(0.478 0 0);
+  --fg-faint: oklch(0.598 0 0);
+
+  /* Ink — emphasis as a fill rather than as a hue. */
+  --ink: oklch(0.205 0 0);
+  --ink-hover: oklch(0.318 0 0);
+  --on-ink: oklch(1 0 0);
+
+  /* Selection, and the one soft neutral a "chosen" row sits on. */
+  --select: oklch(0.884 0 0);
+
+  /* The only chroma in this file. Each one names a STATE. */
+  --ok: oklch(0.546 0.124 154);
   --ok-soft: oklch(0.955 0.03 154);
-  --warn: oklch(0.586 0.124 74);
+  --warn: oklch(0.566 0.124 74);
   --warn-soft: oklch(0.958 0.045 85);
   --err: oklch(0.535 0.183 26);
   --err-soft: oklch(0.955 0.028 20);
+
   --shadow-color: 0 0 0;
-  --shadow-strength: 0.055;
+  --shadow-strength: 0.07;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: oklch(0.176 0.003 286);
-    --bg-raised: oklch(0.219 0.004 286);
-    --bg-sunken: oklch(0.145 0.003 286);
-    --bg-inset: oklch(0.253 0.005 286);
-    --border: oklch(0.296 0.006 286);
-    --border-strong: oklch(0.402 0.008 286);
-    --fg: oklch(0.937 0.003 286);
-    --fg-muted: oklch(0.714 0.008 286);
-    --fg-faint: oklch(0.564 0.009 286);
-    --accent: oklch(0.712 0.163 46);
-    --accent-hover: oklch(0.769 0.147 50);
-    --accent-fg: oklch(0.176 0.03 40);
-    --accent-soft: oklch(0.276 0.045 42);
-    --accent-ring: oklch(0.712 0.163 46 / 0.5);
+    --bg: oklch(0.178 0 0);
+    --bg-raised: oklch(0.216 0 0);
+    --bg-sunken: oklch(0.152 0 0);
+    --bg-inset: oklch(0.262 0 0);
+    --border: oklch(0.301 0 0);
+    --border-strong: oklch(0.408 0 0);
+    --fg: oklch(0.962 0 0);
+    --fg-muted: oklch(0.719 0 0);
+    --fg-faint: oklch(0.586 0 0);
+
+    /* Ink inverts with the page: the loudest fill is always the one
+     * furthest from the background, which in the dark is white. */
+    --ink: oklch(0.962 0 0);
+    --ink-hover: oklch(0.865 0 0);
+    --on-ink: oklch(0.178 0 0);
+
+    --select: oklch(0.345 0 0);
+
     --ok: oklch(0.762 0.143 158);
-    --ok-soft: oklch(0.27 0.045 158);
+    --ok-soft: oklch(0.276 0.045 158);
     --warn: oklch(0.79 0.132 79);
-    --warn-soft: oklch(0.29 0.045 79);
-    --err: oklch(0.699 0.163 21);
-    --err-soft: oklch(0.29 0.06 21);
+    --warn-soft: oklch(0.293 0.045 79);
+    --err: oklch(0.712 0.163 21);
+    --err-soft: oklch(0.293 0.06 21);
+
     --shadow-color: 0 0 0;
-    --shadow-strength: 0.4;
+    --shadow-strength: 0.45;
   }
 }
 
@@ -83,10 +125,10 @@
   --color-fg: var(--fg);
   --color-muted: var(--fg-muted);
   --color-faint: var(--fg-faint);
-  --color-accent: var(--accent);
-  --color-accent-hover: var(--accent-hover);
-  --color-accent-fg: var(--accent-fg);
-  --color-accent-soft: var(--accent-soft);
+  --color-ink: var(--ink);
+  --color-ink-hover: var(--ink-hover);
+  --color-on-ink: var(--on-ink);
+  --color-select: var(--select);
   --color-ok: var(--ok);
   --color-ok-soft: var(--ok-soft);
   --color-warn: var(--warn);
@@ -98,14 +140,34 @@
     system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial,
     sans-serif;
   --font-mono:
-    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-    "Liberation Mono", monospace;
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
+    monospace;
 
-  --radius-card: 0.75rem;
+  /* The type scale, stated once. `2xs` and `code` are the two steps this
+   * app was writing as arbitrary values; `base` and `lg` are pulled in
+   * from Tailwind's defaults because a 16px body and an 18px card title
+   * read as a marketing page, not as a tool. */
+  --text-2xs: 0.6875rem;
+  --text-2xs--line-height: 1rem;
+  --text-code: 0.8125rem;
+  --text-code--line-height: 1.35rem;
+  --text-base: 0.9375rem;
+  --text-base--line-height: 1.55;
+  --text-lg: 1.0625rem;
+  --text-lg--line-height: 1.4;
+  --text-xl: 1.25rem;
+  --text-xl--line-height: 1.35;
 
-  --shadow-panel:
-    0 1px 2px rgb(var(--shadow-color) / var(--shadow-strength)),
-    0 8px 24px -12px rgb(var(--shadow-color) / var(--shadow-strength));
+  /* One radius, four derived steps, so "rounded like the rest of it" is
+   * a decision made once. sm 6 · md 8 · lg 10 · xl 14 · 2xl 20. */
+  --radius: 0.625rem;
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 10px);
+
+  /* The only shadow. Things that float, and nothing else. */
   --shadow-pop:
     0 4px 8px -4px rgb(var(--shadow-color) / var(--shadow-strength)),
     0 16px 40px -16px rgb(var(--shadow-color) / var(--shadow-strength));
@@ -125,20 +187,21 @@
     color: var(--fg);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
-    font-size: 0.9375rem;
-    line-height: 1.55;
+    text-rendering: optimizeLegibility;
+    font-size: var(--text-sm);
+    line-height: 1.5;
   }
 
-  /* Keyboard focus stays visible everywhere; the accent ring is the one
-   * signal a keyboard-only user has for where they are. */
+  /* Keyboard focus stays visible everywhere. With no accent hue the ring
+   * is ink, which is the highest-contrast outline either theme has. */
   :focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid var(--ink);
     outline-offset: 2px;
-    border-radius: 0.375rem;
+    border-radius: var(--radius-sm);
   }
 
   ::selection {
-    background: var(--accent-soft);
+    background: var(--select);
     color: var(--fg);
   }
 
@@ -148,28 +211,40 @@
     scrollbar-width: thin;
     scrollbar-color: var(--border-strong) transparent;
   }
+
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--border-strong);
+    border-radius: 4px;
+  }
 }
 
 @layer components {
   /* Prose for rendered model output. Scoped to `.aui-md` so it can never
    * leak into the chrome around it. */
   .aui-md {
-    @apply text-[0.9375rem] leading-relaxed;
+    @apply text-base leading-relaxed;
   }
   .aui-md > * + * {
     @apply mt-3;
   }
   .aui-md h1 {
-    @apply mt-5 text-xl font-semibold tracking-tight;
+    @apply mt-5 text-lg font-semibold tracking-tight;
   }
   .aui-md h2 {
-    @apply mt-5 text-lg font-semibold tracking-tight;
+    @apply mt-5 text-base font-semibold tracking-tight;
   }
   .aui-md h3,
   .aui-md h4,
   .aui-md h5,
   .aui-md h6 {
-    @apply mt-4 text-base font-semibold;
+    @apply mt-4 text-sm font-semibold;
   }
   .aui-md ul {
     @apply list-disc space-y-1 pl-5;
@@ -181,8 +256,14 @@
   .aui-md li > ol {
     @apply mt-1;
   }
+  /* A link has no hue to be recognised by, so the underline carries it:
+   * always present, thickened on hover rather than switched on. One rule
+   * for prose links and for the inline links in the chrome — the two used
+   * to be an accent colour each and would now be two copies of a
+   * five-utility string that has to stay in step. */
+  .link,
   .aui-md a {
-    @apply text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent;
+    @apply font-medium text-fg underline decoration-line-strong decoration-2 underline-offset-2 hover:decoration-fg;
   }
   .aui-md blockquote {
     @apply border-l-2 border-line-strong pl-3 text-muted italic;
@@ -201,7 +282,7 @@
     @apply bg-sunken font-medium;
   }
   .aui-md :not(pre) > code {
-    @apply rounded bg-inset px-1 py-0.5 font-mono text-[0.85em];
+    @apply rounded-sm bg-inset px-1 py-0.5 font-mono text-[0.85em];
   }
   /* A fenced block renders as `<CodeHeader/>` followed by `<pre>` — two
    * siblings, not a wrapper — so the card outline is drawn by joining
@@ -211,7 +292,7 @@
     @apply mt-3 rounded-t-lg border border-b-0 border-line;
   }
   .aui-md pre {
-    @apply overflow-x-auto rounded-lg border border-line bg-sunken p-3 font-mono text-[0.8125rem] leading-relaxed;
+    @apply overflow-x-auto rounded-lg border border-line bg-sunken p-3 font-mono text-code;
   }
   .aui-md .aui-code-header + pre {
     @apply mt-0 rounded-t-none border-t-0;

--- a/ui/src/lib/logo-geometry.test.ts
+++ b/ui/src/lib/logo-geometry.test.ts
@@ -1,0 +1,53 @@
+// The mark is drawn twice — by `components/logo.tsx`, which imports the
+// geometry, and by `public/favicon.svg`, which is a static file nothing
+// links to the component. Two structures that must agree about one thing,
+// with nothing enforcing it, is this repo's dominant defect shape, and the
+// failure here is silent in the worst possible way: the tab would keep
+// showing the old mark while the app showed the new one, and nobody looks
+// at a favicon on purpose.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  CELL_PATH,
+  CORE_R,
+  SPOKES_PATH,
+  STROKE_WIDTH,
+  VIEWBOX,
+} from "./logo-geometry.ts";
+
+const favicon = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "..", "..", "public", "favicon.svg"),
+  "utf8",
+);
+
+test("the favicon draws the same mark as the component", () => {
+  assert.ok(favicon.includes(`viewBox="${VIEWBOX}"`), "viewBox");
+  assert.ok(favicon.includes(`d="${CELL_PATH}"`), "cell outline");
+  assert.ok(favicon.includes(`d="${SPOKES_PATH}"`), "spokes");
+  assert.ok(favicon.includes(`r="${CORE_R}"`), "core radius");
+  assert.ok(favicon.includes(`stroke-width="${STROKE_WIDTH}"`), "stroke width");
+});
+
+test("the favicon carries its own colour in both themes", () => {
+  // It cannot inherit `currentColor` from the page, so it has to state a
+  // light value and a dark one. A favicon with one colour disappears into
+  // one of the two browser chromes.
+  assert.match(favicon, /prefers-color-scheme:\s*dark/);
+  assert.equal(favicon.match(/color:\s*#[0-9a-f]{6}/gi)?.length, 2);
+});
+
+test("the mark is hueless: it never names a colour of its own", () => {
+  // The component inherits `currentColor`; the geometry module must not
+  // start carrying a fill or stroke value, or the "no brand hue" rule
+  // acquires an exception nobody can see from the stylesheet.
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "logo-geometry.ts"),
+    "utf8",
+  );
+  assert.doesNotMatch(source, /#[0-9a-fA-F]{3,8}\b|oklch\(|rgb\(|hsl\(/);
+});

--- a/ui/src/lib/logo-geometry.ts
+++ b/ui/src/lib/logo-geometry.ts
@@ -1,0 +1,42 @@
+/**
+ * The Ferrox mark, as numbers.
+ *
+ * Ferrox is iron oxide, and the structure of α-iron — ferrite — is
+ * body-centred cubic. Seen down its body diagonal a cubic cell projects
+ * to a regular hexagon with three visible edges meeting at the centre,
+ * and the body-centred atom sits exactly on that meeting point. So the
+ * mark is a real thing rather than a decoration: an outline (the cell),
+ * three spokes (the visible edges) and one filled node (the atom at the
+ * centre of the cell). It is drawn in strokes of `currentColor`, so it
+ * inherits the text colour in either theme and at any size, and at 16px
+ * it collapses to a legible hexagon-with-a-core rather than to mush.
+ *
+ * The geometry lives here, and not inside the component, because it is
+ * drawn TWICE: once by `components/logo.tsx` and once by
+ * `public/favicon.svg`, which is a static file no bundler links to the
+ * component. Two structures that must agree about one thing is this
+ * repo's dominant defect shape, so `logo-geometry.test.ts` reads the
+ * favicon off disk and asserts it carries these exact strings.
+ */
+
+/** Everything below is expressed in this box. */
+export const VIEWBOX = "0 0 24 24";
+
+/**
+ * The cell outline: a pointy-top hexagon of radius 9 about (12, 12).
+ * Vertices at 90°, 30°, 330°, 270°, 210°, 150°; 9·cos30° = 7.79.
+ */
+export const CELL_PATH =
+  "M12 3 19.79 7.5 19.79 16.5 12 21 4.21 16.5 4.21 7.5Z";
+
+/**
+ * The three cube edges that stay visible in this projection, running
+ * from the centre out to alternating vertices.
+ */
+export const SPOKES_PATH = "M12 12 12 3M12 12 19.79 16.5M12 12 4.21 16.5";
+
+/** The body-centred atom. */
+export const CORE_R = 2.2;
+
+/** Stroke weight at the 24-unit scale: 1.6 gives ~1.07px at 16px. */
+export const STROKE_WIDTH = 1.6;

--- a/ui/src/lib/theme.test.ts
+++ b/ui/src/lib/theme.test.ts
@@ -1,0 +1,89 @@
+// The palette, asserted rather than promised.
+//
+// Three invariants live in `index.css` as prose, and prose does not fail a
+// build. Each of these has a silent failure mode: a token added to one
+// theme and not the other renders as an unresolved `var()` (transparent,
+// in exactly one theme, on exactly one screen); a `--color-*` pointing at
+// a token that was renamed emits no CSS at all, so the utility class just
+// stops working; and a hue creeping back into the neutral ramp is
+// invisible in a diff of oklch triples but is the entire brief.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const css = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "..", "index.css"),
+  "utf8",
+);
+
+/** The tokens allowed to carry chroma, and what each one names. */
+const SEMANTIC = ["ok", "ok-soft", "warn", "warn-soft", "err", "err-soft"];
+
+/** `--name: value` pairs from one brace-delimited block. */
+function declarations(block: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const [, name, value] of block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    out.set(name, value.trim());
+  }
+  return out;
+}
+
+/** The `:root { … }` block that follows `from`, up to its closing brace. */
+function rootBlock(source: string, from: number): string {
+  const open = source.indexOf(":root {", from);
+  assert.notEqual(open, -1, "expected a :root block");
+  const close = source.indexOf("}", open);
+  assert.notEqual(close, -1, "unterminated :root block");
+  return source.slice(open, close);
+}
+
+const darkAt = css.indexOf("@media (prefers-color-scheme: dark)");
+assert.notEqual(darkAt, -1, "the dark theme block is missing");
+
+const light = declarations(rootBlock(css, 0));
+const dark = declarations(rootBlock(css, darkAt));
+
+test("the two themes define the same token names", () => {
+  assert.deepEqual([...dark.keys()].sort(), [...light.keys()].sort());
+  assert.ok(light.size > 20, "suspiciously few tokens parsed");
+});
+
+test("every Tailwind colour points at a token that exists", () => {
+  const theme = css.slice(css.indexOf("@theme inline"));
+  const refs = [...theme.matchAll(/--color-[\w-]+\s*:\s*var\((--[\w-]+)\)/g)];
+  assert.ok(refs.length > 10, "suspiciously few --color-* mappings parsed");
+  for (const [, token] of refs) {
+    assert.ok(light.has(token), `--color-* points at unknown ${token}`);
+  }
+});
+
+test("the neutral ramp is hueless — nothing carries a brand colour", () => {
+  // This is the user-visible rule: chroma means "a state", and nothing
+  // else. If a fourth hue is ever wanted, it has to answer what state it
+  // names, and be added to SEMANTIC on purpose.
+  for (const [theme, tokens] of [
+    ["light", light],
+    ["dark", dark],
+  ] as const) {
+    for (const [name, value] of tokens) {
+      const oklch = /^oklch\(\s*[\d.]+\s+([\d.]+)\s/.exec(value);
+      if (!oklch) continue;
+      const chroma = Number(oklch[1]);
+      const semantic = SEMANTIC.includes(name.slice(2));
+      if (semantic) {
+        assert.ok(chroma > 0, `${theme} ${name} lost its hue: ${value}`);
+      } else {
+        assert.equal(chroma, 0, `${theme} ${name} carries a hue: ${value}`);
+      }
+    }
+  }
+});
+
+test("the semantic states are all still declared", () => {
+  for (const name of SEMANTIC) {
+    assert.ok(light.has(`--${name}`), `--${name} went missing`);
+  }
+});

--- a/ui/src/screens/activity.tsx
+++ b/ui/src/screens/activity.tsx
@@ -62,7 +62,7 @@ function Counter({
       className="rounded-lg border border-line bg-inset/40 px-3 py-2"
       title={hint}
     >
-      <p className="text-[0.6875rem] tracking-wide text-faint uppercase">
+      <p className="text-2xs tracking-wide text-faint uppercase">
         {label}
       </p>
       <p className="mt-0.5 font-mono text-lg tabular-nums">{value}</p>
@@ -367,7 +367,7 @@ export function ActivityScreen() {
           ).map(([label, values]) => (
             <Card key={label}>
               <CardBody className="space-y-2 p-3">
-                <p className="text-[0.6875rem] tracking-wide text-faint uppercase">
+                <p className="text-2xs tracking-wide text-faint uppercase">
                   {label}
                 </p>
                 <Sparkline label={label} values={[...values]} />
@@ -423,7 +423,7 @@ export function ActivityScreen() {
                             type="button"
                             onClick={header.column.getToggleSortingHandler()}
                             className={cn(
-                              "flex w-full items-center gap-1 px-3 py-2 text-[0.6875rem] font-semibold tracking-wide text-faint uppercase hover:text-fg",
+                              "flex w-full items-center gap-1 px-3 py-2 text-2xs font-semibold tracking-wide text-faint uppercase hover:text-fg",
                               numeric && "justify-end",
                             )}
                           >
@@ -434,7 +434,7 @@ export function ActivityScreen() {
                             <Icon
                               className={cn(
                                 "size-3",
-                                sorted ? "text-accent" : "opacity-40",
+                                sorted ? "text-fg" : "opacity-40",
                               )}
                             />
                           </button>

--- a/ui/src/screens/chat.tsx
+++ b/ui/src/screens/chat.tsx
@@ -159,7 +159,7 @@ function ModelSwitcher({
     <Popover.Root onOpenChange={(open) => open && refresh()}>
       <Popover.Trigger asChild>
         <Button variant="default" size="sm" className="max-w-[16rem]">
-          <span className="truncate font-mono text-[0.6875rem]">
+          <span className="truncate font-mono text-2xs">
             {active ?? "no model loaded"}
           </span>
           <ChevronDown className="text-faint" />
@@ -170,7 +170,7 @@ function ModelSwitcher({
           align="end"
           sideOffset={6}
           collisionPadding={12}
-          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] rounded-card border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] rounded-xl border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           {unsupported ? (
             <p className="p-2 text-xs text-faint">
@@ -182,7 +182,7 @@ function ModelSwitcher({
           ) : !inventory.models.length ? (
             <p className="p-2 text-xs text-faint">
               No checkpoints found.{" "}
-              <Link to="/ui/models" className="text-accent underline">
+              <Link to="/ui/models" className="link">
                 Download one
               </Link>
               .
@@ -200,7 +200,7 @@ function ModelSwitcher({
                       className={cn(
                         "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors",
                         isActive
-                          ? "bg-accent-soft text-accent"
+                          ? "bg-inset font-medium text-fg"
                           : "hover:bg-inset disabled:opacity-50",
                       )}
                     >
@@ -215,7 +215,7 @@ function ModelSwitcher({
                         <span className="block truncate font-mono text-xs">
                           {entry.id}
                         </span>
-                        <span className="block truncate text-[0.6875rem] text-faint">
+                        <span className="block truncate text-2xs text-faint">
                           {[entry.quant, entry.arch, fmtBytes(entry.size_bytes)]
                             .filter(Boolean)
                             .join(" · ")}
@@ -228,11 +228,11 @@ function ModelSwitcher({
             </ul>
           )}
           {error ? (
-            <p className="mt-1 rounded-lg bg-err-soft px-2 py-1.5 text-[0.6875rem] text-err">
+            <p className="mt-1 rounded-lg bg-err-soft px-2 py-1.5 text-2xs text-err">
               {error}
             </p>
           ) : null}
-          <p className="mt-1 border-t border-line px-2 pt-1.5 text-[0.6875rem] text-faint">
+          <p className="mt-1 border-t border-line px-2 pt-1.5 text-2xs text-faint">
             Loading a checkpoint swaps it for every client of this server. A
             request already in flight finishes on the weights it started on.
           </p>
@@ -265,7 +265,7 @@ function SamplingPanel({
           align="end"
           sideOffset={6}
           collisionPadding={12}
-          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] space-y-3 rounded-card border border-line bg-raised p-3 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(24rem,calc(100vw-1.5rem))] space-y-3 rounded-xl border border-line bg-raised p-3 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           <div className="grid grid-cols-3 gap-2">
             <Field label="temperature">
@@ -340,7 +340,7 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
       <Popover.Trigger asChild>
         <Button variant="default" size="sm" className="max-w-[14rem]">
           <MessagesSquare className="text-faint" />
-          <span className="truncate text-[0.6875rem]">
+          <span className="truncate text-2xs">
             {current ? conversationLabel(current) : "New conversation"}
           </span>
           <ChevronDown className="text-faint" />
@@ -351,7 +351,7 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
           align="end"
           sideOffset={6}
           collisionPadding={12}
-          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-card border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-xl border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         >
           {!summaries.length ? (
             <p className="p-2 text-xs text-faint">
@@ -370,14 +370,14 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
                       className={cn(
                         "min-w-0 flex-1 rounded-lg px-2 py-1.5 text-left transition-colors",
                         isActive
-                          ? "bg-accent-soft text-accent"
+                          ? "bg-inset font-medium text-fg"
                           : "hover:bg-inset",
                       )}
                     >
                       <span className="block truncate text-xs">
                         {conversationLabel(entry)}
                       </span>
-                      <span className="block truncate text-[0.6875rem] text-faint">
+                      <span className="block truncate text-2xs text-faint">
                         {[
                           `${entry.message_count} message${entry.message_count === 1 ? "" : "s"}`,
                           entry.model,
@@ -399,7 +399,7 @@ function ConversationPicker({ transcript }: { transcript: Transcript }) {
               })}
             </ul>
           )}
-          <p className="mt-1 border-t border-line px-2 pt-1.5 text-[0.6875rem] text-faint">
+          <p className="mt-1 border-t border-line px-2 pt-1.5 text-2xs text-faint">
             Stored on the server, not in this browser. Deleting one deletes it
             for every client of this server, and nothing is ever deleted to
             make room.
@@ -441,7 +441,7 @@ function ChatInner({
           <Badge tone="err">synthetic weights</Badge>
         ) : null}
         {transcript.saving ? (
-          <span className="text-[0.6875rem] text-faint">saving…</span>
+          <span className="text-2xs text-faint">saving…</span>
         ) : null}
         <span className="flex-1" />
         {transcript.mode === "server" ? (
@@ -520,7 +520,7 @@ function ChatInner({
         <Thread
           disabledReason={disabledReason}
           footer={
-            <p className="text-center text-[0.6875rem] text-faint">
+            <p className="text-center text-2xs text-faint">
               {transcript.mode === "server"
                 ? "Transcript is stored on the server, branches included, and survives this browser."
                 : transcript.mode === "local"

--- a/ui/src/screens/chat/markdown.tsx
+++ b/ui/src/screens/chat/markdown.tsx
@@ -26,7 +26,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 function CodeHeader({ language, code }: CodeHeaderProps) {
   return (
     <div className="aui-code-header flex items-center gap-2 bg-inset px-3 py-1.5">
-      <span className="font-mono text-[0.6875rem] tracking-wide text-faint uppercase">
+      <span className="font-mono text-2xs tracking-wide text-faint uppercase">
         {language || "text"}
       </span>
       <span className="flex-1" />

--- a/ui/src/screens/chat/thread.tsx
+++ b/ui/src/screens/chat/thread.tsx
@@ -10,16 +10,17 @@ import {
 } from "@assistant-ui/react";
 import {
   ArrowDown,
+  ArrowUp,
   ChevronLeft,
   ChevronRight,
   CircleAlert,
   Copy,
-  CornerDownLeft,
   Pencil,
   RefreshCw,
   Square,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { FerroxMark } from "@/components/logo";
 import { cn } from "@/lib/utils";
 import { MarkdownText } from "@/screens/chat/markdown";
 import { ReasoningPart } from "@/screens/chat/reasoning";
@@ -58,14 +59,14 @@ function StatLine() {
   const pieces = [outcome, stats.line].filter(Boolean);
   if (!pieces.length) {
     return stats.requestId ? (
-      <p className="mt-2 font-mono text-[0.6875rem] text-faint">
+      <p className="mt-2 font-mono text-2xs text-faint">
         {stats.requestId}
       </p>
     ) : null;
   }
   return (
     <p
-      className="mt-2 font-mono text-[0.6875rem] leading-relaxed text-faint"
+      className="mt-2 font-mono text-2xs leading-relaxed text-faint"
       title="Reported by the server in the final SSE chunk's usage block. The browser holds no stopwatch."
     >
       {pieces.join("  ·  ")}
@@ -84,7 +85,7 @@ function BranchPicker({ className }: { className?: string }) {
           <ChevronLeft />
         </Button>
       </BranchPickerPrimitive.Previous>
-      <span className="font-mono text-[0.6875rem]">
+      <span className="font-mono text-2xs">
         <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
       </span>
       <BranchPickerPrimitive.Next asChild>
@@ -98,7 +99,10 @@ function BranchPicker({ className }: { className?: string }) {
 
 const UserMessage: FC = () => (
   <MessagePrimitive.Root className="group flex w-full flex-col items-end gap-1">
-    <div className="max-w-[min(44rem,88%)] rounded-2xl rounded-br-md bg-accent px-3.5 py-2 text-accent-fg">
+    {/* A raised neutral, not a filled block. A solid bubble in the one
+        emphasis colour the app has would turn a long conversation into a
+        stripe; the tail and the alignment already say who is speaking. */}
+    <div className="max-w-[min(44rem,88%)] rounded-2xl rounded-br-md border border-line bg-inset px-3.5 py-2 text-fg">
       <MessagePrimitive.Parts />
     </div>
     <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
@@ -138,11 +142,8 @@ const EditComposer: FC = () => (
 const AssistantMessage: FC = () => (
   <MessagePrimitive.Root className="group flex w-full flex-col gap-1">
     <div className="flex gap-3">
-      <span
-        aria-hidden
-        className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-md border border-line bg-inset text-[0.625rem] font-bold text-accent"
-      >
-        Fe
+      <span className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-md border border-line bg-inset text-muted">
+        <FerroxMark className="size-3.5" />
       </span>
       <div className="min-w-0 flex-1">
         <div className="min-w-0">
@@ -194,12 +195,7 @@ function Empty({ disabledReason }: { disabledReason: string | null }) {
   return (
     <ThreadPrimitive.Empty>
       <div className="flex flex-col items-center gap-5 px-4 py-14 text-center">
-        <span
-          aria-hidden
-          className="grid size-12 place-items-center rounded-2xl bg-accent text-lg font-bold text-accent-fg shadow-panel"
-        >
-          Fe
-        </span>
+        <FerroxMark className="size-11 text-fg" />
         <div className="space-y-1.5">
           <p className="text-base font-semibold tracking-tight">
             Talk to your local model
@@ -242,7 +238,7 @@ function Composer({ disabledReason }: { disabledReason: string | null }) {
   return (
     <ComposerPrimitive.Root
       className={cn(
-        "flex w-full items-end gap-2 rounded-2xl border border-line bg-raised p-2 shadow-panel transition-colors focus-within:border-accent",
+        "flex w-full items-end gap-2 rounded-2xl border border-line bg-raised p-2 transition-colors focus-within:border-line-strong",
         disabledReason && "opacity-70",
       )}
     >
@@ -260,19 +256,30 @@ function Composer({ disabledReason }: { disabledReason: string | null }) {
         // adapter POSTs /v1/cancel with the request_id the server named
         // on the first chunk. It cancels on the server, not just here.
         <ComposerPrimitive.Cancel asChild>
-          <Button variant="default" size="icon" aria-label="Stop generating">
-            <Square className="fill-current" />
+          <Button variant="default" size="round" aria-label="Stop generating">
+            {/* A square is optically larger than a circle of the same
+                box, so the stop glyph is drawn smaller than the arrow
+                rather than at the size class's default. */}
+            <Square className="size-3 fill-current" />
           </Button>
         </ComposerPrimitive.Cancel>
       ) : (
         <ComposerPrimitive.Send asChild>
           <Button
             variant="primary"
-            size="icon"
+            size="round"
             aria-label="Send"
             disabled={!!disabledReason}
           >
-            <CornerDownLeft />
+            {/* An up arrow, not the ↵ corner-arrow that was here. The
+                corner glyph hangs its mass down and to the left, so in a
+                circle it is off-centre on BOTH axes and can only be
+                fixed by a nudge nobody can check. This one is symmetric
+                left-to-right, so the horizontal centre is free; the head
+                puts more ink in the top half than the shaft puts in the
+                bottom, so the perceived centre sits high and the glyph
+                is dropped half a pixel to bring it back. */}
+            <ArrowUp className="translate-y-[0.5px]" />
           </Button>
         </ComposerPrimitive.Send>
       )}

--- a/ui/src/screens/connect.tsx
+++ b/ui/src/screens/connect.tsx
@@ -52,7 +52,7 @@ function Snippet({
       </CardHeader>
       <CardBody className="space-y-2 p-0">
         <p className="px-4 pt-3 text-xs text-faint">{note}</p>
-        <pre className="overflow-x-auto px-4 pb-4 font-mono text-[0.8125rem] leading-relaxed">
+        <pre className="overflow-x-auto px-4 pb-4 font-mono text-code leading-relaxed">
           <code>{code}</code>
         </pre>
       </CardBody>
@@ -165,13 +165,13 @@ curl -s ${base}${routes.adminStats} | jq '.recent[-1]'`,
         <CardHeader>
           <CardTitle>Connection</CardTitle>
           <span className="flex-1" />
-          <span className="font-mono text-[0.6875rem] text-faint">
+          <span className="font-mono text-2xs text-faint">
             {status}
           </span>
         </CardHeader>
         <CardBody>
           <form
-            className="flex flex-wrap items-end gap-3"
+            className="flex flex-col gap-2"
             onSubmit={(e) => {
               e.preventDefault();
               const nextKey = key.trim();
@@ -181,42 +181,50 @@ curl -s ${base}${routes.adminStats} | jq '.recent[-1]'`,
               setSavedOrigin(apiBase());
             }}
           >
-            <Field
-              label="API base URL"
-              className="min-w-56 flex-1"
-              htmlFor="apibase"
-              hint={
-                origin
-                  ? "Cross-origin: the server needs FERROX_CORS_ORIGINS set to this app's origin."
-                  : `Empty — this app's own requests go to ${window.location.origin} and the dev server proxies them. Snippets below assume the server is at its default ${DEFAULT_SERVER_ORIGIN}.`
-              }
-            >
-              <Input
-                id="apibase"
-                value={origin}
-                onChange={(e) => setOrigin(e.target.value)}
-                placeholder="http://127.0.0.1:8383  (empty = same origin)"
-                className="font-mono text-xs"
-              />
-            </Field>
-            <Field
-              label="API key (FERROX_API_KEY)"
-              className="min-w-56 flex-1"
-              htmlFor="apikey"
-            >
-              <Input
-                id="apikey"
-                type="password"
-                autoComplete="off"
-                value={key}
-                onChange={(e) => setKey(e.target.value)}
-                placeholder="unset — this server may not require one"
-              />
-            </Field>
-            <Button type="submit" variant="primary">
-              <KeyRound />
-              Save
-            </Button>
+            {/* The three controls share one row, and the base URL's
+                explanation sits UNDER it rather than in the field's own
+                hint slot. As a hint it was two lines long, which made its
+                column taller than the other two and — with `items-end` —
+                staggered the API key field and the Save button down beside
+                a gap. A caption is the same words without the layout. */}
+            <div className="flex flex-wrap items-end gap-3">
+              <Field
+                label="API base URL"
+                className="min-w-56 flex-1"
+                htmlFor="apibase"
+              >
+                <Input
+                  id="apibase"
+                  value={origin}
+                  onChange={(e) => setOrigin(e.target.value)}
+                  placeholder="http://127.0.0.1:8383  (empty = same origin)"
+                  className="font-mono text-xs"
+                />
+              </Field>
+              <Field
+                label="API key (FERROX_API_KEY)"
+                className="min-w-56 flex-1"
+                htmlFor="apikey"
+              >
+                <Input
+                  id="apikey"
+                  type="password"
+                  autoComplete="off"
+                  value={key}
+                  onChange={(e) => setKey(e.target.value)}
+                  placeholder="unset — this server may not require one"
+                />
+              </Field>
+              <Button type="submit" variant="primary">
+                <KeyRound />
+                Save
+              </Button>
+            </div>
+            <p className="text-2xs text-faint">
+              {origin
+                ? "Cross-origin: the server needs FERROX_CORS_ORIGINS set to this app's origin."
+                : `Empty — this app's own requests go to ${window.location.origin} and the dev server proxies them. Snippets below assume the server is at its default ${DEFAULT_SERVER_ORIGIN}.`}
+            </p>
           </form>
         </CardBody>
         <CardFooter className="space-y-1">

--- a/ui/src/screens/models.tsx
+++ b/ui/src/screens/models.tsx
@@ -132,7 +132,7 @@ function TaskCard({
                 ? "ok"
                 : task.status === "cancelled"
                   ? "neutral"
-                  : "accent"
+                  : "strong"
           }
         >
           {task.status}
@@ -148,7 +148,7 @@ function TaskCard({
         )}
       </div>
       {terminal ? null : <Progress fraction={fraction} label={task.label} />}
-      <p className="font-mono text-[0.6875rem] text-faint">
+      <p className="font-mono text-2xs text-faint">
         {facts.join("  ·  ")}
       </p>
     </li>
@@ -409,7 +409,7 @@ export function ModelsScreen() {
 
         <CardFooter>
           Pick which of these answers in the model menu at the top of{" "}
-          <Link to="/ui/chat" className="text-accent underline">
+          <Link to="/ui/chat" className="link">
             Chat
           </Link>
           . A swap loads the checkpoint for every client of this server; an


### PR DESCRIPTION
Three things were asked for: a real mark instead of the letters "Fe", no
orange, and a circular send button. No dependency added; `npm run check`,
`npm run build` and `npm run licenses` are green.

## The mark

<img src="https://raw.githubusercontent.com/antonellof/ferrox/ui/neutral-palette-and-logo/ui/public/favicon.svg" width="160"> &nbsp;&nbsp;&nbsp; <img src="https://raw.githubusercontent.com/antonellof/ferrox/ui/neutral-palette-and-logo/ui/public/favicon.svg" width="32"> &nbsp;&nbsp; <img src="https://raw.githubusercontent.com/antonellof/ferrox/ui/neutral-palette-and-logo/ui/public/favicon.svg" width="16">

160px · 32px · 16px, all the same file.

Ferrox is iron oxide, and the structure of α-iron — ferrite — is
**body-centred cubic**. A cubic cell seen down its body diagonal projects
to a regular hexagon with three visible edges meeting at the centre, and
the body-centred atom sits exactly on that meeting point. So the mark is a
thing rather than a decoration: one outline (the cell), three spokes (the
visible edges), one filled node (the atom). It is also the shape that
survives being shrunk — at 16px it collapses to a legible
hexagon-with-a-core, which is the size that decides whether a mark is a
mark or a picture of one.

It is inline SVG on `currentColor`, so one definition serves the sidebar
wordmark, the assistant avatar (14px), the chat empty state (44px) and the
favicon, in both themes, with no raster asset anywhere.

**It is drawn twice, so a test holds the two together.**
`components/logo.tsx` imports the geometry; `public/favicon.svg` is a
static file no bundler links to the component, and it needs a colour of
its own because a favicon cannot inherit `currentColor` from the page (it
carries its own `prefers-color-scheme` rule and no tile, so it reads on
light and dark browser chrome alike). Two structures that must agree about
one thing with nothing enforcing it is this repo's dominant defect shape,
and this is its most silent instance — the tab would keep showing the old
mark and nobody looks at a favicon on purpose. So the geometry lives in
`lib/logo-geometry.ts` and `logo-geometry.test.ts` reads the favicon off
disk and asserts it carries the same path strings, radius and stroke.

## The palette, and what emphasis is now

`--accent: oklch(0.518 0.164 39.5)` is **gone**, and so is the 286° blue
tint the neutral ramp was carrying. The ramp is zero-chroma, and the only
chromatic tokens left in the file are `ok`, `warn` and `err`.

That is the whole decision: **chroma now means exactly one thing — a
state.** A red badge cannot be mistaken for decoration when nothing else
in the app is coloured, which makes the semantic states *stronger* than
they were beside a brand hue, not weaker. Each of them also still carries
a word or an icon, never colour alone: the health pill says `ready` /
`unreachable` beside its dot, capability rows say `available` or
`cuda_not_built` beside their ✓/✗, `Notice` has an icon per tone, and
every badge is a word.

Emphasis is carried by four levers instead, loudest first:

| lever | what it is | where it is spent |
|---|---|---|
| **ink** | `--ink`, a solid fill: near-black in light, near-white in dark | exactly ONE primary action per view |
| **weight** | 500 selected / label, 600 title, never bold | "you are here", labels |
| **surface** | raised / inset / sunken behind a hairline | grouping, selection |
| **contrast** | `fg` / `muted` / `faint` | rank inside a block |

`--ink` is `--fg` by value. The separate name exists so that "this is the
loudest thing on the screen" is a decision a component **states** rather
than one it borrows from a text colour, and so that it inverts with the
page: the loudest fill is always the one furthest from the background.

### Every place colour was doing a job, and what replaced it

| was | now |
|---|---|
| sidebar active row: `bg-accent-soft text-accent` | `bg-inset font-medium text-fg` — surface + weight |
| model menu selected row | same, plus the check that was already there |
| conversation picker selected row | same |
| user's chat bubble: solid `bg-accent` | `bg-inset` + hairline; a solid bubble in the one emphasis colour turns a long conversation into a stripe |
| primary buttons: orange fill | ink fill |
| inline + prose links: `text-accent underline` | `font-medium` + a permanent underline, thickened on hover — one `.link` rule shared by chrome and `.aui-md a` |
| progress bar, sparkline | ink / `currentColor` |
| focus ring | ink, the highest-contrast outline either theme has |
| `::selection` | a dedicated neutral `--select` |
| brand mark, assistant avatar, empty state | `currentColor` |
| sort-indicator on the active Activity column | `text-fg` vs `opacity-40` |
| download-task badge `tone="accent"` | new `tone="strong"` — contrast, not colour. "In progress" is not a verdict, and a column of brand-coloured badges reads as an alarm |
| `--accent-ring` | it was declared in both themes and used by nothing. Deleted |

### The rule is asserted, not promised

`lib/theme.test.ts` parses `index.css` and fails if:

- any non-semantic token grows chroma (**this is the "no orange" rule as a
  gate** — a hue creeping back is invisible in a diff of oklch triples),
- a semantic token *loses* its chroma,
- the `:root` and dark blocks stop defining the same key set,
- a `--color-*` points at a token that no longer exists.

Sabotaged once to confirm it can fail: putting `0.164 39.5` back on
`--border` turns it red, and I checked the mutation actually landed in the
file before believing the run.

## The circular send button

`size="round"` — a 36px circle, ink fill, white arrow. Two notes:

- **The glyph changed for the sake of the centring.** The `↵`
  corner-arrow that was there hangs its mass down and to the left, so in a
  circle it is off-centre on *both* axes and can only be fixed by a nudge
  nobody can check. An up arrow (which is what a circular send button
  wants anyway) is symmetric left-to-right, so the horizontal centre is
  free and verifiable; its head puts more ink in the top half than its
  shaft puts in the bottom, so it is dropped half a pixel. Measured in the
  browser: horizontal offset `0.0000009px`, vertical `+0.5px`.
- **Stop is the same circle with a smaller square**, because a square is
  optically larger than a circle of the same box.

The radius moved from the button's base class onto its *size*, because two
radius utilities on one element resolve by stylesheet order rather than
class order — "the later class wins" would have been a coin flip.

## Carried over from the closed #179, rewritten against current main

Not cherry-picked; #179 conflicts with the health pill and models screen
that have landed since. The ideas that were worth keeping:

- **A six-step type scale.** `text-[0.6875rem]` appeared **23 times** in
  the app, `text-[0.8125rem]` four more — one magic number restated 23
  times, the repo's dominant defect shape wearing a stylesheet. They are
  `text-2xs` and `text-code` now.
- 8px rhythm for chrome, 16/24 for content; one `--radius` with four
  derived steps.
- **Borders separate, shadows only float.** `--shadow-panel` is deleted;
  `--shadow-pop` survives for popovers and the mobile drawer, which
  genuinely float.
- The token-parity discipline, now enforced by the test above.

What #179 did *not* do, and this does: it kept the orange and merely moved
it. Removing the hue entirely is what makes the emphasis discipline
mandatory rather than optional.

## Two defects found by looking at it, not by reading it

- **A `w-full` table with auto layout does not overflow when it is too
  wide — it WRAPS.** At 430px `708.7 MB` was breaking across two lines and
  every row in the inventory was **57px instead of 39px**, with nothing to
  scroll. Cells are `whitespace-nowrap` now, and `TableScroll` does the job
  it exists for: measured 893px of table inside a 386px box, and
  `scrollWidth - clientWidth == 0` on the page itself.
- **On Connect the base-URL hint was two lines long** inside the field's
  own `hint` slot, which made its column taller than the other two and —
  with `items-end` — staggered the API-key field and the Save button down
  beside a gap. Same words, moved to a caption under the row; the three
  controls now sit on one line.

## What I verified in a browser, and what only in tests

Real Chrome against a real `ferrox-server` (Llama-3.2-1B-Instruct-Q4_K_M
on Metal, port 8395, Vite on 5199). Screenshots were taken but are not
committed.

**In the browser:**

- All four screens, **light**: Chat (empty state, a live streamed answer
  with a fenced code block, the stat line, the user bubble, the assistant
  avatar), Models, Activity (counters, the three ink sparklines, the
  request table), Connect.
- All four screens, **dark**. `prefers-color-scheme` cannot be emulated
  through this tooling, so the dark palette was forced by injecting the
  same token block — which is faithful here precisely because the theme is
  *only* those tokens: there is not one `dark:` variant anywhere in `src/`,
  and `index.css` has exactly one `prefers-color-scheme` block. Ink
  correctly inverts (white send button, dark arrow), and computed styles
  were read back to confirm rather than trusting the capture.
- **430px**, in an iframe so the media queries evaluate against a real
  narrow viewport: the mobile header and wordmark, the composer, the
  horizontally-scrolling table (this is where the wrapping defect showed).
- Popovers: the health pill (still status, not a picker — the #178
  behaviour is untouched), the model menu (selected row is neutral +
  weight + check), the conversation picker.
- **The mark at 16/20/24/32/48/96/160px**, rendered from the shipped
  `favicon.svg` rather than a copy, and `favicon.svg` loaded as its own
  document to confirm its `:root { color }` resolves.
- The send button's geometry read out of the DOM: 36×36, `border-radius`
  full, `background oklch(0.205 0 0)`, icon offset `(0, +0.5px)`.

**Only in tests / at build time:** the token-parity and hue assertions,
the favicon↔component geometry match, and the licence check. The
download-task `strong` badge was verified by reading the code path, not by
running a download.

**Not touched:** anything outside `ui/`, the one-model-selector rule, the
entry-state behaviour from #178, the no-client-stopwatch rule, the
no-raw-HTML rule, and the `duration_ms`/`decode_ms` separation.
