### PR TITLE
feat(cli): port llama-batched-bench as `ferrox batched-bench`

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,6 +71,31 @@ as `{id}_{backend}.json`. A run that fails leaves the previous receipt
 in place instead of overwriting it. `--render` rewrites the engine table
 in `RESULTS.md` between HTML markers and leaves the Open notes alone.
 
+## Batched throughput (`ferrox batched-bench`)
+
+`ferrox bench` is one sequence. `ferrox batched-bench` is
+`llama-batched-bench`: throughput against the number of parallel
+sequences, through the continuous batcher's engine seams
+(`forward_batch_last_host_kv` per prompt, `forward_multi_seq` per
+decode step) with no HTTP. Same ten columns as upstream, so a ferrox
+table and a llama.cpp table paste side by side.
+
+```bash
+./target/release/ferrox batched-bench -m models/tinyllama-1.1b-chat-v1.0.Q8_0.gguf \
+  -c 2048 -npp 128,512 -ntg 128 -npl 1,2,4,8
+llama-batched-bench -m models/tinyllama-1.1b-chat-v1.0.Q8_0.gguf \
+  -c 2048 -npp 128,512 -ntg 128 -npl 1,2,4,8
+```
+
+It runs under the same contract as `ferrox bench`: the quiet-host,
+thermal and free-memory bars below (the memory bar counts the largest
+row's KV on top of the weights), one discarded warmup per row that
+must agree with the timed pass on both input and output, and a receipt
+(`--receipt`) that is refused when its `--backend-label` is not the
+backend that ran. `-b`, `-kvu`, `-fa` and `-tb` are refused by name;
+`docs/CLI.md` has the flag table. No batched rows are published in
+`RESULTS.md` yet.
+
 ## When a run stops instead of printing a number
 
 Four checks run before the timer starts. Each one exists because the

--- a/crates/ferrox-cli/src/batched_bench/mod.rs
+++ b/crates/ferrox-cli/src/batched_bench/mod.rs
@@ -1,0 +1,465 @@
+//! `ferrox batched-bench` -- a `llama-batched-bench` work-alike.
+//!
+//! Throughput as a function of batch size: for every combination of
+//! prompt length (`-npp`), generation length (`-ntg`) and parallel
+//! sequences (`-npl`), one row reporting prompt speed, decode speed
+//! and the total, in the same ten columns `llama-batched-bench`
+//! prints so the two tables can be read side by side. The workload is
+//! `tools/batched-bench/batched-bench.cpp:132-235` and the row format
+//! is `:245`; `workload.rs` and `report.rs` cite the lines they mirror.
+//!
+//! # What it drives
+//!
+//! Not HTTP (`ferrox serve-bench` does that) and not a third decode
+//! path. Prefill goes through `Decoder::forward_batch_last_host_kv`,
+//! one sequence at a time, which is what the continuous batcher does
+//! for a row it admits; decode goes through `Decoder::forward_multi_seq`,
+//! which is the batcher's per-tick step (`ferrox-server/src/serving/
+//! batch/worker.rs:470`). So the numbers are the engine seams the
+//! server runs on, measured without the server around them.
+//!
+//! # What it reuses from `ferrox bench`
+//!
+//! The measurement contract (`bench_contract`): quiet, cool, not-full
+//! host before the clock; host state on both sides of the run; a
+//! receipt refused at write time when its label disagrees with the
+//! backend that ran. And the guards (`bench_guard`): token streams
+//! asserted before the run, cold caches asserted per repetition, the
+//! prompt and decode lengths re-read from the KV afterwards, and the
+//! determinism pair -- identical input (workload digest) and identical
+//! output (greedy pick) between the discarded warmup and the timed
+//! run. Every row runs twice for exactly that reason: a single timed
+//! pass has nothing to be compared against.
+//!
+//! # Flags that refuse
+//!
+//! `-b` (`n_batch`), `-kvu`, `-fa` and `-tb` are accepted by the
+//! parser and refused by name, because ferrox has nothing behind them
+//! and a flag that is accepted and ignored has burned this repo before.
+//! [`refuse_unhonoured_flags`] is an exhaustive destructure, so a new
+//! flag cannot be added without deciding which side it is on.
+
+mod report;
+mod workload;
+
+use crate::bench_contract;
+use crate::bench_model::active_backend;
+use crate::host_state;
+use anyhow::Context;
+use clap::{Parser, ValueEnum};
+use ferrox_models::{select_engine_kind, Decoder, ModelConfig, SelectedEngineKind};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use workload::{Combo, Shape};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    /// The markdown table `llama-batched-bench` prints by default.
+    Md,
+    /// One JSON object per row, `--output-format jsonl` upstream.
+    Jsonl,
+}
+
+/// `llama-batched-bench`'s flags, under llama.cpp's spellings where
+/// `main.rs` rewrites them (`-npp`, `-ntg`, `-npl`, `-pps`, `-tgs`,
+/// `-ub`, `-ngl`) and clap's long forms otherwise.
+#[derive(Parser, Debug)]
+pub struct BatchedBenchArgs {
+    /// GGUF to benchmark.
+    #[arg(short = 'm', long)]
+    pub model: String,
+    /// Prompt lengths to sweep (`-npp 128,256,512`).
+    #[arg(long = "n-pp", value_delimiter = ',', required = true)]
+    pub n_pp: Vec<usize>,
+    /// Generation lengths to sweep (`-ntg 128,256`).
+    #[arg(long = "n-tg", value_delimiter = ',', required = true)]
+    pub n_tg: Vec<usize>,
+    /// Parallel sequence counts to sweep (`-npl 1,2,4,8`).
+    #[arg(long = "n-pl", value_delimiter = ',', required = true)]
+    pub n_pl: Vec<usize>,
+    /// `-pps`: one prompt shared by every sequence (prefilled once,
+    /// then copied) instead of one prompt per sequence.
+    #[arg(long = "pp-shared")]
+    pub pp_shared: bool,
+    /// `-tgs`: decode each sequence to completion in turn
+    /// (`0 0 0 ... 1 1 1 ...`) instead of one step across all of them
+    /// per call (`0123 0123 ...`).
+    #[arg(long = "tg-separate")]
+    pub tg_separate: bool,
+    /// `n_kv_max`: combinations needing more positions than this are
+    /// skipped, as upstream does. `0` = the GGUF's own context length.
+    #[arg(short = 'c', long, default_value_t = 0)]
+    pub ctx_size: usize,
+    /// `-ub`: prompt tokens per forward call. Each sequence's prompt
+    /// is fed in chunks of this size, the physical batch upstream.
+    #[arg(long = "ubatch-size", default_value_t = 512)]
+    pub ubatch_size: usize,
+    /// CPU threads (`0` = performance-core default).
+    #[arg(short = 't', long, default_value_t = 0)]
+    pub threads: usize,
+    /// GPU layers: `0` forces CPU, anything else offloads.
+    #[arg(long = "n-gpu-layers", default_value_t = 0)]
+    pub n_gpu_layers: usize,
+    #[arg(long = "output-format", value_enum, default_value_t = OutputFormat::Md)]
+    pub output_format: OutputFormat,
+    /// Backend label for the receipt (`cpu` / `metal` / `cuda`). Must
+    /// match the backend that runs, or the receipt is refused.
+    #[arg(long, default_value = "cpu")]
+    pub backend_label: String,
+    /// Write a JSON receipt of every row to this path.
+    #[arg(long)]
+    pub receipt: Option<PathBuf>,
+    /// Refuse to start when the host's 1-minute load average is at or
+    /// above this. `0` disables the check and marks the receipt as
+    /// not quiet-host.
+    #[arg(long, default_value_t = host_state::DEFAULT_MAX_LOAD)]
+    pub max_load: f64,
+
+    // ---- accepted so they can be refused by name ----
+    /// REFUSED. `n_batch` is upstream's logical batch; ferrox has no
+    /// logical/physical split, `-ub` is the chunk it actually feeds.
+    #[arg(short = 'b', long = "batch-size", hide_short_help = true)]
+    pub batch_size: Option<usize>,
+    /// REFUSED. `-kvu` shares one KV buffer across sequences; this
+    /// tool gives every sequence its own cache, so `N_KV` is always
+    /// `B*(PP+TG)`.
+    #[arg(long = "kv-unified", hide_short_help = true)]
+    pub kv_unified: bool,
+    /// REFUSED. ferrox has no flash-attention switch to honour.
+    #[arg(long = "flash-attn", hide_short_help = true)]
+    pub flash_attn: Option<String>,
+    /// REFUSED. ferrox has one thread pool for prefill and decode.
+    #[arg(long = "threads-batch", hide_short_help = true)]
+    pub threads_batch: Option<usize>,
+}
+
+/// Every flag the parser accepts is either honoured or refused here,
+/// and the destructure has no `..`, so adding a field without
+/// deciding which does not compile.
+fn refuse_unhonoured_flags(args: &BatchedBenchArgs) -> anyhow::Result<()> {
+    let BatchedBenchArgs {
+        model: _,
+        n_pp: _,
+        n_tg: _,
+        n_pl: _,
+        pp_shared: _,
+        tg_separate: _,
+        ctx_size: _,
+        ubatch_size: _,
+        threads: _,
+        n_gpu_layers: _,
+        output_format: _,
+        backend_label: _,
+        receipt: _,
+        max_load: _,
+        batch_size,
+        kv_unified,
+        flash_attn,
+        threads_batch,
+    } = args;
+    if let Some(b) = batch_size {
+        anyhow::bail!(
+            "-b {b} (n_batch) is refused: ferrox has no logical batch distinct from the \
+             physical one. `-ub` is the number of prompt tokens fed per forward call and \
+             is the only batch size this tool honours; drop -b."
+        );
+    }
+    if *kv_unified {
+        anyhow::bail!(
+            "-kvu is refused: this tool gives every sequence its own KV cache, so a shared \
+             prompt is COPIED into each one and N_KV is B*(PP+TG) whether or not -pps is \
+             set. A unified buffer would report a smaller N_KV for work this engine does \
+             not do that way; drop -kvu."
+        );
+    }
+    if let Some(v) = flash_attn {
+        anyhow::bail!(
+            "-fa {v} is refused: ferrox has no flash-attention switch, so the flag would be \
+             accepted and change nothing. Drop it; the row is measured with the attention \
+             kernel the engine always uses."
+        );
+    }
+    if let Some(t) = threads_batch {
+        anyhow::bail!(
+            "-tb {t} is refused: ferrox has one thread pool for prefill and decode (-t). \
+             A separate batch thread count would be accepted and ignored; drop -tb."
+        );
+    }
+    Ok(())
+}
+
+/// A sweep value of zero is a row that would print NaN (`0/0`) in the
+/// same column as measured ones; upstream prints it, this refuses it.
+fn ensure_positive(flag: &str, values: &[usize]) -> anyhow::Result<()> {
+    anyhow::ensure!(!values.is_empty(), "{flag} needs at least one value");
+    if let Some(z) = values.iter().position(|&v| v == 0) {
+        anyhow::bail!(
+            "{flag} value {z} is 0: a zero-length prompt or generation divides zero work \
+             by a duration and prints NaN beside the measured rows"
+        );
+    }
+    Ok(())
+}
+
+pub fn run(args: BatchedBenchArgs) -> anyhow::Result<()> {
+    refuse_unhonoured_flags(&args)?;
+    ensure_positive("-npp", &args.n_pp)?;
+    ensure_positive("-ntg", &args.n_tg)?;
+    ensure_positive("-npl", &args.n_pl)?;
+    anyhow::ensure!(args.ubatch_size > 0, "-ub 0 would feed no tokens per call");
+    // The label only matters if a receipt is written, and then it is
+    // checked twice by the same predicate: here, so a sweep is not run
+    // for a receipt that will be refused, and at write time.
+    if args.receipt.is_some() {
+        bench_contract::ensure_label_matches_backend(&args.backend_label, active_backend())?;
+    }
+
+    let (load_start, thermal_start) = bench_contract::preflight_host(args.max_load)?;
+    let model = crate::pull::resolve_model_path(&args.model)?;
+    let path = Path::new(&model);
+    if !path.exists() {
+        anyhow::bail!("model not found: {model}");
+    }
+
+    let file = ferrox_gguf::ShardedGguf::open(path)?;
+    let arch = file
+        .metadata_str("general.architecture")
+        .unwrap_or("unknown")
+        .to_string();
+    let kind = select_engine_kind(&arch).map_err(|e| anyhow::anyhow!("{e}"))?;
+    // `forward_multi_seq` is a `Decoder` method; the dedicated engines
+    // have no multi-sequence step, and a per-sequence `forward_token`
+    // loop would measure something the batcher never runs.
+    if kind != SelectedEngineKind::GenericDecoder {
+        anyhow::bail!(
+            "`ferrox batched-bench` covers the generic decoder only; arch {arch} selects \
+             {kind:?}, which has no multi-sequence decode step to measure"
+        );
+    }
+    let config = ModelConfig::from_gguf(&file)
+        .with_context(|| format!("reading model config for arch {arch}"))?;
+
+    let n_kv_max = if args.ctx_size > 0 {
+        args.ctx_size
+    } else {
+        file.metadata_u64(&format!("{arch}.context_length"))
+            .map(|v| v as usize)
+            .with_context(|| {
+                format!("{arch}.context_length is not in the GGUF; pass -c <n_kv_max>")
+            })?
+    };
+
+    let shape = Shape {
+        pp_shared: args.pp_shared,
+        tg_separate: args.tg_separate,
+        ubatch: args.ubatch_size,
+    };
+    let combos = plan_combos(
+        &args.n_pp,
+        &args.n_tg,
+        &args.n_pl,
+        shape.pp_shared,
+        n_kv_max,
+    );
+    anyhow::ensure!(
+        !combos.is_empty(),
+        "every combination needs more than n_kv_max = {n_kv_max} positions; raise -c or \
+         shrink the sweep"
+    );
+
+    // The KV for the largest row, on top of the weights, before either
+    // is allocated: a run that pages is timing the page file.
+    let largest_kv = combos
+        .iter()
+        .map(|c| c.n_kv(shape.pp_shared))
+        .max()
+        .unwrap_or(0);
+    let kv_gb = (largest_kv * kv_bytes_per_position(&config)) as f64 / 1024.0 / 1024.0 / 1024.0;
+    bench_contract::ensure_weights_fit(args.max_load, path, kv_gb)?;
+
+    let load_t = Instant::now();
+    let decoder = Decoder::from_gguf(path, config)?;
+    let load_s = load_t.elapsed().as_secs_f64();
+
+    let backend = active_backend();
+    let threads = ferrox_core::threads::resolve_cpu_threads();
+    let header = report::Header {
+        n_kv_max,
+        n_ubatch: shape.ubatch,
+        is_pp_shared: shape.pp_shared,
+        is_tg_separate: shape.tg_separate,
+        n_gpu_layers: args.n_gpu_layers,
+        n_threads: threads,
+        backend,
+    };
+    if args.output_format == OutputFormat::Md {
+        println!();
+        println!("{}", report::header_line(&header));
+        println!();
+        for line in report::TABLE_HEADER {
+            println!("{line}");
+        }
+    }
+
+    let mut rows = Vec::with_capacity(combos.len());
+    for combo in combos {
+        let measured = workload::measure(&decoder, combo, &shape)?;
+        match args.output_format {
+            OutputFormat::Md => println!("{}", report::md_row(&measured)),
+            OutputFormat::Jsonl => println!("{}", report::jsonl_row(&header, &measured)),
+        }
+        rows.push(measured);
+    }
+
+    eprintln!(
+        "\nferrox batched-bench: load {load_s:.2}s, every row timed once after {} discarded \
+         warmup pass",
+        crate::bench_guard::WARMUP_REPS
+    );
+    let bench_contract::HostAfter {
+        load_end,
+        thermal_end,
+        engine_env,
+    } = bench_contract::report_host_after("ferrox batched-bench", load_start, &thermal_start);
+
+    if let Some(dest) = &args.receipt {
+        let host = bench_contract::HostState {
+            load_start,
+            load_end,
+            thermal_start,
+            thermal_end,
+        };
+        let common = bench_contract::receipt_common(
+            &args.backend_label,
+            backend,
+            threads,
+            load_s,
+            host,
+            &engine_env,
+        )?;
+        report::write_receipt(dest, common, &header, &model, &arch, &rows)?;
+        eprintln!(
+            "ferrox batched-bench: receipt written to {}",
+            dest.display()
+        );
+    }
+    Ok(())
+}
+
+/// The sweep in upstream's order (`batched-bench.cpp:132-143`): `pp`
+/// outermost, then `tg`, then `pl`, and a combination whose KV would
+/// not fit `n_kv_max` is left out -- upstream `continue`s silently,
+/// this says which rows it dropped and why.
+fn plan_combos(
+    n_pp: &[usize],
+    n_tg: &[usize],
+    n_pl: &[usize],
+    pp_shared: bool,
+    n_kv_max: usize,
+) -> Vec<Combo> {
+    let mut out = Vec::new();
+    for &pp in n_pp {
+        for &tg in n_tg {
+            for &pl in n_pl {
+                let combo = Combo { pp, tg, pl };
+                let n_kv = combo.n_kv(pp_shared);
+                if n_kv > n_kv_max {
+                    eprintln!(
+                        "ferrox batched-bench: skipping {} -- needs {n_kv} KV positions, \
+                         n_kv_max is {n_kv_max}",
+                        combo.label()
+                    );
+                    continue;
+                }
+                out.push(combo);
+            }
+        }
+    }
+    out
+}
+
+/// Host-side KV bytes per position: K and V, `f32`, every layer.
+fn kv_bytes_per_position(config: &ModelConfig) -> usize {
+    config.n_layers * config.n_kv_heads * config.head_dim * 2 * std::mem::size_of::<f32>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> BatchedBenchArgs {
+        BatchedBenchArgs::try_parse_from(
+            std::iter::once("batched-bench").chain(argv.iter().copied()),
+        )
+        .expect("parses")
+    }
+
+    const BASE: &[&str] = &[
+        "-m", "x.gguf", "--n-pp", "8", "--n-tg", "4", "--n-pl", "1,2",
+    ];
+
+    /// Each refused flag must reach its refusal: a gate keyed on a flag
+    /// the parser does not accept would never fire.
+    #[test]
+    fn every_unhonoured_flag_is_refused_by_name() {
+        for (extra, needle) in [
+            (vec!["-b", "2048"], "-b 2048 (n_batch) is refused"),
+            (vec!["--kv-unified"], "-kvu is refused"),
+            (vec!["--flash-attn", "on"], "-fa on is refused"),
+            (vec!["--threads-batch", "4"], "-tb 4 is refused"),
+        ] {
+            let argv: Vec<&str> = BASE.iter().copied().chain(extra).collect();
+            let err = refuse_unhonoured_flags(&parse(&argv))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains(needle), "{err}");
+        }
+        assert!(refuse_unhonoured_flags(&parse(BASE)).is_ok());
+    }
+
+    #[test]
+    fn the_sweep_lists_are_comma_separated_and_required() {
+        let a = parse(BASE);
+        assert_eq!(a.n_pl, vec![1, 2]);
+        assert_eq!(a.ubatch_size, 512, "upstream's n_ubatch default");
+        assert!(BatchedBenchArgs::try_parse_from(["batched-bench", "-m", "x.gguf"]).is_err());
+    }
+
+    /// A zero in any list is a NaN row; upstream prints it, this
+    /// refuses before loading anything.
+    #[test]
+    fn a_zero_sweep_value_is_refused_before_the_model_loads() {
+        let err = ensure_positive("-ntg", &[128, 0]).unwrap_err().to_string();
+        assert!(err.contains("-ntg value 1 is 0"), "{err}");
+        assert!(ensure_positive("-npp", &[]).is_err());
+        assert!(ensure_positive("-npp", &[1]).is_ok());
+    }
+
+    /// `batched-bench.cpp:132-143`: pp outermost, then tg, then pl,
+    /// and the rows that do not fit are dropped from the sweep rather
+    /// than run against a context they exceed.
+    #[test]
+    fn combos_come_in_upstream_order_and_oversized_rows_are_dropped() {
+        let got = plan_combos(&[8, 16], &[4], &[1, 2], false, 40);
+        let labels: Vec<String> = got.iter().map(Combo::label).collect();
+        // 16*4... pp16 tg4 pl2 needs 2*(16+4)=40, fits exactly; pp16 pl2
+        // with tg4 is the largest. Nothing exceeds 40 here.
+        assert_eq!(
+            labels,
+            ["pp8 tg4 pl1", "pp8 tg4 pl2", "pp16 tg4 pl1", "pp16 tg4 pl2"]
+        );
+        let got = plan_combos(&[8, 16], &[4], &[1, 2], false, 39);
+        let labels: Vec<String> = got.iter().map(Combo::label).collect();
+        assert_eq!(labels, ["pp8 tg4 pl1", "pp8 tg4 pl2", "pp16 tg4 pl1"]);
+    }
+
+    #[test]
+    fn kv_bytes_count_k_and_v_in_f32_for_every_layer() {
+        let mut config = ferrox_models::config::test_dense_fixture();
+        config.n_layers = 3;
+        config.n_kv_heads = 2;
+        config.head_dim = 8;
+        assert_eq!(kv_bytes_per_position(&config), 3 * 2 * 8 * 2 * 4);
+    }
+}

