### PR TITLE
fix(tokenizer): honour llama.cpp's parse_special default and stop promoting NORMAL entries to special

### DIFF
--- a/crates/ferrox-cli/src/imatrix.rs
+++ b/crates/ferrox-cli/src/imatrix.rs
@@ -142,9 +142,15 @@ pub fn run(args: ImatrixArgs) -> Result<()> {
         .with_context(|| format!("reading calibration text {}", args.file.display()))?;
 
     let t0 = Instant::now();
-    let (decoder, tokens, _eos) =
-        crate::verify_engine::load_and_tokenize(Path::new(&path), &text, None)
-            .context("loading the model and tokenizing the calibration text")?;
+    let (decoder, tokens, _eos) = crate::verify_engine::load_and_tokenize(
+        Path::new(&path),
+        &text,
+        // llama-imatrix's default (`common.h`: `parse_special = false`):
+        // calibration text that mentions `<s>` is text.
+        ferrox_models::tokenizer::SpecialTokens::AsText,
+        None,
+    )
+    .context("loading the model and tokenizing the calibration text")?;
     println!(
         "imatrix: tokenization and load took {:.1} s; {} tokens",
         t0.elapsed().as_secs_f64(),

--- a/crates/ferrox-cli/src/layer_divergence.rs
+++ b/crates/ferrox-cli/src/layer_divergence.rs
@@ -448,8 +448,12 @@ fn child_probe(args: &DivergenceArgs, backend: &str, prompt: &str) -> anyhow::Re
 /// Child side: one prefill, then read every layer's cache.
 fn emit(model: &str, prompt: &str, prompt_tokens: Option<usize>) -> anyhow::Result<()> {
     let path = crate::pull::resolve_model_path(model)?;
-    let (decoder, tokens, _eos) =
-        crate::verify_engine::load_and_tokenize(Path::new(&path), prompt, prompt_tokens)?;
+    let (decoder, tokens, _eos) = crate::verify_engine::load_and_tokenize(
+        Path::new(&path),
+        prompt,
+        ferrox_models::tokenizer::SpecialTokens::Parse,
+        prompt_tokens,
+    )?;
     let mut caches = fresh_caches(&decoder);
     let _ = decoder.forward_batch_last(&tokens, 0, &mut caches);
 

--- a/crates/ferrox-cli/src/parity.rs
+++ b/crates/ferrox-cli/src/parity.rs
@@ -137,9 +137,13 @@ pub fn run(args: ParityArgs) -> anyhow::Result<()> {
 
     let prompt = args.prompt.clone().unwrap_or_else(|| PROMPT.to_string());
 
-    let (tokens, ferrox_logits) =
-        crate::verify_engine::prefill_logits(Path::new(&path), &prompt, args.prompt_tokens)
-            .context("ferrox prefill")?;
+    let (tokens, ferrox_logits) = crate::verify_engine::prefill_logits(
+        Path::new(&path),
+        &prompt,
+        ferrox_models::tokenizer::SpecialTokens::Parse,
+        args.prompt_tokens,
+    )
+    .context("ferrox prefill")?;
 
     // The reference is pinned to llama.cpp's CPU path (n_gpu_layers = 0),
     // because ferrox's CPU path is the one cross-validated against NumPy.

--- a/crates/ferrox-cli/src/parity/tokenize.rs
+++ b/crates/ferrox-cli/src/parity/tokenize.rs
@@ -29,11 +29,16 @@
 //! * **Vocab size**, because two different id spaces make every
 //!   comparison below it meaningless rather than merely failing.
 //!
-//! `parse_special = true` on the llama side because ferrox's tokenizers
-//! always carve special tokens out of raw text first; `false` would ask
-//! the two sides different questions. No corpus case contains a
-//! special-token literal, so today the setting is not load-bearing — it
-//! is set correctly so that adding such a case later stays honest.
+//! * **Both `parse_special` settings**, every case. They are different
+//!   questions -- is `<|im_end|>` in the input the end-of-turn token or
+//!   six characters of prose -- and llama.cpp answers both, so ferrox
+//!   has to. The sweep used to dump only `parse_special = true`, on the
+//!   grounds that ferrox always parsed specials and no corpus case
+//!   contained one. Both halves of that were the hole: ferrox's
+//!   unconditional parsing WAS the divergence from llama.cpp's default,
+//!   and a corpus with no marker in it could not see it. The
+//!   `special-markers-as-prose` case and the second run per case exist
+//!   so that this class turns the sweep red.
 
 mod corpus;
 
@@ -42,7 +47,7 @@ use corpus::{Case, CORPUS};
 use ferrox_gguf::ShardedGguf;
 use ferrox_models::tokenizer::{
     should_add_bos_token, GgufBpeTokenizer, GgufSpmTokenizer, GgufUnigramTokenizer,
-    GgufWordPieceTokenizer,
+    GgufWordPieceTokenizer, SpecialTokens,
 };
 use std::path::Path;
 use std::process::Command;
@@ -58,7 +63,22 @@ struct Reference {
     add_bos: bool,
     add_eos: bool,
     n_vocab: usize,
-    cases: Vec<Vec<u32>>,
+    /// One entry per corpus case, in corpus order; each holds the ids
+    /// for every [`SpecialTokens`] setting, in [`SETTINGS`] order.
+    cases: Vec<[Vec<u32>; SETTINGS.len()]>,
+}
+
+/// The `parse_special` settings every case is compared under. The
+/// dumper writes them in THIS order (`tools/llama_logits.c`, FXTK v2:
+/// `false` first), and the reader below indexes by it.
+const SETTINGS: [SpecialTokens; 2] = [SpecialTokens::AsText, SpecialTokens::Parse];
+
+/// How a setting is named in the report, as llama.cpp spells it.
+fn setting_name(mode: SpecialTokens) -> &'static str {
+    match mode {
+        SpecialTokens::AsText => "parse_special=false",
+        SpecialTokens::Parse => "parse_special=true",
+    }
 }
 
 /// Where two id sequences first stop agreeing, with enough around it to
@@ -79,10 +99,12 @@ pub(super) struct Divergence {
     pub ferrox_len: usize,
 }
 
+/// One corpus case under one `parse_special` setting.
 pub(super) struct CaseOutcome {
     pub name: &'static str,
     pub why: &'static str,
     pub text: &'static str,
+    pub mode: SpecialTokens,
     pub n_tokens: usize,
     pub divergence: Option<Divergence>,
 }
@@ -149,12 +171,12 @@ impl Encoder {
         })
     }
 
-    fn encode(&self, text: &str) -> Vec<u32> {
+    fn encode(&self, text: &str, mode: SpecialTokens) -> Vec<u32> {
         match self {
-            Encoder::Bpe(t) => t.encode(text),
-            Encoder::Spm(t) => t.encode(text),
-            Encoder::Unigram(t) => t.encode(text),
-            Encoder::WordPiece(t) => t.encode(text),
+            Encoder::Bpe(t) => t.encode(text, mode),
+            Encoder::Spm(t) => t.encode(text, mode),
+            Encoder::Unigram(t) => t.encode(text, mode),
+            Encoder::WordPiece(t) => t.encode(text, mode),
         }
     }
 
@@ -208,18 +230,27 @@ pub(super) fn run(dumper: &Path, model: &Path) -> anyhow::Result<Option<Report>>
         );
     }
 
+    let encoder = &encoder;
     let cases = CORPUS
         .iter()
         .zip(&reference.cases)
