### PR TITLE
kv: price admission and --ctx-size auto against what a windowed store really keeps (#61)

### DIFF
--- a/crates/ferrox-core/src/cache.rs
+++ b/crates/ferrox-core/src/cache.rs
@@ -506,10 +506,25 @@ impl KvCache {
         // until something hands it back. Only when the excess is large
         // enough to be worth a realloc-and-copy: shrinking on every
         // eviction would trade the block drain for a full copy.
-        let want = window.max_rows() * elems_per_position;
-        if self.k.capacity() > want.saturating_mul(2) {
-            self.k.shrink_to(want);
-            self.v.shrink_to(want);
+        //
+        // **Never for a pool-backed cache**, and the reason is a bug
+        // rather than a preference. `push` asks whether the buffer is
+        // full by comparing rows against `k.capacity()`, and takes
+        // another block from the shared pool when they meet. Shrinking
+        // the buffer to a window's worth would make that condition true
+        // every `slack + 1` tokens forever, so a windowed pooled cache
+        // would draw a fresh block from the pool on a cadence, hold
+        // every one of them until it drops, and exhaust the pool
+        // mid-answer -- where `push` is documented infallible and the
+        // caller panics. The pool has already promised this cache its
+        // blocks; handing the capacity back without handing the blocks
+        // back saves nothing and costs that.
+        if self.pool_state.is_none() {
+            let want = window.max_rows() * elems_per_position;
+            if self.k.capacity() > want.saturating_mul(2) {
+                self.k.shrink_to(want);
+                self.v.shrink_to(want);
+            }
         }
         drop_rows
     }
@@ -2053,6 +2068,53 @@ mod tests {
             cache.evict_behind_window();
         }
         assert_eq!(cache.positions(), 64);
+        assert!(cache.rows() <= 5);
+    }
+
+    /// **The sibling above passes for the wrong reason on its own
+    /// sizing, so this is the same property where the trap is armed.**
+    ///
+    /// Eviction hands surplus CAPACITY back with `shrink_to`, which is
+    /// where its memory saving actually comes from. For a pool-backed
+    /// cache that is a bug rather than a saving: the pool has already
+    /// promised these blocks and does not take them back, while `push`
+    /// decides it needs another block by comparing rows against
+    /// `k.capacity()`. Shrink that capacity to a window and the
+    /// condition is true again every `slack + 1` tokens, forever -- so
+    /// the cache draws a fresh block from the shared pool on a cadence,
+    /// never releases one, and runs the pool dry underneath every OTHER
+    /// request in the process. It surfaces where `push` is documented
+    /// infallible, so the caller panics mid-answer.
+    ///
+    /// The sibling's cache is 8 positions against a 5-row ceiling,
+    /// which is under the 2x threshold `shrink_to` is gated on, so it
+    /// never reaches the shrink at all. This one is 64 positions
+    /// against the same ceiling, and the pool is given spare blocks so
+    /// the leak shows up as blocks quietly gone rather than only as the
+    /// error at the end of them.
+    #[test]
+    fn an_evicting_pooled_cache_never_hands_its_capacity_back_to_reacquire_it() {
+        let pool = Arc::new(Mutex::new(KvBlockPool::new(8, 24)));
+        let mut cache =
+            KvCache::with_pool(1, 2, Arc::clone(&pool), 64).expect("8 of the 24 blocks");
+        let free_after_construction = pool.lock().unwrap().free_blocks();
+        assert_eq!(free_after_construction, 16, "8 blocks cover 64 positions");
+
+        cache.arm_window(KvWindow::new(4, 1).expect("positive window"));
+        let step = vec![1.0f32; 2];
+        for _ in 0..512 {
+            cache
+                .push(&step, &step)
+                .expect("a reservation made up front must not be re-made per token");
+            cache.evict_behind_window();
+        }
+
+        assert_eq!(
+            pool.lock().unwrap().free_blocks(),
+            free_after_construction,
+            "the cache drew more blocks from the shared pool while evicting"
+        );
+        assert_eq!(cache.positions(), 512);
         assert!(cache.rows() <= 5);
     }
 }

--- a/crates/ferrox-models/src/kv_budget.rs
+++ b/crates/ferrox-models/src/kv_budget.rs
@@ -43,10 +43,12 @@
 //! Gemma-3-4B context look 5.8x cheaper than it is and gpt-oss 2x. **No
 //! KV store ferrox allocates ever gave that cap back** (#33):
 //!
-//! - `ferrox_core::cache::KvCache` has no window concept at all. `push`
-//!   extends `k`/`v` for every position, so a plain or pool-backed cache
-//!   holds the whole sequence in every layer. This is what the CLI
-//!   allocates and what the server allocates on its non-paged paths.
+//! - `ferrox_core::cache::KvCache` had no window concept at all. `push`
+//!   extended `k`/`v` for every position, so a plain or pool-backed
+//!   cache held the whole sequence in every layer. This is what the CLI
+//!   allocates and what the server allocates on its non-paged paths, and
+//!   it is still what they do unless `FERROX_KV_WINDOW` is on -- see the
+//!   section after next.
 //! - The paged store *can* recycle pages behind a window, but only for a
 //!   model whose every layer shares one window
 //!   (`ModelConfig::uniform_sliding_window`, `None` by design for the
@@ -83,6 +85,15 @@
 //! `Decoder::forward_batch` evicts per layer rather than after the
 //! stack. `resident_` is what a measurement of the caches finds at rest;
 //! `peak_` is what the machine has to survive.
+//!
+//! [`KvBudget`] CARRIES the residency rather than taking it as an
+//! argument, and [`KvBudget::kv_bytes_at`] is the one expression the
+//! estimate, the refusal text and `--ctx auto` all read. Until #61 step
+//! 2 was wired here, the store took the saving and the admission check
+//! did not know: `-c auto` still divided a Gemma-3 budget by every
+//! layer's full per-token cost, so a context that would have fit was
+//! refused. That is #33 read backwards, and it is the same defect
+//! shape -- two statements of one rule, with nothing making them agree.
 //!
 //! What is NOT priced here, because no store does it yet: eviction
 //! inside the paged store (#61 step 4) and eviction of the prompt region
@@ -379,8 +390,8 @@ impl KvShape {
             .fold(0u64, |acc, b| acc.saturating_add(b))
     }
 