--- a/crates/ferrox-cli/src/batched_bench/report.rs
+++ b/crates/ferrox-cli/src/batched_bench/report.rs
@@ -1,0 +1,296 @@
+//! How a batched-bench row is printed and recorded.
+//!
+//! The markdown table is `tools/batched-bench/batched-bench.cpp:128-129`
+//! (header) and `:245` (row), reproduced width for width so a ferrox
+//! table and a llama.cpp table paste side by side. The JSONL line is
+//! `:238-243` minus the keys that would describe things ferrox does
+//! not have (`n_batch`, `flash_attn`, `n_threads_batch`): a key with a
+//! made-up value is worse than a missing one in a file meant for
+//! comparison.
+
+use super::workload::Measured;
+use std::path::Path;
+
+/// The run-wide values upstream prints before the table (`:126`).
+#[derive(Debug, Clone, Copy)]
+pub(super) struct Header {
+    pub n_kv_max: usize,
+    pub n_ubatch: usize,
+    pub is_pp_shared: bool,
+    pub is_tg_separate: bool,
+    pub n_gpu_layers: usize,
+    pub n_threads: usize,
+    pub backend: &'static str,
+}
+
+/// `:126`, with ferrox's values and without the three fields that
+/// have no ferrox meaning.
+pub(super) fn header_line(h: &Header) -> String {
+    format!(
+        "ferrox batched-bench: n_kv_max = {}, n_ubatch = {}, is_pp_shared = {}, \
+         is_tg_separate = {}, n_gpu_layers = {}, n_threads = {}, backend = {}",
+        h.n_kv_max,
+        h.n_ubatch,
+        h.is_pp_shared as u8,
+        h.is_tg_separate as u8,
+        h.n_gpu_layers,
+        h.n_threads,
+        h.backend
+    )
+}
+
+/// `:128-129`, byte for byte. Pinned by a test against the literal
+/// C format so a width cannot drift.
+pub(super) const TABLE_HEADER: [&str; 2] = [
+    "|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |",
+    "|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|",
+];
+
+/// `:245`: `|%6d | %6d | %4d | %6d | %8.3f | %8.2f | %8.3f | %8.2f | %8.3f | %8.2f |`.
+pub(super) fn md_row(m: &Measured) -> String {
+    format!(
+        "|{:>6} | {:>6} | {:>4} | {:>6} | {:>8.3} | {:>8.2} | {:>8.3} | {:>8.2} | {:>8.3} | {:>8.2} |",
+        m.combo.pp,
+        m.combo.tg,
+        m.combo.pl,
+        m.n_kv,
+        m.t_pp,
+        m.speed_pp,
+        m.t_tg,
+        m.speed_tg,
+        m.t,
+        m.speed
+    )
+}
+
+/// `:238-243`, with the same per-row keys and the header keys ferrox
+/// can answer for.
+pub(super) fn jsonl_row(h: &Header, m: &Measured) -> String {
+    serde_json::json!({
+        "n_kv_max": h.n_kv_max,
+        "n_ubatch": h.n_ubatch,
+        "is_pp_shared": h.is_pp_shared as u8,
+        "is_tg_separate": h.is_tg_separate as u8,
+        "n_gpu_layers": h.n_gpu_layers,
+        "n_threads": h.n_threads,
+        "backend": h.backend,
+        "pp": m.combo.pp,
+        "tg": m.combo.tg,
+        "pl": m.combo.pl,
+        "n_kv": m.n_kv,
+        "t_pp": m.t_pp,
+        "speed_pp": m.speed_pp,
+        "t_tg": m.t_tg,
+        "speed_tg": m.speed_tg,
+        "t": m.t,
+        "speed": m.speed,
+        "workload_digest": m.digest.hex(),
+    })
+    .to_string()
+}
+
+/// The receipt: the shared envelope (already checked by
+/// `bench_contract::receipt_common`) plus this run's rows.
+pub(super) fn write_receipt(
+    dest: &Path,
+    mut receipt: serde_json::Map<String, serde_json::Value>,
+    h: &Header,
+    model: &str,
+    arch: &str,
+    rows: &[Measured],
+) -> anyhow::Result<()> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let rows: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|m| {
+            serde_json::json!({
+                "pp": m.combo.pp,
+                "tg": m.combo.tg,
+                "pl": m.combo.pl,
+                "n_kv": m.n_kv,
+                "t_pp": m.t_pp,
+                "speed_pp": m.speed_pp,
+                "t_tg": m.t_tg,
+                "speed_tg": m.speed_tg,
+                "t": m.t,
+                "speed": m.speed,
+                "workload_digest": m.digest.hex(),
+            })
+        })
+        .collect();
+    let serde_json::Value::Object(own) = serde_json::json!({
+        "schema": 1,
+        "kind": "batched",
+        "model_path": model,
+        "arch": arch,
+        "n_kv_max": h.n_kv_max,
+        "n_ubatch": h.n_ubatch,
+        "is_pp_shared": h.is_pp_shared,
+        "is_tg_separate": h.is_tg_separate,
+        "n_gpu_layers": h.n_gpu_layers,
+        "rows": rows,
+    }) else {
+        unreachable!("json! with braces is an object");
+    };
+    receipt.extend(own);
+    std::fs::write(
+        dest,
+        serde_json::to_string_pretty(&serde_json::Value::Object(receipt))? + "\n",
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::workload::Combo;
+    use super::*;
+    use crate::bench_guard::WorkloadDigest;
+
+    fn sample() -> Measured {
+        Measured {
+            combo: Combo {
+                pp: 128,
+                tg: 128,
+                pl: 2,
+            },
+            n_kv: 512,
+            t_pp: 0.198,
+            speed_pp: 1295.19,
+            t_tg: 5.029,
+            speed_tg: 50.90,
+            t: 5.227,
+            speed: 97.95,
+            digest: WorkloadDigest::new(),
+        }
+    }
+
+    /// The README's sample row for these exact values, from
+    /// `tools/batched-bench/README.md`. Every column width is upstream's
+    /// `%6d | %6d | %4d | %6d | %8.3f | %8.2f | %8.3f | %8.2f | %8.3f | %8.2f`.
+    #[test]
+    fn a_row_prints_in_upstream_widths() {
+        assert_eq!(
+            md_row(&sample()),
+            "|   128 |    128 |    2 |    512 |    0.198 |  1295.19 |    5.029 |    50.90 |    5.227 |    97.95 |"
+        );
+    }
+
+    /// The header and separator are upstream's `:128-129` expanded by
+    /// hand; the row must be exactly as wide as both, or the columns
+    /// do not line up when the two tables are pasted together.
+    #[test]
+    fn the_header_separator_and_rows_are_the_same_width() {
+        let row = md_row(&sample());
+        assert_eq!(TABLE_HEADER[0].len(), row.len());
+        assert_eq!(TABLE_HEADER[1].len(), row.len());
+        // Column boundaries: every `|` in the row sits under one in
+        // the separator.
+        for (i, (a, b)) in TABLE_HEADER[1].chars().zip(row.chars()).enumerate() {
+            if a == '|' {
+                assert_eq!(b, '|', "row column boundary drifted at byte {i}");
+            }
+        }
+    }
+
+    /// The header line is what `printf("|%6s | %6s | %4s | %6s | %8s |
+    /// ...")` produces for the column names; pinned so a renamed
+    /// column shows up as a diff against upstream.
+    #[test]
+    fn the_table_header_is_upstreams_format_string_expanded() {
+        let expected = format!(
+            "|{:>6} | {:>6} | {:>4} | {:>6} | {:>8} | {:>8} | {:>8} | {:>8} | {:>8} | {:>8} |",
+            "PP", "TG", "B", "N_KV", "T_PP s", "S_PP t/s", "T_TG s", "S_TG t/s", "T s", "S t/s"
+        );
+        assert_eq!(TABLE_HEADER[0], expected);
+        let sep = format!(
+            "|{:>6}-|-{:>6}-|-{:>4}-|-{:>6}-|-{:>8}-|-{:>8}-|-{:>8}-|-{:>8}-|-{:>8}-|-{:>8}-|",
+            "------",
+            "------",
+            "----",
+            "------",
+            "--------",
+            "--------",
+            "--------",
+            "--------",
+            "--------",
+            "--------"
+        );
+        assert_eq!(TABLE_HEADER[1], sep);
+    }
+
+    fn header() -> Header {
+        Header {
+            n_kv_max: 2048,
+            n_ubatch: 512,
+            is_pp_shared: false,
+            is_tg_separate: false,
+            n_gpu_layers: 0,
+            n_threads: 6,
+            backend: "CPU",
+        }
+    }
+
+    /// The per-row keys are upstream's (`:240`), so a jq pipeline
+    /// written for `llama-batched-bench` output reads ferrox output.
+    #[test]
+    fn jsonl_rows_carry_upstreams_per_row_keys() {
+        let v: serde_json::Value = serde_json::from_str(&jsonl_row(&header(), &sample())).unwrap();
+        for key in [
+            "pp",
+            "tg",
+            "pl",
+            "n_kv",
+            "t_pp",
+            "speed_pp",
+            "t_tg",
+            "speed_tg",
+            "t",
+            "speed",
+            "n_kv_max",
+            "n_gpu_layers",
+            "n_threads",
+            "is_pp_shared",
+        ] {
+            assert!(v.get(key).is_some(), "missing {key}");
+        }
+        assert_eq!(v["pl"], 2);
+        assert_eq!(v["n_kv"], 512);
+        assert_eq!(v["is_pp_shared"], 0, "upstream prints the flag as an int");
+        // What ferrox has no value for is absent, not invented.
+        for key in ["n_batch", "flash_attn", "n_threads_batch"] {
+            assert!(v.get(key).is_none(), "{key} would be a fabricated value");
+        }
+    }
+
+    #[test]
+    fn the_header_line_prints_flags_as_ints_like_upstream() {
+        let line = header_line(&Header {
+            is_pp_shared: true,
+            ..header()
+        });
+        assert!(line.contains("is_pp_shared = 1"), "{line}");
+        assert!(line.contains("is_tg_separate = 0"), "{line}");
+        assert!(line.contains("n_kv_max = 2048"), "{line}");
+    }
+
+    #[test]
+    fn a_receipt_keeps_the_envelope_and_adds_the_rows() {
+        let dir = std::env::temp_dir().join(format!(
+            "ferrox-batched-bench-receipt-{}",
+            std::process::id()
+        ));
+        let dest = dir.join("nested").join("r.json");
+        let mut envelope = serde_json::Map::new();
+        envelope.insert("backend".into(), "cpu".into());
+        write_receipt(&dest, envelope, &header(), "m.gguf", "llama", &[sample()]).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&dest).unwrap()).unwrap();
+        assert_eq!(v["backend"], "cpu", "the envelope survives the merge");
+        assert_eq!(v["kind"], "batched");
+        assert_eq!(v["rows"][0]["n_kv"], 512);
+        assert_eq!(v["rows"][0]["workload_digest"], WorkloadDigest::new().hex());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/ferrox-cli/src/batched_bench/workload.rs
+++ b/crates/ferrox-cli/src/batched_bench/workload.rs
@@ -1,0 +1,319 @@
+//! One `llama-batched-bench` row: the workload of
+//! `tools/batched-bench/batched-bench.cpp:145-235`, driven through the
+//! seams the continuous batcher uses, with every `bench_guard` check
+//! `ferrox bench` applies to its own rows.
+//!
+//! Upstream runs each combination once after a global 16-token warmup
+//! (`:110-122`). Here each combination runs `WARMUP_REPS` untimed
+//! passes and then one timed pass, and the two must feed the same
+//! tokens and produce the same greedy picks. That costs a second pass
+//! per row and buys the determinism assertion `ferrox bench` has: a
+//! single pass has nothing to disagree with.
+
+use crate::bench_guard::{self, WorkloadDigest};
+use crate::bench_model::{check_result, decode_tokens, fresh_caches, probe, synthetic_tokens};
+use ferrox_core::cache::KvCache;
+use ferrox_models::Decoder;
+use std::time::Instant;
+
+/// One `(PP, TG, B)` cell of the sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Combo {
+    pub pp: usize,
+    pub tg: usize,
+    pub pl: usize,
+}
+
+impl Combo {
+    /// `batched-bench.cpp:139` with `kv_unified = false` (the `-kvu`
+    /// arm is refused): a shared prompt is copied into every sequence,
+    /// so both branches come to `pl * (pp + tg)`. Written as upstream
+    /// writes it so the two can be read line for line.
+    pub fn n_kv(&self, pp_shared: bool) -> usize {
+        let Combo { pp, tg, pl } = *self;
+        if pp_shared {
+            pl * pp + pl * tg
+        } else {
+            pl * (pp + tg)
+        }
+    }
+
+    pub fn label(&self) -> String {
+        format!("pp{} tg{} pl{}", self.pp, self.tg, self.pl)
+    }
+}
+
+/// The run-wide switches that change what a row does.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct Shape {
+    /// `-pps`: prefill one prompt and copy its KV to every sequence
+    /// (`:147,168-171`).
+    pub pp_shared: bool,
+    /// `-tgs`: `0 0 0 ... 1 1 1 ...` instead of `0123 0123 ...`
+    /// (`:189-223`).
+    pub tg_separate: bool,
+    /// Prompt tokens per forward call (`-ub`).
+    pub ubatch: usize,
+}
+
+/// A measured row, in the units upstream prints (`:229-235`).
+#[derive(Debug, Clone)]
+pub(super) struct Measured {
+    pub combo: Combo,
+    pub n_kv: usize,
+    pub t_pp: f64,
+    pub speed_pp: f64,
+    pub t_tg: f64,
+    pub speed_tg: f64,
+    pub t: f64,
+    pub speed: f64,
+    /// Digest of every token fed inside the two timed regions, prompt
+    /// then decode, so two receipts for the same row can be shown to
+    /// have measured the same work.
+    pub digest: WorkloadDigest,
+}
+
+/// Runs one combination: `WARMUP_REPS` untimed passes, one timed.
+pub(super) fn measure(decoder: &Decoder, combo: Combo, shape: &Shape) -> anyhow::Result<Measured> {
+    let Combo { pp, tg, pl } = combo;
+    let label = combo.label();
+    let vocab = decoder.config.vocab_size;
+
+    // `:147`: one prompt when shared, else one per sequence. Built and
+    // checked BEFORE the clock, like every stream `ferrox bench` feeds.
+    let n_prompts = if shape.pp_shared { 1 } else { pl };
+    let prompts: Vec<Vec<usize>> = (0..n_prompts)
+        .map(|s| synthetic_tokens(vocab, pp, s))
+        .collect();
+    for (s, prompt) in prompts.iter().enumerate() {
+        bench_guard::check_prompt_before(&format!("{label} prompt {s}"), pp, prompt, vocab)?;
+    }
+    let gens: Vec<Vec<usize>> = (0..pl).map(|s| decode_tokens(vocab, tg, s)).collect();
+    for (s, gen) in gens.iter().enumerate() {
+        bench_guard::check_prompt_before(&format!("{label} decode {s}"), tg, gen, vocab)?;
+    }
+
+    let mut first_digest: Option<WorkloadDigest> = None;
+    let mut first_pp: Vec<Option<(usize, f32)>> = vec![None; n_prompts];
+    let mut first_tg: Vec<Option<(usize, f32)>> = vec![None; pl];
+    let mut samples_pp = Vec::with_capacity(1);
+    let mut samples_tg = Vec::with_capacity(1);
+
+    for rep in 0..1 + bench_guard::WARMUP_REPS {
+        // `:153` clears the memory; here every sequence starts from a
+        // cache that is asserted cold rather than assumed so.
+        let mut caches: Vec<Vec<KvCache>> = (0..n_prompts).map(|_| fresh_caches(decoder)).collect();
+        for c in &caches {
+            bench_guard::check_caches_cold(&label, rep, &probe(c))?;
+        }
+        let mut digest = WorkloadDigest::new();
+
+        // `:155-166`: the prompt phase. Upstream puts every sequence's
+        // prompt in one batch and lets `n_ubatch` slice it; ferrox has
+        // no cross-sequence prefill, so each prompt is fed in `-ub`
+        // chunks through the call the batcher makes for an admitted
+        // row (`serving/batch/prefill.rs:165-171`). The host-KV
+        // variant is deliberate: `forward_multi_seq` attends over host
+        // rows, and on Metal the plain variant leaves them zeroed.
+        let mut pp_logits: Vec<Vec<f32>> = Vec::with_capacity(n_prompts);
+        let t = Instant::now();
+        for (s, prompt) in prompts.iter().enumerate() {
+            let mut logits = Vec::new();
+            let mut pos = 0;
+            for chunk in prompt.chunks(shape.ubatch) {
+                digest.feed_all(chunk);
+                logits = decoder.forward_batch_last_host_kv(chunk, pos, &mut caches[s]);
+                pos += chunk.len();
+            }
+            pp_logits.push(logits);
+        }
+        let dt_pp = t.elapsed().as_secs_f64();
+
+        for c in &caches {
+            bench_guard::check_prefill_after(&label, pp, &probe(c))?;
+        }
+        for (s, logits) in pp_logits.iter().enumerate() {
+            check_result(
+                &format!("{label} prompt {s}"),
+                rep,
+                logits,
+                &mut first_pp[s],
+            )?;
+        }
+
+        // `:168-185`: a shared prompt is copied to the other sequences
+        // between the two timers. Upstream's `llama_memory_seq_cp` is a
+        // KV clone here, and the clones are re-checked: a copy that
+        // came back short would make every decode step attend over
+        // less than the prompt.
+        if shape.pp_shared {
+            let clones: Vec<Vec<KvCache>> = (1..pl).map(|_| caches[0].clone()).collect();
+            caches.extend(clones);
+            for c in &caches {
+                bench_guard::check_prefill_after(&label, pp, &probe(c))?;
+            }
+        }
+        anyhow::ensure!(
+            caches.len() == pl,
+            "{label}: {} sequences hold KV for a {pl}-sequence row",
+            caches.len()
+        );
+
+        // `:187-225`: the decode phase, through the batcher's step.
+        let mut tg_logits: Vec<Vec<f32>> = vec![Vec::new(); pl];
+        let t = Instant::now();
+        if shape.tg_separate {
+            // `:189-205`: 0 0 0 ... 1 1 1 ... -- a one-sequence batch
+            // per call, through the same entry point, so the two
+            // patterns differ only in how the batch is grouped.
+            for (j, gen) in gens.iter().enumerate() {
+                for (i, &tok) in gen.iter().enumerate() {
+                    digest.feed(tok);
+                    let out = decoder.forward_multi_seq(&[tok], &[pp + i], &mut caches[j..=j]);
+                    tg_logits[j] = out.into_iter().next().unwrap_or_default();
+                }
+            }
+        } else {
+            // `:207-223`: 0123 0123 ... -- one call per step across
+            // every sequence, at each sequence's own position.
+            let mut toks = vec![0usize; pl];
+            let mut positions = vec![0usize; pl];
+            for i in 0..tg {
+                for (j, gen) in gens.iter().enumerate() {
+                    toks[j] = gen[i];
+                    positions[j] = pp + i;
+                    digest.feed(gen[i]);
+                }
+                let out = decoder.forward_multi_seq(&toks, &positions, &mut caches);
+                anyhow::ensure!(
+                    out.len() == pl,
+                    "{label} step {i}: forward_multi_seq returned {} logit rows for {pl} \
+                     sequences",
+                    out.len()
+                );
+                tg_logits = out;
+            }
+        }
+        let dt_tg = t.elapsed().as_secs_f64();
+
+        // The batched step pushes to and attends from the host cache on
+        // every backend (`decoder/attn_block.rs`, `KvStep::Batched`), so
+        // unlike `ferrox bench` the host cache is always the record and
+        // the length check always runs.
+        for c in &caches {
+            bench_guard::check_decode_after(&label, pp, tg, &probe(c), true)?;
+        }
+        let first = *first_digest.get_or_insert(digest);
+        bench_guard::check_same_workload(&label, rep, first, digest)?;
+        for (s, logits) in tg_logits.iter().enumerate() {
+            check_result(
+                &format!("{label} decode {s}"),
+                rep,
+                logits,
+                &mut first_tg[s],
+            )?;
+        }
+        if rep >= bench_guard::WARMUP_REPS {
+            samples_pp.push(dt_pp);
+            samples_tg.push(dt_tg);
+        }
+    }
+
+    // One timed pass per row is what upstream reports; the warmup
+    // accounting guard says exactly one landed.
+    bench_guard::check_timed_samples(&label, 1, samples_pp.len())?;
+    bench_guard::check_timed_samples(&label, 1, samples_tg.len())?;
+    let t_pp = samples_pp[0];
+    let t_tg = samples_tg[0];
+    let rates = rates(combo, shape.pp_shared, t_pp, t_tg);
+    bench_guard::check_sample_rates(&label, &[rates.speed_pp, rates.speed_tg, rates.speed])?;
+
+    Ok(Measured {
+        combo,
+        n_kv: combo.n_kv(shape.pp_shared),
+        t_pp,
+        speed_pp: rates.speed_pp,
+        t_tg,
+        speed_tg: rates.speed_tg,
+        t: rates.t,
+        speed: rates.speed,
+        digest: first_digest.unwrap_or_default(),
+    })
+}
+
+/// The three rates of `batched-bench.cpp:229-235`, separated from the
+/// timing so the arithmetic can be pinned without a model.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct Rates {
+    pub speed_pp: f64,
+    pub speed_tg: f64,
+    pub t: f64,
+    pub speed: f64,
+}
+
+pub(super) fn rates(combo: Combo, pp_shared: bool, t_pp: f64, t_tg: f64) -> Rates {
+    let Combo { pp, tg, pl } = combo;
+    let t = t_pp + t_tg;
+    // `:233`: a shared prompt is `pp` tokens of work, not `pl*pp`.
+    let prompt_tokens = if pp_shared { pp } else { pl * pp };
+    Rates {
+        speed_pp: prompt_tokens as f64 / t_pp,
+        // `:234`
+        speed_tg: (pl * tg) as f64 / t_tg,
+        t,
+        // `:235`
+        speed: (prompt_tokens + pl * tg) as f64 / t,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `batched-bench.cpp:139`, both arms, with `-kvu` off: the two
+    /// spellings agree, and the README's `N_KV = B*(PP+TG)` holds.
+    #[test]
+    fn n_kv_is_sequences_times_prompt_plus_generation_in_both_modes() {
+        let c = Combo {
+            pp: 128,
+            tg: 64,
+            pl: 4,
+        };
+        assert_eq!(c.n_kv(false), 4 * (128 + 64));
+        assert_eq!(c.n_kv(true), 4 * 128 + 4 * 64);
+    }
+
+    /// `:233-235`: a shared prompt counts once in S_PP and S, and the
+    /// decode rate is always over every sequence's tokens.
+    #[test]
+    fn rates_credit_a_shared_prompt_once_and_decode_across_every_sequence() {
+        let c = Combo {
+            pp: 100,
+            tg: 10,
+            pl: 4,
+        };
+        let separate = rates(c, false, 2.0, 1.0);
+        assert_eq!(separate.speed_pp, 400.0 / 2.0);
+        assert_eq!(separate.speed_tg, 40.0 / 1.0);
+        assert_eq!(separate.t, 3.0);
+        assert_eq!(separate.speed, 440.0 / 3.0);
+
+        let shared = rates(c, true, 2.0, 1.0);
+        assert_eq!(shared.speed_pp, 100.0 / 2.0);
+        assert_eq!(shared.speed_tg, 40.0 / 1.0);
+        assert_eq!(shared.speed, 140.0 / 3.0);
+    }
+
+    #[test]
+    fn the_row_label_names_all_three_dimensions() {
+        assert_eq!(
+            Combo {
+                pp: 8,
+                tg: 4,
+                pl: 2
+            }
+            .label(),
+            "pp8 tg4 pl2"
+        );
+    }
+}

--- a/crates/ferrox-cli/src/bench_contract.rs
+++ b/crates/ferrox-cli/src/bench_contract.rs
@@ -1,0 +1,364 @@
+//! The envelope every timed engine run shares: what is checked before
+//! the clock starts, what is reported after it stops, and what a
+//! receipt must carry to be worth reading later.
+//!
+//! `ferrox bench` and `ferrox batched-bench` measure different
+//! workloads through different engine seams, but the measurement
+//! contract around them is ONE thing: a quiet, cool host with the
+//! weights in RAM; the load and thermal state recorded on both sides
+//! of the run; a receipt whose backend label is the backend that ran
+//! and whose GPU row names its card. Each of those rules exists
+//! because it was broken once and published (#126 is the label one).
+//! Having them here, as functions both tools call, is what keeps the
+//! second tool from drifting away from the first the way copied code
+//! does in this repo.
+
+use crate::bench_guard;
+use crate::host_state::{self, ThermalReading};
+use std::path::Path;
+
+/// What the host was doing around this run, for the receipt.
+#[derive(Clone, Copy)]
+pub struct HostState {
+    pub load_start: Option<f64>,
+    pub load_end: Option<f64>,
+    pub thermal_start: ThermalReading,
+    pub thermal_end: ThermalReading,
+}
+
+/// The checks that run BEFORE anything is loaded: a timed run on a
+/// busy or hot host produces a number that looks like a measurement
+/// and is not one.
+///
+/// `--max-load 0` is the documented "measure anyway, not publishable"
+/// escape; the thermal bar shares it rather than growing a second flag
+/// that has to be remembered separately.
+///
+/// Returns the starting load average and thermal reading so the
+/// after-run report can show the delta.
+pub fn preflight_host(max_load: f64) -> anyhow::Result<(Option<f64>, ThermalReading)> {
+    let load_start = host_state::ensure_quiet_enough(max_load)?;
+    let thermal_start = host_state::thermal_reading();
+    host_state::ensure_cool_enough(&thermal_start, max_load > 0.0)?;
+    Ok((load_start, thermal_start))
+}
+
+/// A busy host and a hot host are refused by [`preflight_host`]. A FULL
+/// host is the same failure with a different cause: the weights page
+/// to disk and the run times the page file. The file size is the floor
+/// on the footprint, `extra_gb` is whatever the workload will allocate
+/// on top of it (KV caches, for a run that knows its context up
+/// front), and `--max-load 0` waives this the same way it waives the
+/// other two.
+pub fn ensure_weights_fit(max_load: f64, weights: &Path, extra_gb: f64) -> anyhow::Result<()> {
+    if max_load <= 0.0 {
+        return Ok(());
+    }
+    if let Ok(meta) = std::fs::metadata(weights) {
+        let weights_gb = meta.len() as f64 / 1024.0 / 1024.0 / 1024.0;
+        host_state::ensure_fits_in_ram(weights_gb + extra_gb, 2.0)?;
+    }
+    Ok(())
+}
+
+/// What the host looked like when the run finished, plus the engine
+/// knobs that were in effect for it.
+pub struct HostAfter {
+    pub load_end: Option<f64>,
+    pub thermal_end: ThermalReading,
+    /// Non-default `FERROX_*` variables, see
+    /// [`bench_guard::nondefault_engine_env`].
+    pub engine_env: Vec<(String, String)>,
+}
+
+/// Reads the host again after the run and prints the before/after pair
+/// to stderr under `tool`'s name, warning when the run started cool and
+/// finished thermally limited -- its later repetitions ran under
+/// different physics than its first ones.
+pub fn report_host_after(
+    tool: &str,
+    load_start: Option<f64>,
+    thermal_start: &ThermalReading,
+) -> HostAfter {
+    let load_end = host_state::load_average_1min();
+    let thermal_end = host_state::thermal_reading();
+    eprintln!(
+        "{tool}: host 1-min load {} -> {}, {} -> {}",
+        fmt_load(load_start),
+        fmt_load(load_end),
+        thermal_start.describe(),
+        thermal_end.describe(),
+    );
+    if !thermal_start.is_degraded() && thermal_end.is_degraded() {
+        eprintln!(
+            "{tool}: WARNING -- the host became thermally limited during this \
+             run ({}); the later repetitions did not run under the same conditions \
+             as the first",
+            thermal_end.describe()
+        );
+    }
+    let engine_env = bench_guard::nondefault_engine_env(std::env::vars());
+    if !engine_env.is_empty() {
+        eprintln!(
+            "{tool}: non-default engine env in effect: {}",
+            engine_env
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+    }
+    HostAfter {
+        load_end,
+        thermal_end,
+        engine_env,
+    }
+}
+
+/// Serializes a thermal reading so that "we did not measure" and
+/// "we measured, and it was nominal" can never be read as the same
+/// thing. `measured` is stated outright rather than left to be
+/// inferred from a null, because a field that is always null while
+/// implying it was measured is exactly the lie this receipt exists to
+/// prevent.
+fn thermal_json(r: &ThermalReading) -> serde_json::Value {
+    serde_json::json!({
+        "measured": r.measured(),
+        "pressure": r.pressure.map(|p| p.as_str()),
+        "source": r.source,
+        "cpu_speed_limit_percent": r.cpu_speed_limit_percent,
+        "degraded": r.measured().then(|| r.is_degraded()),
+    })
+}
+
+/// A load average we could not read prints as `?`, never as `0.00`.
+pub fn fmt_load(l: Option<f64>) -> String {
+    l.map(|l| format!("{l:.2}"))
+        .unwrap_or_else(|| "?".to_string())
+}
+
+/// Whether a receipt's `backend` label describes the backend that ran.
+///
+/// The label is lowercase and comes from the suite (`cpu`, `metal`,
+/// `cuda`); the active backend is what `active_backend` resolved.
+/// Compared case-insensitively and nothing else: a mismatch is always
+/// a defect, never a naming convention.
+pub fn backend_label_agrees(label: &str, active: &str) -> bool {
+    label.eq_ignore_ascii_case(active)
+}
+
+/// The accelerator a non-CPU run executed on, as the backend itself
+/// reports it.
+///
+/// Returns `None` on CPU, where `host_spec` already describes the
+/// machine, and `None` when a GPU backend cannot name its device --
+/// which the receipt writer treats as a refusal rather than a blank,
+/// because an unnamed card is what made ten CUDA rows unattributable.
+fn accelerator_name(backend: &str) -> Option<String> {
+    match backend {
+        #[cfg(feature = "cuda")]
+        "CUDA" => ferrox_cuda::gpu::probe().and_then(|i| i.first_device_name),
+        #[cfg(feature = "metal")]
+        "Metal" => ferrox_metal::gpu::probe(),
+        _ => None,
+    }
+}
+
+/// The label a receipt is about to be written under, checked against
+/// the backend that ran, BEFORE anything is timed.
+///
+/// The write-time check in [`receipt_common`] is the discipline; this
+/// is the same predicate asked early so a mislabelled run is refused
+/// in a millisecond rather than after the whole sweep. Both call the
+/// one function, so they cannot disagree.
+pub fn ensure_label_matches_backend(label: &str, active: &str) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        backend_label_agrees(label, active),
+        "refusing to write a receipt labelled `{label}` for a run that executed on \
+         {active}. The label is what the ledger publishes; the active backend is what \
+         ran (#126)."
+    );
+    Ok(())
+}
+
+/// The fields every engine receipt carries, and the two refusals that
+/// decide whether it is written at all.
+///
+/// The caller merges its own workload-specific fields in on top;
+/// nothing here depends on what was measured, only on where and how.
+pub fn receipt_common(
+    label: &str,
+    backend_active: &str,
+    threads: usize,
+    load_s: f64,
+    host: HostState,
+    engine_env: &[(String, String)],
+) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {
+    // WHAT the machine was, never WHICH machine it was. A receipt is
+    // public, and `--render` reads every receipt in the directory:
+    // without this, rows from two hosts merge into one table with no
+    // column saying so.
+    let host_spec_json = {
+        let spec = host_state::host_spec();
+        serde_json::json!({
+            "label": host_state::host_label(&spec),
+            "cpu": spec.cpu,
+            "arch": spec.arch,
+            "cores": spec.cores,
+            "perf_cores": spec.perf_cores,
+            "ram_gb": spec.ram_gb.map(|g| (g * 10.0).round() / 10.0),
+            "os": spec.os,
+        })
+    };
+    // A receipt may not claim one backend and record another. Every
+    // `cpu` row in the ledger did exactly that (#126), and the
+    // contradiction sat in the file: `backend: "cpu"` beside
+    // `backend_active: "Metal"`. Two fields that must agree, with
+    // nothing comparing them, which is this repo's oldest bug shape.
+    // Asked first so a mislabelled receipt is refused AS mislabelled
+    // in every build, not as "no accelerator" in a CPU-only one.
+    ensure_label_matches_backend(label, backend_active)?;
+
+    // `host_spec` names the CPU. For a `cpu` row that is the whole
+    // machine; for a `cuda` or `metal` row it is the least interesting
+    // part. Ten published CUDA rows carried a Xeon's model number and
+    // NOTHING about the card, in a file whose own header says rows are
+    // never compared across machines -- there was no field to compare
+    // them by, so a Pascal row and an Ampere row grouped as one host.
+    let accelerator = accelerator_name(backend_active);
+    if backend_active != "CPU" && accelerator.is_none() {
+        anyhow::bail!(
+            "refusing to write a `{label}` receipt that does not name the accelerator it \
+             ran on. A GPU gap is meaningless without the card: the ledger groups rows by \
+             host, and two different GPUs in one host section are two different machines."
+        );
+    }
+
+    let serde_json::Value::Object(map) = serde_json::json!({
+        "backend": label,
+        "backend_active": backend_active,
+        "threads": threads,
+        "warmup_reps": bench_guard::WARMUP_REPS,
+        "load_s": load_s,
+        // Null, not zero, when the platform would not say -- see host_state.
+        "host_load_1min_start": host.load_start,
+        "host_load_1min_end": host.load_end,
+        "host_thermal_start": thermal_json(&host.thermal_start),
+        "host_thermal_end": thermal_json(&host.thermal_end),
+        // The single field an auditor reads first: was this row taken
+        // under the measurement contract's quiet-host bar at all?
+        "quiet_host": host.load_start.map(|l| l < host_state::DEFAULT_MAX_LOAD),
+        "host_spec": host_spec_json,
+        // The card, for a row that ran on one. `null` for `cpu` rows,
+        // where `host_spec` already is the machine.
+        "accelerator": accelerator,
+        // Non-default `FERROX_*` knobs in effect. Some of them (MoE
+        // stage ablation, the fail-closed loader override) change how
+        // much work the engine does, so a row taken under one is not
+        // comparable to a row taken without it.
+        "engine_env": engine_env
+            .iter()
+            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+            .collect::<serde_json::Map<_, _>>(),
+        "ferrox_version": env!("CARGO_PKG_VERSION"),
+    }) else {
+        unreachable!("json! with braces is an object");
+    };
+    Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The receipt guard that #126 needed and did not have.
+    #[test]
+    fn a_cpu_label_does_not_describe_a_metal_run() {
+        assert!(backend_label_agrees("cpu", "CPU"));
+        assert!(backend_label_agrees("metal", "Metal"));
+        assert!(backend_label_agrees("cuda", "CUDA"));
+        assert!(
+            !backend_label_agrees("cpu", "Metal"),
+            "this exact pair is what all 13 published cpu receipts recorded"
+        );
+        assert!(!backend_label_agrees("metal", "CPU"));
+        assert!(!backend_label_agrees("cuda", "Metal"));
+    }
+
+    /// The early check and the write-time check are one predicate;
+    /// this pins that the early one refuses the same pair.
+    #[test]
+    fn the_early_label_check_refuses_the_published_mismatch() {
+        let err = ensure_label_matches_backend("cpu", "Metal")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("labelled `cpu`"), "{err}");
+        assert!(err.contains("executed on Metal"), "{err}");
+        assert!(ensure_label_matches_backend("cpu", "CPU").is_ok());
+    }
+
+    /// A `cpu` row has no accelerator and must not be refused for it.
+    #[test]
+    fn the_cpu_backend_names_no_accelerator() {
+        assert_eq!(accelerator_name("CPU"), None);
+    }
+
+    fn unmeasured_host() -> HostState {
+        HostState {
+            load_start: None,
+            load_end: None,
+            thermal_start: host_state::ThermalReading::default(),
+            thermal_end: host_state::ThermalReading::default(),
+        }
+    }
+
+    /// The write-time refusal, exercised through the function both
+    /// receipt writers call rather than through either writer.
+    #[test]
+    fn a_receipt_labelled_for_another_backend_is_not_written() {
+        let err = receipt_common("cpu", "Metal", 4, 1.0, unmeasured_host(), &[])
+            .map(|_| ())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("#126"), "{err}");
+    }
+
+    /// A GPU row that cannot name its card is refused too. In a build
+    /// without that backend the probe always answers `None`, which is
+    /// exactly the "cannot name it" case.
+    #[test]
+    fn a_gpu_receipt_without_an_accelerator_name_is_not_written() {
+        let err = receipt_common("metal", "Metal", 4, 1.0, unmeasured_host(), &[])
+            .map(|_| ())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not name the accelerator"), "{err}");
+    }
+
+    #[test]
+    fn a_cpu_receipt_carries_the_shared_fields_and_no_accelerator() {
+        let map = receipt_common("cpu", "CPU", 4, 1.5, unmeasured_host(), &[]).unwrap();
+        assert_eq!(map["backend"], "cpu");
+        assert_eq!(map["backend_active"], "CPU");
+        assert_eq!(map["threads"], 4);
+        assert_eq!(map["accelerator"], serde_json::Value::Null);
+        // Unmeasured, not "quiet": a null load must not read as passing.
+        assert_eq!(map["quiet_host"], serde_json::Value::Null);
+        assert_eq!(map["host_thermal_start"]["measured"], false);
+        assert_eq!(map["warmup_reps"], bench_guard::WARMUP_REPS);
+    }
+
+    /// The fits-in-RAM check is waived by `--max-load 0`, the same
+    /// switch that waives the load and thermal bars, and only by it.
+    /// An exabyte of KV on top of any real file does not fit any host
+    /// that reports its free memory.
+    #[test]
+    fn the_ram_check_is_waived_with_the_load_check() {
+        let me = std::env::current_exe().expect("the test binary exists");
+        assert!(ensure_weights_fit(0.0, &me, 1e9).is_ok());
+        if host_state::free_ram_gb().is_some() {
+            let err = ensure_weights_fit(2.0, &me, 1e9).unwrap_err().to_string();
+            assert!(err.contains("would run from swap"), "{err}");
+        }
+    }
+}