-        .map(|(case, llama_ids)| {
-            let ferrox_ids = encoder.encode(case.text);
-            CaseOutcome {
-                name: case.name,
-                why: case.why,
-                text: case.text,
-                n_tokens: llama_ids.len(),
-                divergence: first_divergence(llama_ids, &ferrox_ids, &|id| encoder.piece(id)),
-            }
+        .flat_map(|(case, llama_runs)| {
+            SETTINGS
+                .iter()
+                .zip(llama_runs)
+                .map(move |(&mode, llama_ids)| {
+                    let ferrox_ids = encoder.encode(case.text, mode);
+                    CaseOutcome {
+                        name: case.name,
+                        why: case.why,
+                        text: case.text,
+                        mode,
+                        n_tokens: llama_ids.len(),
+                        divergence: first_divergence(llama_ids, &ferrox_ids, &|id| {
+                            encoder.piece(id)
+                        }),
+                    }
+                })
         })
         .collect();
 
@@ -283,8 +314,10 @@ pub(super) fn print_report(r: &Report) {
         .unwrap_or_else(|| r.model.clone());
     let verdict = if r.diverged() { "DIVERGES" } else { "MATCH" };
     println!(
-        "tokenizer {name}: {verdict} ({} cases / {} tokens, pre={}, ferrox vs llama.cpp)",
-        r.cases.len(),
+        "tokenizer {name}: {verdict} ({} cases x {} parse_special settings / {} tokens, pre={}, \
+         ferrox vs llama.cpp)",
+        r.cases.len() / SETTINGS.len(),
+        SETTINGS.len(),
         r.n_tokens(),
         r.pre
     );
@@ -308,19 +341,21 @@ pub(super) fn print_report(r: &Report) {
 
     if r.n_bad() == 0 {
         println!(
-            "  all {} cases tokenize identically (digit runs, multi-space, indents, blank \
-             lines, CJK, emoji, contractions).",
-            r.cases.len()
+            "  all {} cases tokenize identically under both parse_special settings (digit \
+             runs, multi-space, indents, blank lines, CJK, emoji, contractions, special-token \
+             markers as prose).",
+            r.cases.len() / SETTINGS.len()
         );
         return;
     }
 
-    println!("  {}/{} cases diverge:", r.n_bad(), r.cases.len());
+    println!("  {}/{} case runs diverge:", r.n_bad(), r.cases.len());
     for c in r.cases.iter().filter(|c| c.divergence.is_some()) {
         let d = c.divergence.as_ref().expect("filtered on is_some");
         println!(
-            "\n  [{}] token {} of {} (llama) / {} (ferrox), byte ~{} of {}",
+            "\n  [{} @ {}] token {} of {} (llama) / {} (ferrox), byte ~{} of {}",
             c.name,
+            setting_name(c.mode),
             d.index,
             d.llama_len,
             d.ferrox_len,
@@ -412,8 +447,11 @@ fn parse_result(bytes: &[u8]) -> anyhow::Result<Reference> {
     }
     let mut at = 4usize;
     let version = u32_at(&mut at)?;
-    if version != 1 {
-        anyhow::bail!("reference tokenization is FXTK v{version}, this build reads v1");
+    if version != 2 {
+        anyhow::bail!(
+            "reference tokenization is FXTK v{version}, this build reads v2 (one run per \
+             parse_special setting). Rebuild the dumper with ./tools/build_llama_logits.sh"
+        );
     }
     let flags = u32_at(&mut at)?;
     let n_vocab = u32_at(&mut at)? as usize;
@@ -421,16 +459,31 @@ fn parse_result(bytes: &[u8]) -> anyhow::Result<Reference> {
 
     let mut cases = Vec::with_capacity(n_cases);
     for i in 0..n_cases {
-        let n = u32_at(&mut at)? as usize;
-        let mut ids = Vec::with_capacity(n);
-        for _ in 0..n {
-            let raw = u32_at(&mut at)? as i32;
-            if raw < 0 {
-                anyhow::bail!("reference tokenization case {i} holds a negative token id {raw}");
+        let mut runs: [Vec<u32>; SETTINGS.len()] = Default::default();
+        for run in runs.iter_mut() {
+            let n = u32_at(&mut at)? as usize;
+            // Every id is four bytes on the wire, so a declared count
+            // cannot exceed the bytes left; a torn file says so here
+            // rather than in a giant allocation.
+            let remaining = bytes.len().saturating_sub(at) / 4;
+            if n > remaining {
+                anyhow::bail!(
+                    "reference tokenization case {i} declares {n} ids with {remaining} left"
+                );
             }
-            ids.push(raw as u32);
+            let mut ids = Vec::with_capacity(n);
+            for _ in 0..n {
+                let raw = u32_at(&mut at)? as i32;
+                if raw < 0 {
+                    anyhow::bail!(
+                        "reference tokenization case {i} holds a negative token id {raw}"
+                    );
+                }
+                ids.push(raw as u32);
+            }
+            *run = ids;
         }
-        cases.push(ids);
+        cases.push(runs);
     }
     if at != bytes.len() {
         anyhow::bail!(
@@ -597,31 +650,51 @@ mod tests {
         assert_eq!(blob.len(), 20);
     }
 
-    fn result_blob(flags: u32, n_vocab: u32, cases: &[&[i32]]) -> Vec<u8> {
+    /// A v2 result: every case is two runs, `parse_special` false then
+    /// true.
+    fn result_blob(flags: u32, n_vocab: u32, cases: &[[&[i32]; 2]]) -> Vec<u8> {
         let mut b = Vec::from(*b"FXTK");
-        b.extend_from_slice(&1u32.to_le_bytes());
+        b.extend_from_slice(&2u32.to_le_bytes());
         b.extend_from_slice(&flags.to_le_bytes());
         b.extend_from_slice(&n_vocab.to_le_bytes());
         b.extend_from_slice(&(cases.len() as u32).to_le_bytes());
-        for c in cases {
-            b.extend_from_slice(&(c.len() as u32).to_le_bytes());
-            for id in *c {
-                b.extend_from_slice(&id.to_le_bytes());
+        for runs in cases {
+            for c in runs {
+                b.extend_from_slice(&(c.len() as u32).to_le_bytes());
+                for id in *c {
+                    b.extend_from_slice(&id.to_le_bytes());
+                }
             }
         }
         b
     }
 
     #[test]
-    fn a_result_file_round_trips_flags_vocab_and_cases() {
-        let blob = result_blob(0b11, 128_256, &[&[1, 2, 3], &[]]);
+    fn a_result_file_round_trips_flags_vocab_and_both_runs_of_every_case() {
+        // The prose case's shape: `<s>` is three ids as text and one
+        // when parsed, so the two runs of one case differ in length.
+        let blob = result_blob(0b11, 128_256, &[[&[1, 2, 3], &[9]], [&[], &[]]]);
         let r = parse_result(&blob).expect("well-formed result must parse");
         assert!(r.add_bos && r.add_eos);
         assert_eq!(r.n_vocab, 128_256);
-        assert_eq!(r.cases, vec![vec![1u32, 2, 3], vec![]]);
+        assert_eq!(r.cases, vec![[vec![1u32, 2, 3], vec![9]], [vec![], vec![]]]);
 
-        let none = parse_result(&result_blob(0, 32, &[&[7]])).unwrap();
+        let none = parse_result(&result_blob(0, 32, &[[&[7], &[7]]])).unwrap();
         assert!(!none.add_bos && !none.add_eos);
+    }
+
+    /// A dumper built from the v1 source writes one run per case. Read
+    /// as v2 that would pair case N's ids with case N+1's and report
+    /// nonsense divergences, so the version is refused by name.
+    #[test]
+    fn a_version_one_result_is_refused_and_names_the_rebuild() {
+        let mut blob = result_blob(0, 32, &[[&[1], &[1]]]);
+        blob[4..8].copy_from_slice(&1u32.to_le_bytes());
+        let err = parse_result(&blob).unwrap_err().to_string();
+        assert!(
+            err.contains("FXTK v1") && err.contains("build_llama_logits.sh"),
+            "got {err}"
+        );
     }
 
     #[test]
@@ -633,17 +706,25 @@ mod tests {
 
         // Truncated mid-case: a short read must not become a short
         // sequence that then reports a divergence at the wrong place.
-        let mut blob = result_blob(0, 32, &[&[1, 2, 3]]);
+        let mut blob = result_blob(0, 32, &[[&[1, 2, 3], &[1, 2, 3]]]);
         blob.truncate(blob.len() - 5);
         assert!(parse_result(&blob).is_err());
 
         // Trailing bytes mean the two sides disagree about the layout.
-        let mut blob = result_blob(0, 32, &[&[1]]);
+        let mut blob = result_blob(0, 32, &[[&[1], &[1]]]);
         blob.push(0);
         assert!(parse_result(&blob).is_err());
 
         // A negative id would silently become a huge u32 index.
-        assert!(parse_result(&result_blob(0, 32, &[&[-3]])).is_err());
+        assert!(parse_result(&result_blob(0, 32, &[[&[-3], &[3]]])).is_err());
+
+        // A count larger than the bytes left is a torn file, refused
+        // before any allocation sized by it.
+        let mut blob = result_blob(0, 32, &[[&[1], &[1]]]);
+        let at = blob.len() - 8;
+        blob[at..at + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+        let err = parse_result(&blob).unwrap_err().to_string();
+        assert!(err.contains("declares"), "got {err}");
     }
 
     #[test]

--- a/crates/ferrox-cli/src/parity/tokenize/corpus.rs
+++ b/crates/ferrox-cli/src/parity/tokenize/corpus.rs
@@ -1,7 +1,7 @@
 //! The corpus `ferrox parity` tokenizes on both engines.
 //!
 //! Its own module because the corpus IS the coverage claim: what these
-//! nineteen strings contain decides which pre-tokenizer bugs the oracle
+//! twenty-one strings contain decides which tokenizer bugs the oracle
 //! next door can see, and that is a separate thing to review from the
 //! comparison machinery. The test at the bottom asserts the claim, so
 //! trimming the corpus to "the cases that pass" goes red instead of
@@ -134,6 +134,29 @@ pub(super) const CORPUS: &[Case] = &[
               whitespace clause.",
         text: " ",
     },
+    Case {
+        name: "special-markers-as-prose",
+        why: "special-token markers MENTIONED in text. Under parse_special=false llama.cpp \
+              tokenizes a CONTROL marker as the characters it is written with; ferrox used \
+              to parse it unconditionally, and promoted any NORMAL entry shaped like `<...>` \
+              (Qwen2.5's `<s>`) to special under BOTH settings. Off by one token per mention \
+              on any document that discusses tokenizers.",
+        text: "Mistral wraps a turn in `<s>[INST] ... [/INST]` and ends it with `</s>`; \
+               Llama-3 opens with `<|begin_of_text|>` and ends a turn with `<|eot_id|>`; \
+               ChatML puts `<|im_start|>user` before and `<|im_end|>` after; gemma uses \
+               `<bos>`, `<start_of_turn>`, `<end_of_turn>` and `<eos>`; Qwen's pad is \
+               `<|endoftext|>`, Phi's is `<|end|>`, and BERT brackets with `[CLS]` and \
+               `[SEP]`. An `<unk>` or `<pad>` may also appear.",
+    },
+    Case {
+        name: "special-markers-glued",
+        why: "markers at the very start of the input, glued to text, and followed by a \
+              newline: the shape a rendered chat template has. Exercises the SPM dummy-prefix \
+              rule after a special (`add_space_prefix && is_prev_special`) as well as which \
+              entries are special at all.",
+        text: "<s>hello</s><|im_start|>user\nhi<|im_end|>\n<start_of_turn>model\n\
+               <|begin_of_text|>[CLS] a [SEP]<|endoftext|>",
+    },
 ];
 
 #[cfg(test)]
@@ -230,6 +253,39 @@ mod tests {
         assert!(
             longest_digit_run(case("alnum-mixtures")) >= 3,
             "digits welded to letters and dots"
+        );
+        // One marker per tokenizer family the sweep covers, so that on
+        // every local checkpoint at least one of them is a real special
+        // entry and the parse_special=false run has something to keep
+        // as prose.
+        for marker in [
+            "<s>",
+            "</s>",
+            "<|begin_of_text|>",
+            "<|eot_id|>",
+            "<|im_start|>",
+            "<|im_end|>",
+            "<bos>",
+            "<eos>",
+            "<end_of_turn>",
+            "<|endoftext|>",
+            "<|end|>",
+            "[CLS]",
+            "[SEP]",
+            "<unk>",
+        ] {
+            assert!(
+                case("special-markers-as-prose").contains(marker),
+                "the prose case must mention {marker}"
+            );
+        }
+        assert!(
+            case("special-markers-glued").starts_with("<s>"),
+            "a marker at the very start of the input"
+        );
+        assert!(
+            case("special-markers-glued").contains("<|im_end|>\n"),
+            "a marker followed by a newline, as a chat template renders it"
         );
 
         // Names are printed in the report and looked up above, so they

--- a/crates/ferrox-cli/src/perplexity.rs
+++ b/crates/ferrox-cli/src/perplexity.rs
@@ -261,9 +261,16 @@ pub fn run(args: PerplexityArgs) -> anyhow::Result<()> {
     // over is the one `parity` proves against llama.cpp. A second
     // spelling of "encode, then add BOS if the checkpoint says to" is
     // exactly the drift that makes two numbers incomparable.
-    let (decoder, tokens, _eos) =
-        crate::verify_engine::load_and_tokenize(Path::new(&path), &text, None)
-            .context("loading the model and tokenizing the corpus")?;
+    let (decoder, tokens, _eos) = crate::verify_engine::load_and_tokenize(
+        Path::new(&path),
+        &text,
+        // llama-perplexity tokenizes its corpus with
+        // `common_tokenize(ctx, params.prompt, true)`, whose
+        // `parse_special` defaults to false.
+        ferrox_models::tokenizer::SpecialTokens::AsText,
+        None,
+    )
+    .context("loading the model and tokenizing the corpus")?;
 
     // The per-window BOS reset needs the id itself, and needs to know
     // whether this checkpoint uses one at all. Same predicate as the

--- a/crates/ferrox-cli/src/quant_sensitivity.rs
+++ b/crates/ferrox-cli/src/quant_sensitivity.rs
@@ -187,8 +187,12 @@ pub fn run(args: QuantSensitivityArgs) -> anyhow::Result<()> {
 
     let prompt = args.prompt.clone().unwrap_or_else(|| PROMPT.to_string());
     let path = crate::pull::resolve_model_path(&args.model)?;
-    let (mut decoder, tokens, _eos) =
-        crate::verify_engine::load_and_tokenize(Path::new(&path), &prompt, args.prompt_tokens)?;
+    let (mut decoder, tokens, _eos) = crate::verify_engine::load_and_tokenize(
+        Path::new(&path),
+        &prompt,
+        ferrox_models::tokenizer::SpecialTokens::Parse,
+        args.prompt_tokens,
+    )?;
 
     let n_layers = decoder.layers.len();
     let (from, to) = parse_layer_range(args.layers.as_deref(), n_layers)?;

--- a/crates/ferrox-cli/src/run.rs
+++ b/crates/ferrox-cli/src/run.rs
@@ -9,6 +9,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use clap::{Args, ValueEnum};
 use ferrox_core::cache::KvCache;
 use ferrox_gguf::ShardedGguf;
+use ferrox_models::tokenizer::SpecialTokens;
 use ferrox_models::{
     ensure_generic_decoder, load_gemma4_engine_from_path, load_glm52_engine_from_path,
     load_mla_engine_from_path, select_engine_kind, Decoder, Engine, GgufBpeTokenizer,
@@ -932,11 +933,27 @@ enum CliTokenizer {
 }
 
 impl CliTokenizer {
-    fn encode(&self, text: &str) -> Vec<usize> {
+    /// `specials` is llama.cpp's `parse_special`. The prompt sites pass
+    /// `Parse`, as `llama-completion` does for its prompt
+    /// (`tools/completion/completion.cpp`: `common_tokenize(ctx, prompt,
+    /// true, true)`); the DRY breakers below pass `AsText`.
+    fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<usize> {
         match self {
-            CliTokenizer::Bpe(t) => t.encode(text).into_iter().map(|id| id as usize).collect(),
-            CliTokenizer::Spm(t) => t.encode(text).into_iter().map(|id| id as usize).collect(),
-            CliTokenizer::Unigram(t) => t.encode(text).into_iter().map(|id| id as usize).collect(),
+            CliTokenizer::Bpe(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|id| id as usize)
+                .collect(),
+            CliTokenizer::Spm(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|id| id as usize)
+                .collect(),
+            CliTokenizer::Unigram(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|id| id as usize)
+                .collect(),
         }
     }
 
@@ -983,7 +1000,7 @@ impl ferrox_models::dry::DryVocab for CliTokenizer {
     }
 
     fn tokenize(&self, text: &str) -> Vec<usize> {
-        self.encode(text)
+        self.encode(text, SpecialTokens::AsText)
     }
 }
 
@@ -1380,7 +1397,7 @@ pub fn run_infer(args: InferArgs) -> anyhow::Result<()> {
     let decoder = load_decoder_streaming_if_needed(path, config)?;
     eprintln!("ferrox: loaded in {:.2}s", load_t.elapsed().as_secs_f64());
 
-    let mut tokens = tokenizer.encode(&prompt);
+    let mut tokens = tokenizer.encode(&prompt, SpecialTokens::Parse);
     // Match llama.cpp vocab add_bos (qwen2/BPE default false). Blindly
     // prepending bos_token_id poisons Qwen2-MoE (`<|endoftext|>`).
     ferrox_models::tokenizer::prepend_bos(
@@ -1560,7 +1577,7 @@ fn run_mla_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow::Re
     };
     eprintln!("ferrox: loaded in {:.2}s", load_t.elapsed().as_secs_f64());
 
-    let mut tokens = tokenizer.encode(&prompt);
+    let mut tokens = tokenizer.encode(&prompt, SpecialTokens::Parse);
     ferrox_models::tokenizer::prepend_bos(
         &mut tokens,
         bos_id.filter(|_| ferrox_models::tokenizer::should_add_bos_token(file)),
@@ -1691,7 +1708,7 @@ fn run_gemma4_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow:
     let engine = *engine;
     eprintln!("ferrox: loaded in {:.2}s", load_t.elapsed().as_secs_f64());
 
-    let mut tokens = tokenizer.encode(&prompt);
+    let mut tokens = tokenizer.encode(&prompt, SpecialTokens::Parse);
     ferrox_models::tokenizer::prepend_bos(
         &mut tokens,
         bos_id.filter(|_| ferrox_models::tokenizer::should_add_bos_token(file)),
@@ -1821,7 +1838,7 @@ fn run_glm52_infer(args: InferArgs, path: &Path, file: &ShardedGguf) -> anyhow::
     };
     eprintln!("ferrox: loaded in {:.2}s", load_t.elapsed().as_secs_f64());
 
-    let mut tokens = tokenizer.encode(&prompt);
+    let mut tokens = tokenizer.encode(&prompt, SpecialTokens::Parse);
     ferrox_models::tokenizer::prepend_bos(
         &mut tokens,
         bos_id.filter(|_| ferrox_models::tokenizer::should_add_bos_token(file)),

--- a/crates/ferrox-cli/src/verify.rs
+++ b/crates/ferrox-cli/src/verify.rs
@@ -211,8 +211,13 @@ fn child_tokens(
 /// Child side: greedy-decode `N_TOKENS` and print the ids.
 fn emit_tokens(model: &str, prompt: &str, prompt_tokens: Option<usize>) -> anyhow::Result<()> {
     let path = crate::pull::resolve_model_path(model)?;
-    let (ids, prompt_len) =
-        crate::verify_engine::greedy_token_ids(Path::new(&path), prompt, N_TOKENS, prompt_tokens)?;
+    let (ids, prompt_len) = crate::verify_engine::greedy_token_ids(
+        Path::new(&path),
+        prompt,
+        ferrox_models::tokenizer::SpecialTokens::Parse,
+        N_TOKENS,
+        prompt_tokens,
+    )?;
     let joined: Vec<String> = ids.iter().map(|t| t.to_string()).collect();
     println!("{LEN_TAG}{prompt_len}");
     println!("{TAG}{}", joined.join(" "));

--- a/crates/ferrox-cli/src/verify_engine.rs
+++ b/crates/ferrox-cli/src/verify_engine.rs
@@ -11,7 +11,9 @@ use ferrox_models::config::ModelConfig;
 use ferrox_models::decoder::Decoder;
 use ferrox_models::engine::Engine;
 use ferrox_models::engine_factory::{load_gemma4_engine_from_path, ServedEngine};
-use ferrox_models::tokenizer::{GgufBpeTokenizer, GgufSpmTokenizer, GgufUnigramTokenizer};
+use ferrox_models::tokenizer::{
+    GgufBpeTokenizer, GgufSpmTokenizer, GgufUnigramTokenizer, SpecialTokens,
+};
 use ferrox_models::GEMMA4_ARCHES;
 use std::path::Path;
 
@@ -22,11 +24,23 @@ enum Tok {
 }
 
 impl Tok {
-    fn encode(&self, text: &str) -> Vec<usize> {
+    fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<usize> {
         match self {
-            Tok::Bpe(t) => t.encode(text).into_iter().map(|i| i as usize).collect(),
-            Tok::Spm(t) => t.encode(text).into_iter().map(|i| i as usize).collect(),
-            Tok::Unigram(t) => t.encode(text).into_iter().map(|i| i as usize).collect(),
+            Tok::Bpe(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|i| i as usize)
+                .collect(),
+            Tok::Spm(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|i| i as usize)
+                .collect(),
+            Tok::Unigram(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|i| i as usize)
+                .collect(),
         }
     }
 }
@@ -47,10 +61,11 @@ impl Tok {
 pub fn greedy_token_ids(
     path: &Path,
     prompt: &str,
+    specials: SpecialTokens,
     n: usize,
     prompt_tokens: Option<usize>,
 ) -> anyhow::Result<(Vec<u32>, usize)> {
-    let (decoder, tokens, eos) = load_and_tokenize(path, prompt, prompt_tokens)?;
+    let (decoder, tokens, eos) = load_and_tokenize(path, prompt, specials, prompt_tokens)?;
 
     let mut caches: Vec<KvCache> = (0..decoder.layers.len())
         .map(|_| KvCache::new(decoder.config.n_kv_heads, decoder.config.head_dim))
@@ -83,9 +98,11 @@ pub fn greedy_token_ids(
 pub fn prefill_logits(
     path: &Path,
     prompt: &str,
+    specials: SpecialTokens,
     prompt_tokens: Option<usize>,
 ) -> anyhow::Result<(Vec<u32>, Vec<f32>)> {
-    let (file, tokens, _eos, runtime_ctx) = tokenize_checkpoint(path, prompt, prompt_tokens)?;
+    let (file, tokens, _eos, runtime_ctx) =
+        tokenize_checkpoint(path, prompt, specials, prompt_tokens)?;
     let arch = file
         .metadata_str("general.architecture")
         .unwrap_or_default();
@@ -116,9 +133,18 @@ fn prefill_logits_gemma4(path: &Path, tokens: &[usize]) -> anyhow::Result<(Vec<u
 }
 
 /// Tokenize a prompt the same way verify/parity do, without loading weights.
+///
+/// `specials` is llama.cpp's `parse_special`, and the caller says which
+/// because the tools above this differ: a prompt handed to `verify`,
+/// `parity`, `layer-divergence` or `quant-sensitivity` is parsed like
+/// `llama-completion`'s (`Parse`); the corpus `perplexity` and `imatrix`
+/// read is text, and `llama-perplexity` (`common_tokenize(ctx,
+/// params.prompt, true)`, default `false`) and `llama-imatrix`
+/// (`common.h`: `parse_special = false`) both keep it that way.
 fn tokenize_checkpoint(
     path: &Path,
     prompt: &str,
+    specials: SpecialTokens,
     prompt_tokens: Option<usize>,
 ) -> anyhow::Result<(ShardedGguf, Vec<usize>, Option<usize>, usize)> {
     let file = ShardedGguf::open(path)?;
@@ -135,7 +161,7 @@ fn tokenize_checkpoint(
         .metadata_u64("tokenizer.ggml.bos_token_id")
         .map(|v| v as usize);
 
-    let mut tokens = tokenizer.encode(prompt);
+    let mut tokens = tokenizer.encode(prompt, specials);
     if ferrox_models::tokenizer::should_add_bos_token(&file) {
         if let Some(b) = bos {
             if tokens.first() != Some(&b) {
@@ -159,9 +185,11 @@ fn tokenize_checkpoint(
 pub(crate) fn load_and_tokenize(
     path: &Path,
     prompt: &str,
+    specials: SpecialTokens,
     prompt_tokens: Option<usize>,
 ) -> anyhow::Result<(Decoder, Vec<usize>, Option<usize>)> {
-    let (file, tokens, eos, runtime_ctx) = tokenize_checkpoint(path, prompt, prompt_tokens)?;
+    let (file, tokens, eos, runtime_ctx) =
+        tokenize_checkpoint(path, prompt, specials, prompt_tokens)?;
     let arch = file
         .metadata_str("general.architecture")
         .unwrap_or_default();

--- a/crates/ferrox-models/examples/gemma3_chat_sim.rs
+++ b/crates/ferrox-models/examples/gemma3_chat_sim.rs
@@ -1,7 +1,7 @@
 use ferrox_core::KvCache;
 use ferrox_gguf::GgufFile;
 use ferrox_models::decoder::Decoder;
-use ferrox_models::tokenizer::GgufSpmTokenizer;
+use ferrox_models::tokenizer::{GgufSpmTokenizer, SpecialTokens};
 use ferrox_models::ModelConfig;
 
 fn main() {
@@ -9,7 +9,11 @@ fn main() {
     let file = GgufFile::open(path).unwrap();
     let tok = GgufSpmTokenizer::from_gguf(&file).unwrap();
     let prompt = "<start_of_turn>user\nWhat is the capital of France? Answer with one word.<end_of_turn>\n<start_of_turn>model\n";
-    let mut tokens: Vec<usize> = tok.encode(prompt).into_iter().map(|t| t as usize).collect();
+    let mut tokens: Vec<usize> = tok
+        .encode(prompt, SpecialTokens::Parse)
+        .into_iter()
+        .map(|t| t as usize)
+        .collect();
     let bos = 2usize;
     if tokens.first() != Some(&bos) {
         tokens.insert(0, bos);

--- a/crates/ferrox-models/examples/gemma3_tok.rs
+++ b/crates/ferrox-models/examples/gemma3_tok.rs
@@ -1,5 +1,5 @@
 use ferrox_gguf::GgufFile;
-use ferrox_models::tokenizer::GgufSpmTokenizer;
+use ferrox_models::tokenizer::{GgufSpmTokenizer, SpecialTokens};
 use std::env;
 
 fn main() {
@@ -8,7 +8,7 @@ fn main() {
     // Try SPM first
     let tok = GgufSpmTokenizer::from_gguf(&file).expect("spm");
     let prompt = "<start_of_turn>user\nWhat is the capital of France? Answer with one word.<end_of_turn>\n<start_of_turn>model\n";
-    let ids = tok.encode(prompt);
+    let ids = tok.encode(prompt, SpecialTokens::Parse);
     println!("n={}", ids.len());
     println!("{:?}", &ids[..ids.len().min(40)]);
 }

--- a/crates/ferrox-models/src/embedding_model.rs
+++ b/crates/ferrox-models/src/embedding_model.rs
@@ -18,7 +18,7 @@ use crate::encoder::{EncodeError, PairSequence, TextEncoder};
 use crate::loader::LoadError;
 use crate::pooling::{l2_normalize, pool, PoolingType};
 use crate::rank_head::{load_rank_head, RankHead};
-use crate::tokenizer::{GgufWordPieceTokenizer, TokenizerLoadError};
+use crate::tokenizer::{GgufWordPieceTokenizer, SpecialTokens, TokenizerLoadError};
 
 /// Encoder architectures upstream builds from `bert.cpp` and the other
 /// embedding rows in the capability catalog, with what each one needs
@@ -241,8 +241,14 @@ impl EmbeddingModel {
     /// pieces wrapped in the model's own special tokens. Public because
     /// `/v1/embeddings` has to report `usage.prompt_tokens`, and that
     /// number is this length — llama.cpp counts the specials too.
+    ///
+    /// `SpecialTokens::Parse`, as llama.cpp's `/v1/embeddings` does
+    /// (`tools/server/server-context.cpp`, `handle_embeddings_impl`:
+    /// `tokenize_input_prompts(..., /* add_special */ true,
+    /// /* parse_special */ true)`).
     pub fn token_ids(&self, text: &str) -> Vec<u32> {
-        self.encoder.wrap_special(&self.tokenizer.encode(text))
+        self.encoder
+            .wrap_special(&self.tokenizer.encode(text, SpecialTokens::Parse))
     }
 
     /// Text for `ids`, through this checkpoint's own vocabulary.
@@ -295,11 +301,17 @@ impl EmbeddingModel {
     /// [`Self::token_ids`] is separate from [`Self::embed`] — a route
     /// has to report `usage.prompt_tokens`, and that number is
     /// `tokens.len()`.
+    ///
+    /// `SpecialTokens::AsText` for both halves, as llama.cpp's
+    /// `format_prompt_rerank` does (`tools/server/server-common.cpp`:
+    /// `tokenize_input_subprompt(vocab, mctx, query, false, false)` and
+    /// the same for `doc`). A document that mentions `[SEP]` must not be
+    /// able to end the query half early.
     pub fn rerank_input(&self, query: &str, document: &str) -> Result<PairSequence, EmbedError> {
         self.encoder
             .wrap_special_pair(
-                &self.tokenizer.encode(query),
-                &self.tokenizer.encode(document),
+                &self.tokenizer.encode(query, SpecialTokens::AsText),
+                &self.tokenizer.encode(document, SpecialTokens::AsText),
             )
             .ok_or_else(|| EmbedError::NoPairInput {
                 arch: self.arch.clone(),

--- a/crates/ferrox-models/src/engine.rs
+++ b/crates/ferrox-models/src/engine.rs
@@ -36,6 +36,7 @@ use crate::kimi_decoder::{
     kimi_forward_token, KimiDecodeState, KimiDecoderConfig, KimiDecoderWeights,
 };
 use crate::kimi_tokenizer::KimiTokenizer;
+use crate::tokenizer::SpecialTokens;
 use ferrox_core::cache::KvCache;
 use ferrox_core::weight_matrix::WeightMatrix;
 
@@ -343,7 +344,10 @@ impl Engine for DeepseekV4Engine {
 /// loop encode/decode without caring which concrete tokenizer it was
 /// given.
 pub trait TextTokenizer {
-    fn encode(&self, text: &str) -> Vec<usize>;
+    /// `specials` is llama.cpp's `parse_special`: whether a literal
+    /// marker in `text` is the token it names or the characters it is
+    /// written with. See [`SpecialTokens`] for which callers want which.
+    fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<usize>;
     fn decode(&self, ids: &[usize]) -> String;
 
     /// The raw bytes, before any UTF-8 decision is made about them.
@@ -361,8 +365,8 @@ pub trait TextTokenizer {
 }
 
 impl TextTokenizer for KimiTokenizer {
-    fn encode(&self, text: &str) -> Vec<usize> {
-        KimiTokenizer::encode(self, text)
+    fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<usize> {
+        KimiTokenizer::encode(self, text, specials)
             .into_iter()
             .map(|id| id as usize)
             .collect()

--- a/crates/ferrox-models/src/kimi_generate.rs
+++ b/crates/ferrox-models/src/kimi_generate.rs
@@ -15,6 +15,7 @@ use crate::kimi_decoder::{
 use crate::kimi_tokenizer::KimiTokenizer;
 use crate::penalty_window::PenaltyWindow;
 use crate::sampling::{Sampler, SamplingParams};
+use crate::tokenizer::SpecialTokens;
 
 /// Encodes `prompt`, runs it through the decoder to prime `KimiDecodeState`,
 /// then samples up to `max_new_tokens` further tokens (greedy if
@@ -80,7 +81,10 @@ fn generate_on_workers(
     eos_id: Option<u32>,
     seed: u64,
 ) -> (String, Vec<u32>) {
-    let prompt_ids = tokenizer.encode(prompt);
+    // `AsText`: the prompt is user text, and `tokenization_kimi.py`
+    // encodes that with `disallowed_special=()`. There is no template
+    // in front of it here whose markers would need parsing.
+    let prompt_ids = tokenizer.encode(prompt, SpecialTokens::AsText);
     let mut state = KimiDecodeState::new(weights, kda_cfg);
     let mut sampler = Sampler::new(seed);
     // The two halves of the penalty window, kept apart because that is

--- a/crates/ferrox-models/src/kimi_tokenizer.rs
+++ b/crates/ferrox-models/src/kimi_tokenizer.rs
@@ -30,6 +30,7 @@
 //! publicly documented tiktoken algorithm description, not copied from
 //! any source file.
 
+use crate::tokenizer::{SpecialKind, SpecialTokenTable, SpecialTokens, TextOrSpecial};
 use base64::Engine;
 use fancy_regex::Regex;
 use std::collections::HashMap;
@@ -181,6 +182,9 @@ pub struct KimiTokenizer {
     encoder: HashMap<Vec<u8>, u32>,
     decoder: HashMap<u32, Vec<u8>>,
     special_tokens: HashMap<String, u32>,
+    /// The same specials as a carve-out table, for
+    /// [`SpecialTokens::Parse`] -- tiktoken's `allowed_special="all"`.
+    special_table: SpecialTokenTable,
     split_re: Regex,
 }
 
@@ -191,10 +195,16 @@ impl KimiTokenizer {
     ) -> Result<Self, KimiTokenizerError> {
         let decoder = encoder.iter().map(|(k, v)| (*v, k.clone())).collect();
         let split_re = Regex::new(PAT_STR)?;
+        let special_table = SpecialTokenTable::from_entries(
+            special_tokens
+                .iter()
+                .map(|(name, &id)| (name.as_str(), id, SpecialKind::Control)),
+        );
         Ok(KimiTokenizer {
             encoder,
             decoder,
             special_tokens,
+            special_table,
             split_re,
         })
     }
@@ -207,13 +217,24 @@ impl KimiTokenizer {
         self.special_tokens.get(name).copied()
     }
 
-    /// Encodes ordinary text (no inline special-token recognition --
-    /// matches the real `disallowed_special=()` path used for
-    /// untrusted/user text in `tokenization_kimi.py`, so a literal
-    /// `<|...|>` substring in the input is BPE-encoded like any other
-    /// text, never misread as a control token).
-    pub fn encode(&self, text: &str) -> Vec<u32> {
+    /// Encodes text. [`SpecialTokens::AsText`] is the real
+    /// `disallowed_special=()` path `tokenization_kimi.py` uses for
+    /// untrusted/user text: a literal `<|...|>` substring is BPE-encoded
+    /// like any other text, never misread as a control token.
+    /// [`SpecialTokens::Parse`] is `allowed_special="all"`: every name
+    /// in `tokenizer_config.json` is carved out as its id.
+    pub fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<u32> {
         let mut out = Vec::new();
+        for seg in self.special_table.split(text, specials) {
+            match seg {
+                TextOrSpecial::Special(id) => out.push(id),
+                TextOrSpecial::Text(run) => self.encode_text_run(run, &mut out),
+            }
+        }
+        out
+    }
+
+    fn encode_text_run(&self, text: &str, out: &mut Vec<u32>) {
         for piece in self.split_re.find_iter(text) {
             let piece = piece.expect("split regex match should not error mid-scan");
             let bytes = piece.as_str().as_bytes();
@@ -223,7 +244,6 @@ impl KimiTokenizer {
             }
             out.extend(byte_pair_merge(bytes, &self.encoder));
         }
-        out
     }
 
     pub fn decode(&self, ids: &[u32]) -> String {
@@ -292,9 +312,26 @@ mod tests {
     fn encode_decode_roundtrips_on_a_tiny_synthetic_vocab() {
         let ranks = tiny_ranks();
         let tok = KimiTokenizer::new(ranks, HashMap::new()).expect("regex must compile");
-        let ids = tok.encode("hello");
+        let ids = tok.encode("hello", SpecialTokens::AsText);
         let back = tok.decode(&ids);
         assert_eq!(back, "hello");
+    }
+
+    /// tiktoken's two modes: `disallowed_special=()` leaves a written
+    /// marker as bytes, `allowed_special="all"` returns its id.
+    #[test]
+    fn a_written_marker_is_bytes_as_text_and_one_id_when_parsed() {
+        let ranks = tiny_ranks();
+        let specials = HashMap::from([("[EOS]".to_string(), 9_000u32)]);
+        let tok = KimiTokenizer::new(ranks, specials).expect("regex must compile");
+        let as_text = tok.encode("hello[EOS]", SpecialTokens::AsText);
+        assert!(!as_text.contains(&9_000), "got {as_text:?}");
+        let parsed = tok.encode("hello[EOS]", SpecialTokens::Parse);
+        assert_eq!(parsed.last(), Some(&9_000), "got {parsed:?}");
+        assert_eq!(
+            &parsed[..parsed.len() - 1],
+            &tok.encode("hello", SpecialTokens::AsText)[..]
+        );
     }
 
     #[test]

--- a/crates/ferrox-models/src/tokenizer.rs
+++ b/crates/ferrox-models/src/tokenizer.rs
@@ -30,11 +30,14 @@
 
 mod pretokenize;
 mod scored_vocab;
+mod special;
 mod unicode;
 mod unicode_data;
 mod wordpiece;
 
 use scored_vocab::ScoredVocab;
+pub use special::SpecialTokens;
+pub(crate) use special::{SpecialKind, SpecialTokenTable, TextOrSpecial};
 pub use wordpiece::{GgufWordPieceTokenizer, NormalizerOptions};
 
 /// The `tokenizer.ggml.pre` values whose llama.cpp arm sets
@@ -375,11 +378,9 @@ pub struct GgufBpeTokenizer {
     merge_rank: std::collections::HashMap<(String, String), usize>,
     byte_to_unicode: [char; 256],
     unicode_to_byte: std::collections::HashMap<char, u8>,
-    /// Control/user-defined tokens (chat-template markers and similar
-    /// added special tokens) from `tokenizer.ggml.token_type`, matched
-    /// as atomic substrings before normal BPE runs -- see
-    /// `split_on_special_tokens`.
-    special_tokens: Vec<(String, u32)>,
+    /// The vocabulary's special entries, carved out of the input before
+    /// BPE runs on what is left -- see [`special::SpecialTokenTable`].
+    special_tokens: SpecialTokenTable,
     /// Compiled pre-tokenization pattern (GPT-2 word regex, or
     /// newline-only for Gemma-4 SPM-BPE).
     pretokenize_pattern: fancy_regex::Regex,
@@ -400,205 +401,6 @@ pub enum TokenizerLoadError {
          needs one score per token; this checkpoint cannot be tokenized"
     )]
     ScoresVocabLengthMismatch { tokens: usize, scores: usize },
-}
-
-/// GGUF's real `tokenizer.ggml.token_type` per-token integer tag,
-/// confirmed directly against llama.cpp's real `llama_token_type` enum
-/// (`include/llama.h`) and its real GGUF-loading code
-/// (`src/llama-vocab.cpp`'s `toktypes[i]` switch), not guessed: this is
-/// a plain sequential enum on disk (`1=NORMAL, 2=UNKNOWN, 3=CONTROL,
-/// 4=USER_DEFINED, 5=UNUSED, 6=BYTE`), a different and simpler
-/// representation than llama.cpp's own *internal* bit-flag
-/// `llama_token_attr` type, which is derived from this at load time,
-/// not what's actually stored in the file.
-const GGML_TOKEN_TYPE_CONTROL: i64 = 3;
-const GGML_TOKEN_TYPE_USER_DEFINED: i64 = 4;
-
-/// Reads `tokenizer.ggml.token_type` (if present) and returns the
-/// `(token_text, id)` pairs for every CONTROL or USER_DEFINED entry
-/// (chat-template markers like `<|user|>`/`<|assistant|>`, and similar
-/// added special tokens) -- these must be recognized as atomic
-/// vocabulary entries during encoding rather than shattered into
-/// ordinary BPE/SPM/Unigram pieces, matching real llama.cpp's
-/// `tokenizer_st_partition` behavior (`src/llama-vocab.cpp`): special
-/// tokens are located as literal substrings and carved out of the
-/// input *before* normal tokenization runs on what's left, not folded
-/// into the regular vocabulary-matching pass.
-fn load_special_tokens(
-    file: &impl ferrox_gguf::TensorSource,
-    id_to_token: &[String],
-) -> Vec<(String, u32)> {
-    let Some(ferrox_gguf::GgufValue::Array(items)) = file.metadata("tokenizer.ggml.token_type")
-    else {
-        return Vec::new();
-    };
-    items
-        .iter()
-        .zip(id_to_token.iter())
-        .enumerate()
-        .filter_map(|(id, (v, text))| {
-            let ty = match v {
-                ferrox_gguf::GgufValue::I32(t) => *t as i64,
-                ferrox_gguf::GgufValue::U32(t) => *t as i64,
-                _ => return None,
-            };
-            // A checkpoint that flags its markers is the easy case.
-            //
-            // Not every one does. Yi-1.5-6B-Chat lists `<|im_start|>`
-            // (id 6) and `<|im_end|>` (id 7) as NORMAL, so this filter
-            // dropped them, the splitter never saw them, and
-            // `<|im_end|>` tokenized as SIX ordinary BPE pieces instead
-            // of the single token the model was trained on. Its prompt
-            // was malformed and its turn marker could not be matched by
-            // id, so nothing stopped and the marker came back as text
-            // mid-answer.
-            //
-            // So a token that LOOKS like a marker and exists verbatim in
-            // the vocabulary is treated as one whatever its type says.
-            // The shape test is what keeps this narrow: ordinary words
-            // are in the vocabulary too, and promoting those would split
-            // real text.
-            (ty == GGML_TOKEN_TYPE_CONTROL
-                || ty == GGML_TOKEN_TYPE_USER_DEFINED
-                || looks_like_marker(text))
-            .then(|| (text.clone(), id as u32))
-        })
-        .collect()
-}
-
-/// Is this vocabulary entry shaped like a special marker?
-///
-/// Deliberately strict: `<|...|>` and `<...>` with no whitespace, at
-/// least three characters. That covers `<|im_end|>`, `<|endoftext|>`,
-/// `<end_of_turn>` and `</s>` while excluding ordinary text, which also
-/// lives in the vocabulary and must keep tokenizing normally.
-fn looks_like_marker(text: &str) -> bool {
-    let t = text.trim();
-    if t.len() < 3 || t.contains(char::is_whitespace) {
-        return false;
-    }
-    (t.starts_with("<|") && t.ends_with("|>")) || (t.starts_with('<') && t.ends_with('>'))
-}
-
-/// One chunk of `split_on_special_tokens`'s output: either a raw text
-/// run to tokenize normally, or an already-resolved special token id.
-enum TextOrSpecial<'a> {
-    Text(&'a str),
-    Special(u32),
-}
-
-/// Splits `text` around every literal occurrence of any of `specials`
-/// (longest-match-first on ties, matching real llama.cpp's
-/// `tokenizer_st_partition`), leaving the text runs between/around
-/// them untouched for the caller's normal tokenization pass. Returns
-/// the whole input as one `Text` chunk when `specials` is empty (the
-/// overwhelmingly common fast path, since most GGUF files carry no
-/// `tokenizer.ggml.token_type` metadata at all).
-fn split_on_special_tokens<'a>(
-    text: &'a str,
-    specials: &[(String, u32)],
-) -> Vec<TextOrSpecial<'a>> {
-    if specials.is_empty() {
-        return vec![TextOrSpecial::Text(text)];
-    }
-    let mut segments = Vec::new();
-    let mut pos = 0usize;
-    while pos < text.len() {
-        let mut best: Option<(usize, usize, u32)> = None; // (start, len, id)
-        for (s, id) in specials {
-            if s.is_empty() {
-                continue;
-            }
-            if let Some(rel) = text[pos..].find(s.as_str()) {
-                let start = pos + rel;
-                let len = s.len();
-                let better = match best {
-                    None => true,
-                    Some((bstart, blen, _)) => start < bstart || (start == bstart && len > blen),
-                };
-                if better {
-                    best = Some((start, len, *id));
-                }
-            }
-        }
-        match best {
-            None => break,
-            Some((start, len, id)) => {
-                if start > pos {
-                    segments.push(TextOrSpecial::Text(&text[pos..start]));
-                }
-                segments.push(TextOrSpecial::Special(id));
-                pos = start + len;
-            }
-        }
-    }
-    if pos < text.len() {
-        segments.push(TextOrSpecial::Text(&text[pos..]));
-    }
-    segments
-}
-
-#[cfg(test)]
-mod special_token_split_tests {
-    use super::*;
-
-    fn text_of<'a>(seg: &TextOrSpecial<'a>) -> Option<&'a str> {
-        match seg {
-            TextOrSpecial::Text(t) => Some(t),
-            TextOrSpecial::Special(_) => None,
-        }
-    }
-
-    #[test]
-    fn empty_specials_list_returns_the_whole_text_unsplit() {
-        let segs = split_on_special_tokens("hello world", &[]);
-        assert_eq!(segs.len(), 1);
-        assert_eq!(text_of(&segs[0]), Some("hello world"));
-    }
-
-    #[test]
-    fn splits_around_a_single_special_token_in_the_middle() {
-        let specials = vec![("<|user|>".to_string(), 42u32)];
-        let segs = split_on_special_tokens("before<|user|>after", &specials);
-        assert_eq!(segs.len(), 3);
-        assert_eq!(text_of(&segs[0]), Some("before"));
-        assert!(matches!(segs[1], TextOrSpecial::Special(42)));
-        assert_eq!(text_of(&segs[2]), Some("after"));
-    }
-
-    #[test]
-    fn multiple_occurrences_and_multiple_distinct_specials_all_split() {
-        let specials = vec![
-            ("<|user|>".to_string(), 1u32),
-            ("<|assistant|>".to_string(), 2u32),
-        ];
-        let segs = split_on_special_tokens("<|user|>hi<|assistant|>hello<|user|>bye", &specials);
-        let kinds: Vec<Option<&str>> = segs.iter().map(text_of).collect();
-        assert_eq!(
-            kinds,
-            vec![None, Some("hi"), None, Some("hello"), None, Some("bye")]
-        );
-        assert!(matches!(segs[0], TextOrSpecial::Special(1)));
-        assert!(matches!(segs[2], TextOrSpecial::Special(2)));
-        assert!(matches!(segs[4], TextOrSpecial::Special(1)));
-    }
-
-    #[test]
-    fn longest_match_wins_on_a_tied_start_position() {
-        // "<|user|>" and a hypothetical shorter overlapping prefix
-        // starting at the same position must prefer the longer match.
-        let specials = vec![("<|user|>".to_string(), 1u32), ("<|u".to_string(), 99u32)];
-        let segs = split_on_special_tokens("<|user|>x", &specials);
-        assert!(matches!(segs[0], TextOrSpecial::Special(1)));
-    }
-
-    #[test]
-    fn no_match_at_all_returns_the_whole_text_as_one_segment() {
-        let specials = vec![("<|user|>".to_string(), 1u32)];
-        let segs = split_on_special_tokens("plain text with no specials", &specials);
-        assert_eq!(segs.len(), 1);
-        assert_eq!(text_of(&segs[0]), Some("plain text with no specials"));
-    }
 }
 
 impl GgufBpeTokenizer {
@@ -651,7 +453,7 @@ impl GgufBpeTokenizer {
             }
             BpeEncodingStyle::SpmWhitespace => pretokenize::newline_regex(),
         };
-        let special_tokens = load_special_tokens(file, &id_to_token);
+        let special_tokens = SpecialTokenTable::from_gguf(file, &id_to_token);
 
         Ok(GgufBpeTokenizer {
             token_to_id,
@@ -740,12 +542,14 @@ impl GgufBpeTokenizer {
         }
     }
 
-    /// Encodes text: specials first, then style-specific pretokenize +
-    /// `encode_word`. Gemma-4 escapes spaces to `▁` and splits only on
-    /// newlines; newline-only chunks look up the whole string in vocab
-    /// (multi-newline tokens) before BPE.
-    pub fn encode(&self, text: &str) -> Vec<u32> {
-        split_on_special_tokens(text, &self.special_tokens)
+    /// Encodes text: specials first (those `specials` lets through),
+    /// then style-specific pretokenize + `encode_word`. Gemma-4 escapes
+    /// spaces to `▁` and splits only on newlines; newline-only chunks
+    /// look up the whole string in vocab (multi-newline tokens) before
+    /// BPE.
+    pub fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<u32> {
+        self.special_tokens
+            .split(text, specials)
             .into_iter()
             .flat_map(|seg| -> Vec<u32> {
                 match seg {
@@ -922,10 +726,10 @@ pub struct GgufSpmTokenizer {
     /// [`GgufUnigramTokenizer`] so that the score lookup exists once
     /// rather than once per tokenizer.
     vocab: ScoredVocab,
-    /// Control/user-defined tokens from `tokenizer.ggml.token_type`,
-    /// matched as atomic substrings before normal merging -- see
-    /// `split_on_special_tokens`.
-    special_tokens: Vec<(String, u32)>,
+    /// The vocabulary's special entries, carved out of the input before
+    /// SentencePiece-BPE runs on what is left -- see
+    /// [`special::SpecialTokenTable`].
+    special_tokens: SpecialTokenTable,
     /// `tokenizer.ggml.add_space_prefix` (llama.cpp default `true` for
     /// SPM). When true, each normal-text run after a special (and the
     /// start of the string) is prefixed with SentencePiece `▁`. Gemma
@@ -985,7 +789,7 @@ impl Ord for SpmMergeCandidate {
 impl GgufSpmTokenizer {
     pub fn from_gguf(file: &impl ferrox_gguf::TensorSource) -> Result<Self, TokenizerLoadError> {
         let vocab = ScoredVocab::from_gguf(file)?;
-        let special_tokens = load_special_tokens(file, vocab.tokens());
+        let special_tokens = SpecialTokenTable::from_gguf(file, vocab.tokens());
         // llama.cpp defaults SPM `add_space_prefix` to true, then lets
         // `tokenizer.ggml.add_space_prefix` override (Gemma sets false).
         let add_space_prefix = match file.metadata("tokenizer.ggml.add_space_prefix") {
@@ -1012,16 +816,17 @@ impl GgufSpmTokenizer {
     /// which every real SentencePiece-BPE vocabulary includes for
     /// exactly this purpose) before merging begins.
     ///
-    /// Control/user-defined tokens (chat-template markers like
-    /// `<|user|>`) are first carved out as atomic substrings via
-    /// `split_on_special_tokens`, matching real llama.cpp's
-    /// `tokenizer_st_partition` behavior, so they're never shattered
-    /// into byte-fallback pieces; each remaining raw-text run between
-    /// them is merged independently. A leading dummy `▁` is applied to
-    /// a run only when [`Self::add_space_prefix`] is true (llama.cpp
-    /// `add_space_prefix && is_prev_special` for each fragment).
-    pub fn encode(&self, text: &str) -> Vec<u32> {
-        split_on_special_tokens(text, &self.special_tokens)
+    /// Special entries that `specials` lets through (chat-template
+    /// markers like `<|user|>`) are first carved out as atomic
+    /// substrings, matching real llama.cpp's `tokenizer_st_partition`
+    /// behavior, so they're never shattered into byte-fallback pieces;
+    /// each remaining raw-text run between them is merged
+    /// independently. A leading dummy `▁` is applied to a run only when
+    /// [`Self::add_space_prefix`] is true (llama.cpp `add_space_prefix
+    /// && is_prev_special` for each fragment).
+    pub fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<u32> {
+        self.special_tokens
+            .split(text, specials)
             .into_iter()
             .flat_map(|seg| match seg {
                 TextOrSpecial::Special(id) => vec![id],
@@ -1266,10 +1071,9 @@ pub struct GgufUnigramTokenizer {
     /// single-character "unknown token" fallback transition, matching
     /// the real `unknown_token_score_penalty` constant.
     unknown_token_score: f64,
-    /// Control/user-defined tokens from `tokenizer.ggml.token_type`,
-    /// matched as atomic substrings before the Viterbi pass -- see
-    /// `split_on_special_tokens`.
-    special_tokens: Vec<(String, u32)>,
+    /// The vocabulary's special entries, carved out of the input before
+    /// Viterbi runs on what is left -- see [`special::SpecialTokenTable`].
+    special_tokens: SpecialTokenTable,
 }
 
 impl GgufUnigramTokenizer {
@@ -1292,7 +1096,7 @@ impl GgufUnigramTokenizer {
         // A real score, not `+INFINITY`: `ScoredVocab` refuses an empty
         // vocabulary, so this fold always sees at least one entry.
         let unknown_token_score = vocab.min_score() as f64 - 10.0;
-        let special_tokens = load_special_tokens(file, vocab.tokens());
+        let special_tokens = SpecialTokenTable::from_gguf(file, vocab.tokens());
 
         Ok(GgufUnigramTokenizer {
             vocab,
@@ -1314,11 +1118,12 @@ impl GgufUnigramTokenizer {
     /// accumulate enough rounding error to flip which of two
     /// near-tied segmentations looks best.
     ///
-    /// Control/user-defined tokens (chat-template markers) are first
-    /// carved out as atomic substrings via `split_on_special_tokens`;
-    /// each remaining raw-text run is Viterbi-segmented independently.
-    pub fn encode(&self, text: &str) -> Vec<u32> {
-        split_on_special_tokens(text, &self.special_tokens)
+    /// Special entries that `specials` lets through (chat-template
+    /// markers) are first carved out as atomic substrings; each
+    /// remaining raw-text run is Viterbi-segmented independently.
+    pub fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<u32> {
+        self.special_tokens
+            .split(text, specials)
             .into_iter()
             .flat_map(|seg| match seg {
                 TextOrSpecial::Special(id) => vec![id],
@@ -1489,7 +1294,7 @@ mod gguf_vocab_tests {
             "Hello, World! 123",
             "ferrox is a pure-Rust inference engine.",
         ] {
-            let ids = tok.encode(sentence);
+            let ids = tok.encode(sentence, SpecialTokens::AsText);
             assert!(!ids.is_empty());
             let decoded = tok.decode(&ids);
             assert_eq!(
@@ -1509,7 +1314,7 @@ mod gguf_vocab_tests {
         // ferrox were still doing one giant merge over the whole
         // string (the pre-pretokenizer behavior), a cross-boundary
         // merge could produce a different sequence.
-        let combined = tok.encode("cat dog");
+        let combined = tok.encode("cat dog", SpecialTokens::AsText);
         let mut separate = tok.encode_word("cat");
         separate.extend(tok.encode_word(" dog"));
         assert_eq!(
@@ -1559,7 +1364,7 @@ mod gguf_vocab_tests {
             "para one\n\npara two\n",
             "line one\r\nline two\r\n",
         ] {
-            let ids = tok.encode(text);
+            let ids = tok.encode(text, SpecialTokens::AsText);
             assert_eq!(
                 tok.decode(&ids),
                 text,
@@ -1569,7 +1374,7 @@ mod gguf_vocab_tests {
 
         // And the loss was real: the tab between `a` and `b` is its own
         // token, not absorbed into either neighbour.
-        let ids = tok.encode("a\tb");
+        let ids = tok.encode("a\tb", SpecialTokens::AsText);
         assert_eq!(
             ids.len(),
             3,
@@ -1661,9 +1466,18 @@ mod gguf_spm_tests {
     #[test]
     fn matches_known_reference_encodings() {
         let tok = load_real_fixture();
-        assert_eq!(tok.encode("Hello world"), vec![15043, 3186]);
-        assert_eq!(tok.encode(" Hello world"), vec![29871, 15043, 3186]);
-        assert_eq!(tok.encode("Hello World"), vec![15043, 2787]);
+        assert_eq!(
+            tok.encode("Hello world", SpecialTokens::AsText),
+            vec![15043, 3186]
+        );
+        assert_eq!(
+            tok.encode(" Hello world", SpecialTokens::AsText),
+            vec![29871, 15043, 3186]
+        );
+        assert_eq!(
+            tok.encode("Hello World", SpecialTokens::AsText),
+            vec![15043, 2787]
+        );
     }
 
     /// Real regression test, found serving a real chat checkpoint:
@@ -1685,7 +1499,7 @@ mod gguf_spm_tests {
 
         let user_id = 269u32;
         let assistant_id = 270u32;
-        let ids = tok.encode("<|user|>hello<|assistant|>");
+        let ids = tok.encode("<|user|>hello<|assistant|>", SpecialTokens::Parse);
 
         assert_eq!(ids.first().copied(), Some(user_id), "ids={ids:?}");
         assert_eq!(ids.last().copied(), Some(assistant_id), "ids={ids:?}");
@@ -1704,12 +1518,12 @@ mod gguf_spm_tests {
     fn byte_fallback_handles_control_characters() {
         let tok = load_real_fixture();
         assert_eq!(
-            tok.encode("\t"),
+            tok.encode("\t", SpecialTokens::AsText),
             vec![29871, 12],
             "tab must byte-fallback to <0x09> = token 12"
         );
         assert_eq!(
-            tok.encode("\n"),
+            tok.encode("\n", SpecialTokens::AsText),
             vec![29871, 13],
             "newline must byte-fallback to <0x0A> = token 13"
         );
@@ -1772,7 +1586,7 @@ mod gguf_spm_tests {
                 .split_whitespace()
                 .map(|s| s.parse().unwrap())
                 .collect();
-            let got = tok.encode(text);
+            let got = tok.encode(text, SpecialTokens::AsText);
             assert_eq!(got, expected, "case #{i}: text={text:?}");
             checked += 1;
         }
@@ -1794,7 +1608,7 @@ mod gguf_spm_tests {
         // strips exactly one leading space from decoded output, but
         // the raw decode legitimately includes it.
         let text = "Hello world";
-        let ids = tok.encode(text);
+        let ids = tok.encode(text, SpecialTokens::AsText);
         assert_eq!(tok.decode(&ids), " Hello world");
     }
 
@@ -1807,7 +1621,7 @@ mod gguf_spm_tests {
         // `encode` always prepends a dummy leading space (SentencePiece
         // convention, see `decode_reverses_encode_for_ascii_text`
         // above), so the decoded round-trip carries it too.
-        let newline_id = tok.encode("\n");
+        let newline_id = tok.encode("\n", SpecialTokens::AsText);
         assert_eq!(tok.decode(&newline_id), " \n");
 
         // A multi-byte UTF-8 character split across several
@@ -1815,7 +1629,7 @@ mod gguf_spm_tests {
         // once reassembled -- not as mojibake or individually-invalid
         // UTF-8 fragments.
         let emoji = "🦀";
-        let ids = tok.encode(emoji);
+        let ids = tok.encode(emoji, SpecialTokens::AsText);
         assert_eq!(tok.decode(&ids), format!(" {emoji}"));
     }
 }
@@ -1890,7 +1704,7 @@ mod gguf_unigram_tests {
             ),
         ];
         for (text, expected) in cases {
-            let got = tok.encode(text);
+            let got = tok.encode(text, SpecialTokens::AsText);
             assert_eq!(&got, expected, "text={text:?}");
         }
     }
@@ -1898,7 +1712,7 @@ mod gguf_unigram_tests {
     #[test]
     fn decode_reverses_encode_for_ascii_text() {
         let tok = load_real_fixture();
-        let ids = tok.encode("hello world");
+        let ids = tok.encode("hello world", SpecialTokens::AsText);
         // encode's leading dummy `▁` decodes back to a leading space,
         // same SentencePiece convention as GgufSpmTokenizer.
         assert_eq!(tok.decode(&ids), " hello world");
@@ -1969,7 +1783,7 @@ mod gguf_unigram_tests {
             .with_scores(&scores);
         let tok = GgufUnigramTokenizer::from_gguf(&file).expect("lengths agree");
         assert_eq!(tok.vocab_size(), 100);
-        let ids = tok.encode("piece97");
+        let ids = tok.encode("piece97", SpecialTokens::AsText);
         assert!(
             ids.contains(&97),
             "the piece with the highest id must be reachable: ids={ids:?}"

--- a/crates/ferrox-models/src/tokenizer/scored_vocab.rs
+++ b/crates/ferrox-models/src/tokenizer/scored_vocab.rs
@@ -104,7 +104,7 @@ impl ScoredVocab {
     }
 
     /// The token texts in id order, for the callers that walk the
-    /// vocabulary itself (`load_special_tokens` zips it against
+    /// vocabulary itself (`SpecialTokenTable::from_gguf` zips it against
     /// `tokenizer.ggml.token_type`; Unigram measures its longest
     /// piece).
     pub(crate) fn tokens(&self) -> &[String] {

--- a/crates/ferrox-models/src/tokenizer/special.rs
+++ b/crates/ferrox-models/src/tokenizer/special.rs
@@ -1,0 +1,458 @@
+//! Special tokens: which vocabulary entries are one, and whether a
+//! literal marker in the input is parsed as the token it names.
+//!
+//! Shared by every GGUF tokenizer in this crate (BPE, SPM, Unigram,
+//! WordPiece), so the four cannot come to disagree about what a special
+//! token is. Transcribed from llama.cpp's `src/llama-vocab.cpp`, and
+//! every rule below cites the line it came from.
+//!
+//! # The two questions
+//!
+//! **Which entries are special?** llama.cpp's `cache_special_tokens`
+//! (`llama-vocab.cpp:2948-2952`): every token whose attribute is
+//! `CONTROL`, `USER_DEFINED` or `UNKNOWN`. The attribute starts as the
+//! file's `tokenizer.ggml.token_type` (`:2447-2458`) and is then
+//! adjusted by name: every text in [`EOG_TOKEN_TEXTS`] is promoted to
+//! `CONTROL` whatever the file said (`:2800-2832`, "control-looking
+//! token ... its type will be overridden"), and two family-specific
+//! demotions follow (`:2880-2937`).
+//!
+//! That is the WHOLE rule. This module used to add one of its own -- any
+//! vocabulary entry shaped like `<...>` was treated as special -- and
+//! that made Qwen2.5's `<s>`, which its vocabulary carries as an ordinary
+//! NORMAL entry, tokenize as one id where llama.cpp gives three (`<`,
+//! `s`, `>`), under BOTH `parse_special` settings. A document that
+//! mentions `<s>` in prose was off by one token per mention.
+//!
+//! **Is a marker in the text parsed?** llama.cpp's `parse_special`
+//! (`llama.h`, `llama_tokenize`: "Allow tokenizing special and/or
+//! control tokens which otherwise are not exposed and treated as
+//! plaintext"). Its `tokenizer_st_partition` (`:3163-3175`) skips
+//! `CONTROL` and `UNKNOWN` entries when it is false and still carves
+//! out `USER_DEFINED` ones, because HuggingFace's tokenizers do. The
+//! library default is `false` (`common/common.h:1015`), and this crate
+//! used to behave as if it were always `true`: prose that mentioned
+//! `<|im_end|>` inside backticks became the end-of-turn token. Every
+//! `encode` now takes a [`SpecialTokens`] so a caller says which it
+//! wants, and the callers are matched to llama.cpp's one by one -- the
+//! table is in the PR that introduced this module.
+//!
+//! Not ported: the `LSTRIP`/`RSTRIP` attributes llama.cpp sets by model
+//! name for jina-v2, phi-3 and modern-bert (`:3020-3047`), which strip
+//! whitespace next to a special. No local checkpoint carries them, so
+//! there is no fixture to hold an implementation to.
+
+use super::EOG_TOKEN_TEXTS;
+
+/// Whether a literal special-token marker in the input (`<s>`,
+/// `<|im_end|>`, `[SEP]`) is carved out as the token it names or
+/// tokenized as the characters it is written with.
+///
+/// llama.cpp's `parse_special`. Callers choose per site, because the
+/// right answer differs: a rendered chat prompt needs its template's own
+/// markers parsed, while a stop string, a DRY sequence breaker or a
+/// rerank document is plain text whatever it happens to mention.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpecialTokens {
+    /// `parse_special = false`, llama.cpp's library default. `CONTROL`
+    /// and `UNKNOWN` entries are ordinary text; `USER_DEFINED` ones are
+    /// still carved out (`llama-vocab.cpp:3169-3174`).
+    AsText,
+    /// `parse_special = true`: every special entry is matched as an
+    /// atomic substring before normal tokenization runs.
+    Parse,
+}
+
+/// The attribute that makes an entry special, from llama.cpp's
+/// `llama_token_attr` (`include/llama.h`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SpecialKind {
+    /// `LLAMA_TOKEN_ATTR_CONTROL`: parsed only under [`SpecialTokens::Parse`].
+    Control,
+    /// `LLAMA_TOKEN_ATTR_USER_DEFINED`: parsed under both settings.
+    UserDefined,
+    /// `LLAMA_TOKEN_ATTR_UNKNOWN`: parsed only under [`SpecialTokens::Parse`].
+    Unknown,
+}
+
+impl SpecialKind {
+    /// `tokenizer_st_partition`'s gate (`llama-vocab.cpp:3169`): with
+    /// `parse_special == false`, control and unknown tokens are skipped.
+    fn is_parsed(self, mode: SpecialTokens) -> bool {
+        match mode {
+            SpecialTokens::Parse => true,
+            SpecialTokens::AsText => self == SpecialKind::UserDefined,
+        }
+    }
+}
+
+/// GGUF's `tokenizer.ggml.token_type` per-token integer tag, matching
+/// llama.cpp's `llama_token_type` enum (`include/llama.h`) and its
+/// GGUF-loading switch (`llama-vocab.cpp:2447-2458`). A plain sequential
+/// enum on disk (`1=NORMAL, 2=UNKNOWN, 3=CONTROL, 4=USER_DEFINED,
+/// 5=UNUSED, 6=BYTE`), which is a different and simpler representation
+/// than llama.cpp's internal bit-flag `llama_token_attr`.
+const GGML_TOKEN_TYPE_UNKNOWN: i64 = 2;
+const GGML_TOKEN_TYPE_CONTROL: i64 = 3;
+const GGML_TOKEN_TYPE_USER_DEFINED: i64 = 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SpecialToken {
+    pub text: String,
+    pub id: u32,
+    pub kind: SpecialKind,
+}
+
+/// One chunk of [`SpecialTokenTable::split`]'s output: either a raw
+/// text run to tokenize normally, or an already-resolved special id.
+pub(crate) enum TextOrSpecial<'a> {
+    Text(&'a str),
+    Special(u32),
+}
+
+/// The special entries of one vocabulary, in the order llama.cpp
+/// partitions on them.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SpecialTokenTable {
+    /// Longest text first (`llama-vocab.cpp:2954-2958`); ties keep id
+    /// order, which llama.cpp's unstable sort leaves unspecified.
+    entries: Vec<SpecialToken>,
+}
+
+impl SpecialTokenTable {
+    /// Reads `tokenizer.ggml.token_type` and applies llama.cpp's by-name
+    /// adjustments. `id_to_token` is the vocabulary in id order.
+    pub fn from_gguf(file: &impl ferrox_gguf::TensorSource, id_to_token: &[String]) -> Self {
+        let mut kinds: Vec<Option<SpecialKind>> = vec![None; id_to_token.len()];
+
+        if let Some(ferrox_gguf::GgufValue::Array(items)) =
+            file.metadata("tokenizer.ggml.token_type")
+        {
+            for (kind, v) in kinds.iter_mut().zip(items) {
+                let ty = match v {
+                    ferrox_gguf::GgufValue::I32(t) => *t as i64,
+                    ferrox_gguf::GgufValue::U32(t) => *t as i64,
+                    _ => continue,
+                };
+                *kind = match ty {
+                    GGML_TOKEN_TYPE_CONTROL => Some(SpecialKind::Control),
+                    GGML_TOKEN_TYPE_USER_DEFINED => Some(SpecialKind::UserDefined),
+                    GGML_TOKEN_TYPE_UNKNOWN => Some(SpecialKind::Unknown),
+                    _ => None,
+                };
+            }
+        }
+
+        // `llama-vocab.cpp:2800-2832`: every end-of-generation text is
+        // CONTROL whatever the file said. Yi-1.5-6B-Chat ships
+        // `<|im_end|>` as NORMAL; this is what makes it one token there
+        // (and `<|im_start|>`, which is not on the list, stays
+        // shattered -- on llama.cpp too).
+        for (id, text) in id_to_token.iter().enumerate() {
+            if EOG_TOKEN_TEXTS.contains(&text.as_str()) {
+                kinds[id] = Some(SpecialKind::Control);
+            }
+        }
+
+        // `llama-vocab.cpp:2880-2912`: gpt-oss / solar-open render
+        // `<|end|>` as USER_DEFINED so it is parsed even as plain text.
+        let has = |t: &str| id_to_token.iter().any(|x| x == t);
+        if has("<|end|>")
+            && ((has("<|return|>") && has("<|call|>")) || (has("<|calls|>") && has("<|flush|>")))
+        {
+            for (id, text) in id_to_token.iter().enumerate() {
+                if text == "<|end|>" {
+                    kinds[id] = Some(SpecialKind::UserDefined);
+                }
+            }
+        }
+        // `llama-vocab.cpp:2914-2937`: gemma-4 / paddleocr carry `</s>`
+        // as an ordinary word once `<|tool_response>` is present.
+        if has("<|tool_response>") && has("</s>") {
+            for (id, text) in id_to_token.iter().enumerate() {
+                if text == "</s>" {
+                    kinds[id] = None;
+                }
+            }
+        }
+
+        Self::from_entries(
+            kinds
+                .into_iter()
+                .enumerate()
+                .filter_map(|(id, kind)| Some((id_to_token[id].as_str(), id as u32, kind?))),
+        )
+    }
+
+    /// A table from `(text, id, kind)` triples: for a vocabulary that
+    /// carries its specials outside GGUF metadata (Kimi's
+    /// `tokenizer_config.json`), and for tests. The GGUF constructor
+    /// above ends here too, so there is one ordering rule.
+    pub fn from_entries<'a>(
+        entries: impl IntoIterator<Item = (&'a str, u32, SpecialKind)>,
+    ) -> Self {
+        let mut entries: Vec<SpecialToken> = entries
+            .into_iter()
+            // An empty special would match everywhere and nowhere.
+            .filter(|(text, _, _)| !text.is_empty())
+            .map(|(text, id, kind)| SpecialToken {
+                text: text.to_string(),
+                id,
+                kind,
+            })
+            .collect();
+        // Stable, so equal lengths keep id order.
+        entries.sort_by_key(|e| std::cmp::Reverse(e.text.len()));
+        SpecialTokenTable { entries }
+    }
+
+    /// Splits `text` around every literal occurrence of every special
+    /// entry `mode` lets through, leaving the text runs between them
+    /// for the caller's normal tokenization pass.
+    ///
+    /// A port of `tokenizer_st_partition` (`llama-vocab.cpp:3163-3268`):
+    /// specials are taken longest first, and each one splits every raw
+    /// fragment left by the ones before it. Order matters when two
+    /// specials overlap, and this is llama.cpp's order.
+    pub fn split<'a>(&self, text: &'a str, mode: SpecialTokens) -> Vec<TextOrSpecial<'a>> {
+        let mut fragments = vec![TextOrSpecial::Text(text)];
+        for special in self.entries.iter().filter(|s| s.kind.is_parsed(mode)) {
+            let mut next = Vec::with_capacity(fragments.len());
+            for fragment in fragments {
+                match fragment {
+                    TextOrSpecial::Special(id) => next.push(TextOrSpecial::Special(id)),
+                    TextOrSpecial::Text(run) => {
+                        let mut rest = run;
+                        while let Some(at) = rest.find(special.text.as_str()) {
+                            if at > 0 {
+                                next.push(TextOrSpecial::Text(&rest[..at]));
+                            }
+                            next.push(TextOrSpecial::Special(special.id));
+                            rest = &rest[at + special.text.len()..];
+                        }
+                        if !rest.is_empty() {
+                            next.push(TextOrSpecial::Text(rest));
+                        }
+                    }
+                }
+            }
+            fragments = next;
+        }
+        fragments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrox_gguf::{GgufError, GgufValue, TensorInfo, TensorSource};
+
+    fn text_of<'a>(seg: &TextOrSpecial<'a>) -> Option<&'a str> {
+        match seg {
+            TextOrSpecial::Text(t) => Some(t),
+            TextOrSpecial::Special(_) => None,
+        }
+    }
+
+    fn table(specials: &[(&str, u32)]) -> SpecialTokenTable {
+        SpecialTokenTable::from_entries(
+            specials
+                .iter()
+                .map(|&(t, id)| (t, id, SpecialKind::Control)),
+        )
+    }
+
+    #[test]
+    fn an_empty_table_returns_the_whole_text_unsplit() {
+        let segs = table(&[]).split("hello world", SpecialTokens::Parse);
+        assert_eq!(segs.len(), 1);
+        assert_eq!(text_of(&segs[0]), Some("hello world"));
+    }
+
+    #[test]
+    fn splits_around_a_single_special_token_in_the_middle() {
+        let segs = table(&[("<|sep|>", 99)]).split("before<|sep|>after", SpecialTokens::Parse);
+        assert_eq!(segs.len(), 3);
+        assert_eq!(text_of(&segs[0]), Some("before"));
+        assert!(matches!(segs[1], TextOrSpecial::Special(99)));
+        assert_eq!(text_of(&segs[2]), Some("after"));
+    }
+
+    #[test]
+    fn multiple_occurrences_and_multiple_distinct_specials_all_split() {
+        let segs = table(&[("<a>", 1), ("<b>", 2)]).split("<a>x<b>y<a>", SpecialTokens::Parse);
+        let ids: Vec<u32> = segs
+            .iter()
+            .filter_map(|s| match s {
+                TextOrSpecial::Special(id) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(ids, vec![1, 2, 1]);
+        let texts: Vec<&str> = segs.iter().filter_map(text_of).collect();
+        assert_eq!(texts, vec!["x", "y"]);
+    }
+
+    /// llama.cpp partitions longest-first, so a marker that is a prefix
+    /// of a longer one never steals the longer one's match.
+    #[test]
+    fn the_longest_special_is_carved_out_before_a_prefix_of_it() {
+        let segs = table(&[("<s>", 1), ("<s>x", 2)]).split("<s>x", SpecialTokens::Parse);
+        assert_eq!(segs.len(), 1);
+        assert!(matches!(segs[0], TextOrSpecial::Special(2)));
+    }
+
+    #[test]
+    fn no_match_at_all_returns_the_whole_text_as_one_segment() {
+        let segs = table(&[("<|zzz|>", 5)]).split("nothing here", SpecialTokens::Parse);
+        assert_eq!(segs.len(), 1);
+        assert_eq!(text_of(&segs[0]), Some("nothing here"));
+    }
+
+    /// The gate this module exists for. `tokenizer_st_partition` skips
+    /// CONTROL and UNKNOWN entries when `parse_special` is false and
+    /// still carves out USER_DEFINED ones (`llama-vocab.cpp:3169-3174`).
+    #[test]
+    fn as_text_leaves_control_and_unknown_markers_as_prose_but_still_parses_user_defined() {
+        let t = SpecialTokenTable::from_entries(vec![
+            ("<|im_end|>", 7, SpecialKind::Control),
+            ("<unk>", 0, SpecialKind::Unknown),
+            ("<|user|>", 9, SpecialKind::UserDefined),
+        ]);
+        let segs = t.split("a<|im_end|>b<unk>c<|user|>d", SpecialTokens::AsText);
+        let texts: Vec<&str> = segs.iter().filter_map(text_of).collect();
+        assert_eq!(texts, vec!["a<|im_end|>b<unk>c", "d"]);
+        assert!(matches!(segs[1], TextOrSpecial::Special(9)));
+
+        let segs = t.split("a<|im_end|>b<unk>c<|user|>d", SpecialTokens::Parse);
+        let ids: Vec<u32> = segs
+            .iter()
+            .filter_map(|s| match s {
+                TextOrSpecial::Special(id) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(ids, vec![7, 0, 9]);
+    }
+
+    struct MetaOnly(std::collections::HashMap<String, GgufValue>);
+
+    impl TensorSource for MetaOnly {
+        fn metadata(&self, key: &str) -> Option<&GgufValue> {
+            self.0.get(key)
+        }
+        fn find_tensor(&self, _name: &str) -> Option<&TensorInfo> {
+            None
+        }
+        fn tensor_bytes(&self, name: &str) -> Result<&[u8], GgufError> {
+            Err(GgufError::TensorNotFound(name.to_string()))
+        }
+        fn tensor_mapped_range(
+            &self,
+            name: &str,
+        ) -> Result<
+            (
+                std::sync::Arc<ferrox_gguf::MmapHandle>,
+                std::ops::Range<usize>,
+            ),
+            GgufError,
+        > {
+            Err(GgufError::TensorNotFound(name.to_string()))
+        }
+    }
+
+    fn vocab(tokens: &[(&str, i32)]) -> (MetaOnly, Vec<String>) {
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            "tokenizer.ggml.token_type".to_string(),
+            GgufValue::Array(tokens.iter().map(|&(_, ty)| GgufValue::I32(ty)).collect()),
+        );
+        let id_to_token = tokens.iter().map(|&(t, _)| t.to_string()).collect();
+        (MetaOnly(m), id_to_token)
+    }
+
+    /// Qwen2.5-1.5B's vocabulary carries `<s>` (id 128245) as NORMAL,
+    /// and llama.cpp tokenizes it as `<`, `s`, `>` under both settings.
+    /// A shape-based promotion made it one token here; that is the
+    /// off-by-one `ferrox imatrix` measured on `docs/CLI.md`.
+    #[test]
+    fn a_normal_typed_entry_shaped_like_a_marker_is_not_special() {
+        let (file, ids) = vocab(&[("<", 1), ("s", 1), (">", 1), ("<s>", 1), ("<|im_end|>", 3)]);
+        let t = SpecialTokenTable::from_gguf(&file, &ids);
+        let segs = t.split("<s><|im_end|>", SpecialTokens::Parse);
+        let texts: Vec<&str> = segs.iter().filter_map(text_of).collect();
+        assert_eq!(texts, vec!["<s>"]);
+        assert!(matches!(segs[1], TextOrSpecial::Special(4)));
+    }
+
+    /// `llama-vocab.cpp:2800-2832`: an end-of-generation text is CONTROL
+    /// whatever the file says. Yi-1.5-6B-Chat is the checkpoint that
+    /// needs it -- `<|im_end|>` is NORMAL in its file.
+    #[test]
+    fn an_end_of_generation_text_is_control_even_when_the_file_says_normal() {
+        let (file, ids) = vocab(&[("<|im_start|>", 1), ("<|im_end|>", 1)]);
+        let t = SpecialTokenTable::from_gguf(&file, &ids);
+        assert_eq!(
+            t.entries,
+            vec![SpecialToken {
+                text: "<|im_end|>".to_string(),
+                id: 1,
+                kind: SpecialKind::Control
+            }]
+        );
+    }
+
+    #[test]
+    fn user_defined_and_unknown_types_are_special_and_normal_byte_and_unused_are_not() {
+        let (file, ids) = vocab(&[
+            ("<unk>", 2),
+            ("<ctl>", 3),
+            ("<usr>", 4),
+            ("<unused>", 5),
+            ("<0x00>", 6),
+            ("word", 1),
+        ]);
+        let t = SpecialTokenTable::from_gguf(&file, &ids);
+        let kinds: Vec<(u32, SpecialKind)> = t.entries.iter().map(|e| (e.id, e.kind)).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                (0, SpecialKind::Unknown),
+                (1, SpecialKind::Control),
+                (2, SpecialKind::UserDefined)
+            ]
+        );
+    }
+
+    /// `llama-vocab.cpp:2914-2937`: gemma-4 ships `</s>` beside
+    /// `<|tool_response>`, and there it is an ordinary word.
+    #[test]
+    fn gemma4_style_end_of_sentence_is_demoted_beside_tool_response() {
+        let (file, ids) = vocab(&[("</s>", 3), ("<|tool_response>", 3)]);
+        let t = SpecialTokenTable::from_gguf(&file, &ids);
+        assert_eq!(t.entries.iter().map(|e| e.id).collect::<Vec<_>>(), vec![1]);
+    }
+
+    /// `llama-vocab.cpp:2880-2912`: gpt-oss's `<|end|>` becomes
+    /// USER_DEFINED, so it is parsed even as plain text.
+    #[test]
+    fn harmony_end_is_user_defined_when_return_and_call_are_present() {
+        let (file, ids) = vocab(&[("<|end|>", 3), ("<|return|>", 3), ("<|call|>", 3)]);
+        let t = SpecialTokenTable::from_gguf(&file, &ids);
+        let end = t.entries.iter().find(|e| e.text == "<|end|>").unwrap();
+        assert_eq!(end.kind, SpecialKind::UserDefined);
+        let segs = t.split("x<|end|>y", SpecialTokens::AsText);
+        assert!(matches!(segs[1], TextOrSpecial::Special(0)));
+    }
+
+    #[test]
+    fn a_file_without_token_types_has_only_the_by_name_specials() {
+        let file = MetaOnly(std::collections::HashMap::new());
+        let ids: Vec<String> = ["a", "<|eot_id|>", "b"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let t = SpecialTokenTable::from_gguf(&file, &ids);
+        assert_eq!(t.entries.iter().map(|e| e.id).collect::<Vec<_>>(), vec![1]);
+    }
+}

--- a/crates/ferrox-models/src/tokenizer/wordpiece.rs
+++ b/crates/ferrox-models/src/tokenizer/wordpiece.rs
@@ -53,7 +53,7 @@
 //! nothing, exactly as it matches nothing upstream.
 
 use super::unicode;
-use super::{load_special_tokens, split_on_special_tokens, TextOrSpecial, TokenizerLoadError};
+use super::{SpecialTokenTable, SpecialTokens, TextOrSpecial, TokenizerLoadError};
 use std::collections::HashMap;
 
 /// The phantom space llama.cpp's converter puts in front of every
@@ -114,11 +114,11 @@ pub struct GgufWordPieceTokenizer {
     max_token_len: usize,
     unk_id: u32,
     normalizer: NormalizerOptions,
-    /// `CONTROL`/`USER_DEFINED` entries, carved out of raw text before
+    /// The vocabulary's special entries, carved out of raw text before
     /// normalization runs. For a BERT vocabulary this is `[PAD]`,
     /// `[UNK]`, `[CLS]`, `[SEP]` and `[MASK]`, which is exactly
     /// llama.cpp's `cache_special_tokens` for the same file.
-    special_tokens: Vec<(String, u32)>,
+    special_tokens: SpecialTokenTable,
 }
 
 impl GgufWordPieceTokenizer {
@@ -153,7 +153,7 @@ impl GgufWordPieceTokenizer {
             .map(|v| v as u32)
             .unwrap_or(DEFAULT_UNK_ID);
 
-        let special_tokens = load_special_tokens(file, &id_to_token);
+        let special_tokens = SpecialTokenTable::from_gguf(file, &id_to_token);
 
         Ok(GgufWordPieceTokenizer {
             token_to_id,
@@ -179,9 +179,11 @@ impl GgufWordPieceTokenizer {
     /// decision lives with [`super::should_add_bos_token`] and
     /// [`super::prepend_bos`] for every tokenizer in this crate, and
     /// baking it in here would double it for callers that already do it.
-    pub fn encode(&self, text: &str) -> Vec<u32> {
+    /// `specials` is llama.cpp's `parse_special`: whether a literal
+    /// `[SEP]` in the text is the separator or five characters.
+    pub fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<u32> {
         let mut out = Vec::new();
-        for seg in split_on_special_tokens(text, &self.special_tokens) {
+        for seg in self.special_tokens.split(text, specials) {
             match seg {
                 TextOrSpecial::Special(id) => out.push(id),
                 TextOrSpecial::Text(t) => self.encode_normal_run(t, &mut out),
@@ -364,6 +366,7 @@ fn preprocess(text: &str, opts: NormalizerOptions) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tokenizer::SpecialKind;
 
     const BOTH: NormalizerOptions = NormalizerOptions {
         lowercase: true,
@@ -502,7 +505,10 @@ mod tests {
             max_token_len,
             unk_id: 1,
             normalizer: BOTH,
-            special_tokens: vec![("[CLS]".to_string(), 2), ("[SEP]".to_string(), 3)],
+            special_tokens: SpecialTokenTable::from_entries([
+                ("[CLS]", 2, SpecialKind::Control),
+                ("[SEP]", 3, SpecialKind::Control),
+            ]),
         }
     }
 
@@ -511,8 +517,8 @@ mod tests {
         let t = toy();
         // ▁un + able, which only works because `able` carries no phantom
         // space and so cannot match at position 0.
-        assert_eq!(t.encode("unable"), [4, 9]);
-        assert_eq!(t.encode("hello"), [5]);
+        assert_eq!(t.encode("unable", SpecialTokens::AsText), [4, 9]);
+        assert_eq!(t.encode("hello", SpecialTokens::AsText), [5]);
     }
 
     /// Longest match first, not merely *a* match.
@@ -526,9 +532,13 @@ mod tests {
     #[test]
     fn the_longest_match_wins_where_a_shorter_one_would_also_cover() {
         let t = toy();
-        assert_eq!(t.encode("unaffable"), [11, 9], "▁unaff + able");
+        assert_eq!(
+            t.encode("unaffable", SpecialTokens::AsText),
+            [11, 9],
+            "▁unaff + able"
+        );
         assert_ne!(
-            t.encode("unaffable"),
+            t.encode("unaffable", SpecialTokens::AsText),
             [4, 8, 9],
             "▁un + aff + able is the shortest-first answer"
         );
@@ -541,7 +551,11 @@ mod tests {
     #[test]
     fn a_continuation_piece_cannot_start_a_word() {
         let t = toy();
-        assert_eq!(t.encode("aff"), [1], "no ▁aff, so [UNK]");
+        assert_eq!(
+            t.encode("aff", SpecialTokens::AsText),
+            [1],
+            "no ▁aff, so [UNK]"
+        );
     }
 
     /// The whole point of the all-or-nothing rule. `worlds` matches
@@ -552,26 +566,33 @@ mod tests {
     fn a_partly_covered_word_discards_its_pieces_and_becomes_one_unknown() {
         let t = toy();
         assert_eq!(
-            t.encode("worlds"),
+            t.encode("worlds", SpecialTokens::AsText),
             [1],
             "a partial cover must be discarded, not kept"
         );
         // The same word without the stray byte does cover, which is what
         // makes the assertion above about the fallback rule rather than
         // about the vocabulary being too small.
-        assert_eq!(t.encode("world"), [7]);
+        assert_eq!(t.encode("world", SpecialTokens::AsText), [7]);
     }
 
     #[test]
     fn each_word_falls_back_independently() {
         let t = toy();
-        assert_eq!(t.encode("hello zzz world"), [5, 1, 7]);
+        assert_eq!(
+            t.encode("hello zzz world", SpecialTokens::AsText),
+            [5, 1, 7]
+        );
     }
 
     #[test]
     fn punctuation_is_its_own_word_and_matches_its_own_piece() {
         let t = toy();
-        assert_eq!(t.encode("hello."), [5, 6], "▁hello then ▁.");
+        assert_eq!(
+            t.encode("hello.", SpecialTokens::AsText),
+            [5, 6],
+            "▁hello then ▁."
+        );
     }
 
     #[test]
@@ -579,7 +600,19 @@ mod tests {
         let t = toy();
         // Without the carve-out the brackets would each be their own
         // punctuation word and `[CLS]` would come back as four unknowns.
-        assert_eq!(t.encode("[CLS]hello[SEP]"), [2, 5, 3]);
+        assert_eq!(t.encode("[CLS]hello[SEP]", SpecialTokens::Parse), [2, 5, 3]);
+    }
+
+    /// llama.cpp's default: a `[SEP]` written in the text is text. The
+    /// toy vocabulary has no `[`, so the marker shatters to unknowns
+    /// around `hello`, which is what upstream does with
+    /// `parse_special = false`.
+    #[test]
+    fn as_text_leaves_a_written_marker_to_the_normal_pass() {
+        let t = toy();
+        let ids = t.encode("[CLS]hello[SEP]", SpecialTokens::AsText);
+        assert!(!ids.contains(&2) && !ids.contains(&3), "got {ids:?}");
+        assert!(ids.contains(&5), "hello survives: {ids:?}");
     }
 
     #[test]

--- a/crates/ferrox-models/tests/bos_policy.rs
+++ b/crates/ferrox-models/tests/bos_policy.rs
@@ -18,6 +18,7 @@ use common::collect_gguf;
 use ferrox_models::chat_template::{ChatTemplate, RenderOptions};
 use ferrox_models::tokenizer::{
     prepend_bos, should_add_bos_token, GgufBpeTokenizer, GgufSpmTokenizer, GgufUnigramTokenizer,
+    SpecialTokens,
 };
 use serde_json::json;
 
@@ -41,9 +42,9 @@ impl Tok {
 
     fn encode(&self, text: &str) -> Vec<u32> {
         match self {
-            Tok::Bpe(t) => t.encode(text),
-            Tok::Spm(t) => t.encode(text),
-            Tok::Unigram(t) => t.encode(text),
+            Tok::Bpe(t) => t.encode(text, SpecialTokens::Parse),
+            Tok::Spm(t) => t.encode(text, SpecialTokens::Parse),
+            Tok::Unigram(t) => t.encode(text, SpecialTokens::Parse),
         }
     }
 }

--- a/crates/ferrox-models/tests/checkpoint_receipts.rs
+++ b/crates/ferrox-models/tests/checkpoint_receipts.rs
@@ -19,7 +19,7 @@ use ferrox_core::cache::KvCache;
 use ferrox_gguf::ShardedGguf;
 use ferrox_models::config::{ModelConfig, RopeLayout};
 use ferrox_models::decoder::Decoder;
-use ferrox_models::tokenizer::GgufBpeTokenizer;
+use ferrox_models::tokenizer::{GgufBpeTokenizer, SpecialTokens};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -142,7 +142,7 @@ fn llama31_8b_q4km_forced_continuation_receipt() {
     let decoder = Decoder::from_gguf(path, config.clone()).expect("load decoder");
 
     let mut tokens: Vec<usize> = tok
-        .encode(&receipt.prompt.rendered)
+        .encode(&receipt.prompt.rendered, SpecialTokens::Parse)
         .into_iter()
         .map(|t| t as usize)
         .collect();

--- a/crates/ferrox-models/tests/common/mod.rs
+++ b/crates/ferrox-models/tests/common/mod.rs
@@ -235,17 +235,17 @@ fn stretch(mut tokens: Vec<usize>, want: usize, bos: Option<usize>) -> Vec<usize
 /// cover: a suite that silently ran a different prompt would report a
 /// pass it had not earned.
 pub fn prompt_tokens(file: &ferrox_gguf::ShardedGguf, prompt: &str, want: usize) -> Vec<usize> {
-    use ferrox_models::tokenizer::{GgufBpeTokenizer, GgufSpmTokenizer};
+    use ferrox_models::tokenizer::{GgufBpeTokenizer, GgufSpmTokenizer, SpecialTokens};
     let raw: Vec<usize> = match file.metadata_str("tokenizer.ggml.model") {
         Some("gpt2" | "gemma4") => GgufBpeTokenizer::from_gguf(file)
             .expect("bpe tokenizer")
-            .encode(prompt)
+            .encode(prompt, SpecialTokens::Parse)
             .into_iter()
             .map(|i| i as usize)
             .collect(),
         Some("llama") => GgufSpmTokenizer::from_gguf(file)
             .expect("spm tokenizer")
-            .encode(prompt)
+            .encode(prompt, SpecialTokens::Parse)
             .into_iter()
             .map(|i| i as usize)
             .collect(),

--- a/crates/ferrox-models/tests/cpu_pool_token_parity.rs
+++ b/crates/ferrox-models/tests/cpu_pool_token_parity.rs
@@ -30,7 +30,7 @@ use ferrox_core::cache::KvCache;
 use ferrox_gguf::ShardedGguf;
 use ferrox_models::config::ModelConfig;
 use ferrox_models::decoder::Decoder;
-use ferrox_models::tokenizer::GgufBpeTokenizer;
+use ferrox_models::tokenizer::{GgufBpeTokenizer, SpecialTokens};
 
 const PROMPT: &str = "The capital of France is";
 const MAX_NEW_TOKENS: usize = 12;
@@ -88,7 +88,11 @@ fn greedy_tokens(path: &Path) -> Vec<usize> {
     let tok = GgufBpeTokenizer::from_gguf(&file).expect("tokenizer");
     let decoder = Decoder::from_gguf(path, config.clone()).expect("load decoder");
 
-    let prompt: Vec<usize> = tok.encode(PROMPT).into_iter().map(|t| t as usize).collect();
+    let prompt: Vec<usize> = tok
+        .encode(PROMPT, SpecialTokens::Parse)
+        .into_iter()
+        .map(|t| t as usize)
+        .collect();
     let mut caches: Vec<KvCache> = (0..config.n_layers)
         .map(|_| KvCache::new(config.n_kv_heads, config.head_dim))
         .collect();

--- a/crates/ferrox-models/tests/gemma2_metal_quality_gate.rs
+++ b/crates/ferrox-models/tests/gemma2_metal_quality_gate.rs
@@ -15,7 +15,7 @@ use ferrox_core::cache::KvCache;
 use ferrox_gguf::ShardedGguf;
 use ferrox_models::config::ModelConfig;
 use ferrox_models::decoder::Decoder;
-use ferrox_models::tokenizer::{should_add_bos_token, GgufSpmTokenizer};
+use ferrox_models::tokenizer::{should_add_bos_token, GgufSpmTokenizer, SpecialTokens};
 
 const PROMPT: &str = "The capital of France is";
 const MAX_NEW: usize = 24;
@@ -37,7 +37,11 @@ fn argmax(logits: &[f32]) -> usize {
 }
 
 fn greedy_continuation(decoder: &Decoder, tok: &GgufSpmTokenizer, file: &ShardedGguf) -> String {
-    let mut tokens: Vec<usize> = tok.encode(PROMPT).into_iter().map(|t| t as usize).collect();
+    let mut tokens: Vec<usize> = tok
+        .encode(PROMPT, SpecialTokens::Parse)
+        .into_iter()
+        .map(|t| t as usize)
+        .collect();
     if should_add_bos_token(file) {
         if let Some(bos) = file.metadata_u64("tokenizer.ggml.bos_token_id") {
             let bos = bos as usize;

--- a/crates/ferrox-models/tests/gemma4_real_contract.rs
+++ b/crates/ferrox-models/tests/gemma4_real_contract.rs
@@ -33,7 +33,7 @@ use std::path::{Path, PathBuf};
 use ferrox_gguf::{GgufFile, TensorSource};
 use ferrox_models::engine::Engine;
 use ferrox_models::gemma4_gguf_loader::{load_gemma4_engine, read_gemma4_hparams};
-use ferrox_models::tokenizer::{should_add_bos_token, GgufBpeTokenizer};
+use ferrox_models::tokenizer::{should_add_bos_token, GgufBpeTokenizer, SpecialTokens};
 
 const PROMPT: &str = "The capital of France is";
 const MAX_NEW_TOKENS: usize = 8;
@@ -244,7 +244,11 @@ fn gemma4_greedy_decode_answers_paris() {
     if should_add_bos_token(&file) {
         tokens.push(file.metadata_u64("tokenizer.ggml.bos_token_id").unwrap() as usize);
     }
-    tokens.extend(tok.encode(PROMPT).into_iter().map(|t| t as usize));
+    tokens.extend(
+        tok.encode(PROMPT, SpecialTokens::Parse)
+            .into_iter()
+            .map(|t| t as usize),
+    );
 
     let mut state = engine.new_state();
     let mut logits = Vec::new();

--- a/crates/ferrox-models/tests/gemma4_tok_smoke.rs
+++ b/crates/ferrox-models/tests/gemma4_tok_smoke.rs
@@ -1,6 +1,6 @@
 //! Ignored smoke: Gemma-4 SPM-BPE vs sanity checks on the local GGUF.
 use ferrox_gguf::GgufFile;
-use ferrox_models::tokenizer::{should_add_bos_token, GgufBpeTokenizer};
+use ferrox_models::tokenizer::{should_add_bos_token, GgufBpeTokenizer, SpecialTokens};
 
 fn gemma4_path() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../models/gemma-4-E2B-it-Q4_K_M.gguf")
@@ -20,8 +20,8 @@ fn gemma4_bpe_roundtrip_and_counts() {
     assert!(tok.has_merges());
     assert_eq!(tok.vocab_size(), 262144);
 
-    let how = tok.encode("How are you");
-    let paris = tok.encode("The capital of France is");
+    let how = tok.encode("How are you", SpecialTokens::AsText);
+    let paris = tok.encode("The capital of France is", SpecialTokens::AsText);
     assert!(
         how.len() >= 3,
         "expected multi-token for How are you, got {how:?}"

--- a/crates/ferrox-models/tests/kimi_real_data.rs
+++ b/crates/ferrox-models/tests/kimi_real_data.rs
@@ -598,7 +598,7 @@ fn kimi_tokenizer_matches_the_real_tiktoken_library_on_real_vocab() {
     ];
 
     for (text, expected) in cases {
-        let ids = tok.encode(text);
+        let ids = tok.encode(text, ferrox_models::tokenizer::SpecialTokens::AsText);
         assert_eq!(ids, *expected, "encode({text:?}) mismatch");
         let back = tok.decode(&ids);
         assert_eq!(&back, text, "decode roundtrip mismatch for {text:?}");

--- a/crates/ferrox-models/tests/qwen2moe_paris.rs
+++ b/crates/ferrox-models/tests/qwen2moe_paris.rs
@@ -11,7 +11,7 @@ use ferrox_core::cache::KvCache;
 use ferrox_gguf::ShardedGguf;
 use ferrox_models::config::ModelConfig;
 use ferrox_models::decoder::Decoder;
-use ferrox_models::tokenizer::GgufBpeTokenizer;
+use ferrox_models::tokenizer::{GgufBpeTokenizer, SpecialTokens};
 
 const PROMPT: &str = "The capital of France is";
 const MAX_NEW_TOKENS: usize = 16;
@@ -57,7 +57,11 @@ fn qwen2moe_cpu_greedy_paris_regression() {
     let tok = GgufBpeTokenizer::from_gguf(&file).expect("tokenizer");
     let decoder = Decoder::from_gguf(&path, config.clone()).expect("load decoder");
 
-    let mut tokens: Vec<usize> = tok.encode(PROMPT).into_iter().map(|t| t as usize).collect();
+    let mut tokens: Vec<usize> = tok
+        .encode(PROMPT, SpecialTokens::Parse)
+        .into_iter()
+        .map(|t| t as usize)
+        .collect();
     // llama.cpp qwen2 pre: add_bos=false — do not prepend bos_token_id.
 
     eprintln!("prompt tokens ({}) = {tokens:?}", tokens.len());

--- a/crates/ferrox-models/tests/smollm2_metal_paris.rs
+++ b/crates/ferrox-models/tests/smollm2_metal_paris.rs
@@ -17,7 +17,7 @@ use ferrox_core::cache::KvCache;
 use ferrox_gguf::ShardedGguf;
 use ferrox_models::config::ModelConfig;
 use ferrox_models::decoder::Decoder;
-use ferrox_models::tokenizer::GgufBpeTokenizer;
+use ferrox_models::tokenizer::{GgufBpeTokenizer, SpecialTokens};
 
 const PROMPT: &str = "The capital of France is";
 const MAX_NEW_TOKENS: usize = 16;
@@ -66,7 +66,11 @@ fn smollm2_metal_greedy_paris_regression() {
     let tok = GgufBpeTokenizer::from_gguf(&file).expect("tokenizer");
     let decoder = Decoder::from_gguf(&path, config.clone()).expect("load decoder");
 
-    let mut tokens: Vec<usize> = tok.encode(PROMPT).into_iter().map(|t| t as usize).collect();
+    let mut tokens: Vec<usize> = tok
+        .encode(PROMPT, SpecialTokens::Parse)
+        .into_iter()
+        .map(|t| t as usize)
+        .collect();
 
     let mut caches: Vec<KvCache> = (0..config.n_layers)
         .map(|_| KvCache::new(config.n_kv_heads, config.head_dim))

--- a/crates/ferrox-models/tests/wordpiece_llama_cpp_parity.rs
+++ b/crates/ferrox-models/tests/wordpiece_llama_cpp_parity.rs
@@ -64,6 +64,7 @@
 //! looks like one, and inputs that normalize away to nothing.
 
 use ferrox_gguf::ShardedGguf;
+use ferrox_models::tokenizer::SpecialTokens;
 use ferrox_models::GgufWordPieceTokenizer;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -71,7 +72,9 @@ use std::process::Command;
 struct Golden {
     name: &'static str,
     text: &'static str,
-    /// llama.cpp's ids for `text`, with `add_special = false`.
+    /// llama.cpp's ids for `text`, with `add_special = false` and
+    /// `parse_special = true` (the `bracket-specials` case is `[CLS]`
+    /// as id 101, which only the parsed setting gives).
     llama: &'static [u32],
 }
 
@@ -446,7 +449,7 @@ fn ferrox_matches_the_recorded_llama_cpp_tokenization() {
     let mut failures = Vec::new();
     let mut tokens = 0usize;
     for case in GOLDEN {
-        let ferrox = tok.encode(case.text);
+        let ferrox = tok.encode(case.text, SpecialTokens::Parse);
         tokens += case.llama.len();
         if ferrox != case.llama {
             failures.push(report(&tok, case.name, case.text, case.llama, &ferrox));
@@ -667,8 +670,10 @@ fn reference_tokenize(dumper: &Path, model: &Path, texts: &[&str]) -> (u32, usiz
 }
 
 /// The FXTK result format `tools/llama_logits.c` writes:
-/// `"FXTK" | u32 version | u32 flags | u32 n_vocab | u32 n_cases |
-/// repeat( u32 n_ids | n_ids * u32 )`.
+/// `"FXTK" | u32 version=2 | u32 flags | u32 n_vocab | u32 n_cases |
+/// repeat( run(parse_special=false) run(parse_special=true) )`, each
+/// run `u32 n_ids | n_ids * u32`. Only the parsed run is kept, because
+/// that is the setting the recorded table was made under.
 fn parse_fxtk(bytes: &[u8]) -> (u32, usize, Vec<Vec<u32>>) {
     assert_eq!(&bytes[..4], b"FXTK", "not an FXTK result file");
     let mut at = 4usize;
@@ -677,12 +682,20 @@ fn parse_fxtk(bytes: &[u8]) -> (u32, usize, Vec<Vec<u32>>) {
         at += 4;
         v
     };
-    assert_eq!(next(), 1, "this test reads FXTK v1");
+    assert_eq!(
+        next(),
+        2,
+        "this test reads FXTK v2; rebuild the dumper with ./tools/build_llama_logits.sh"
+    );
     let flags = next();
     let n_vocab = next() as usize;
     let n_cases = next() as usize;
     let cases = (0..n_cases)
         .map(|_| {
+            let n_as_text = next() as usize;
+            for _ in 0..n_as_text {
+                next();
+            }
             let n = next() as usize;
             (0..n).map(|_| next()).collect()
         })

--- a/crates/ferrox-server/src/anthropic.rs
+++ b/crates/ferrox-server/src/anthropic.rs
@@ -97,6 +97,7 @@ use crate::{
     stats, ApiError, AppState, ChatCompletionRequest, ChatMessage, MessageContent, StopParam,
     ThinkingSwitch, ToolCallFunctionIn, ToolCallIn, ToolDef, ToolFunctionDef,
 };
+use ferrox_models::tokenizer::SpecialTokens;
 
 /// Stream silence after which a protocol-native `ping` goes out.
 ///
@@ -1712,7 +1713,7 @@ pub(crate) async fn count_tokens(
         // (`generate::generate` calls `prepend_bos`). `Model` exposes no
         // BOS id, so this can read one token low on a checkpoint that
         // has one; it is stated rather than guessed at.
-        let input_tokens = model.encode(&prompt).len();
+        let input_tokens = model.encode(&prompt, SpecialTokens::Parse).len();
         Ok::<Value, ApiError>(json!({"input_tokens": input_tokens}))
     })();
 

--- a/crates/ferrox-server/src/completion/mod.rs
+++ b/crates/ferrox-server/src/completion/mod.rs
@@ -61,6 +61,7 @@ use crate::decode_task::{self, DecodeHandles};
 use crate::generate::GenerationParams;
 use crate::sampling_knobs::SamplingKnobs;
 use crate::{sse, stats, unsupported_feature, ApiError, AppState};
+use ferrox_models::tokenizer::SpecialTokens;
 
 mod wire;
 
@@ -569,7 +570,7 @@ pub(crate) async fn completion(
                          server does not quietly substitute a smaller one",
                     )
                 })?;
-            let prompt_tokens = handles.model().encode(&prompt).len();
+            let prompt_tokens = handles.model().encode(&prompt, SpecialTokens::Parse).len();
             limit.saturating_sub(prompt_tokens)
         }
     };

--- a/crates/ferrox-server/src/embeddings.rs
+++ b/crates/ferrox-server/src/embeddings.rs
@@ -47,6 +47,7 @@ use axum::Json;
 use serde::Deserialize;
 
 use ferrox_models::pooling::{l2_normalize, pool, PoolingType};
+use ferrox_models::tokenizer::SpecialTokens;
 use ferrox_models::EmbeddingModel;
 
 use crate::openai_extra::Call;
@@ -257,7 +258,8 @@ async fn decoder_embeddings(
         let mut out = Vec::with_capacity(inputs.len());
         let mut prompt_tokens = 0usize;
         for (i, text) in inputs.iter().enumerate() {
-            let tokens = model.encode(text);
+            // `Parse`, as llama.cpp's `handle_embeddings_impl` does.
+            let tokens = model.encode(text, SpecialTokens::Parse);
             prompt_tokens += tokens.len();
             if let Some(vocab) = model.vocab_size() {
                 if let Some(&bad) = tokens.iter().find(|&&t| t >= vocab) {

--- a/crates/ferrox-server/src/generate.rs
+++ b/crates/ferrox-server/src/generate.rs
@@ -17,7 +17,7 @@ use ferrox_core::cache::{
     PagedStoreExhausted, SharedPagedKv,
 };
 use ferrox_models::sampling::SamplingParams;
-use ferrox_models::tokenizer::{prepend_bos, StopTokens};
+use ferrox_models::tokenizer::{prepend_bos, SpecialTokens, StopTokens};
 use ferrox_models::{Ceiling, Decoder, Engine, KvElem, KvShape, PrefixCache, TextTokenizer};
 
 use crate::budget::ContextCeiling;
@@ -1313,7 +1313,10 @@ pub fn generate(
         }
     };
 
-    let mut tokens = tokenizer.encode(prompt);
+    // `Parse`: the prompt is what a chat template rendered, or a raw
+    // completion, and llama.cpp's server tokenizes both with
+    // `parse_special = true`. See `Model::encode`.
+    let mut tokens = tokenizer.encode(prompt, SpecialTokens::Parse);
     prepend_bos(&mut tokens, bos_id);
     let prompt_tokens = tokens.len();
     if let Some(&bad) = tokens.iter().find(|&&t| t >= vocab_size) {
@@ -1842,7 +1845,8 @@ pub fn generate_engine<E: Engine, T: TextTokenizer>(
     mut emit: impl FnMut(&str),
 ) -> Result<(FinishReason, Usage), DecodeError> {
     let vocab_size = engine.vocab_size();
-    let mut tokens = tokenizer.encode(prompt);
+    // `Parse`, as the GGUF path above. See `Model::encode`.
+    let mut tokens = tokenizer.encode(prompt, SpecialTokens::Parse);
     prepend_bos(&mut tokens, bos_id);
     let prompt_tokens = tokens.len();
     if let Some(&bad) = tokens.iter().find(|&&t| t >= vocab_size) {

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -101,7 +101,7 @@ pub use cli::{ServerArgs, BUILT_WITH_CUDA, BUILT_WITH_METAL};
 use ferrox_core::cache::KvBlockPool;
 use ferrox_models::kimi_tokenizer::KimiTokenizer;
 use ferrox_models::sampling::SamplingParams;
-use ferrox_models::tokenizer::StopTokens;
+use ferrox_models::tokenizer::{SpecialTokens, StopTokens};
 use ferrox_models::{Decoder, Gemma4Engine, KimiEngine, MlaEngine, PrefixCache};
 use generate::{FinishReason, GenerationParams};
 pub(crate) use loaded::{ActiveModel, Loaded};
@@ -222,18 +222,44 @@ impl Model {
         }
     }
 
-    pub(crate) fn encode(&self, text: &str) -> Vec<usize> {
+    /// `specials` is llama.cpp's `parse_special`, and each caller is
+    /// matched to the llama.cpp server site it mirrors
+    /// (`tools/server/server-context.cpp` unless said otherwise):
+    ///
+    /// * a prompt, rendered from a chat template or given raw --
+    ///   `/v1/chat/completions`, `/v1/completions`, `/v1/messages`,
+    ///   `count_tokens`, slot save: `Parse`, as
+    ///   `tokenize_input_prompts(..., true, true)` does for both
+    ///   completion routes. llama.cpp's server does NOT tokenize a
+    ///   message's content separately from the template around it, so
+    ///   neither does this one; a document that mentions `<|im_end|>`
+    ///   inside a chat message is parsed on both engines. Doing better
+    ///   would need the template renderer to hand back which spans are
+    ///   content, and is deliberately not done here so the two engines
+    ///   agree about the prompt.
+    /// * pooled decoder embeddings: `Parse` (`handle_embeddings_impl`).
+    /// * `/v1/tokenize`: the request's own `parse_special`, default
+    ///   `true` (`json_value(body, "parse_special", true)`).
+    /// * DRY sequence breakers: `AsText`
+    ///   (`llama-sampler.cpp`: `vocab.tokenize(str, false, false)`).
+    /// * a stop string that is one token: `Parse`. This is ferrox's own
+    ///   mechanism (llama.cpp matches stop strings on decoded text and
+    ///   tokenizes them only to trim `n_probs`), and a caller who names
+    ///   `<|eot_id|>` as a stop means the token.
+    /// * a tool-call opener that anchors the paged KV window: `Parse`,
+    ///   because the opener is a special token where the family has one.
+    pub(crate) fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<usize> {
         match self {
-            Model::Gguf(m) => m.tokenizer.encode(text),
+            Model::Gguf(m) => m.tokenizer.encode(text, specials),
             Model::Kimi(m) => m
                 .tokenizer
-                .encode(text)
+                .encode(text, specials)
                 .into_iter()
                 .map(|id| id as usize)
                 .collect(),
-            Model::Mla(m) => m.tokenizer.encode(text),
-            Model::Gemma4(m) => m.tokenizer.encode(text),
-            Model::Glm52(m) => m.tokenizer.encode(text),
+            Model::Mla(m) => m.tokenizer.encode(text, specials),
+            Model::Gemma4(m) => m.tokenizer.encode(text, specials),
+            Model::Glm52(m) => m.tokenizer.encode(text, specials),
         }
     }
 
@@ -341,7 +367,7 @@ impl ferrox_models::dry::DryVocab for Model {
     }
 
     fn tokenize(&self, text: &str) -> Vec<usize> {
-        self.encode(text)
+        self.encode(text, SpecialTokens::AsText)
     }
 }
 
@@ -2248,8 +2274,9 @@ fn run_generation_emit(
     // one answer rather than two that can drift.
     let params = &{
         let mut resolved = params.clone();
-        resolved.stop_token_ids =
-            crate::stop::resolve_stop_tokens(&resolved.stop, |text| model.encode(text));
+        resolved.stop_token_ids = crate::stop::resolve_stop_tokens(&resolved.stop, |text| {
+            model.encode(text, SpecialTokens::Parse)
+        });
         resolved
     };
     let used_batcher = matches!((model, continuous_batcher), (Model::Gguf(_), Some(_)));
@@ -2258,7 +2285,7 @@ fn run_generation_emit(
     let (finish, usage) = match model {
         Model::Gguf(m) => {
             if let Some(batcher) = continuous_batcher {
-                let mut tokens = m.tokenizer.encode(prompt);
+                let mut tokens = m.tokenizer.encode(prompt, SpecialTokens::Parse);
                 ferrox_models::tokenizer::prepend_bos(&mut tokens, m.bos_id);
                 let (finish, _generated_ids, text, usage) = if synthetic {
                     batcher.generate(tokens, params.clone(), m.stop_tokens.clone())?
@@ -4384,7 +4411,7 @@ async fn run(mcp_config_path: Option<PathBuf>, exit_on_stdin_close: bool) -> any
                 .opener(),
                 |text| {
                     gguf.tokenizer
-                        .encode(text)
+                        .encode(text, SpecialTokens::Parse)
                         .into_iter()
                         .map(|t| t as u32)
                         .collect()

--- a/crates/ferrox-server/src/loaded.rs
+++ b/crates/ferrox-server/src/loaded.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 use axum::http::StatusCode;
 use axum::Json;
 
+use ferrox_models::tokenizer::SpecialTokens;
 use ferrox_models::EmbeddingModel;
 
 use crate::{budget, serving, ApiError, Model};
@@ -187,9 +188,14 @@ impl ActiveModel {
     /// Deliberately NOT reached through `generative()`: routes that
     /// need a decode still go through it and still refuse, and this
     /// pair is the only thing that steps around it.
-    pub(crate) fn encode_any(&self, text: &str) -> Vec<usize> {
+    ///
+    /// `specials` reaches the generative tokenizer as is. An encoder's
+    /// `token_ids` is the embedding input, which llama.cpp tokenizes
+    /// with `parse_special = true` and which wraps its own `[CLS]` /
+    /// `[SEP]`; there is no separate setting to honour on that side.
+    pub(crate) fn encode_any(&self, text: &str, specials: SpecialTokens) -> Vec<usize> {
         match &self.loaded {
-            Loaded::Generative(m) => m.encode(text),
+            Loaded::Generative(m) => m.encode(text, specials),
             Loaded::Encoder(e) => e.token_ids(text).into_iter().map(|t| t as usize).collect(),
         }
     }

--- a/crates/ferrox-server/src/model.rs
+++ b/crates/ferrox-server/src/model.rs
@@ -29,7 +29,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use ferrox_gguf::ShardedGguf;
-use ferrox_models::tokenizer::StopTokens;
+use ferrox_models::tokenizer::{SpecialTokens, StopTokens};
 use ferrox_models::{
     deepseek_v4_pro, glm_5_2, kimi_k3, load_gemma4_engine_from_path, load_glm52_engine_from_path,
     load_mla_engine_from_path, select_engine_kind, ByteTokenizer, Decoder, Gemma4Engine,
@@ -157,13 +157,28 @@ pub enum ServerTokenizer {
 }
 
 impl ServerTokenizer {
-    pub fn encode(&self, text: &str) -> Vec<usize> {
+    /// `specials` is llama.cpp's `parse_special`. Every route picks the
+    /// setting its llama.cpp counterpart uses; see the callers of
+    /// `Model::encode`.
+    pub fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<usize> {
         match self {
-            ServerTokenizer::Bpe(t) => t.encode(text).into_iter().map(|id| id as usize).collect(),
-            ServerTokenizer::Spm(t) => t.encode(text).into_iter().map(|id| id as usize).collect(),
-            ServerTokenizer::Unigram(t) => {
-                t.encode(text).into_iter().map(|id| id as usize).collect()
-            }
+            ServerTokenizer::Bpe(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|id| id as usize)
+                .collect(),
+            ServerTokenizer::Spm(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|id| id as usize)
+                .collect(),
+            ServerTokenizer::Unigram(t) => t
+                .encode(text, specials)
+                .into_iter()
+                .map(|id| id as usize)
+                .collect(),
+            // A byte vocabulary has no special entries, so the setting
+            // has nothing to select.
             ServerTokenizer::Byte => ByteTokenizer::encode(text)
                 .into_iter()
                 .map(|id| id as usize)
@@ -204,8 +219,8 @@ impl ServerTokenizer {
 }
 
 impl TextTokenizer for ServerTokenizer {
-    fn encode(&self, text: &str) -> Vec<usize> {
-        ServerTokenizer::encode(self, text)
+    fn encode(&self, text: &str, specials: SpecialTokens) -> Vec<usize> {
+        ServerTokenizer::encode(self, text, specials)
     }
 
     fn decode(&self, ids: &[usize]) -> String {

--- a/crates/ferrox-server/src/openai_extra.rs
+++ b/crates/ferrox-server/src/openai_extra.rs
@@ -16,6 +16,7 @@ use crate::attribution::Attribution;
 use crate::generate::{FinishReason, GenerationParams};
 use crate::sampling_knobs::SamplingKnobs;
 use crate::{unsupported_feature, ApiError, AppState};
+use ferrox_models::tokenizer::SpecialTokens;
 
 /// What one of the small endpoints knows before it does any work.
 ///
@@ -110,11 +111,10 @@ pub(crate) struct TokenizeRequest {
     #[serde(default)]
     add_special: Option<bool>,
     /// llama.cpp: tokenize special-token text as special tokens rather
-    /// than as plaintext. Upstream defaults to `true`, and ferrox's
-    /// tokenizers always split on special tokens
-    /// (`ferrox_models::tokenizer::split_on_special_tokens`), so `true`
-    /// is honoured and `false` is REFUSED BY NAME rather than silently
-    /// ignored.
+    /// than as plaintext. Upstream defaults to `true`
+    /// (`server-context.cpp`: `json_value(body, "parse_special", true)`)
+    /// and so does this server; `false` tokenizes `<|im_start|>` as the
+    /// characters it is written with.
     #[serde(default)]
     parse_special: Option<bool>,
     /// llama.cpp: return `{"id", "piece"}` objects instead of bare ids.
@@ -153,13 +153,6 @@ impl TokenizeRequest {
     /// Every knob this server does not implement, refused by name
     /// before any work happens.
     fn reject_unsupported(&self) -> Result<(), ApiError> {
-        if self.parse_special == Some(false) {
-            return Err(unsupported_feature(
-                "`parse_special: false` is not implemented: ferrox's tokenizers always split \
-                 on special-token text, so this server cannot tokenize `<|im_start|>` as \
-                 plain characters. Omit the field or send `true` (llama.cpp's default)",
-            ));
-        }
         if self.with_pieces == Some(true) {
             return Err(unsupported_feature(
                 "`with_pieces: true` is not implemented: ferrox's tokenizers expose decoded \
@@ -169,6 +162,15 @@ impl TokenizeRequest {
             ));
         }
         Ok(())
+    }
+
+    /// The `parse_special` setting the request asked for, with
+    /// llama.cpp's default when it did not say.
+    fn specials(&self) -> SpecialTokens {
+        match self.parse_special {
+            Some(false) => SpecialTokens::AsText,
+            Some(true) | None => SpecialTokens::Parse,
+        }
     }
 }
 
@@ -422,7 +424,7 @@ fn tokenize_inner(
     // generative model" on an encoder-only server, which is the right
     // refusal for a decode and the wrong one for this (issue #28).
     let active = state.require_active()?;
-    let mut tokens = active.encode_any(text);
+    let mut tokens = active.encode_any(text, req.specials());
     if req.add_special == Some(true) {
         // The same helper the generation path uses, so `add_special`
         // reports the prompt the model would actually be given --
@@ -559,30 +561,21 @@ mod tests {
         serde_json::from_value(value).expect("request")
     }
 
-    /// The two llama.cpp knobs this server does not implement. Both
-    /// deserialize, so serde would happily have dropped them; the
-    /// point of declaring them is that they are refused BY NAME.
+    /// The llama.cpp knob this server does not implement. It
+    /// deserializes, so serde would happily have dropped it; the point
+    /// of declaring it is that it is refused BY NAME.
     #[test]
-    fn the_tokenize_knobs_ferrox_lacks_are_refused_by_name() {
-        for (field, body) in [
-            (
-                "parse_special",
-                serde_json::json!({"content": "hi", "parse_special": false}),
-            ),
-            (
-                "with_pieces",
-                serde_json::json!({"content": "hi", "with_pieces": true}),
-            ),
-        ] {
-            let (status, body) = tokenize_request(body)
+    fn the_tokenize_knob_ferrox_lacks_is_refused_by_name() {
+        let field = "with_pieces";
+        let (status, body) =
+            tokenize_request(serde_json::json!({"content": "hi", "with_pieces": true}))
                 .reject_unsupported()
                 .expect_err("this is not implemented");
-            assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{field}");
-            assert!(
-                body.0["error"]["message"].as_str().unwrap().contains(field),
-                "the refusal must name {field}: {body:?}"
-            );
-        }
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{field}");
+        assert!(
+            body.0["error"]["message"].as_str().unwrap().contains(field),
+            "the refusal must name {field}: {body:?}"
+        );
     }
 
     /// The values ferrox *does* honour must not be refused: upstream's
@@ -595,6 +588,25 @@ mod tests {
         )
         .reject_unsupported()
         .expect("these are the values this server implements");
+    }
+
+    /// `parse_special` maps onto the tokenizer's setting, and an absent
+    /// field is llama.cpp's default of `true`. `false` used to be
+    /// refused by name because ferrox parsed specials unconditionally.
+    #[test]
+    fn parse_special_selects_the_tokenizer_setting_and_defaults_to_true() {
+        assert_eq!(
+            tokenize_request(serde_json::json!({"content": "hi"})).specials(),
+            SpecialTokens::Parse
+        );
+        assert_eq!(
+            tokenize_request(serde_json::json!({"content": "hi", "parse_special": true}))
+                .specials(),
+            SpecialTokens::Parse
+        );
+        let off = tokenize_request(serde_json::json!({"content": "hi", "parse_special": false}));
+        off.reject_unsupported().expect("false is implemented now");
+        assert_eq!(off.specials(), SpecialTokens::AsText);
     }
 
     /// One field under two spellings. Absent means absent -- llama.cpp

--- a/crates/ferrox-server/src/slots/mod.rs
+++ b/crates/ferrox-server/src/slots/mod.rs
@@ -307,7 +307,7 @@ async fn save(
     let active = state.require_active()?;
     let cache = require_prefix_cache(&state)?;
     let (identity, decoder) = serving_identity(&active)?;
-    let mut tokens = active.encode_any(prompt);
+    let mut tokens = active.encode_any(prompt, ferrox_models::tokenizer::SpecialTokens::Parse);
     ferrox_models::tokenizer::prepend_bos(
         &mut tokens,
         active.generative_opt().and_then(|m| m.bos_id()),

--- a/docs/API.md
+++ b/docs/API.md
@@ -1258,8 +1258,8 @@ The request body accepts both dialects on both paths:
 | both at once | **400.** They are one field, and guessing which was meant would tokenize text the caller did not ask about |
 | neither | **400** naming both. llama.cpp answers an empty array here; ferrox does not, because an empty array cannot be told apart from tokenizing `""` |
 | `add_special` | Supported. Prepends the same BOS id the generation path prepends, including its no-op on a checkpoint whose metadata says not to add one, so the count matches the prompt the model would really see |
-| `parse_special: true` (upstream's default) | Supported. ferrox's tokenizers always split on special-token text |
-| `parse_special: false` | **501 by name.** ferrox cannot tokenize `<|im_start|>` as plain characters |
+| `parse_special: true` (upstream's default) | Supported. Special-token markers in the text are the tokens they name |
+| `parse_special: false` | Supported. `<|im_start|>` is tokenized as the characters it is written with, as llama.cpp does |
 | `with_pieces` | **501 by name.** ferrox's tokenizers expose decoded text, not the raw per-token piece bytes, so a byte-fallback token could not be given llama.cpp's `piece` byte array |
 | `model` | Accepted and ignored; this server serves one model at a time |
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -213,8 +213,9 @@ picking a side:
 - Most upstream templates open with `{{ bos_token }}`: gemma-2/3/4
   (`<bos>`), Mistral-Instruct and Phi-3 (`<s>`), Llama-3
   (`<|begin_of_text|>`), DeepSeek-R1-Distill. Rendering one puts BOS in the
-  *text*, and encoding splits on special-token text, so it comes back as
-  the BOS *id* in position 0.
+  *text*, and a rendered prompt is encoded with special-token markers
+  parsed (llama.cpp's `parse_special = true`, as its server does), so it
+  comes back as the BOS *id* in position 0.
 - Unsloth deliberately **strips** `{{ bos_token }}` from the templates it
   bakes into its GGUF exports, so that a runtime adding BOS itself does not
   double it. TinyLlama's checked-in template is the local example.
@@ -719,9 +720,7 @@ Deviations, all stated: one chunk per forward pass where `llama-imatrix`
 folds `n_batch / n_ctx` chunks into one batch as separate sequences
 (same rows in the same order, so the same sums); no perplexity printed,
 because `ferrox perplexity` already computes that number by llama.cpp's
-method; special-token strings in the text are always parsed, which is
-`llama-imatrix --parse-special`, because ferrox's tokenizers have no
-mode that does not; no `--in-file` combining of earlier matrices; and
+method; no `--in-file` combining of earlier matrices; and
 expert streaming (`Stored` experts) is refused because a streamed
 expert's weight view has no stable identity.
 
@@ -755,16 +754,20 @@ the weights enter the fit as relative importances -- but that is a
 statement about the effect, not a claim the files match.
 
 Two things to check before trusting a comparison. The text must
-tokenize identically: on the repo's own markdown docs ferrox's
-Qwen2-style BPE produced 17208 tokens where `llama-tokenize
---no-escape` produced 17209 (one token fewer somewhere in the 100
-bytes ``es open with `{{ bos_token }}`: gemma-2/3/4\n  (`<bos>`),
-Mistral-Instruct and Phi-3 (`<s>`), Llama-3``), and `llama-imatrix`'s
-own default, which does not parse special-token markers, produced
-17218 because the docs contain six `<|...|>` strings. Either
-difference shifts every chunk boundary and turns a 1e-3 comparison
-into a 1e-1 one. And it must be the same text through the same
-number of chunks, since a chunk count is a token count.
+tokenize identically, and it once did not: on the repo's own markdown
+docs ferrox's Qwen2-style BPE produced 17208 tokens where
+`llama-tokenize --no-escape` produced 17209, one fewer at each
+mention of `<s>` -- Qwen2.5's vocabulary carries `<s>` as an ordinary
+entry that llama.cpp never treats as special, and ferrox promoted it
+on its shape. That is fixed, and `ferrox imatrix` now tokenizes its
+text with special-token markers left as text, which is
+`llama-imatrix`'s own default (`parse_special = false`); a doc that
+mentions `<|im_end|>` is six characters on both engines. `ferrox
+parity`'s tokenizer sweep carries a case of markers-as-prose under
+both `parse_special` settings so the class stays closed. Either kind
+of difference shifts every chunk boundary and turns a 1e-3 comparison
+into a 1e-1 one. And it must be the same text through the same number
+of chunks, since a chunk count is a token count.
 
 ## Split and merge GGUF (`ferrox gguf-split`)
 

--- a/tools/llama_logits.c
+++ b/tools/llama_logits.c
@@ -66,13 +66,25 @@
 // the two sides do not have to share a host endianness):
 //
 //   cases   "FXTK" | u32 n_cases | repeat( u32 n_bytes | n_bytes text )
-//   result  "FXTK" | u32 version=1 | u32 flags | u32 n_vocab
-//                  | u32 n_cases  | repeat( u32 n_tokens | n_tokens i32 )
+//   result  "FXTK" | u32 version=2 | u32 flags | u32 n_vocab
+//                  | u32 n_cases  | repeat( run(parse_special=false)
+//                                           run(parse_special=true) )
+//           run    u32 n_tokens | n_tokens i32
 //           flags bit0 = add_bos, bit1 = add_eos, as the vocab reports
 //           them. The ids themselves are dumped with add_special=false,
 //           so the BOS policy is compared as a FLAG rather than being
 //           baked into every sequence, where one disagreement would
 //           misreport every case as a tokenizer divergence.
+//
+//           Every case is tokenized TWICE, once per parse_special
+//           setting, because the two are different questions and
+//           ferrox has to answer both. Version 1 dumped only the
+//           parse_special=true answer, and that hid a real defect:
+//           ferrox parsed special-token markers unconditionally, so a
+//           document that MENTIONED `<|im_end|>` in prose was off by
+//           one token against llama.cpp's default, and the only
+//           reference the oracle had was the one setting on which the
+//           two agreed.
 //
 // CPU only (n_gpu_layers = 0) in the logits mode: the ferrox side of the
 // comparison is its CPU path, which is the one cross-validated against
@@ -96,7 +108,7 @@
 #endif
 
 #define FXTK_MAGIC "FXTK"
-#define FXTK_VERSION 1u
+#define FXTK_VERSION 2u
 
 // Exit code for "llama.cpp itself cannot load this checkpoint". Kept
 // distinct from the generic failure code because it is not evidence
@@ -291,19 +303,18 @@ static int cmd_tokenize(const char * model_path, const char * in_path, const cha
             break;
         }
         // add_special = false: BOS/EOS policy travels in `flags`.
-        // parse_special = true: ferrox's tokenizers always carve special
-        // tokens out of raw text, so the reference must too or the two
-        // sides are answering different questions.
-        const int32_t n = llama_tokenize(vocab, text, text_len, toks, cap, false, true);
-        if (n < 0) {
-            fprintf(stderr, "case %u needs %d tokens, buffer held %d\n", i, -n, cap);
-            free(toks);
-            rc = 1;
-            break;
-        }
-        wr_u32(f, (uint32_t) n);
-        for (int32_t t = 0; t < n; t++) {
-            wr_i32(f, (int32_t) toks[t]);
+        // parse_special: both, false first. See the format note above.
+        for (int parse_special = 0; parse_special <= 1 && rc == 0; parse_special++) {
+            const int32_t n = llama_tokenize(vocab, text, text_len, toks, cap, false, parse_special != 0);
+            if (n < 0) {
+                fprintf(stderr, "case %u needs %d tokens, buffer held %d\n", i, -n, cap);
+                rc = 1;
+                break;
+            }
+            wr_u32(f, (uint32_t) n);
+            for (int32_t t = 0; t < n; t++) {
+                wr_i32(f, (int32_t) toks[t]);
+            }
         }
         free(toks);
     }


### PR DESCRIPTION
## The defect, reproduced

`ferrox imatrix` (#195) measured ferrox one token short of `llama-tokenize` on `docs/CLI.md` and `ferrox parity` had not seen it. Both sides tokenized `docs/CLI.md` on `Qwen2.5-1.5B-Instruct-Q4_K_M` (build 7650, `--no-bos --no-escape`):

| | tokens | first divergence |
|---|---|---|
| ferrox (main) | 16115 | |
| `llama-tokenize` (parse_special=true, the tool's default) | 16117 | token **3516**, at `` `<s>[INST] `` |
| `llama-tokenize --no-parse-special` (the library default) | 16126 | token **144**, at `` `<\|im_end\|>` `` |

At 3516 llama.cpp gives `27:"<"  82:"s"  43626:">\`"`; ferrox gave `128245:"<s>"  63:"\`"`. Qwen2.5's file carries `<s>` (128245) as a **NORMAL** entry, and llama.cpp never treats it as special under either setting; ferrox promoted any vocabulary entry shaped like `<...>` (`looks_like_marker`, added for Yi-1.5's NORMAL-typed `<|im_end|>`), which swept in `<s>`, `</s>`, `<unk>`, `<?>` and `<()>`. Same divergence twice per document.

Under llama.cpp's **library default** there are two more classes: ferrox parsed every CONTROL marker in prose unconditionally, so `` `<|im_end|>` `` and `` `<|endoftext|>` `` inside backticks became the control tokens.

## Which side llama.cpp agrees with

* `llama_tokenize`'s `parse_special` (`include/llama.h`): "Allow tokenizing special and/or control tokens which otherwise are not exposed and treated as plaintext." `common_tokenize` defaults it to **false** (`common/common.h:1015`).
* `tokenizer_st_partition` (`src/llama-vocab.cpp:3163-3175`): with `parse_special == false`, CONTROL and UNKNOWN entries are skipped; USER_DEFINED ones are still carved out.
* Which entries are special at all: `cache_special_tokens` (`:2948-2952`) = CONTROL | USER_DEFINED | UNKNOWN from `tokenizer.ggml.token_type` (`:2447-2458`), plus every EOG name promoted to CONTROL (`:2800-2832`, "control-looking token ... its type will be overridden"), plus the gpt-oss `<|end|>` and gemma-4 `</s>` adjustments (`:2880-2937`). Nothing shape-based.

So the `<s>` half was a ferrox bug under both settings, and the `<|im_end|>` half was a policy: ferrox behaved as `parse_special = true` everywhere.

## The fix

`tokenizer/special.rs` (new; moved out of the 2243-line `tokenizer.rs`, which is 2057 now) is one table for BPE, SPM, Unigram, WordPiece and Kimi: llama.cpp's rule for which entries are special, a port of `tokenizer_st_partition` (longest first, each splitting every remaining fragment), and `SpecialTokens::{AsText, Parse}`. Every `encode` takes it, so a caller cannot avoid choosing.

**Where each caller lands** (llama.cpp site in parentheses):

| caller | setting | llama.cpp |
|---|---|---|
| server `/v1/chat/completions`, `/v1/completions`, `/v1/messages` prompt, `count_tokens`, slot save | Parse | `server-context.cpp` `tokenize_input_prompts(..., true, true)` |
| server pooled decoder embeddings, BERT `token_ids` | Parse | `handle_embeddings_impl` |
| `/v1/tokenize` | request's `parse_special`, default true; `false` was 501-by-name and is now implemented | `json_value(body, "parse_special", true)` |
| rerank query and document | AsText | `server-common.cpp:1571-1572` |
| DRY sequence breakers (server and CLI) | AsText | `llama-sampler.cpp` `vocab.tokenize(str, false, false)` |
| `ferrox run` prompt; verify / parity / layer-divergence / quant-sensitivity prompts | Parse | `completion.cpp:320` `common_tokenize(ctx, prompt, true, true)` |
| `ferrox perplexity`, `ferrox imatrix` corpus | AsText | `perplexity.cpp:310`; `common.h:714` |
| stop strings resolved to one id | Parse | ferrox's own mechanism; a caller naming `<|eot_id|>` means the token |
| Kimi (`run-kimi`) | AsText; Parse carves `tokenizer_config.json` specials | tiktoken `disallowed_special=()` / `allowed_special="all"` |

**One thing the task statement assumed that llama.cpp does not do.** The brief said llama.cpp's server parses the template's markers but not user content. It does not: `/v1/chat/completions` renders the template to one string and tokenizes it with `parse_special = true` (`server-context.cpp:5282`), so a chat message that mentions `<|im_end|>` is parsed as the control token on both engines. This PR matches that, and says so at `Model::encode`, rather than inventing a split the oracle could not check. Doing better needs the template renderer to hand back which spans are content; that is a separate change and would make ferrox and llama.cpp disagree about the prompt.

Not ported: LSTRIP/RSTRIP attributes llama.cpp sets by model name (jina-v2, phi-3, modern-bert; `:3020-3047`). No local checkpoint carries them; the module says so.

## The oracle

`tools/llama_logits.c` writes FXTK **v2**: each corpus case tokenized twice, `parse_special` false then true, and `ferrox parity` compares ferrox under both. A v1 dumper is refused by name (rebuild with `tools/build_llama_logits.sh`). Two corpus cases carry markers: `special-markers-as-prose` (backticked markers from every family the sweep covers, asserted one by one) and `special-markers-glued` (`<s>hello</s><|im_start|>user\nhi<|im_end|>\n...`, the shape a rendered template has, which also exercises the SPM dummy-prefix rule after a special).

**Red on main** (new oracle, old tokenizer), Qwen2.5-1.5B:
```
tokenizer Qwen2.5-1.5B-Instruct-Q4_K_M: DIVERGES (21 cases x 2 parse_special settings / 1187 tokens, pre=qwen2)
  4/42 case runs diverge:
  [special-markers-as-prose @ parse_special=false] token 7 of 144 (llama) / 130 (ferrox)
  [special-markers-as-prose @ parse_special=true]  token 7 of 132 (llama) / 130 (ferrox)
  [special-markers-glued @ parse_special=false]    token 0 of 46 (llama) / 30 (ferrox)
  [special-markers-glued @ parse_special=true]     token 0 of 33 (llama) / 30 (ferrox)
```

**Green after**, all 20 local checkpoints, against a current libllama (`.scratch/llama.cpp/build`): DeepSeek-R1-Distill-Qwen-1.5B, Llama-3.2-1B x5 quants, Llama-3.2-3B, Llama-3.1-8B, Mistral-7B-Instruct-v0.2, Phi-4-mini, Qwen1.5-MoE, Qwen2.5-1.5B, Yi-1.5-6B, bge-small, gemma-2-2b, gemma-4-E2B, ms-marco-MiniLM, olmoe-1b-7b, tinyllama-1.1b: **MATCH (21 cases x 2 parse_special settings)** on every one.

Against the Homebrew 7650 bottle, three checkpoints differ and each is the bottle's vintage, not ferrox: its EOG list predates the `</s>` entry that makes it CONTROL (Qwen2.5, Qwen1.5-MoE, DeepSeek-R1-Distill under `parse_special=true`; gemma-2 under `false`), its BERT normalizer is the one `tools/build_llama_logits.sh` already documents (bge, ms-marco `emoji`, also red on main), and it cannot load gemma-4. Same finding as issue #111: the reference's vintage is part of the result.

## Gates

`cargo test --workspace` 3009 passed; clippy `-D warnings` clean in debug and release; `cargo fmt --all` clean. Nine new tests, each sabotaged once with the mutation grep-confirmed in the file and the test seen red: the `AsText` gate (3 tests red across special/wordpiece/kimi), the EOG-by-name promotion, NORMAL-typed entries, both family demotions, longest-first ordering, the FXTK v2 version check, the id-count bound, the corpus marker claims, and the `/v1/tokenize` default.

Docs: `docs/CLI.md` (the imatrix passage now records the cause; the "ferrox has no mode that does not parse" deviation is gone) and `docs/API.md` (`parse_special: false` is supported).