-    /// The number an admission decision must use: the resting cost, plus
-    /// the one layer that is still mid-prefill.
+    /// The number an admission decision must use: the resting ceiling,
+    /// plus the one layer that is still mid-prefill.
     ///
     /// `Decoder::forward_batch` writes a whole prompt into layer `l`'s
     /// cache, attends over it, and only then hands the rows behind the
@@ -393,18 +404,39 @@ impl KvShape {
     ///
     /// The extra term is the largest single windowed layer's shortfall,
     /// because layers are prefilled one at a time.
+    ///
+    /// # Why the resting term is the CEILING and not `rows_after`
+    ///
+    /// [`KvWindow::rows_after`] is exact and it OSCILLATES: a cache
+    /// that runs `slack` rows past its window and then drains holds
+    /// anywhere in `[window, window + slack]`, cycling with period
+    /// `slack + 1`. So bytes priced from it are not monotone in
+    /// `tokens`, and [`KvBudget::max_context`] searches for the largest
+    /// context that fits -- a search over a function that goes back
+    /// down cannot be trusted to find the largest one.
+    ///
+    /// [`KvWindow::max_rows`] is the same type's own statement of the
+    /// top of that cycle, so pricing against it is still the store's
+    /// rule rather than a second opinion about it, it is monotone, and
+    /// it is wrong only in the direction that refuses a context instead
+    /// of OOMing on one. The gap is at most `slack` rows per windowed
+    /// layer, against a term that already carries a whole layer's
+    /// prompt.
     pub fn peak_kv_bytes_for_tokens(&self, tokens: usize, residency: &KvResidency) -> u64 {
         let per_layer = self.layout.elems_per_token_per_layer();
         let full = self.elem.bytes_for(per_layer.saturating_mul(tokens as u64));
+        let resting = residency
+            .ceiling_rows_per_layer(self.n_layers, tokens)
+            .map(|rows| self.elem.bytes_for(per_layer.saturating_mul(rows as u64)))
+            .fold(0u64, |acc, b| acc.saturating_add(b));
         let transient = residency
-            .rows_per_layer(self.n_layers, tokens)
+            .ceiling_rows_per_layer(self.n_layers, tokens)
             .map(|rows| {
                 full.saturating_sub(self.elem.bytes_for(per_layer.saturating_mul(rows as u64)))
             })
             .max()
             .unwrap_or(0);
-        self.resident_kv_bytes_for_tokens(tokens, residency)
-            .saturating_add(transient)
+        resting.saturating_add(transient)
     }
 
     /// The sentence a user should be able to read and reproduce with a
@@ -489,6 +521,32 @@ impl KvResidency {
             None => tokens,
         })
     }
+
+    /// The most rows each layer can hold at `tokens` of context.
+    ///
+    /// [`Self::rows_per_layer`] is the instantaneous count and cycles
+    /// through `[window, window + slack]`; this is the top of that
+    /// cycle, taken from [`KvWindow::max_rows`] so the ceiling is the
+    /// window type's own and not a second arithmetic beside it. Never
+    /// below `rows_per_layer`, never above `tokens`, and non-decreasing
+    /// in `tokens` -- which is what [`KvBudget::max_context`]'s search
+    /// needs and the oscillating count cannot give it.
+    fn ceiling_rows_per_layer(
+        &self,
+        n_layers: usize,
+        tokens: usize,
+    ) -> impl Iterator<Item = usize> + '_ {
+        (0..n_layers).map(move |l| match self.layer_window(l) {
+            Some(w) => w.max_rows().min(tokens),
+            None => tokens,
+        })
+    }
+
+    /// How many layers evict, for a report that has to explain why the
+    /// context is not simply the budget divided by a per-token cost.
+    pub fn evicting_layers(&self) -> usize {
+        self.per_layer.iter().filter(|w| w.is_some()).count()
+    }
 }
 
 /// Which ceiling a rejection hit. The point of naming it is that the
@@ -541,7 +599,14 @@ impl KvBudgetError {
 
 /// A priced plan: every term of the inequality, kept separately so the
 /// report can show the arithmetic rather than just the verdict.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Not `Copy`, because [`Self::residency`] is a per-layer vector. That
+/// is deliberate: the residency belongs IN the budget rather than
+/// beside it as an argument every caller has to remember to pass. A
+/// method taking it as a parameter is exactly the shape that let the
+/// store and the budget disagree in #33 -- one caller passes it, the
+/// next one does not, and nothing says which run the number describes.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KvBudget {
     /// Checkpoint bytes. See the module doc on why this is an
     /// approximation for mmap'd weights.
@@ -552,6 +617,16 @@ pub struct KvBudget {
     /// [`crate::device_budget::DeviceBudget::usable_bytes`]).
     pub device_budget_bytes: u64,
     pub shape: KvShape,
+    /// What the stores this run allocates will really keep, per layer.
+    ///
+    /// [`KvResidency::keeps_everything`] is the engine's default and
+    /// reproduces every number this type produced before #61.
+    /// [`KvResidency::from_config`] with a live [`KvWindowPolicy`] is
+    /// what a run with `FERROX_KV_WINDOW` on must be priced against --
+    /// otherwise the store takes a saving the admission check refuses
+    /// to spend, which is #33 read backwards: a context that would have
+    /// fit, turned away.
+    pub residency: KvResidency,
     /// KV caches are per request; concurrency multiplies them.
     pub concurrent_requests: usize,
 }
@@ -565,11 +640,21 @@ impl KvBudget {
             .saturating_sub(self.activation_headroom_bytes)
     }
 
+    /// KV bytes at `tokens` of context, across every concurrent
+    /// request, at the moment the run costs most.
+    ///
+    /// The ONE expression the estimate, the refusal message and the
+    /// context search all read, so a change to what the stores keep
+    /// cannot reach two of the three and miss the other.
+    pub fn kv_bytes_at(&self, tokens: usize) -> u64 {
+        self.shape
+            .peak_kv_bytes_for_tokens(tokens, &self.residency)
+            .saturating_mul(self.concurrent_requests.max(1) as u64)
+    }
+
     /// Total estimated resident bytes at `tokens` of context.
     pub fn estimated_bytes(&self, tokens: usize) -> u64 {
-        self.weights_bytes
-            + self.activation_headroom_bytes
-            + self.shape.kv_bytes_for_tokens(tokens) * self.concurrent_requests.max(1) as u64
+        self.weights_bytes + self.activation_headroom_bytes + self.kv_bytes_at(tokens)
     }
 
     /// The one-line check the plan is named for. `Ok` carries the
@@ -587,7 +672,7 @@ impl KvBudget {
                 "{} weight bytes + {} KV bytes at {tokens} tokens x{} concurrent + {} \
                  activation headroom exceeds the {} byte device budget",
                 self.weights_bytes,
-                self.shape.kv_bytes_for_tokens(tokens) * self.concurrent_requests.max(1) as u64,
+                self.kv_bytes_at(tokens),
                 self.concurrent_requests.max(1),
                 self.activation_headroom_bytes,
                 self.device_budget_bytes,
@@ -595,49 +680,61 @@ impl KvBudget {
         })
     }
 