--- a/crates/ferrox-cli/src/bench_guard.rs
+++ b/crates/ferrox-cli/src/bench_guard.rs
@@ -168,9 +168,11 @@ pub fn check_prefill_after(
     Ok(())
 }
 
-/// The decode equivalent: one priming token plus `n_gen` steps must
-/// leave exactly `n_gen + 1` positions in every layer's cache. A short
-/// cache means steps were skipped, which inflates the rate.
+/// The decode equivalent: `n_primed` positions already in the cache
+/// (one priming token for a `tg<N>` row, the whole prompt for a
+/// batched-bench row) plus `n_gen` steps must leave exactly
+/// `n_primed + n_gen` positions in every layer's cache. A short cache
+/// means steps were skipped, which inflates the rate.
 ///
 /// Only meaningful when the HOST cache is the record. With GPU offload
 /// the KV lives in device memory and the host `KvCache` is never
@@ -185,6 +187,7 @@ pub fn check_prefill_after(
 /// different facts and a receipt that conflates them is worth less.
 pub fn check_decode_after(
     test: &str,
+    n_primed: usize,
     n_gen: usize,
     caches: &[CacheProbe],
     host_kv_is_the_record: bool,
@@ -193,7 +196,7 @@ pub fn check_decode_after(
         // The device holds the KV. There is nothing here to count.
         return Ok(false);
     }
-    let expected = n_gen + 1;
+    let expected = n_primed + n_gen;
     if let Some((layer, c)) = caches
         .iter()
         .enumerate()
@@ -201,8 +204,8 @@ pub fn check_decode_after(
     {
         anyhow::bail!(
             "{test}: layer {layer} advanced the KV cache to {} positions, expected \
-             {expected} (one prime + {n_gen} decode steps) -- decode steps were \
-             skipped and the rate would count them anyway",
+             {expected} ({n_primed} primed + {n_gen} decode steps) -- decode steps \
+             were skipped and the rate would count them anyway",
             c.seq_len
         );
     }
@@ -226,7 +229,7 @@ mod decode_guard_tests {
             };
             4
         ];
-        let ran = check_decode_after("tg128", 128, &empty, false)
+        let ran = check_decode_after("tg128", 1, 128, &empty, false)
             .expect("a device-resident cache must not refuse the run");
         assert!(
             !ran,
@@ -243,7 +246,7 @@ mod decode_guard_tests {
             k_len: 3,
             v_len: 3,
         }];
-        let err = check_decode_after("tg128", 128, &short, true)
+        let err = check_decode_after("tg128", 1, 128, &short, true)
             .expect_err("a short host cache means skipped decode steps");
         assert!(err.to_string().contains("expected 129"));
     }
@@ -255,7 +258,7 @@ mod decode_guard_tests {
             k_len: 129,
             v_len: 129,
         }];
-        assert!(check_decode_after("tg128", 128, &good, true).expect("must pass"));
+        assert!(check_decode_after("tg128", 1, 128, &good, true).expect("must pass"));
     }
 }
 
@@ -560,12 +563,25 @@ mod tests {
 
     #[test]
     fn skipped_decode_steps_are_caught_by_the_final_cache_length() {
-        assert!(check_decode_after("tg128", 128, &filled(4, 129, 64), true).is_ok());
-        let err = check_decode_after("tg128", 128, &filled(4, 65, 64), true)
+        assert!(check_decode_after("tg128", 1, 128, &filled(4, 129, 64), true).is_ok());
+        let err = check_decode_after("tg128", 1, 128, &filled(4, 65, 64), true)
             .unwrap_err()
             .to_string();
         assert!(err.contains("expected 129"), "{err}");
         assert!(err.contains("decode steps were skipped"), "{err}");
+    }
+
+    /// A batched-bench row primes with the whole prompt, not one
+    /// token, so the expected length is `pp + tg`. Pinned so the prime
+    /// count cannot quietly go back to being a constant.
+    #[test]
+    fn a_prompt_primed_cache_is_expected_to_hold_prompt_plus_decode_positions() {
+        assert!(check_decode_after("pp128 tg64", 128, 64, &filled(4, 192, 64), true).is_ok());
+        let err = check_decode_after("pp128 tg64", 128, 64, &filled(4, 129, 64), true)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("expected 192"), "{err}");
+        assert!(err.contains("128 primed + 64"), "{err}");
     }
 
     #[test]