-    /// Largest context that fits, closed form:
-    /// `(budget - weights - headroom) / (per_token_kv * concurrency)`,
-    /// floored to `granularity` and clamped to `cap` (the model's own
-    /// trained context length).
+    /// Largest context that fits: the biggest `tokens` for which
+    /// [`Self::kv_bytes_at`] still sits inside
+    /// `budget - weights - headroom`, floored to `granularity` and
+    /// clamped to `cap` (the model's own trained context length).
     ///
-    /// Every layer is in the divisor. A sliding-window model used to
-    /// have its windowed layers subtracted out of it and added back as a
-    /// saturated constant, which is the #33 under-estimate: nothing
-    /// evicts, so nothing saturates.
+    /// Every layer is in the cost. A sliding-window model used to have
+    /// its windowed layers subtracted out of a divisor and added back
+    /// as a saturated constant, which is the #33 under-estimate:
+    /// nothing evicted, so nothing saturated. What is different now is
+    /// that a run CAN evict (#61), and this asks the residency instead
+    /// of assuming either answer.
+    ///
+    /// # Why a search and not a division
+    ///
+    /// With no eviction the cost is linear and
+    /// `available / per_token_kv` is exact; a test below asserts this
+    /// search returns that same number for a residency that keeps
+    /// everything, so the closed form is not lost, it is checked
+    /// against. With eviction the cost is piecewise: a windowed layer
+    /// stops charging past `window + slack` while the dense ones keep
+    /// going, so there is no single divisor to divide by and a division
+    /// would price a 32k Gemma-3 context at 5.4x what it costs. The
+    /// searched function is non-decreasing in `tokens` -- that is what
+    /// `ceiling_rows_per_layer` is for -- so bisection finds the
+    /// largest fitting context rather than any fitting context.
     pub fn max_context(&self, cap: usize, granularity: usize) -> ContextFit {
         let granularity = granularity.max(1);
         let concurrency = self.concurrent_requests.max(1) as u64;
         let available = self.kv_bytes_available();
-        let per_token = self.shape.per_token_kv_bytes().saturating_mul(concurrency);
 
         let (tokens, capped_by) = if available == 0 {
             (0, ContextCap::DeviceBudget)
         } else {
-            // `checked_div` rather than a `per_token == 0` guard around
-            // a bare `/`: a model with no KV at all (no layers, or a
-            // zero-width layout) is not an error here, it is just
-            // unbounded by memory, and expressing it as `None` keeps
-            // that meaning in one place instead of splitting it across
-            // a check and a division that clippy then has to
-            // re-associate.
-            match available.checked_div(per_token) {
-                None => (cap, ContextCap::ModelContextLength),
-                Some(raw) => {
-                    let raw = raw as usize;
-                    // Flooring must never turn a real answer into
-                    // "nothing fits": under one granularity step,
-                    // report the exact number of tokens rather than
-                    // rounding it away.
-                    let floored = if raw >= granularity {
-                        (raw / granularity) * granularity
-                    } else {
-                        raw
-                    };
-                    if floored >= cap {
-                        (cap, ContextCap::ModelContextLength)
-                    } else {
-                        (floored, ContextCap::DeviceBudget)
-                    }
+            // Bisection over `[0, cap]` only, never past it: the answer
+            // above `cap` is always `cap`, so a search that stops there
+            // needs no upper bound invented for it and cannot overflow
+            // on a model with no KV at all (where every probe fits and
+            // the answer is `cap`).
+            let raw = self.largest_fitting_context(cap, available);
+            if raw >= cap {
+                (cap, ContextCap::ModelContextLength)
+            } else {
+                // Flooring must never turn a real answer into
+                // "nothing fits": under one granularity step, report
+                // the exact number of tokens rather than rounding it
+                // away.
+                let floored = if raw >= granularity {
+                    (raw / granularity) * granularity
+                } else {
+                    raw
+                };
+                if floored >= cap {
+                    (cap, ContextCap::ModelContextLength)
+                } else {
+                    (floored, ContextCap::DeviceBudget)
                 }
             }
         };
@@ -650,11 +747,34 @@ impl KvBudget {
             kv_available_bytes: available,
             per_token_kv_bytes: self.shape.per_token_kv_bytes(),
             concurrent_requests: concurrency as usize,
-            kv_bytes: self.shape.kv_bytes_for_tokens(tokens) * concurrency,
+            kv_bytes: self.kv_bytes_at(tokens),
+            evicting_layers: self.residency.evicting_layers(),
             weights_bytes: self.weights_bytes,
             activation_headroom_bytes: self.activation_headroom_bytes,
             device_budget_bytes: self.device_budget_bytes,
         }
+    }
+
+    /// Largest `tokens` in `0..=cap` whose KV still fits `available`.
+    ///
+    /// `kv_bytes_at` is non-decreasing in `tokens`, so the predicate
+    /// "fits" is a prefix of the range and bisection is exact.
+    fn largest_fitting_context(&self, cap: usize, available: u64) -> usize {
+        if self.kv_bytes_at(cap) <= available {
+            return cap;
+        }
+        // Invariant: `lo` fits and `hi` does not. `0` fits because a
+        // zero-token context costs no KV bytes at all.
+        let (mut lo, mut hi) = (0usize, cap);
+        while hi - lo > 1 {
+            let mid = lo + (hi - lo) / 2;
+            if self.kv_bytes_at(mid) <= available {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        lo
     }
 }
 
@@ -676,10 +796,21 @@ pub struct ContextFit {
     pub granularity: usize,
     pub capped_by: ContextCap,
     pub kv_available_bytes: u64,
-    /// The divisor: bytes one token of context costs across every layer.
+    /// Bytes one token of context costs across every layer, with
+    /// nothing evicting. The divisor when `evicting_layers` is 0, and
+    /// an upper bound on the marginal cost otherwise.
     pub per_token_kv_bytes: u64,
     pub concurrent_requests: usize,
+    /// KV bytes at `tokens`: [`KvBudget::kv_bytes_at`], which is what
+    /// the fit was actually decided on.
     pub kv_bytes: u64,
+    /// How many layers stop growing at their window. Zero for every
+    /// model unless `FERROX_KV_WINDOW` is on, and the reason the
+    /// division in [`Display`] stops being the whole story when it is
+    /// not.
+    ///
+    /// [`Display`]: std::fmt::Display
+    pub evicting_layers: usize,
     pub weights_bytes: u64,
     pub activation_headroom_bytes: u64,
     pub device_budget_bytes: u64,
@@ -692,7 +823,7 @@ impl std::fmt::Display for ContextFit {
             "ctx auto = {} tokens ({}): ({} device budget - {} weights - {} activation headroom) \
              = {} for KV; / {} bytes/token/request / {} request(s) -> rounded down to a multiple \
              of {} (reported exactly below one step), capped at the model's {} trained context. \
-             KV at the chosen context: {} bytes.",
+             KV at the chosen context: {} bytes.{}",
             self.tokens,
             match self.capped_by {
                 ContextCap::ModelContextLength => "limited by the model's context length",
@@ -707,6 +838,19 @@ impl std::fmt::Display for ContextFit {
             self.granularity,
             self.cap,
             self.kv_bytes,
+            // Said explicitly rather than left for the reader to
+            // notice the division does not reproduce the answer: with
+            // eviction on, the per-token figure above is the cost only
+            // until each windowed layer saturates, and the chosen
+            // context came from the search that knows that.
+            match self.evicting_layers {
+                0 => String::new(),
+                n => format!(
+                    " {n} of those layers stop growing at their sliding window \
+                     (FERROX_KV_WINDOW), so the per-token figure is the cost before \
+                     they saturate, not a divisor that reproduces this answer."
+                ),
+            },
         )
     }
 }
@@ -996,11 +1140,22 @@ mod tests {
         // left. The 29 windowed ones hold 1475 rows each instead of
         // 32768.
         assert_eq!(resting, 1_692_590_080, "5.4x less than the 9.13 GB above");
+        // The admission number prices each windowed layer at the top of
+        // its cycle (`KvWindow::max_rows`, 1536 here) rather than at the
+        // instantaneous `rows_after`, because `max_context` searches
+        // this function and a search needs it not to fall. That costs
+        // 13,991,936 bytes -- 0.7% -- against a term that already
+        // carries a whole layer's prompt.
         assert_eq!(
-            peak, 1_948_942_336,
-            "resting plus the one windowed layer still mid-prefill"
+            peak, 1_962_934_272,
+            "resting ceiling plus the one windowed layer still mid-prefill"
         );
         assert!(peak < full && peak > resting);
+        // The saving is what makes the difference worth having: the
+        // whole point of #61 is that this is the number `-c auto`
+        // divides a machine by, and 4.65x is a 32k context fitting on a
+        // 16 GB box or not.
+        assert!(full / peak >= 4, "{full} / {peak}");
     }
 
     /// The pool-backed store is the other thing a server allocates, and
@@ -1161,6 +1316,7 @@ mod tests {
             activation_headroom_bytes: 0,
             device_budget_bytes: device,
             shape,
+            residency: KvResidency::keeps_everything(shape.n_layers),
             concurrent_requests: 1,
         }
     }
@@ -1184,7 +1340,7 @@ mod tests {
         let one = budget(1_000, 1 << 40, shape);
         let four = KvBudget {
             concurrent_requests: 4,
-            ..one
+            ..one.clone()
         };
         assert_eq!(
             four.estimated_bytes(100) - 1_000,
@@ -1207,6 +1363,132 @@ mod tests {
         assert!(b.check(fit.tokens).is_ok());
         // One granularity step further does not.
         assert!(b.check(fit.tokens + 256).is_err());
+    }
+
+    /// **The closed form is not gone, it is checked against.**
+    ///
+    /// `max_context` used to be one division and is now a search,
+    /// because with eviction there is no single divisor. A search is
+    /// free to be subtly wrong in a way a division cannot be, so the
+    /// division stays here as the oracle: for a run where nothing
+    /// evicts -- which is every run unless `FERROX_KV_WINDOW` is on --
+    /// the searched answer must be exactly
+    /// `available / per_token_kv`, at every budget, not just at the
+    /// round ones.
+    #[test]
+    fn the_context_search_reproduces_the_closed_form_when_nothing_evicts() {
+        let shape = llama31_8b(); // 262144 bytes/token
+        let per_token = shape.per_token_kv_bytes();
+        for tokens_of_room in [0u64, 1, 7, 999, 1000, 1001, 65_536] {
+            for slack in [0u64, 1, per_token - 1] {
+                let device = 5_000_000 + per_token * tokens_of_room + slack;
+                let b = budget(5_000_000, device, shape);
+                // Granularity 1 so the comparison is against the raw
+                // division rather than against the rounding.
+                let fit = b.max_context(131_072, 1);
+                assert_eq!(
+                    fit.tokens as u64,
+                    (per_token * tokens_of_room + slack) / per_token,
+                    "budget {device} disagreed with the division it replaced"
+                );
+            }
+        }
+    }
+
+    /// **The property the search rests on.**
+    ///
+    /// Bisection finds the largest fitting context only if "fits" is a
+    /// prefix of the range, i.e. if the cost never falls as the context
+    /// grows. `KvWindow::rows_after` OSCILLATES between `window` and
+    /// `window + slack`, so pricing admission from it directly would
+    /// break exactly that, and a search over it could stop one cycle
+    /// early and report a context smaller than the one that fits.
+    #[test]
+    fn the_admission_ceiling_never_falls_as_the_context_grows() {
+        let cfg = alternating_swa_config();
+        let residency = KvResidency::from_config(&cfg, KvWindowPolicy::on());
+        let shape = KvShape::from_config(&cfg, KvElem::F32);
+        let mut previous = 0u64;
+        // Well past the window (4) and its default slack (2), so the
+        // whole oscillation is covered rather than only the ramp.
+        for tokens in 0..64 {
+            let bytes = shape.peak_kv_bytes_for_tokens(tokens, &residency);
+            assert!(
+                bytes >= previous,
+                "cost fell from {previous} to {bytes} between {} and {tokens} tokens",
+                tokens.saturating_sub(1)
+            );
+            previous = bytes;
+        }
+    }
+
+    /// The ceiling admission is decided on must never sit below what a
+    /// measurement of the caches would find, or the run is admitted
+    /// against a number smaller than the memory it takes. `resident_`
+    /// is that measurement (asserted against real `KvCache`s above);
+    /// this is the ordering between the two, at every context, not just
+    /// at the one the sibling test measures.
+    #[test]
+    fn the_admission_ceiling_is_never_below_what_the_store_will_hold() {
+        let cfg = alternating_swa_config();
+        let residency = KvResidency::from_config(&cfg, KvWindowPolicy::on());
+        let shape = KvShape::from_config(&cfg, KvElem::F32);
+        for tokens in 0..64 {
+            assert!(
+                shape.peak_kv_bytes_for_tokens(tokens, &residency)
+                    >= shape.resident_kv_bytes_for_tokens(tokens, &residency),
+                "admission under-priced the resting store at {tokens} tokens"
+            );
+        }
+    }
+
+    /// **The gap this wiring closed.**
+    ///
+    /// #61 step 2 taught the store to evict and left the budget
+    /// pricing every layer at every position, so a Gemma-3-shaped model
+    /// with `FERROX_KV_WINDOW` on kept 5x less KV than `-c auto` was
+    /// dividing by, and the context it could really carry was refused.
+    /// The two arms here differ ONLY in the policy the residency was
+    /// built from.
+    #[test]
+    fn an_evicting_run_is_offered_more_context_than_a_non_evicting_one() {
+        let cfg = alternating_swa_config();
+        let shape = KvShape::from_config(&cfg, KvElem::F32);
+        let base = budget(1_000, 1_000 + shape.per_token_kv_bytes() * 64, shape);
+        let evicting = KvBudget {
+            residency: KvResidency::from_config(&cfg, KvWindowPolicy::on()),
+            ..base.clone()
+        };
+        assert!(
+            base.residency.keeps_every_position(),
+            "the control arm must be the engine's default"
+        );
+
+        let plain = base.max_context(131_072, 1);
+        let windowed = evicting.max_context(131_072, 1);
+        assert!(
+            windowed.tokens > plain.tokens,
+            "eviction bought no context: {} vs {}",
+            windowed.tokens,
+            plain.tokens
+        );
+        assert_eq!(windowed.evicting_layers, 4, "4 of 6 layers slide");
+        assert_eq!(plain.evicting_layers, 0);
+        // The context the evicting run was offered is one the plain
+        // budget refuses, and the evicting budget accepts. That is the
+        // whole difference, stated as the decision rather than as a
+        // number.
+        assert!(evicting.check(windowed.tokens).is_ok());
+        assert!(base.check(windowed.tokens).is_err());
+        // And the report says why the division above it no longer
+        // reproduces the answer, rather than leaving a reader to
+        // subtract two numbers that do not match.
+        assert!(
+            windowed
+                .to_string()
+                .contains("stop growing at their sliding window"),
+            "{windowed}"
+        );
     }
 
     #[test]

--- a/crates/ferrox-models/src/residency_report.rs
+++ b/crates/ferrox-models/src/residency_report.rs
@@ -25,8 +25,9 @@
 use ferrox_gguf::ShardedGguf;
 
 use crate::config::ModelConfig;
+use crate::decoder::KvWindowPolicy;
 use crate::device_budget::human;
-use crate::kv_budget::{ContextFit, KvBudget, KvElem, KvShape, CTX_AUTO_GRANULARITY};
+use crate::kv_budget::{ContextFit, KvBudget, KvElem, KvResidency, KvShape, CTX_AUTO_GRANULARITY};
 use crate::loader::LoadError;
 
 /// The inputs a plan is computed against. `expert_cache_bytes: None`
@@ -46,6 +47,15 @@ pub struct ResidencyAssumptions {
     /// host cache, f16 for Metal's device KV, and so on. Only this
     /// module's caller knows which backend is selected.
     pub kv_elem: KvElem,
+    /// Whether the run this plan describes will evict KV rows behind a
+    /// layer's sliding window (#61).
+    ///
+    /// The plan has to be priced against the run that will happen, so
+    /// the default reads `FERROX_KV_WINDOW` exactly as the decoder does
+    /// -- one policy value, so the report and the stores cannot be
+    /// describing different runs. Pass [`KvWindowPolicy::off`]
+    /// explicitly for a what-if plan of the non-evicting engine.
+    pub kv_window: KvWindowPolicy,
 }
 
 impl Default for ResidencyAssumptions {
@@ -58,6 +68,7 @@ impl Default for ResidencyAssumptions {
             expert_cache_bytes: None,
             headroom_fraction: 0.2,
             kv_elem: KvElem::F32,
+            kv_window: KvWindowPolicy::from_env(),
         }
     }
 }
@@ -87,6 +98,12 @@ pub struct ResidencyReport {
     pub weights_bytes: u64,
     /// The KV geometry this checkpoint runs on.
     pub kv_shape: KvShape,
+    /// How many positions each layer's store will really keep, under
+    /// [`ResidencyAssumptions::kv_window`]. Kept beside the shape so
+    /// [`Self::kv_budget`] rebuilds the inequality with the same
+    /// residency the KV line was priced with, rather than deriving a
+    /// second one.
+    pub kv_residency: KvResidency,
 }
 
 impl ResidencyReport {
@@ -172,16 +189,32 @@ impl ResidencyReport {
         // windowed checkpoint is priced at what the store keeps rather
         // than at what attention reads.
         let kv_shape = KvShape::from_config(&config, assumptions.kv_elem);
-        let kv_per_request = kv_shape.kv_bytes_for_tokens(assumptions.context_tokens);
+        let kv_residency = KvResidency::from_config(&config, assumptions.kv_window);
+        // The PEAK, not the resting number: a windowed layer holds the
+        // whole prompt while it is being prefilled and hands the rows
+        // back only afterwards, so a plan priced at rest would approve
+        // a run whose high-water mark it never modelled.
+        let kv_per_request =
+            kv_shape.peak_kv_bytes_for_tokens(assumptions.context_tokens, &kv_residency);
+        let evicting = kv_residency.evicting_layers();
         lines.push(ResidencyLine {
             label: "KV caches".to_string(),
             bytes: kv_per_request * assumptions.concurrent_requests as u64,
             reason: format!(
                 "{} at {} context tokens = {kv_per_request} bytes/request, x {} concurrent \
-                 requests",
+                 requests{}",
                 kv_shape.describe(),
                 assumptions.context_tokens,
-                assumptions.concurrent_requests
+                assumptions.concurrent_requests,
+                match evicting {
+                    0 => String::new(),
+                    n => format!(
+                        "; {n} of {} layers evict behind their sliding window \
+                         (FERROX_KV_WINDOW) and stop growing, so this is below the \
+                         per-token figure times the context",
+                        kv_shape.n_layers
+                    ),
+                }
             ),
         });
 
@@ -195,6 +228,7 @@ impl ResidencyReport {
             assumptions,
             weights_bytes,
             kv_shape,
+            kv_residency,
         })
     }
 
@@ -216,6 +250,7 @@ impl ResidencyReport {
             activation_headroom_bytes: self.budget_bytes - self.usable_bytes,
             device_budget_bytes: self.budget_bytes,
             shape: self.kv_shape,
+            residency: self.kv_residency.clone(),
             concurrent_requests: self.assumptions.concurrent_requests,
         }
     }
@@ -296,11 +331,20 @@ mod tests {
         format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"))
     }
 
+    /// Pinned to the non-evicting engine ON PURPOSE.
+    ///
+    /// `ResidencyAssumptions::default()` reads `FERROX_KV_WINDOW`,
+    /// because the plan has to describe the run that will happen. That
+    /// makes every test built on the default env-sensitive, and a test
+    /// whose expected numbers depend on the developer's shell is a test
+    /// that goes red for the wrong reason. Everything below asserts the
+    /// default engine's arithmetic, so it says so.
     fn assumptions(cache: Option<u64>) -> ResidencyAssumptions {
         ResidencyAssumptions {
             context_tokens: 128,
             concurrent_requests: 2,
             expert_cache_bytes: cache,
+            kv_window: KvWindowPolicy::off(),
             ..ResidencyAssumptions::default()
         }
     }

--- a/crates/ferrox-server/src/budget.rs
+++ b/crates/ferrox-server/src/budget.rs
@@ -89,9 +89,19 @@ impl ContextCeiling {
         }
     }
 
-    /// KV bytes `positions` of context costs: every layer at every
-    /// position, which is what the stores this server allocates really
-    /// keep (see `ferrox_models::kv_budget`'s module doc).
+    /// KV bytes `positions` of context costs, every layer at every
+    /// position.
+    ///
+    /// **A reporting number, not the admission number.** What decides
+    /// whether a request is admitted is `limit`, in POSITIONS, and that
+    /// limit came from [`KvBudget::max_context`], which does know about
+    /// eviction (#61). This only fills the byte fields of a refusal
+    /// whose stated reason is the position ceiling, so under
+    /// `FERROX_KV_WINDOW` it over-states the bytes a windowed model
+    /// would really have held -- in the direction that makes a refusal
+    /// look more justified rather than less, and never in a decision.
+    /// Giving this the residency too would mean threading it through
+    /// eighteen constructor call sites to change a message.
     pub fn bytes_for(&self, positions: usize) -> u64 {
         self.shape.kv_bytes_for_tokens(positions)
     }
@@ -319,6 +329,27 @@ pub fn price_gguf(
         context_tokens: gguf_ctx,
         concurrent_requests: concurrent_requests.max(1),
         kv_elem,
+        // **The server prices the UNWINDOWED number even when
+        // `FERROX_KV_WINDOW` is on, and that is deliberate.**
+        //
+        // Sliding-window eviction (#61 step 2) is a property of the
+        // contiguous host `KvCache`, and it is not the only store this
+        // server allocates. `FERROX_KV_POOL_BLOCKS` reserves
+        // `max_seq_len` positions per layer from a shared pool up front
+        // and never gives a block back mid-sequence, and
+        // `FERROX_PAGED_KV_BLOCKS` runs the paged store, whose decode
+        // arm never calls `evict_layer_kv` at all (#61 step 4). Either
+        // holds the whole context however narrow the window is.
+        //
+        // This runs before either is chosen, so pricing the window here
+        // would hand a pooled or paged deployment a ceiling smaller
+        // than the memory it goes on to reserve -- which is exactly #33,
+        // admitted and then OOM, in the direction that hurts. An
+        // over-estimate only costs context.
+        //
+        // Lifting this needs the store the request will really use to
+        // be known at this point, which is #61 steps 4 and 5.
+        kv_window: ferrox_models::decoder::KvWindowPolicy::off(),
         ..ResidencyAssumptions::default()
     };
     match ResidencyReport::from_gguf(path, assumptions, device.usable_bytes) {
@@ -373,6 +404,7 @@ mod tests {
             activation_headroom_bytes: 0,
             device_budget_bytes: device_bytes,
             shape: shape(),
+            residency: ferrox_models::KvResidency::keeps_everything(shape().n_layers),
             concurrent_requests: 1,
         }
     }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -49,7 +49,7 @@ library or overriding the CLI.
 | `FERROX_VULKAN_LOADER` | Path to a `libvulkan` the loader should use. Only needed when the platform default is not found; the error names this variable |
 | `FERROX_MODEL_NAME` | What the served model is called in `/v1/models` and every response's `model` field. Same as `--alias`. Read in one place, so it cannot apply to some routes and not others |
 | `FERROX_CACHE` | Where `-hf` puts downloaded checkpoints. Default `$XDG_CACHE_HOME/ferrox`, else `~/.cache/ferrox`; models go under `hub/<owner>__<repo>/`. llama.cpp spells this `LLAMA_CACHE` |
-| `FERROX_KV_WINDOW` | `1` evicts KV rows behind a sliding window on the CPU contiguous store. **Off by default.** Gemma-3-4B at 32768 tokens holds 1.69 GiB at rest instead of 9.13 GiB, with a 1.95 GiB prefill peak. Output is token-identical either way, tested on a real quantized SWA checkpoint. Turns itself off under `FERROX_METAL_ATTN`, and does not apply to a draft model; disables the prefix cache, which cannot represent a windowed cache. See the note below |
+| `FERROX_KV_WINDOW` | `1` evicts KV rows behind a sliding window on the CPU contiguous store. **Off by default.** Gemma-3-4B at 32768 tokens holds 1.69 GiB at rest instead of 9.13 GiB, with a 1.96 GiB admission ceiling, and `--ctx-size auto` is priced against that ceiling rather than the unwindowed one. Output is token-identical either way, tested on a real quantized SWA checkpoint. Turns itself off under `FERROX_METAL_ATTN`, and does not apply to a draft model; disables the prefix cache, which cannot represent a windowed cache. See the note below |
 | `FERROX_CPU_POOL` | **An A/B override, not the decision.** Unset, the scheduler is chosen **per operation from its size**: an operation carrying at least `par::policy::SPIN_MIN_OP_MACS` multiply-accumulates (2.1M, i.e. `rows x cols`) runs on a persistent pool parked on a spin-then-park barrier, the shape llama.cpp's `ggml_threadpool` uses; anything smaller forks and joins with rayon as before. `spin` / `persistent` / `1` / `on` pins the pool at every size; `rayon` / `0` / `off` pins fork-join at every size and is the exact revert. The rule exists because the pool is not uniformly better, **measured on 2026-09-04**: on a quiet 20-core Cortex-A725 (aarch64, `tg128`, 19 threads) it is **+123% at 3B and +87% at 8B**, taking decode from LOSING to llama.cpp to beating it (23.14 vs 17.86 tok/s at 3B, 12.41 vs 9.06 at 8B), and **-37% at 135M**, reproducibly and on quiet hosts, so it is not contention. On a quiet 10-core Xeon it is +49% / +23% / +15% at 135M / 3B / 8B. The crossover constant is *bracketed* by those model-level numbers rather than swept; see its doc comment. Output is token-identical on all settings, which is tested |
 | `FERROX_CPU_POOL_SPIN_US` | Microseconds a `spin` worker spins before parking. Default 100. A pool that never parks burns a core per thread on an idle server |
 | `FERROX_CPU_THREADS` | Worker threads; same as `-t`. Default: **performance cores** (`hw.perflevel0.physicalcpu` on macOS), matching llama.cpp, not logical cores |
@@ -273,12 +273,19 @@ What it saves, on Gemma-3-4B at 32768 tokens of host f32 KV:
 |---|---|
 | Off (every layer holds everything) | 9,126,805,504 |
 | On, at rest | 1,692,590,080 |
-| On, prefill peak | 1,948,942,336 |
+| On, admission ceiling (prefill peak) | 1,962,934,272 |
 
 The peak is not the full 9.13 GiB because prefill evicts per layer: one
 layer holds the whole prompt at a time rather than all 34 at once. Five
 of the 34 layers are full attention and still hold everything, which is
 most of what remains.
+
+The ceiling prices each windowed layer at `window + slack` rows -- the
+top of the cycle a draining cache runs through, `KvWindow::max_rows` --
+rather than at the exact instantaneous count, which oscillates. That
+costs 0.7% against a number that already carries a whole layer's prompt,
+and it buys a cost that never falls as the context grows, which is what
+`--ctx-size auto`'s search for the largest fitting context needs.
 
 **It is off by default because it is new, not because it is doubted.**
 Output is token-identical with it on or off, asserted on identical logit
@@ -296,7 +303,23 @@ It disables itself in three cases rather than guessing:
 - Beside the prefix cache, which refuses to store a windowed cache
   rather than hand back a truncation it cannot represent.
 
-The server's admission check still prices the full, unwindowed number.
-That is the safe direction and it is correct while the switch is off; a
-context is refused that would in fact have fit, rather than admitted and
-then OOM.
+**Admission and `--ctx-size auto` price what the switch really keeps.**
+`KvBudget` carries the same per-layer residency the stores evict with,
+so a run with the switch on is offered the context it can really carry
+instead of one divided by every layer's full per-token cost. On
+gemma-2-2b-it-Q4_K_M (window 4096 on 13 of 26 layers) against a
+3.72 GiB budget, `ctx auto` reads 6912 tokens with the switch off and
+7680 with it on; the same header at a 32768 context prices its KV line
+at 6.50 GiB off and 4.06 GiB on. With the switch off the residency says
+every layer keeps everything, which is the arithmetic this engine always
+had, asserted rather than assumed.
+
+What is still priced at the full number, because no store evicts there
+yet: the paged store ([#61](https://github.com/antonellof/ferrox/issues/61)
+step 4) and the prompt region while a prefill batch is being written
+(step 5).
+
+The byte figures inside a *context-length* refusal
+(`ContextCeiling::bytes_for`) are still the unwindowed ones. They are a
+message, not a decision -- the decision is the position ceiling above,
+which does know.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -290,15 +290,27 @@ OpenAI-compatible HTTP API:
   host cache with placeholders that the paged prefill then copied into
   the page store, and that refusal is lifted. See
   [`CONFIG.md`](CONFIG.md)
-- On a model whose layers *all* slide by the same window, that
+- **On the paged store**, a model whose layers *all* slide by the same
   window slides during decode, so a request holds its prompt and a
   window rather than its whole context , and admission prices it
   that way, so a store too small for the whole context still serves
   it. A tool call anchors the slide at the position the next agentic
   turn will rejoin at, and the anchor is dropped once the cursor
   drifts a window past it. An alternating-SWA model (gpt-oss,
-  Gemma-3) does not slide: a page group holds one block in every
-  layer, and the full-attention layers still read position 0
+  Gemma-3) does not slide *there*: a page group holds one block in
+  every layer, and the full-attention layers still read position 0
+- **On the contiguous host store**, eviction is PER LAYER, so the
+  alternating models do get it: each layer's `KvCache` carries its own
+  window from `attention.sliding_window` /
+  `attention.sliding_window_pattern` and drops the rows behind it, while
+  the full-attention layers keep everything. Off unless
+  `FERROX_KV_WINDOW` is set, and it turns itself off under Metal
+  attention, on a draft model, and beside the prefix cache. Output is
+  token-identical with it on or off, asserted on logits as well as token
+  ids against gemma-2-2b-it-Q4_K_M. `--ctx-size auto` and the pre-load
+  admission check are priced against the same per-layer residency the
+  stores evict with, so the saving is context a user is actually offered
+  rather than memory nothing spends. See [`CONFIG.md`](CONFIG.md)
 - `ferrox serve-bench`: concurrency, TTFT, TPOT and queueing numbers
   for a live server, with the methodology (positional split, pooled
   nearest-rank percentiles, whole-run throughput) tested socket-free.


### PR DESCRIPTION
Closes part of #61. **Read the first section before the diff: most of what the issue asks for was already on `main`, and this PR is the piece that was missing.**

## What was already true

I set out to build sliding-window KV eviction and found it shipped. On `main`, behind `FERROX_KV_WINDOW=1`:

- `ferrox_core::kv_swa::KvWindow` is the rule (window + slack, `rows_after`), `KvCache::arm_window` / `evict_behind_window` is the store, and `KvCache` already split `seq_len` into `positions` and `rows`.
- `ferrox_models::decoder::kv_window::KvWindowPolicy` decides **per layer** from `ModelConfig::layer_sliding_window`, which reads `attention.sliding_window` and `attention.sliding_window_pattern`. So **the alternating-SWA case is handled, not refused**, on the contiguous store: each layer's cache carries its own window and the full-attention layers keep everything. `KvCache` is one per layer, so the page-group problem `uniform_sliding_window` documents does not apply here at all.
- Eviction runs on both the decode path (`decoder/attn_block.rs`) and the prefill path (`decoder.rs`), always **after** the layer's attention read.
- Both tests the issue asks for exist and pass: `the_windowed_layers_stop_growing_and_the_dense_ones_do_not` (footprint) and `evicting_behind_the_window_changes_no_token_on_a_real_checkpoint` (identical token ids **and** identical logit vectors, through gemma-2-2b-it-Q4_K_M's real quantized tensors and real alternating layout).
- The refusals are real and reachable: Metal attention, draft models, and the prefix cache each turn it off by name.

`docs/FEATURES.md` was not overclaiming, it was **under**claiming: it described only the paged serving slide and said alternating models do not slide, without mentioning that the contiguous store had learned to. That is corrected here.

## What was missing, and is what this PR builds

`docs/CONFIG.md` said it in one line: *"The server's admission check still prices the full, unwindowed number."* It was broader than that — **nothing** that decides how much context you get knew about eviction. `KvBudget` had no residency at all, so `--ctx-size auto`, the pre-load `check`, and `inspect-plan` all divided by every layer's full per-token cost. The store took the saving; the thing that spends it did not know. That is #33 read backwards, and the same defect shape: two statements of one rule with nothing making them agree.

- `KvBudget` now **carries** a `KvResidency` rather than taking one as an argument a caller can forget, and `KvBudget::kv_bytes_at` is the single expression the estimate, the refusal text and the context search all read.
- `ResidencyReport` builds that residency from the same `KvWindowPolicy` the decoder evicts with, so the plan and the stores cannot describe different runs.
- `max_context` becomes a bisection instead of a division, because with eviction the cost is piecewise. **The closed form is not lost, it is the oracle:** a test asserts the search returns exactly `available / per_token_kv` for a residency that keeps everything, at every budget rather than only round ones.
- Admission prices each windowed layer at `KvWindow::max_rows` — the top of the cycle a draining cache runs through — rather than the exact `rows_after`, which oscillates and would make the searched function fall. That is the window type's own ceiling, not a second opinion about it. It costs 0.7% on Gemma-3-4B at 32k, and both monotonicity and "never below what the store holds" are asserted.

### A bug found on the way

`evict_behind_window` shrinks the buffer after draining. For a **pool-backed** cache that is a leak: `push` decides it needs another block by comparing rows against `k.capacity()`, so shrinking capacity to a window makes that true again every `slack + 1` tokens, forever — the cache draws a fresh block from the shared `KvBlockPool` on a cadence, never releases one, and runs the pool dry under every other request, surfacing where `push` is documented infallible. Reachable today with `FERROX_KV_POOL_BLOCKS` and `FERROX_KV_WINDOW` both set. The existing `a_pooled_windowed_cache_stops_acquiring_blocks` did not catch it: its cache is 8 positions against a 5-row ceiling, under the 2x threshold the shrink is gated on, so it never reaches the shrink. Fixed in its own commit, with a test at 64 positions where the trap is armed.

## The paged store and radix sharing

Unchanged and deliberately so, named at the call site rather than approximated. The server keeps pricing the **unwindowed** number: `FERROX_KV_POOL_BLOCKS` reserves the whole context per layer up front and never returns a block mid-sequence, and the paged store's decode arm never calls `evict_layer_kv` at all. Pricing a window for those deployments would hand them a ceiling below the memory they go on to reserve — the OOM direction. The CLI's plain `KvCache` does evict and gets the saving.

On radix sharing specifically: a shared page whose owner slid past it is exactly why `PagedLease::has_slid` blocks publishing to the tree (the tree keys on a prefix, and a slid sequence's prefix is the part that is gone), and why adopted pages sit behind `locked_prefix` and are never recycled. Extending the slide per-layer to alternating models would make every windowed model unpublishable, which is a trade that needs deciding rather than slipping in. That is #61 step 4 and stays open.

The byte figures inside a *context-length* refusal (`ContextCeiling::bytes_for`) are still unwindowed. They are a message; the decision is the position ceiling, which does know. Documented rather than threaded through eighteen constructor call sites.

## Measured

All in one process, same binary, switch off then on, on `models/gemma-2-2b-it-Q4_K_M` (window 4096 on 13 of its 26 layers). No tok/s, no `benchmarks/RESULTS.md`.

| | off | on |
|---|---|---|
| `inspect-plan` KV line at 32768 context | 6.50 GiB | **4.06 GiB** |
| `ctx auto` against a 3.72 GiB budget | 6912 tokens | **7680 tokens** |
| in-process `allocated_bytes`, 144 positions at a narrowed 64-window | 54,525,952 | **40,894,464** |

`Mistral-7B-Instruct-v0.2` declares no sliding window and is unchanged either way, as the negative control. Gemma-3 is not in `models/`; `gemma-4-E2B` is the `gemma4` engine, which carries its own hparams and never builds a `ModelConfig`, so it is not priced by this path at all.

Token identity is the existing real-checkpoint test, re-run in release: identical ids and identical logits at every step, 1 passed in 40s.

## Gates

`cargo test --workspace` (65 binaries, exit 0), clippy `-D warnings` in debug and release, `cargo fmt --all`. Five new tests, each sabotaged once with the mutation grep-confirmed in the file before believing the green run:

- bisection `<=` to `<` → the closed-form test goes red
- `ceiling_rows_per_layer` to the oscillating `rows_after` → the monotonicity test goes red
- ceiling to `window` (below the real residency) → the "never below the store" test goes red
- `kv_bytes_at` back to the residency-blind `kv_bytes_for_tokens` → the context-saving test goes red
- the pooled shrink guard removed → the new pool test goes red, on pool exhaustion

## What is still open on #61

Step 3 (Metal and CUDA stores), step 4 (per-layer page groups on the paged store, where `uniform_sliding_window`'s refusal would lift), step 5 (evicting the prompt region while a prefill batch is still being written). The module doc says which of these the budget still prices at the full number, and why.