--- a/crates/ferrox-cli/src/bench_model.rs
+++ b/crates/ferrox-cli/src/bench_model.rs
@@ -15,8 +15,8 @@
 //! and dedicated [`Gemma4Engine`] (sequential `forward_token` for both
 //! `pp*` and `tg*` until a batched Gemma-4 prefill lands).
 
+use crate::bench_contract::{self, HostState};
 use crate::bench_guard::{self, CacheProbe, WorkloadDigest};
-use crate::host_state::{self, ThermalReading};
 use anyhow::Context;
 use ferrox_core::cache::KvCache;
 use ferrox_models::engine::Engine;
@@ -143,29 +143,13 @@ pub fn run(args: BenchArgs) -> anyhow::Result<()> {
     // Before anything is loaded: a timed run on a busy or hot host
     // produces a number that looks like a measurement and is not one.
     bench_guard::check_repetitions(args.reps)?;
-    let load_start = crate::host_state::ensure_quiet_enough(args.max_load)?;
-    let thermal_start = crate::host_state::thermal_reading();
-    // `--max-load 0` is already the documented "measure anyway, not
-    // publishable" escape; the thermal bar shares it rather than
-    // growing a second flag that has to be remembered separately.
-    crate::host_state::ensure_cool_enough(&thermal_start, args.max_load > 0.0)?;
+    let (load_start, thermal_start) = bench_contract::preflight_host(args.max_load)?;
     let model = crate::pull::resolve_model_path(&args.model)?;
     let path = Path::new(&model);
     if !path.exists() {
         anyhow::bail!("model not found: {model}");
     }
-
-    // A busy host and a hot host are already refused above. A FULL host
-    // is the same failure with a different cause: the weights page to
-    // disk and the run times the page file. The file size is the floor
-    // on the footprint, and `--max-load 0` waives this the same way it
-    // waives the other two.
-    if args.max_load > 0.0 {
-        if let Ok(meta) = std::fs::metadata(path) {
-            let weights_gb = meta.len() as f64 / 1024.0 / 1024.0 / 1024.0;
-            crate::host_state::ensure_fits_in_ram(weights_gb, 2.0)?;
-        }
-    }
+    bench_contract::ensure_weights_fit(args.max_load, path, 0.0)?;
 
     let file = ferrox_gguf::ShardedGguf::open(path)?;
     let arch = file
@@ -237,41 +221,16 @@ pub fn run(args: BenchArgs) -> anyhow::Result<()> {
             row.stddev(),
         );
     }
-    let load_end = crate::host_state::load_average_1min();
-    let thermal_end = crate::host_state::thermal_reading();
     eprintln!(
         "\nferrox bench: load {load_s:.2}s, {} reps + {} discarded warmup each",
         args.reps,
         bench_guard::WARMUP_REPS
     );
-    eprintln!(
-        "ferrox bench: host 1-min load {} -> {}, {} -> {}",
-        fmt_load(load_start),
-        fmt_load(load_end),
-        thermal_start.describe(),
-        thermal_end.describe(),
-    );
-    // A run that started cool and finished hot produced its later
-    // repetitions under different physics than its first ones.
-    if !thermal_start.is_degraded() && thermal_end.is_degraded() {
-        eprintln!(
-            "ferrox bench: WARNING -- the host became thermally limited during this \
-             run ({}); the later repetitions did not run under the same conditions \
-             as the first",
-            thermal_end.describe()
-        );
-    }
-    let engine_env = bench_guard::nondefault_engine_env(std::env::vars());
-    if !engine_env.is_empty() {
-        eprintln!(
-            "ferrox bench: non-default engine env in effect: {}",
-            engine_env
-                .iter()
-                .map(|(k, v)| format!("{k}={v}"))
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
-    }
+    let bench_contract::HostAfter {
+        load_end,
+        thermal_end,
+        engine_env,
+    } = bench_contract::report_host_after("ferrox bench", load_start, &thermal_start);
 
     let ngl = if backend == "CPU" { 0 } else { 99 };
     let llama = if args.compare {
@@ -377,7 +336,7 @@ fn measure_gemma4(engine: &Gemma4Engine, args: &BenchArgs) -> anyhow::Result<Vec
 /// Also where an empty logit vector is caught: a forward pass that
 /// returned nothing cannot be shown to have computed anything, so the
 /// duration it took is not a throughput.
-fn check_result(
+pub(crate) fn check_result(
     test: &str,
     rep: usize,
     logits: &[f32],
@@ -394,7 +353,7 @@ fn check_result(
 }
 
 /// Snapshots every layer's KV cache for the guards in `bench_guard`.
-fn probe(caches: &[KvCache]) -> Vec<CacheProbe> {
+pub(crate) fn probe(caches: &[KvCache]) -> Vec<CacheProbe> {
     caches
         .iter()
         .map(|c| CacheProbe {
@@ -428,7 +387,7 @@ fn probe_gemma4(state: &ferrox_models::gemma4_engine::Gemma4DecodeState) -> Vec<
 /// Reported as prompt tokens per second, as `llama-bench` does.
 fn bench_prefill(decoder: &Decoder, n_prompt: usize, reps: usize) -> anyhow::Result<Row> {
     let test = format!("pp{n_prompt}");
-    let tokens = synthetic_tokens(decoder.config.vocab_size, n_prompt);
+    let tokens = synthetic_tokens(decoder.config.vocab_size, n_prompt, 0);
     // Asserted BEFORE the run: the stream about to be fed is exactly as
     // long as the row's label promises, and every id is in vocabulary.
     bench_guard::check_prompt_before(&test, n_prompt, &tokens, decoder.config.vocab_size)?;
@@ -484,7 +443,7 @@ fn bench_prefill_gemma4(
 ) -> anyhow::Result<Row> {
     let test = format!("pp{n_prompt}");
     let vocab = Engine::vocab_size(engine);
-    let tokens = synthetic_tokens(vocab, n_prompt);
+    let tokens = synthetic_tokens(vocab, n_prompt, 0);
     bench_guard::check_prompt_before(&test, n_prompt, &tokens, vocab)?;
     let mut out = Vec::with_capacity(reps);
     let mut first_digest: Option<WorkloadDigest> = None;
@@ -523,7 +482,7 @@ fn bench_prefill_gemma4(
 /// struct stays empty unless `FERROX_CPU_KV_OFFLOAD=1` syncs it back.
 /// Any assertion that counts host cache positions has to know that, or
 /// it refuses every GPU run for doing nothing wrong.
-fn host_kv_is_the_record() -> bool {
+pub(crate) fn host_kv_is_the_record() -> bool {
     let off = |k: &str| std::env::var(k).map(|v| v == "0").unwrap_or(false);
     let synced = std::env::var("FERROX_CPU_KV_OFFLOAD").as_deref() == Ok("1");
     synced || (off("FERROX_METAL") && off("FERROX_CUDA"))
@@ -532,7 +491,7 @@ fn host_kv_is_the_record() -> bool {
 fn bench_decode(decoder: &Decoder, n_gen: usize, reps: usize) -> anyhow::Result<Row> {
     let test = format!("tg{n_gen}");
     let vocab = decoder.config.vocab_size;
-    let tokens = decode_tokens(vocab, n_gen);
+    let tokens = decode_tokens(vocab, n_gen, 0);
     // The decode stream gets the same BEFORE check the prompt does. It
     // is built up front for exactly that reason: a stream generated
     // inside the timed loop can only be checked once it is too late to
@@ -557,6 +516,7 @@ fn bench_decode(decoder: &Decoder, n_gen: usize, reps: usize) -> anyhow::Result<
         // means steps were skipped, which would inflate the rate.
         let kv_checked = bench_guard::check_decode_after(
             &test,
+            1,
             n_gen,
             &probe(&caches),
             host_kv_is_the_record(),
@@ -579,7 +539,7 @@ fn bench_decode(decoder: &Decoder, n_gen: usize, reps: usize) -> anyhow::Result<
 fn bench_decode_gemma4(engine: &Gemma4Engine, n_gen: usize, reps: usize) -> anyhow::Result<Row> {
     let test = format!("tg{n_gen}");
     let vocab = Engine::vocab_size(engine);
-    let tokens = decode_tokens(vocab, n_gen);
+    let tokens = decode_tokens(vocab, n_gen, 0);
     bench_guard::check_prompt_before(&test, n_gen, &tokens, vocab)?;
     let mut out = Vec::with_capacity(reps);
     let mut first_digest: Option<WorkloadDigest> = None;
@@ -598,6 +558,7 @@ fn bench_decode_gemma4(engine: &Gemma4Engine, n_gen: usize, reps: usize) -> anyh
         let dt = t.elapsed().as_secs_f64();
         let kv_checked = bench_guard::check_decode_after(
             &test,
+            1,
             n_gen,
             &probe_gemma4(&state),
             host_kv_is_the_record(),
@@ -617,7 +578,7 @@ fn bench_decode_gemma4(engine: &Gemma4Engine, n_gen: usize, reps: usize) -> anyh
     })
 }
 
-fn fresh_caches(decoder: &Decoder) -> Vec<KvCache> {
+pub(crate) fn fresh_caches(decoder: &Decoder) -> Vec<KvCache> {
     decoder
         .layers
         .iter()
@@ -628,28 +589,35 @@ fn fresh_caches(decoder: &Decoder) -> Vec<KvCache> {
 /// Token ids that exist in the vocabulary but carry no linguistic
 /// meaning: the point is to move the same bytes through the same
 /// kernels, not to generate text.
-fn synthetic_tokens(vocab: usize, n: usize) -> Vec<usize> {
+///
+/// `seq` offsets the stream so that parallel sequences in a batched
+/// row do not carry identical prompts. Sequence 0 is the stream
+/// `ferrox bench` has always fed, so its published digests still
+/// describe the same work.
+pub(crate) fn synthetic_tokens(vocab: usize, n: usize, seq: usize) -> Vec<usize> {
     let vocab = vocab.max(1);
-    (0..n).map(|i| (i * 7 + 1) % vocab).collect()
+    (0..n)
+        .map(|i| (i * 7 + 1 + seq * SEQ_STRIDE) % vocab)
+        .collect()
 }
 
 /// The token stream a `tg<N>` row feeds after its priming token, built
 /// before the clock starts so its length can be asserted BEFORE the run
 /// rather than only reconstructed from the KV cache afterwards.
-fn decode_tokens(vocab: usize, n_gen: usize) -> Vec<usize> {
+///
+/// `seq` as in [`synthetic_tokens`]: sequence 0 is the historical
+/// stream, other sequences are shifted copies of it.
+pub(crate) fn decode_tokens(vocab: usize, n_gen: usize, seq: usize) -> Vec<usize> {
     let vocab = vocab.max(1);
-    (0..n_gen).map(|i| (i + 1) % vocab).collect()
+    (0..n_gen)
+        .map(|i| (i + 1 + seq * SEQ_STRIDE) % vocab)
+        .collect()
 }
 
-/// Whether a receipt's `backend` label describes the backend that ran.
-///
-/// The label is lowercase and comes from the suite (`cpu`, `metal`,
-/// `cuda`); the active backend is what [`active_backend`] resolved.
-/// Compared case-insensitively and nothing else: a mismatch is always
-/// a defect, never a naming convention.
-fn backend_label_agrees(label: &str, active: &str) -> bool {
-    label.eq_ignore_ascii_case(active)
-}
+/// How far apart two parallel sequences' token streams start. Any
+/// non-zero value distinguishes them; this one is co-prime with the
+/// prompt stride of 7 so no two sequences' prompts coincide either.
+const SEQ_STRIDE: usize = 1013;
 
 pub fn active_backend() -> &'static str {
     #[cfg(feature = "metal")]
@@ -793,37 +761,6 @@ fn parse_llama_bench_table(text: &str) -> std::collections::BTreeMap<String, f64
     out
 }
 
-/// What the host was doing around this run, for the receipt.
-#[derive(Clone, Copy)]
-pub struct HostState {
-    pub load_start: Option<f64>,
-    pub load_end: Option<f64>,
-    pub thermal_start: ThermalReading,
-    pub thermal_end: ThermalReading,
-}
-
-/// Serializes a thermal reading so that "we did not measure" and
-/// "we measured, and it was nominal" can never be read as the same
-/// thing. `measured` is stated outright rather than left to be
-/// inferred from a null, because a field that is always null while
-/// implying it was measured is exactly the lie this receipt exists to
-/// prevent.
-fn thermal_json(r: &ThermalReading) -> serde_json::Value {
-    serde_json::json!({
-        "measured": r.measured(),
-        "pressure": r.pressure.map(|p| p.as_str()),
-        "source": r.source,
-        "cpu_speed_limit_percent": r.cpu_speed_limit_percent,
-        "degraded": r.measured().then(|| r.is_degraded()),
-    })
-}
-
-/// A load average we could not read prints as `?`, never as `0.00`.
-fn fmt_load(l: Option<f64>) -> String {
-    l.map(|l| format!("{l:.2}"))
-        .unwrap_or_else(|| "?".to_string())
-}
-
 #[allow(clippy::too_many_arguments)] // one call site; every field is reported
 fn write_receipt(
     dest: &Path,
@@ -861,52 +798,12 @@ fn write_receipt(
             "workload_digest": row.digest.hex(),
         }));
     }
-    // WHAT the machine was, never WHICH machine it was. A receipt is
-    // public, and `--render` reads every receipt in the directory:
-    // without this, rows from two hosts merge into one table with no
-    // column saying so.
-    let host_spec_json = {
-        let spec = host_state::host_spec();
-        serde_json::json!({
-            "label": host_state::host_label(&spec),
-            "cpu": spec.cpu,
-            "arch": spec.arch,
-            "cores": spec.cores,
-            "perf_cores": spec.perf_cores,
-            "ram_gb": spec.ram_gb.map(|g| (g * 10.0).round() / 10.0),
-            "os": spec.os,
-        })
-    };
-    // `host_spec` names the CPU. For a `cpu` row that is the whole
-    // machine; for a `cuda` or `metal` row it is the least interesting
-    // part. Ten published CUDA rows carried a Xeon's model number and
-    // NOTHING about the card, in a file whose own header says rows are
-    // never compared across machines -- there was no field to compare
-    // them by, so a Pascal row and an Ampere row grouped as one host.
-    let accelerator = accelerator_name(backend);
-    if backend != "CPU" && accelerator.is_none() {
-        anyhow::bail!(
-            "refusing to write a `{}` receipt that does not name the accelerator it ran on. \
-             A GPU gap is meaningless without the card: the ledger groups rows by host, and \
-             two different GPUs in one host section are two different machines.",
-            args.backend
-        );
-    }
-
-    // A receipt may not claim one backend and record another. Every
-    // `cpu` row in the ledger did exactly that (#126), and the
-    // contradiction sat in the file: `backend: "cpu"` beside
-    // `backend_active: "Metal"`. Two fields that must agree, with
-    // nothing comparing them, which is this repo's oldest bug shape.
-    if !backend_label_agrees(&args.backend, backend) {
-        anyhow::bail!(
-            "refusing to write a receipt labelled `{}` for a run that executed on {}. \
-             The label is what the ledger publishes; the active backend is what ran (#126).",
-            args.backend,
-            backend
-        );
-    }
-    let receipt = serde_json::json!({
+    // The shared envelope carries both write-time refusals: a GPU row
+    // that cannot name its card, and a label that disagrees with the
+    // backend that ran (#126).
+    let mut receipt =
+        bench_contract::receipt_common(&args.backend, backend, threads, load_s, host, engine_env)?;
+    let serde_json::Value::Object(own) = serde_json::json!({
         "schema": 2,
         "kind": "engine",
         "id": args.id,
@@ -915,61 +812,18 @@ fn write_receipt(
         "quant": quant_label(file),
         "size_bytes": size_bytes,
         "approx_params": params,
-        "backend": args.backend,
-        "backend_active": backend,
-        "threads": threads,
         "reps": args.reps,
-        "warmup_reps": bench_guard::WARMUP_REPS,
-        "load_s": load_s,
-        // Null, not zero, when the platform would not say -- see host_state.
-        "host_load_1min_start": host.load_start,
-        "host_load_1min_end": host.load_end,
-        "host_thermal_start": thermal_json(&host.thermal_start),
-        "host_thermal_end": thermal_json(&host.thermal_end),
-        // The single field an auditor reads first: was this row taken
-        // under the measurement contract's quiet-host bar at all?
-        "quiet_host": host.load_start.map(|l| l < host_state::DEFAULT_MAX_LOAD),
-        // WHAT the machine was, never WHICH machine it was. A receipt
-        // is public, and `--render` reads every receipt in the
-        // directory: without this, rows from two hosts merge into one
-        // table with no column that says so.
-        "host_spec": host_spec_json,
-        // The card, for a row that ran on one. `null` for `cpu` rows,
-        // where `host_spec` already is the machine.
-        "accelerator": accelerator,
-        // Non-default `FERROX_*` knobs in effect. Some of them (MoE
-        // stage ablation, the fail-closed loader override) change how
-        // much work the engine does, so a row taken under one is not
-        // comparable to a row taken without it.
-        "engine_env": engine_env
-            .iter()
-            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-            .collect::<serde_json::Map<_, _>>(),
-        "ferrox_version": env!("CARGO_PKG_VERSION"),
         "tests": tests,
-    });
+    }) else {
+        unreachable!("json! with braces is an object");
+    };
+    receipt.extend(own);
     std::fs::write(dest, serde_json::to_string_pretty(&receipt)? + "\n")?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::backend_label_agrees;
-
-    /// The receipt guard that #126 needed and did not have.
-    #[test]
-    fn a_cpu_label_does_not_describe_a_metal_run() {
-        assert!(backend_label_agrees("cpu", "CPU"));
-        assert!(backend_label_agrees("metal", "Metal"));
-        assert!(backend_label_agrees("cuda", "CUDA"));
-        assert!(
-            !backend_label_agrees("cpu", "Metal"),
-            "this exact pair is what all 13 published cpu receipts recorded"
-        );
-        assert!(!backend_label_agrees("metal", "CPU"));
-        assert!(!backend_label_agrees("cuda", "Metal"));
-    }
-
     use super::*;
 
     fn row(samples: &[f64]) -> Row {
@@ -1016,9 +870,33 @@ mod tests {
         // one. `vocab` deliberately includes values smaller than the
         // stream, where the modulo wraps.
         for &(vocab, n) in &[(49152usize, 512usize), (7, 512), (2, 4), (49152, 1)] {
-            bench_guard::check_prompt_before("pp", n, &synthetic_tokens(vocab, n), vocab).unwrap();
-            bench_guard::check_prompt_before("tg", n, &decode_tokens(vocab, n), vocab).unwrap();
+            for seq in [0, 1, 31] {
+                bench_guard::check_prompt_before("pp", n, &synthetic_tokens(vocab, n, seq), vocab)
+                    .unwrap();
+                bench_guard::check_prompt_before("tg", n, &decode_tokens(vocab, n, seq), vocab)
+                    .unwrap();
+            }
         }
+    }
+
+    /// Sequence 0 is the stream every published `ferrox bench` digest
+    /// was computed over; adding the `seq` parameter must not have
+    /// moved it. The other sequences must differ from it, or a batched
+    /// row would prefill the same prompt B times.
+    #[test]
+    fn sequence_zero_is_the_historical_stream_and_other_sequences_differ() {
+        let vocab = 32000;
+        let historical: Vec<usize> = (0..64).map(|i| (i * 7 + 1) % vocab).collect();
+        assert_eq!(synthetic_tokens(vocab, 64, 0), historical);
+        assert_ne!(
+            synthetic_tokens(vocab, 64, 1),
+            synthetic_tokens(vocab, 64, 0)
+        );
+        assert_ne!(decode_tokens(vocab, 64, 1), decode_tokens(vocab, 64, 0));
+        assert_ne!(
+            synthetic_tokens(vocab, 64, 2),
+            synthetic_tokens(vocab, 64, 1)
+        );
     }
 
     #[test]
@@ -1028,7 +906,7 @@ mod tests {
         // and after this change still describe the same work.
         let vocab = 32000;
         let inline: Vec<usize> = (0..128).map(|i| (i + 1) % vocab).collect();
-        assert_eq!(decode_tokens(vocab, 128), inline);
+        assert_eq!(decode_tokens(vocab, 128, 0), inline);
     }
 
     #[test]
@@ -1067,43 +945,5 @@ mod tests {
     fn truncate_leaves_short_strings_alone_and_clips_long_ones() {
         assert_eq!(truncate("llama Q8_0", 30), "llama Q8_0");
         assert_eq!(truncate(&"x".repeat(40), 30), "x".repeat(30));
-    }
-}
-
-/// The accelerator a non-CPU run executed on, as the backend itself
-/// reports it.
-///
-/// Returns `None` on CPU, where `host_spec` already describes the
-/// machine, and `None` when a GPU backend cannot name its device --
-/// which the receipt writer treats as a refusal rather than a blank,
-/// because an unnamed card is what made ten CUDA rows unattributable.
-fn accelerator_name(backend: &str) -> Option<String> {
-    match backend {
-        #[cfg(feature = "cuda")]
-        "CUDA" => ferrox_cuda::gpu::probe().and_then(|i| i.first_device_name),
-        #[cfg(feature = "metal")]
-        "Metal" => ferrox_metal::gpu::probe(),
-        _ => None,
-    }
-}
-
-#[cfg(test)]
-mod accelerator_tests {
-    use super::*;
-
-    /// A `cpu` row has no accelerator and must not be refused for it.
-    #[test]
-    fn the_cpu_backend_names_no_accelerator() {
-        assert_eq!(accelerator_name("CPU"), None);
-    }
-
-    /// The guard is keyed on the ACTIVE backend, not the label, for the
-    /// same reason `backend_label_agrees` is: the label is what the
-    /// ledger publishes and the active backend is what ran.
-    #[test]
-    fn only_a_gpu_backend_is_required_to_name_a_device() {
-        for (backend, required) in [("CPU", false), ("CUDA", true), ("Metal", true)] {
-            assert_eq!(backend != "CPU", required, "{backend}");
-        }
     }
 }

--- a/crates/ferrox-cli/src/main.rs
+++ b/crates/ferrox-cli/src/main.rs
@@ -1,8 +1,10 @@
 //! ferrox CLI, llama.cpp-style GGUF completion (`-m`/`-p`/`-n`/…) plus
 //! inspect / presets / smoke / Kimi helpers. See `docs/CLI.md`.
 
+mod batched_bench;
 mod bench_bw;
 mod bench_client;
+mod bench_contract;
 mod bench_guard;
 mod bench_model;
 mod bench_render;
@@ -92,6 +94,13 @@ enum Commands {
     /// HTTP-free and measures kernels against `llama-bench`. This one
     /// answers what the SERVER does under load. Start the server first.
     ServeBench(serve_bench::ServeBenchArgs),
+    /// Throughput as a function of batch size, like
+    /// `llama-batched-bench`: for every `-npp` x `-ntg` x `-npl`
+    /// combination, prompt speed, decode speed and the total, in
+    /// llama.cpp's ten columns. Drives the continuous batcher's engine
+    /// seams directly, no HTTP.
+    #[command(name = "batched-bench")]
+    BatchedBench(batched_bench::BatchedBenchArgs),
     /// Download a GGUF from Hugging Face Hub (`hf download`).
     Pull(pull::PullArgs),
 
@@ -552,6 +561,7 @@ const SUBCOMMANDS: &[&str] = &[
     "smoke",
     "run-real",
     "bench",
+    "batched-bench",
     "verify",
     "layer-divergence",
     "quant-sensitivity",
@@ -602,6 +612,16 @@ fn rewrite_llama_style_argv(args: Vec<String>) -> Vec<String> {
             // looked like the flag did not exist.
             "-hf" => "--hf-repo".into(),
             "-hff" => "--hf-file".into(),
+            // `llama-batched-bench`'s own spellings, for `batched-bench`.
+            "-npp" => "--n-pp".into(),
+            "-ntg" => "--n-tg".into(),
+            "-npl" => "--n-pl".into(),
+            "-pps" => "--pp-shared".into(),
+            "-tgs" => "--tg-separate".into(),
+            "-ub" => "--ubatch-size".into(),
+            "-kvu" => "--kv-unified".into(),
+            "-fa" => "--flash-attn".into(),
+            "-tb" => "--threads-batch".into(),
             _ => arg,
         })
         .collect();
@@ -692,6 +712,7 @@ fn instance_target(command: &Commands) -> Option<(&'static str, Option<String>)>
             }
             Some(("bench", model.clone()))
         }
+        Commands::BatchedBench(args) => Some(("batched-bench", Some(args.model.clone()))),
         Commands::Smoke { preset, .. } => Some(("smoke", Some(preset.clone()))),
         Commands::RunKimi { checkpoint_dir, .. } => {
             Some(("run-kimi", Some(checkpoint_dir.clone())))
@@ -739,21 +760,27 @@ fn main() -> anyhow::Result<()> {
     // and every one of those receipts recorded `backend_active:
     // "Metal"` next to `backend: "cpu"` without anything comparing the
     // two (#126).
-    if let Commands::Bench {
-        threads,
-        n_gpu_layers,
-        suite,
-        render,
-        ..
-    } = &cli.command
-    {
-        // `--suite` and `--render` do not benchmark in THIS process:
-        // the suite spawns a child per entry and render only reads
-        // receipts, so applying a backend here would pin the parent to
-        // one backend for children that each want their own.
-        if !suite && !render {
-            bench_model::apply_env(*threads, *n_gpu_layers)?;
+    match &cli.command {
+        Commands::Bench {
+            threads,
+            n_gpu_layers,
+            suite,
+            render,
+            ..
+        } => {
+            // `--suite` and `--render` do not benchmark in THIS process:
+            // the suite spawns a child per entry and render only reads
+            // receipts, so applying a backend here would pin the parent
+            // to one backend for children that each want their own.
+            if !suite && !render {
+                bench_model::apply_env(*threads, *n_gpu_layers)?;
+            }
         }
+        // Same ordering constraint, same function: the batched bench
+        // writes the same kind of receipt and is refused the same way
+        // when the label and the backend disagree.
+        Commands::BatchedBench(args) => bench_model::apply_env(args.threads, args.n_gpu_layers)?,
+        _ => {}
     }
 
     // Held for the whole run: dropping it deregisters this process.
@@ -768,6 +795,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Run(args) => run::run_infer(args)?,
         Commands::Chat(args) => chat::run_chat(args)?,
         Commands::ServeBench(args) => serve_bench::run_serve_bench(args)?,
+        Commands::BatchedBench(args) => batched_bench::run(args)?,
         Commands::BenchBw(args) => bench_bw::run_bench_bw(args)?,
         // Blocking, and it builds its own Tokio runtime: nothing above
         // this point has started one. It also claims the instance

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1070,6 +1070,79 @@ limited, or short enough on free memory that the weights would page to
 disk. [`benchmarks/README.md`](../benchmarks/README.md) has each check,
 what it reads, and what `--max-load 0` waives.
 
+## Batched benchmark (`ferrox batched-bench`)
+
+Throughput as a function of batch size, like
+[`llama-batched-bench`](https://github.com/ggerganov/llama.cpp/tree/master/tools/batched-bench):
+for every combination of prompt length (`-npp`), generation length
+(`-ntg`) and parallel sequences (`-npl`), one row with the prompt
+speed, the decode speed and the total. Same ten columns, same widths
+(`tools/batched-bench/batched-bench.cpp:128-129,245`), so the two
+tables paste side by side; `--output-format jsonl` prints one object
+per row with upstream's per-row keys.
+
+```bash
+./target/release/ferrox batched-bench -m model.gguf -c 2048 -npp 128,256,512 -ntg 128,256 -npl 1,2,4,8,16,32
+./target/release/ferrox batched-bench -m model.gguf -c 2048 -npp 512 -ntg 128 -npl 1,4,16 -pps      # shared prompt
+./target/release/ferrox batched-bench -m model.gguf -ngl 99 -npp 128 -ntg 128 -npl 8 --output-format jsonl
+# the llama.cpp line to put beside it
+llama-batched-bench -m model.gguf -c 2048 -npp 128,256,512 -ntg 128,256 -npl 1,2,4,8,16,32
+```
+
+```
+|    PP |     TG |    B |   N_KV |   T_PP s | S_PP t/s |   T_TG s | S_TG t/s |      T s |    S t/s |
+|-------|--------|------|--------|----------|----------|----------|----------|----------|----------|
+|   128 |    128 |    1 |    256 |    0.108 |  1186.64 |    3.079 |    41.57 |    3.187 |    80.32 |
+```
+
+`PP`/`TG` are per sequence, `B` is the sequence count, `N_KV = B*(PP+TG)`
+is the KV the row needs, `S_PP` is `B*PP/T_PP` (or `PP/T_PP` with
+`-pps`), `S_TG` is `B*TG/T_TG`, `S` is all tokens over `T_PP + T_TG`.
+That is upstream's arithmetic (`batched-bench.cpp:229-235`), pinned by
+a test.
+
+What it drives is the continuous batcher's own engine seams, without
+the server around them: each prompt goes through
+`Decoder::forward_batch_last_host_kv` in `-ub` chunks, and every decode
+step is one `Decoder::forward_multi_seq` call across the `B` sequences,
+the same call `ferrox-server` makes per tick under
+`FERROX_CONTINUOUS_BATCHING=1`. Two honest differences from upstream:
+ferrox has no cross-sequence prefill, so `B` prompts are `B` calls
+rather than one batch (the number reported is still the time to
+prefill all of them); and the batched decode attends on the host on
+every backend, so `-ngl` offloads the projections and not the
+attention. `ferrox serve-bench` measures the same batcher over HTTP.
+
+| Flag | Meaning |
+|---|---|
+| `-m/--model` | GGUF to benchmark (generic decoder architectures only; the dedicated engines have no multi-sequence step and are refused by name) |
+| `-npp`, `-ntg`, `-npl` | Comma-separated sweeps; all three required, every value > 0 (upstream prints a `NaN` row for `0`, this refuses it) |
+| `-pps` | One prompt shared by every sequence: prefilled once, its KV copied to the others between the two timers (`batched-bench.cpp:168-185`) |
+| `-tgs` | Decode each sequence to completion in turn instead of one step across all of them per call (`:189-223`) |
+| `-c` | `n_kv_max`; a combination needing more is skipped, and the skip is printed rather than silent. `0` = the GGUF's `{arch}.context_length` |
+| `-ub` | Prompt tokens per forward call (default 512, upstream's `n_ubatch`) |
+| `-t`, `-ngl` | As `ferrox bench` |
+| `--output-format` | `md` (default) or `jsonl` |
+| `--receipt`, `--backend-label` | Write a JSON receipt; the label must name the backend that ran or the receipt is refused, before the sweep and again at write time |
+| `--max-load` | The same quiet-host bar as `ferrox bench`, waiving the thermal and free-memory checks with it at `0`. The free-memory check counts the largest row's KV on top of the weights |
+
+Flags `llama-batched-bench` takes that this tool **refuses by name**
+rather than accepting and ignoring: `-b` (`n_batch`; ferrox has no
+logical batch distinct from `-ub`), `-kvu` (every sequence has its own
+cache here, so `N_KV` is `B*(PP+TG)` with or without `-pps`), `-fa`
+(no flash-attention switch to honour) and `-tb` (one thread pool).
+For the same reason the JSONL rows omit `n_batch`, `flash_attn` and
+`n_threads_batch` instead of printing a made-up value for them.
+
+Every row runs twice: one discarded warmup pass and one timed pass,
+and the two must have fed the same tokens and produced the same greedy
+picks, per sequence, for prompt and decode. That is `ferrox bench`'s
+determinism check, and it is the reason each row costs two passes
+where upstream pays one global 16-token warmup. The other `bench_guard`
+checks run too: cold caches per pass, prompt and decode lengths
+re-read from every sequence's KV afterwards (the copied caches under
+`-pps` included), and a rate that is not finite refuses the row.
+
 ### One model at a time
 
 Every command that loads weights (`run`, `bench`, `verify`, `smoke`,

--- a/docs/plans/llama-cpp-full-parity-audit-2026-09-02.md
+++ b/docs/plans/llama-cpp-full-parity-audit-2026-09-02.md
@@ -19,7 +19,7 @@
 | Source files (C++/CUDA/Metal) | **1,103** mapped | **308** Rust files, **~230k** lines | Structural: 140 per-arch graphs vs 1 decoder |
 | Architecture graphs | **140** hand-written | **16** audited + 4 dedicated engines | **P0** — 124 graphs unported |
 | Backends | CPU, CUDA, Metal, Vulkan, SYCL, HIP, OpenCL, … | CPU, Metal, CUDA (partial), Vulkan (beachhead) | **P0** Vulkan; **P1** CUDA GEMM |
-| CLI tools | 15+ binaries | 22+ subcommands; most core tools present | **P2** batched-bench (gguf-split ported 2026-09-09, imatrix 2026-09-11) |
+| CLI tools | 15+ binaries | 23+ subcommands; every core tool present | gguf-split ported 2026-09-09, imatrix and batched-bench 2026-09-11 |
 | Logit parity (local sweep) | reference | 19 models tested | **2 WRONG**, 8 DRIFT (expected K-quant), 6 MATCH, 1 TIE-FLIP, 2 encoder skip |
 
 ### Live parity sweep (2026-09-02)
@@ -124,7 +124,7 @@ ferrox: `decoder.rs` + `engine_factory.rs` + 4 dedicated engines:
 | `llama-tokenize` | via `ferrox parity` tokenizer sweep | partial |
 | `llama-gguf-split` | `ferrox gguf-split` | **ported**: split by tensors or size, merge, `--no-tensor-first-split`, `--dry-run` |
 | `llama-imatrix` | `ferrox imatrix` | **ported** (2026-09-11): same file format both ways, GGUF and legacy `.dat`; sums agree to the forward pass's precision, not bit for bit (see `docs/CLI.md`) |
-| `llama-batched-bench` | — | **missing** |
+| `llama-batched-bench` | `ferrox batched-bench` | **ported** (2026-09-11): same sweep, same ten columns and JSONL keys, drives `forward_multi_seq` directly; `-b`, `-kvu`, `-fa`, `-tb` refused by name |
 | `llama-mtmd` (multimodal) | — | **missing** |
 | `llama-tts` | — | **missing** |
 | `llama-rpc` | — | **missing** |
@@ -250,7 +250,7 @@ Ranked per [`north-star.md`](north-star.md) and [`roadmap.md`](roadmap.md).
 
 - 26 new-code architecture graphs (apertus xIELU, dbrx LayerNorm, bitnet, …)
 - Multimodal (`mtmd`), TTS, RPC
-- batched-bench, LoRA adapters (imatrix ported 2026-09-11)
+- LoRA adapters (imatrix and batched-bench ported 2026-09-11)
 - SYCL/HIP/OpenCL backends
 
 ---

--- a/docs/plans/llama-cpp-gap-inventory.md
+++ b/docs/plans/llama-cpp-gap-inventory.md
@@ -671,7 +671,7 @@ ferrox ships two binaries. Subcommands: `crates/ferrox-cli/src/main.rs:43-393`.
 | `tools/mtmd` (multimodal) | NONE | medium | XL |
 | `tools/tokenize` | Partial: `ferrox parity tokenize` (`main.rs:202`) is a comparison harness, not a dump | low | S |
 | `tools/rpc`, `tools/tts`, `tools/cvector-generator` | NONE | low | XL |
-| `tools/batched-bench` | `ferrox serve-bench` (`main.rs:88`) covers it over HTTP; no HTTP-free equivalent | low | M |
+| `tools/batched-bench` | `ferrox batched-bench` (HTTP-free, drives `forward_multi_seq`; ported 2026-09-11); `ferrox serve-bench` covers the HTTP side | — | done |
 | `tools/fit-params` | `ferrox inspect-plan` (`main.rs:102-127`) is a genuine equivalent, arguably richer | -- | -- |
 | `tools/llama-bench` | `ferrox bench` (`main.rs:289`), an explicit work-alike with `--compare` | -- | -- |
 


### PR DESCRIPTION
## What

`ferrox batched-bench`, the last tool the parity audit listed as **missing**. Throughput as a function of batch size: for every `-npp` x `-ntg` x `-npl` combination, one row with prompt speed, decode speed and the total, in `llama-batched-bench`'s ten columns, width for width, so the two tables paste side by side. `--output-format jsonl` carries upstream's per-row keys.

```
ferrox batched-bench -m model.gguf -c 2048 -npp 128,256,512 -ntg 128,256 -npl 1,2,4,8,16,32 [-pps] [-tgs]
```

## Where it lines up with llama.cpp (file:line in `tools/batched-bench/batched-bench.cpp`)

| ferrox | upstream |
|---|---|
| sweep order and the `n_kv_max` skip (`plan_combos`) | `:132-143` |
| `N_KV` arithmetic (`Combo::n_kv`) | `:139` (with `kv_unified = false`) |
| one prompt per sequence, or one shared prompt (`-pps`) | `:147` |
| shared prompt copied between the two timers | `:168-185` |
| `0 0 0 ... 1 1 1` vs `0123 0123` decode (`-tgs`) | `:189-223` |
| the three rates (`rates`) | `:229-235` |
| table header and separator, pinned byte for byte | `:128-129` |
| row format `%6d \| %6d \| %4d \| %6d \| %8.3f \| %8.2f ...` | `:245` |
| JSONL per-row keys | `:238-243` |

## What it drives

The continuous batcher's own engine seams, no HTTP and no third path: `Decoder::forward_batch_last_host_kv` per prompt in `-ub` chunks (what `serving/batch/prefill.rs:165-171` does for an admitted row) and `Decoder::forward_multi_seq` per decode step (`serving/batch/worker.rs:470`, the per-tick call). `-tgs` is the same entry point with one-sequence batches. Two honest differences from upstream, both in the docs: ferrox has no cross-sequence prefill, so `B` prompts are `B` calls (the reported time still covers all of them); and the batched decode attends on the host on every backend, so `-ngl` offloads the projections, not the attention.

## What it reuses from `ferrox bench`

The host preflight (quiet / thermal / free-memory), the after-run host report and the receipt envelope moved out of `bench_model.rs` into a new `bench_contract.rs`, and both tools call the one function for each. The two write-time receipt refusals live there: a label that disagrees with the backend that ran (#126) and a GPU row that cannot name its card. `bench_model.rs` went from 1109 to 949 lines. Every `bench_guard` check runs per row: streams asserted before the clock, cold caches per pass, prompt and decode lengths re-read from every sequence's KV afterwards (the `-pps` clones included), `check_sample_rates`, `check_timed_samples`, and the determinism pair (`check_same_workload` + `check_same_result` per sequence, prompt and decode) between the discarded warmup and the timed pass. Each row therefore runs twice where upstream pays one global 16-token warmup: a single pass has nothing to disagree with.

Two small parameterisations rather than copies: `check_decode_after` takes the primed count (1 for a `tg` row, `pp` here), and the synthetic token generators take a sequence index, with sequence 0 byte-identical to the historical stream so published `ferrox bench` digests are unchanged (pinned by a test).

## Flags

Honoured: `-m`, `-npp`, `-ntg`, `-npl`, `-pps`, `-tgs`, `-c`, `-ub`, `-t`, `-ngl`, `--output-format {md,jsonl}`, plus `--receipt`, `--backend-label`, `--max-load` from `ferrox bench`.

Refused by name: `-b` (no logical batch distinct from `-ub`), `-kvu` (every sequence has its own cache; `N_KV` is `B*(PP+TG)` either way), `-fa` (no flash-attention switch), `-tb` (one thread pool). The refusal is an exhaustive destructure of the args struct, so a new flag does not compile until it is placed on one side. The JSONL rows omit `n_batch`, `flash_attn`, `n_threads_batch` rather than print a value for them. A zero sweep value (a NaN row upstream) is refused before the model loads; a combination over `n_kv_max` is skipped with a line saying so. Dedicated engines (gemma4 etc.) are refused by name: they have no multi-sequence step.

## Verification

- 22 new tests, each sabotaged once with the mutation grep-confirmed in the file, all red, all reverted. Two runtime sabotages on the tool itself (skip one decode step; feed a different stream on the timed pass) refused with the guard's message.
- Tiny-model runs (SmolLM2-135M Q3_K_M, `-npp 8,16 -ntg 4 -npl 1,2`) on CPU and on a Metal build with `-ngl 99`, `--max-load 0`: every guard passes, the receipt names `Apple M2 Pro`, the mislabelled receipt is refused before the sweep. Shape only; **no numbers measured or published**, `benchmarks/RESULTS.md` untouched.
- `cargo test --workspace`, clippy `-D warnings` debug and release, `cargo fmt --all`. One pre-existing flake seen once in the full parallel run under a loaded host, `ferrox_core::weight_matrix::tests::force_int_dot_moves_the_getter_and_restores_it` (process-global env; crate untouched here, passes 3/3 alone).

Docs: `docs/CLI.md` section, `benchmarks/README.md` section, parity audit and gap inventory rows.

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
