### PR TITLE
perf(metal): #149's host share was mostly an untimed second command buffer; encoding is ~2% and the binding lever is retired unbuilt

### DIFF
--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -127,13 +127,47 @@ Gemma-2's dispatches are 7% of its host cost. The host lever is
 pipelining encode against execution; fusion is a GPU-side lever worth
 ~22% of GPU time.
 
+**2026-09-11: the table above is wrong, and the reason is worth more
+than the correction.** "GPU ms/tok" was the GPU time of ONE command
+buffer per token. A sampled decode token has TWO: the dense stack, and
+the lm_head in `launch_matvec_fused`, which had no timing tag. Its GPU
+time was therefore booked as host time. `FERROX_METAL_GPU_TIMING=1` now
+clocks every submission's encode phase, GPU phase and submit latency,
+and tags the lm_head. Per token, window means from one process (GPU
+columns load-immune; the host was not quiet, so the wall-derived ones
+are upper bounds):
+
+| Model | stack GPU | lm_head GPU | encode (both) | submit latency (both) | CPU between |
+|---|---:|---:|---:|---:|---:|
+| Llama-3.2-1B Q4_K_M | 4.97-5.08 | **1.17-1.28** | 0.15-0.24 | 0.41-0.46 | ~0.06 |
+| Gemma-2-2B Q4_K_M | 12.03-12.44 | **2.78-2.91** | 0.42-0.45 | 0.81-0.88 | ~0.89 |
+
+So the "host" share was mostly the lm_head running on the GPU, and the
+part that IS the host divides three ways. **Encoding**, all ~2400
+argument-binding calls and ~420 dispatches and barriers, is **0.15-0.24 ms
+on Llama-3.2-1B and 0.42-0.45 ms on Gemma-2-2B, 2-3% of wall** -- the
+third independent measurement to say so, after the 0.61 µs injection
+slope (515 × 0.61 = 0.31 ms) and #156's removal of 48 ops for 0.04 ms.
+Argument packing and encode/execute pipelining are each bounded by that
+number, so neither was built. **Submit latency**, commit-to-GPU-start
+plus completion-to-wakeup, is ~0.2 ms per command buffer and there are
+two per token; folding the lm_head into the stack's buffer for sampled
+decode (the greedy fold already does) is the one host lever left, worth
+at most ~0.25 ms, 4% on the 1B. **CPU work between buffers** is Gemma's
+`final_logit_softcap`: a scalar `tanh` over 256k logits, 0.65 ms, more
+than that model's whole encode phase.
+
+And the GPU column changes the ranking: Gemma-2-2B's GPU time alone,
+12.03 + 2.78 = 14.8 ms, already exceeds llama.cpp's 14.74 ms token. The
+worst Metal row is a kernel gap after all, not a host one.
+
 ## Open
 
 | Issue | Gap | What is known |
 |---|---|---|
 | [#133](https://github.com/antonellof/ferrox/issues/133) | CUDA prefill, 22× to 34× | ~4× is tensor cores (`mul_mm` has none), ~5× is undiagnosed kernel efficiency. #148 bought 20–26% and ruled out dequant redundancy and occupancy |
 | [#133](https://github.com/antonellof/ferrox/issues/133) | CUDA decode, 2.2× to 5.0× | memory-bound: 17–22% of card bandwidth against llama.cpp's ~60%. Coalescing closed 9–19× to 2–5×. What limits the rest is not diagnosed — the access pattern was a real cost and was not the last one |
-| [#149](https://github.com/antonellof/ferrox/issues/149) | Metal decode, 1.11× worst row | kernels already beat llama.cpp's whole token, and the cost is host-side. [#156](https://github.com/antonellof/ferrox/pull/156) removed 13% of dispatches and 9% of barriers for **2.3%** of host time, so the count is not the lever and the hypothesis that it was is retired. Barriers were already hazard-driven. What is left is per-dispatch argument binding: ~2400 encoder calls per token against 418 dispatches and barriers |
+| [#149](https://github.com/antonellof/ferrox/issues/149) | Metal decode, 1.11× worst row | the "26% host" was an accounting error: the lm_head runs in a second, untimed command buffer, and its GPU time was booked as host. Encoding, argument binding included, is ~2% of wall (three measurements agree), so packing and pipelining are retired unbuilt. What is left on the host is ~0.2 ms of submit latency per command buffer (two per sampled token) and Gemma's 0.65 ms CPU softcap. Gemma-2's GPU time alone already exceeds llama.cpp's token, so the row is a kernel gap |
 | [#127](https://github.com/antonellof/ferrox/issues/127) | x86 CPU prefill, 6.3× to 10.1× | was a missing kernel tier. [#159](https://github.com/antonellof/ferrox/pull/159) added AVX2 GEMMs for all five interleaved kinds and a per-workload dispatch rule, verified by execution on real AVX2 but **not yet benchmarked**, so this gap number still describes the code before it |
 | [#27](https://github.com/antonellof/ferrox/issues/27) | CPU decode default | the size rule landed in [#155](https://github.com/antonellof/ferrox/pull/155); the crossover constant is bracketed by the published numbers, not swept, and no before/after on a quiet host has been run. `MIN_TASK_MACS` is still there, which the issue asks to delete |
 | [#128](https://github.com/antonellof/ferrox/issues/128) | CPU decode dispatch, **closed** | The condvar wait was real and the cause was rayon's two-armed `join`: from a non-worker thread it injects and blocks on a mutex, ~150 times per token. [#167](https://github.com/antonellof/ferrox/pull/167) runs a whole forward in one `rayon::scope`. Note the trap: #128 had computed scheduling at 6.7% of a token and ruled it out, against a **stale denominator** taken before #155 removed the repack that inflated the token to 17 ms. At ~5 ms the same fixed cost is a much larger share |

--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -5478,7 +5478,7 @@ pub fn launch_moe_decode_stack(
         encoder.endEncoding();
         cmd_buf.commit();
         cmd_buf.waitUntilCompleted();
-        crate::gpu::gpu_timing_note(&cmd_buf, "moe-decode/tok", 32);
+        crate::timing::gpu_timing_note(&cmd_buf, "moe-decode/tok", 32);
 
         for kv in kvs.iter_mut() {
             kv.seq_len = pos + 1;
@@ -6369,7 +6369,7 @@ pub fn launch_prefill_dense_stack(
     cmd_buf.commit();
     cmd_buf.waitUntilCompleted();
     let gpu_us = t_gpu.elapsed().as_micros();
-    crate::gpu::gpu_timing_note(&cmd_buf, "prefill-dense-stack", 1);
+    crate::timing::gpu_timing_note(&cmd_buf, "prefill-dense-stack", 1);
 
     for kv in kvs.iter_mut() {
         kv.seq_len += batch;
@@ -6381,7 +6381,7 @@ pub fn launch_prefill_dense_stack(
         std::slice::from_raw_parts(out_ptr.as_ptr() as *const f32, batch * hidden_dim).to_vec()
     };
     if timing {
-        crate::gpu::mm_timing_add(setup_us, gpu_us, t_read.elapsed().as_micros());
+        crate::timing::mm_timing_add(setup_us, gpu_us, t_read.elapsed().as_micros());
     }
     Ok(out)
 }
@@ -6895,7 +6895,7 @@ mod tests {
     #[test]
     fn metal_mm_timing_env_is_optional() {
         // Documented hook for [`launch_prefill_dense_layer`]: when set, setup/gpu/readback
-        // microseconds accumulate via [`crate::gpu::mm_timing_add`].
+        // microseconds accumulate via [`crate::timing::mm_timing_add`].
         let enabled = std::env::var_os("FERROX_METAL_MM_TIMING").is_some();
         let _ = enabled;
     }

--- a/crates/ferrox-metal/src/attn.rs
+++ b/crates/ferrox-metal/src/attn.rs
@@ -5369,6 +5369,7 @@ pub fn launch_moe_decode_stack(
             moe_scratch_ensure_logits(device, scratch, out_l.rows)?;
         }
 
+        let clock = crate::timing::SubmitClock::start();
         let cmd_buf = queue.commandBuffer().ok_or(MetalError::CommandFailed)?;
         // llama.cpp / dense-stack: one Concurrent encoder for the full graph,
         // barriers only via MemRanges (ggml_mem_ranges).
@@ -5476,9 +5477,7 @@ pub fn launch_moe_decode_stack(
         };
 
         encoder.endEncoding();
-        cmd_buf.commit();
-        cmd_buf.waitUntilCompleted();
-        crate::timing::gpu_timing_note(&cmd_buf, "moe-decode/tok", 32);
+        crate::timing::commit_wait_note(&cmd_buf, "moe-decode/tok", 32, clock);
 
         for kv in kvs.iter_mut() {
             kv.seq_len = pos + 1;
@@ -6331,6 +6330,7 @@ pub fn launch_prefill_dense_stack(
     }
 
     let setup_us = t_setup.elapsed().as_micros();
+    let clock = crate::timing::SubmitClock::start();
     let cmd_buf = queue.commandBuffer().ok_or(MetalError::CommandFailed)?;
     let encoder = compute_encoder_concurrent(&cmd_buf)?;
     // One tracker for the whole stack: layer N+1's first dispatch only
@@ -6365,11 +6365,8 @@ pub fn launch_prefill_dense_stack(
     }
 
     encoder.endEncoding();
-    let t_gpu = std::time::Instant::now();
-    cmd_buf.commit();
-    cmd_buf.waitUntilCompleted();
-    let gpu_us = t_gpu.elapsed().as_micros();
-    crate::timing::gpu_timing_note(&cmd_buf, "prefill-dense-stack", 1);
+    let gpu_us =
+        crate::timing::commit_wait_note(&cmd_buf, "prefill-dense-stack", 1, clock).as_micros();
 
     for kv in kvs.iter_mut() {
         kv.seq_len += batch;

--- a/crates/ferrox-metal/src/decode_dense.rs
+++ b/crates/ferrox-metal/src/decode_dense.rs
@@ -22,8 +22,9 @@ use crate::gpu::{
     shared_metal, MatvecLaunch, MetalError,
 };
 use crate::mem_ranges::MemRanges;
+use crate::timing::{commit_wait_note, SubmitClock};
 use objc2::runtime::ProtocolObject;
-use objc2_metal::{MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue};
+use objc2_metal::{MTLBuffer, MTLCommandEncoder, MTLCommandQueue};
 
 /// Optional attention epilogue ops applied between the QKV matvecs and
 /// RoPE, in CPU-path order: bias add (Qwen2-family `qkv_bias`), then
@@ -217,6 +218,7 @@ pub fn launch_decode_dense_stack(
         })
         .collect::<Result<Vec<_>, MetalError>>()?;
 
+    let clock = SubmitClock::start();
     let cmd_buf = queue.commandBuffer().ok_or(MetalError::CommandFailed)?;
     // Gemma-style post-norms ("sandwich"): these layers take the EAGER
     // residual path below, which is what makes concurrent encode safe here.
@@ -576,9 +578,7 @@ pub fn launch_decode_dense_stack(
     };
 
     encoder.endEncoding();
-    cmd_buf.commit();
-    cmd_buf.waitUntilCompleted();
-    crate::timing::gpu_timing_note(&cmd_buf, "dense-decode/tok", 32);
+    commit_wait_note(&cmd_buf, "dense-decode/tok", 32, clock);
 
     for kv in kvs.iter_mut() {
         kv.seq_len = pos + 1;

--- a/crates/ferrox-metal/src/decode_dense.rs
+++ b/crates/ferrox-metal/src/decode_dense.rs
@@ -5,7 +5,7 @@
 //! host-side cost of encoding this stack is the whole remaining Metal
 //! decode gap, so the encode loop needs to live somewhere it can be read
 //! and changed in full. Per-token GPU/host accounting is in
-//! `crate::gpu::gpu_timing_note` and `crate::mem_ranges`.
+//! `crate::timing::gpu_timing_note` and `crate::mem_ranges`.
 
 use crate::attn::{
     assert_freq_factors_len, borrow_decode_scratch, copy_f32_into, encode_attn_extras,
@@ -578,7 +578,7 @@ pub fn launch_decode_dense_stack(
     encoder.endEncoding();
     cmd_buf.commit();
     cmd_buf.waitUntilCompleted();
-    crate::gpu::gpu_timing_note(&cmd_buf, "dense-decode/tok", 32);
+    crate::timing::gpu_timing_note(&cmd_buf, "dense-decode/tok", 32);
 
     for kv in kvs.iter_mut() {
         kv.seq_len = pos + 1;

--- a/crates/ferrox-metal/src/dispatch.rs
+++ b/crates/ferrox-metal/src/dispatch.rs
@@ -109,6 +109,7 @@ mod tests {
             ("lib.rs", include_str!("lib.rs")),
             ("mem_ranges.rs", include_str!("mem_ranges.rs")),
             ("moe_ids.rs", include_str!("moe_ids.rs")),
+            ("timing.rs", include_str!("timing.rs")),
         ];
         // This file holds the wrapper (the one legitimate caller of the
         // raw dispatch method) and the patterns this test searches for,

--- a/crates/ferrox-metal/src/dispatch.rs
+++ b/crates/ferrox-metal/src/dispatch.rs
@@ -1,12 +1,17 @@
 //! The one place this crate encodes a compute dispatch, and the counters
 //! that measure what a decode token costs the host.
 //!
-//! GitHub issue #149 measured that ferrox's Metal kernels already finish
-//! faster than llama.cpp's whole token, and that 26-29% of decode wall
-//! time is host-side command encoding: `dispatchThreadgroups`,
-//! `emitComputeProgramVariantAndArguments`, `memoryBarrierWithResources`.
-//! The lever is FEWER ENCODED DISPATCHES AND FEWER BARRIERS per token,
-//! which is only actionable if both are counted.
+//! GitHub issue #149 measured that 26-29% of Metal decode wall time was
+//! not GPU time, and read that as host-side command encoding:
+//! `dispatchThreadgroups`, `emitComputeProgramVariantAndArguments`,
+//! `memoryBarrierWithResources`. Counting was the first step, and the
+//! count retired that reading in two stages: PR #156 removed 13% of the
+//! dispatches for 2.3% of the host time, and `crate::timing` then
+//! clocked the encode phase directly at 0.15 ms per token on
+//! Llama-3.2-1B and 0.4 ms on Gemma-2-2B, about 2% of wall. Most of
+//! the 26% was a second, untimed command buffer executing on the GPU.
+//! The counters stay because a claim about encode work still needs
+//! them to be checked.
 //!
 //! So every `dispatchThreadgroups_threadsPerThreadgroup` in the crate
 //! goes through [`dispatch_counted`], and every barrier through

--- a/crates/ferrox-metal/src/gpu.rs
+++ b/crates/ferrox-metal/src/gpu.rs
@@ -54,6 +54,7 @@
 use crate::dispatch::dispatch_counted;
 use crate::moe_ids::IdsBinding;
 use crate::resident_cache::{get_or_build, HostKey, Resident};
+use crate::timing::mm_timing_add;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSString;
@@ -4423,119 +4424,6 @@ fn launch_k_quant_mul_mm_sg(
         mm_timing_add(setup_us, gpu_us, t_read.elapsed().as_micros());
     }
     Ok(out)
-}
-
-use std::sync::atomic::{AtomicU64, Ordering as AtomOrd};
-static MM_SETUP_US: AtomicU64 = AtomicU64::new(0);
-static MM_GPU_US: AtomicU64 = AtomicU64::new(0);
-static MM_READ_US: AtomicU64 = AtomicU64::new(0);
-static MM_CALLS: AtomicU64 = AtomicU64::new(0);
-
-/// Accumulate into the `FERROX_METAL_MM_TIMING` counters (prefill evidence).
-pub(crate) fn mm_timing_add(setup: u128, gpu: u128, read: u128) {
-    MM_SETUP_US.fetch_add(setup as u64, AtomOrd::Relaxed);
-    MM_GPU_US.fetch_add(gpu as u64, AtomOrd::Relaxed);
-    MM_READ_US.fetch_add(read as u64, AtomOrd::Relaxed);
-    let n = MM_CALLS.fetch_add(1, AtomOrd::Relaxed) + 1;
-    // First call + every 224: stack prefill is often one timed launch.
-    if n == 1 || n.is_multiple_of(224) {
-        eprintln!(
-            "ferrox: mul_mm {n} calls -- setup {:.1} ms, gpu {:.1} ms, readback {:.1} ms",
-            MM_SETUP_US.load(AtomOrd::Relaxed) as f64 / 1000.0,
-            MM_GPU_US.load(AtomOrd::Relaxed) as f64 / 1000.0,
-            MM_READ_US.load(AtomOrd::Relaxed) as f64 / 1000.0,
-        );
-    }
-}
-
-/// GPU-clock accumulators for `FERROX_METAL_GPU_TIMING`, keyed by tag.
-///
-/// Wall-clock (`FERROX_METAL_MM_TIMING`) measures how long the host waited,
-/// which on a loaded host is mostly scheduler noise. `MTLCommandBuffer`'s
-/// `GPUStartTime`/`GPUEndTime` measure the command buffer's own occupancy
-/// and stay usable while the machine is busy, so A/B evidence in
-/// `docs/plans/llama-cpp-parity-push.md` is taken from these.
-static GPU_TIMING: std::sync::Mutex<Vec<TimingSlot>> = std::sync::Mutex::new(Vec::new());
-
-/// One tag's running GPU-time total, plus what the host encoded to
-/// produce it.
-///
-/// The encode counters in [`crate::dispatch`] are process-wide, so a
-/// per-submission figure has to come from the DELTA between consecutive
-/// submissions of the same tag rather than from a total divided by a
-/// count -- otherwise a prefill's dispatches land in the decode average.
-/// GitHub issue #149 is about the host cost of encoding, so this number
-/// belongs next to the GPU time it bought, not in a separate readout
-/// somebody has to line up by hand.
-struct TimingSlot {
-    tag: &'static str,
-    n: u64,
-    acc_ns: u64,
-    /// Counter snapshot at the previous submission under this tag.
-    prev: crate::dispatch::EncodeStats,
-    /// Encode work attributed to this tag, summed over `n` submissions.
-    acc_dispatches: u64,
-    acc_barriers: u64,
-    acc_begin_ops: u64,
-}
-
-/// True when `FERROX_METAL_GPU_TIMING` is set (cached; read once).
-pub(crate) fn gpu_timing_enabled() -> bool {
-    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ON.get_or_init(|| std::env::var_os("FERROX_METAL_GPU_TIMING").is_some())
-}
-
-/// Accumulate one command buffer's GPU-side duration under `tag` and log a
-/// running mean every `every` submissions. No-op unless timing is enabled.
-pub(crate) fn gpu_timing_note(
-    cmd_buf: &ProtocolObject<dyn MTLCommandBuffer>,
-    tag: &'static str,
-    every: u64,
-) {
-    if !gpu_timing_enabled() {
-        return;
-    }
-    let dt_ns = ((cmd_buf.GPUEndTime() - cmd_buf.GPUStartTime()) * 1e9).max(0.0) as u64;
-    let now = crate::dispatch::metal_encode_stats();
-    let Ok(mut slots) = GPU_TIMING.lock() else {
-        return;
-    };
-    let slot = match slots.iter_mut().find(|s| s.tag == tag) {
-        Some(s) => s,
-        None => {
-            slots.push(TimingSlot {
-                tag,
-                n: 0,
-                acc_ns: 0,
-                prev: now,
-                acc_dispatches: 0,
-                acc_barriers: 0,
-                acc_begin_ops: 0,
-            });
-            slots.last_mut().expect("just pushed")
-        }
-    };
-    slot.n += 1;
-    slot.acc_ns += dt_ns;
-    slot.acc_dispatches += now.dispatches.saturating_sub(slot.prev.dispatches);
-    slot.acc_barriers += now.barriers.saturating_sub(slot.prev.barriers);
-    slot.acc_begin_ops += now.begin_ops.saturating_sub(slot.prev.begin_ops);
-    slot.prev = now;
-    let n = slot.n;
-    if n.is_multiple_of(every.max(1)) {
-        let per = |acc: u64| acc as f64 / n as f64;
-        eprintln!(
-            "ferrox: metal gpu[{tag}] {:.3} ms avg over {n} (last {:.3} ms); \
-             encode/submission: {:.1} dispatches, {:.1} barriers, \
-             {:.1} hazard checks ({:.2} bar/op)",
-            (slot.acc_ns as f64 / n as f64) / 1e6,
-            dt_ns as f64 / 1e6,
-            per(slot.acc_dispatches),
-            per(slot.acc_barriers),
-            per(slot.acc_begin_ops),
-            slot.acc_barriers as f64 / slot.acc_begin_ops.max(1) as f64,
-        );
-    }
 }
 
 /// Launches Q4_K multi-activation matmul (see [`Q4_K_MUL_MM_KERNEL_SRC`]).

--- a/crates/ferrox-metal/src/gpu.rs
+++ b/crates/ferrox-metal/src/gpu.rs
@@ -5458,6 +5458,7 @@ pub fn launch_matvec_fused(
     // Reuses the dense stack's own `x` buffer when `x` IS the vector
     // that stack just returned, and uploads otherwise. One helper, not
     // one copy per consumer: see `crate::resident_act`.
+    let clock = crate::timing::SubmitClock::start();
     let x_buf = crate::resident_act::upload_or_reuse(device, x)?;
 
     let mut weight_bufs = Vec::with_capacity(launches.len());
@@ -5489,8 +5490,10 @@ pub fn launch_matvec_fused(
         )?;
     }
     encoder.endEncoding();
-    cmd_buf.commit();
-    cmd_buf.waitUntilCompleted();
+    // The lm_head of every sampled (non-greedy) decode token runs here,
+    // in a SECOND command buffer after the dense stack. Untimed, its GPU
+    // time read as host time (GitHub issue #149).
+    crate::timing::commit_wait_note(&cmd_buf, "matvec-fused", 32, clock);
 
     let mut outs = Vec::with_capacity(launches.len());
     for (i, launch) in launches.iter().enumerate() {

--- a/crates/ferrox-metal/src/lib.rs
+++ b/crates/ferrox-metal/src/lib.rs
@@ -39,6 +39,9 @@ mod dispatch;
 mod mem_ranges;
 
 #[cfg(feature = "metal")]
+pub(crate) mod timing;
+
+#[cfg(feature = "metal")]
 mod moe_ids;
 
 #[cfg(feature = "metal")]

--- a/crates/ferrox-metal/src/timing.rs
+++ b/crates/ferrox-metal/src/timing.rs
@@ -6,15 +6,18 @@
 //! - `FERROX_METAL_MM_TIMING`: prefill GEMM wall-clock totals
 //!   (setup / GPU wait / readback), see [`mm_timing_add`].
 //! - `FERROX_METAL_GPU_TIMING`: per-tag GPU-clock time of each command
-//!   buffer beside the encode work that bought it, see
-//!   [`gpu_timing_note`].
+//!   buffer, the host's encode time and submit latency around it, and
+//!   the encode work that bought it, see [`commit_wait_note`].
 //!
-//! Moved out of `gpu.rs` unchanged along the seam GitHub issue #149
-//! touches.
+//! Moved out of `gpu.rs` along the seam GitHub issue #149 touches, and
+//! then given the two host phases it lacked, because lacking them is
+//! what let that issue mistake a second command buffer's GPU time for
+//! host time.
 
 use objc2::runtime::ProtocolObject;
 use objc2_metal::MTLCommandBuffer;
 use std::sync::atomic::{AtomicU64, Ordering as AtomOrd};
+use std::time::{Duration, Instant};
 static MM_SETUP_US: AtomicU64 = AtomicU64::new(0);
 static MM_GPU_US: AtomicU64 = AtomicU64::new(0);
 static MM_READ_US: AtomicU64 = AtomicU64::new(0);
@@ -37,35 +40,223 @@ pub(crate) fn mm_timing_add(setup: u128, gpu: u128, read: u128) {
     }
 }
 
-/// GPU-clock accumulators for `FERROX_METAL_GPU_TIMING`, keyed by tag.
+/// Per-tag accumulators for `FERROX_METAL_GPU_TIMING`.
 ///
 /// Wall-clock (`FERROX_METAL_MM_TIMING`) measures how long the host waited,
 /// which on a loaded host is mostly scheduler noise. `MTLCommandBuffer`'s
 /// `GPUStartTime`/`GPUEndTime` measure the command buffer's own occupancy
 /// and stay usable while the machine is busy, so A/B evidence in
 /// `docs/plans/llama-cpp-parity-push.md` is taken from these.
-static GPU_TIMING: std::sync::Mutex<Vec<TimingSlot>> = std::sync::Mutex::new(Vec::new());
+///
+/// GPU time alone was how GitHub issue #149 mis-read its own numbers:
+/// "host = wall minus GPU" charged to the host everything that was not
+/// the ONE timed command buffer, including a second, untimed one (the
+/// lm_head, `launch_matvec_fused`) that runs on the GPU for 1.2 ms per
+/// token on Llama-3.2-1B and 2.8 ms on Gemma-2-2B. So every submission
+/// now reports three phases from the same clock, and a phase that is
+/// not measured is not attributed to anything:
+///
+/// - **encode**: from [`SubmitClock::start`] to `commit`, the host
+///   building the command buffer;
+/// - **gpu**: `GPUEndTime - GPUStartTime`, the GPU executing it;
+/// - **latency**: the wall time from `commit` to `waitUntilCompleted`
+///   returning, MINUS the GPU time -- submit-to-start plus
+///   end-to-wakeup, the part no lever on encoding can touch.
+static GPU_TIMING: std::sync::Mutex<Ledger> = std::sync::Mutex::new(Ledger::new());
 
-/// One tag's running GPU-time total, plus what the host encoded to
-/// produce it.
+/// Every tag's slot, plus the encode-counter snapshot at the last noted
+/// submission OF ANY TAG.
 ///
 /// The encode counters in [`crate::dispatch`] are process-wide, so a
-/// per-submission figure has to come from the DELTA between consecutive
-/// submissions of the same tag rather than from a total divided by a
-/// count -- otherwise a prefill's dispatches land in the decode average.
-/// GitHub issue #149 is about the host cost of encoding, so this number
-/// belongs next to the GPU time it bought, not in a separate readout
-/// somebody has to line up by hand.
+/// per-submission figure has to come from a DELTA. The delta used to be
+/// taken per tag, between consecutive submissions of the same tag, and
+/// that is wrong as soon as two tags alternate: the dense stack and its
+/// lm_head run once each per token, so the lm_head's line reported the
+/// stack's 210 dispatches as its own. One snapshot for the whole ledger
+/// attributes each dispatch to the next submission noted after it.
+struct Ledger {
+    slots: Vec<TimingSlot>,
+    prev: crate::dispatch::EncodeStats,
+}
+
+impl Ledger {
+    const fn new() -> Self {
+        Self {
+            slots: Vec::new(),
+            prev: crate::dispatch::EncodeStats {
+                dispatches: 0,
+                barriers: 0,
+                begin_ops: 0,
+            },
+        }
+    }
+
+    /// Account one submission and, every `every` submissions under its
+    /// tag, return the figures to print.
+    fn note(&mut self, tag: &'static str, sample: Sample, every: u64) -> Option<Report> {
+        let now = sample.encode_stats;
+        let delta = crate::dispatch::EncodeStats {
+            dispatches: now.dispatches.saturating_sub(self.prev.dispatches),
+            barriers: now.barriers.saturating_sub(self.prev.barriers),
+            begin_ops: now.begin_ops.saturating_sub(self.prev.begin_ops),
+        };
+        self.prev = now;
+        let slot = match self.slots.iter_mut().position(|s| s.tag == tag) {
+            Some(i) => &mut self.slots[i],
+            None => {
+                self.slots.push(TimingSlot::new(tag));
+                self.slots.last_mut().expect("just pushed")
+            }
+        };
+        slot.record(sample, delta);
+        if slot.n.is_multiple_of(every.max(1)) {
+            Some(slot.report())
+        } else {
+            None
+        }
+    }
+}
+
+/// One submission's three phases plus the counters at its completion.
+#[derive(Clone, Copy)]
+struct Sample {
+    gpu_ns: u64,
+    encode_ns: u64,
+    wait_ns: u64,
+    encode_stats: crate::dispatch::EncodeStats,
+}
+
+/// One tag's running totals, plus what the host encoded to produce them.
 struct TimingSlot {
     tag: &'static str,
     n: u64,
-    acc_ns: u64,
-    /// Counter snapshot at the previous submission under this tag.
-    prev: crate::dispatch::EncodeStats,
+    /// GPU-clock nanoseconds.
+    acc_gpu_ns: u64,
+    /// Host wall nanoseconds from encode start to commit.
+    acc_encode_ns: u64,
+    /// Host wall nanoseconds from commit to the wait returning.
+    acc_wait_ns: u64,
+    /// The same three, over the submissions since the last report only.
+    /// A cumulative mean over a decode run carries every priming token
+    /// and every cold buffer in it; the steady state is the window.
+    win_gpu_ns: u64,
+    win_encode_ns: u64,
+    win_wait_ns: u64,
+    win_n: u64,
+    /// GPU nanoseconds of the most recent submission.
+    last_gpu_ns: u64,
     /// Encode work attributed to this tag, summed over `n` submissions.
     acc_dispatches: u64,
     acc_barriers: u64,
     acc_begin_ops: u64,
+}
+
+/// The per-submission means a report line prints, in milliseconds.
+#[derive(Debug, Clone, PartialEq)]
+struct Report {
+    tag: &'static str,
+    n: u64,
+    gpu_ms: f64,
+    last_gpu_ms: f64,
+    encode_ms: f64,
+    latency_ms: f64,
+    win_n: u64,
+    win_gpu_ms: f64,
+    win_encode_ms: f64,
+    win_latency_ms: f64,
+    dispatches: f64,
+    barriers: f64,
+    begin_ops: f64,
+}
+
+impl TimingSlot {
+    fn new(tag: &'static str) -> Self {
+        Self {
+            tag,
+            n: 0,
+            acc_gpu_ns: 0,
+            acc_encode_ns: 0,
+            acc_wait_ns: 0,
+            win_gpu_ns: 0,
+            win_encode_ns: 0,
+            win_wait_ns: 0,
+            win_n: 0,
+            last_gpu_ns: 0,
+            acc_dispatches: 0,
+            acc_barriers: 0,
+            acc_begin_ops: 0,
+        }
+    }
+
+    fn record(&mut self, s: Sample, delta: crate::dispatch::EncodeStats) {
+        self.n += 1;
+        self.acc_gpu_ns += s.gpu_ns;
+        self.acc_encode_ns += s.encode_ns;
+        self.acc_wait_ns += s.wait_ns;
+        self.win_gpu_ns += s.gpu_ns;
+        self.win_encode_ns += s.encode_ns;
+        self.win_wait_ns += s.wait_ns;
+        self.win_n += 1;
+        self.acc_dispatches += delta.dispatches;
+        self.acc_barriers += delta.barriers;
+        self.acc_begin_ops += delta.begin_ops;
+        self.last_gpu_ns = s.gpu_ns;
+    }
+
+    /// The report for the state so far. Resets the window.
+    fn report(&mut self) -> Report {
+        let n = self.n.max(1);
+        let per = |acc: u64| acc as f64 / n as f64;
+        let ms = |acc: u64| per(acc) / 1e6;
+        let win_n = self.win_n.max(1);
+        let win_ms = |acc: u64| acc as f64 / win_n as f64 / 1e6;
+        let r = Report {
+            tag: self.tag,
+            n: self.n,
+            gpu_ms: ms(self.acc_gpu_ns),
+            last_gpu_ms: self.last_gpu_ns as f64 / 1e6,
+            encode_ms: ms(self.acc_encode_ns),
+            latency_ms: (ms(self.acc_wait_ns) - ms(self.acc_gpu_ns)).max(0.0),
+            win_n: self.win_n,
+            win_gpu_ms: win_ms(self.win_gpu_ns),
+            win_encode_ms: win_ms(self.win_encode_ns),
+            win_latency_ms: (win_ms(self.win_wait_ns) - win_ms(self.win_gpu_ns)).max(0.0),
+            dispatches: per(self.acc_dispatches),
+            barriers: per(self.acc_barriers),
+            begin_ops: per(self.acc_begin_ops),
+        };
+        self.win_gpu_ns = 0;
+        self.win_encode_ns = 0;
+        self.win_wait_ns = 0;
+        self.win_n = 0;
+        r
+    }
+}
+
+impl Report {
+    fn print(&self) {
+        eprintln!(
+            "ferrox: metal gpu[{}] {:.3} ms avg over {} (last {:.3} ms); \
+             host/submission: encode {:.3} ms, latency beyond gpu {:.3} ms; \
+             last {}: gpu {:.3} ms, encode {:.3} ms, latency {:.3} ms; \
+             encode/submission: {:.1} dispatches, {:.1} barriers, \
+             {:.1} hazard checks ({:.2} bar/op)",
+            self.tag,
+            self.gpu_ms,
+            self.n,
+            self.last_gpu_ms,
+            self.encode_ms,
+            self.latency_ms,
+            self.win_n,
+            self.win_gpu_ms,
+            self.win_encode_ms,
+            self.win_latency_ms,
+            self.dispatches,
+            self.barriers,
+            self.begin_ops,
+            self.barriers / self.begin_ops.max(f64::MIN_POSITIVE),
+        );
+    }
 }
 
 /// True when `FERROX_METAL_GPU_TIMING` is set (cached; read once).
@@ -74,55 +265,161 @@ pub(crate) fn gpu_timing_enabled() -> bool {
     *ON.get_or_init(|| std::env::var_os("FERROX_METAL_GPU_TIMING").is_some())
 }
 
-/// Accumulate one command buffer's GPU-side duration under `tag` and log a
-/// running mean every `every` submissions. No-op unless timing is enabled.
-pub(crate) fn gpu_timing_note(
+/// The host-side clock of one command buffer, started before its first
+/// encode call. Consumed by [`commit_wait_note`], which is the only way
+/// to finish it: a submission cannot be timed with the encode phase
+/// left out, because leaving it out is how the phase was mis-attributed.
+#[must_use = "a SubmitClock that is not passed to commit_wait_note times nothing"]
+pub(crate) struct SubmitClock {
+    encode_start: Instant,
+}
+
+impl SubmitClock {
+    pub(crate) fn start() -> Self {
+        Self {
+            encode_start: Instant::now(),
+        }
+    }
+}
+
+/// Commit `cmd_buf`, wait for it, and account its three phases under
+/// `tag`, logging a running mean every `every` submissions. Returns how
+/// long the host waited (commit to completion), for callers that keep a
+/// wall-clock total of their own.
+pub(crate) fn commit_wait_note(
     cmd_buf: &ProtocolObject<dyn MTLCommandBuffer>,
     tag: &'static str,
     every: u64,
-) {
+    clock: SubmitClock,
+) -> Duration {
+    let committed = Instant::now();
+    cmd_buf.commit();
+    cmd_buf.waitUntilCompleted();
+    let waited = committed.elapsed();
     if !gpu_timing_enabled() {
-        return;
+        return waited;
     }
-    let dt_ns = ((cmd_buf.GPUEndTime() - cmd_buf.GPUStartTime()) * 1e9).max(0.0) as u64;
-    let now = crate::dispatch::metal_encode_stats();
-    let Ok(mut slots) = GPU_TIMING.lock() else {
-        return;
+    let sample = Sample {
+        gpu_ns: ((cmd_buf.GPUEndTime() - cmd_buf.GPUStartTime()) * 1e9).max(0.0) as u64,
+        encode_ns: committed.duration_since(clock.encode_start).as_nanos() as u64,
+        wait_ns: waited.as_nanos() as u64,
+        encode_stats: crate::dispatch::metal_encode_stats(),
     };
-    let slot = match slots.iter_mut().find(|s| s.tag == tag) {
-        Some(s) => s,
-        None => {
-            slots.push(TimingSlot {
-                tag,
-                n: 0,
-                acc_ns: 0,
-                prev: now,
-                acc_dispatches: 0,
-                acc_barriers: 0,
-                acc_begin_ops: 0,
-            });
-            slots.last_mut().expect("just pushed")
+    let report = match GPU_TIMING.lock() {
+        Ok(mut ledger) => ledger.note(tag, sample, every),
+        Err(_) => None,
+    };
+    if let Some(r) = report {
+        r.print();
+    }
+    waited
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::EncodeStats;
+
+    fn stats(dispatches: u64, barriers: u64) -> EncodeStats {
+        EncodeStats {
+            dispatches,
+            barriers,
+            begin_ops: barriers,
         }
-    };
-    slot.n += 1;
-    slot.acc_ns += dt_ns;
-    slot.acc_dispatches += now.dispatches.saturating_sub(slot.prev.dispatches);
-    slot.acc_barriers += now.barriers.saturating_sub(slot.prev.barriers);
-    slot.acc_begin_ops += now.begin_ops.saturating_sub(slot.prev.begin_ops);
-    slot.prev = now;
-    let n = slot.n;
-    if n.is_multiple_of(every.max(1)) {
-        let per = |acc: u64| acc as f64 / n as f64;
-        eprintln!(
-            "ferrox: metal gpu[{tag}] {:.3} ms avg over {n} (last {:.3} ms); \
-             encode/submission: {:.1} dispatches, {:.1} barriers, \
-             {:.1} hazard checks ({:.2} bar/op)",
-            (slot.acc_ns as f64 / n as f64) / 1e6,
-            dt_ns as f64 / 1e6,
-            per(slot.acc_dispatches),
-            per(slot.acc_barriers),
-            per(slot.acc_begin_ops),
-            slot.acc_barriers as f64 / slot.acc_begin_ops.max(1) as f64,
+    }
+
+    fn sample(gpu_ms: f64, encode_ms: f64, wait_ms: f64, s: EncodeStats) -> Sample {
+        Sample {
+            gpu_ns: (gpu_ms * 1e6) as u64,
+            encode_ns: (encode_ms * 1e6) as u64,
+            wait_ns: (wait_ms * 1e6) as u64,
+            encode_stats: s,
+        }
+    }
+
+    /// Two command buffers per token, one tag each. The lm_head's line
+    /// used to report the dense stack's 210 dispatches, because the
+    /// delta was taken between consecutive submissions of the SAME tag
+    /// and the stack ran in between. Each submission gets exactly the
+    /// work encoded since the previous noted submission, whatever its
+    /// tag was.
+    #[test]
+    fn dispatches_are_attributed_to_the_submission_that_encoded_them() {
+        let mut l = Ledger::new();
+        // Counters are process-wide and monotone: 210 for the stack,
+        // then 1 more for the lm_head, per token.
+        let mut d = 0;
+        for _ in 0..3 {
+            d += 210;
+            let _ = l.note("stack", sample(5.0, 0.1, 5.2, stats(d, 160)), 3);
+            d += 1;
+            let _ = l.note("head", sample(1.0, 0.02, 1.2, stats(d, 160)), 3);
+        }
+        let stack = l
+            .slots
+            .iter_mut()
+            .find(|s| s.tag == "stack")
+            .unwrap()
+            .report();
+        let head = l
+            .slots
+            .iter_mut()
+            .find(|s| s.tag == "head")
+            .unwrap()
+            .report();
+        assert_eq!(stack.dispatches, 210.0);
+        assert_eq!(
+            head.dispatches, 1.0,
+            "the head encodes one matvec, not the stack's 210"
         );
+    }
+
+    /// The cumulative mean carries every priming token in it. The window
+    /// is the steady state, so it must start over after each report
+    /// while the cumulative figures keep counting.
+    #[test]
+    fn the_window_resets_at_each_report_and_the_cumulative_mean_does_not() {
+        let mut l = Ledger::new();
+        // A 100 ms cold first submission, then 3 warm ones at 5 ms.
+        assert!(l
+            .note("t", sample(100.0, 10.0, 101.0, stats(1, 1)), 2)
+            .is_none());
+        let first = l.note("t", sample(5.0, 0.1, 5.2, stats(2, 2)), 2).unwrap();
+        assert_eq!(first.win_n, 2);
+        assert!((first.win_gpu_ms - 52.5).abs() < 1e-9);
+        assert!(l.note("t", sample(5.0, 0.1, 5.2, stats(3, 3)), 2).is_none());
+        let second = l.note("t", sample(5.0, 0.1, 5.2, stats(4, 4)), 2).unwrap();
+        assert_eq!(second.n, 4);
+        assert_eq!(
+            second.win_n, 2,
+            "the window holds only the two since the last report"
+        );
+        assert!(
+            (second.win_gpu_ms - 5.0).abs() < 1e-9,
+            "warm steady state, no cold token in it"
+        );
+        assert!(
+            (second.gpu_ms - 28.75).abs() < 1e-9,
+            "cumulative still carries the cold one"
+        );
+        assert!((second.win_encode_ms - 0.1).abs() < 1e-9);
+    }
+
+    /// Latency is what the wait spent beyond the GPU's own occupancy,
+    /// i.e. submit-to-start plus end-to-wakeup. Reported per phase, not
+    /// folded into "host", because folding it in is the mis-attribution
+    /// this module exists to prevent; and never negative, since a wait
+    /// cannot return before the GPU is done.
+    #[test]
+    fn latency_is_the_wait_beyond_gpu_time_and_never_negative() {
+        let mut l = Ledger::new();
+        let r = l.note("t", sample(4.0, 0.15, 4.4, stats(1, 1)), 1).unwrap();
+        assert!((r.latency_ms - 0.4).abs() < 1e-9);
+        assert!((r.win_latency_ms - 0.4).abs() < 1e-9);
+        assert!((r.encode_ms - 0.15).abs() < 1e-9);
+        // A clock skew that puts GPU time above the wait clamps to zero
+        // rather than reporting a negative host cost.
+        let r = l.note("u", sample(4.0, 0.1, 3.9, stats(2, 2)), 1).unwrap();
+        assert_eq!(r.latency_ms, 0.0);
     }
 }

--- a/crates/ferrox-metal/src/timing.rs
+++ b/crates/ferrox-metal/src/timing.rs
@@ -1,0 +1,128 @@
+//! Where a Metal submission's time goes, measured rather than inferred.
+//!
+//! Two instruments, both opt-in by environment variable and both
+//! process-wide:
+//!
+//! - `FERROX_METAL_MM_TIMING`: prefill GEMM wall-clock totals
+//!   (setup / GPU wait / readback), see [`mm_timing_add`].
+//! - `FERROX_METAL_GPU_TIMING`: per-tag GPU-clock time of each command
+//!   buffer beside the encode work that bought it, see
+//!   [`gpu_timing_note`].
+//!
+//! Moved out of `gpu.rs` unchanged along the seam GitHub issue #149
+//! touches.
+
+use objc2::runtime::ProtocolObject;
+use objc2_metal::MTLCommandBuffer;
+use std::sync::atomic::{AtomicU64, Ordering as AtomOrd};
+static MM_SETUP_US: AtomicU64 = AtomicU64::new(0);
+static MM_GPU_US: AtomicU64 = AtomicU64::new(0);
+static MM_READ_US: AtomicU64 = AtomicU64::new(0);
+static MM_CALLS: AtomicU64 = AtomicU64::new(0);
+
+/// Accumulate into the `FERROX_METAL_MM_TIMING` counters (prefill evidence).
+pub(crate) fn mm_timing_add(setup: u128, gpu: u128, read: u128) {
+    MM_SETUP_US.fetch_add(setup as u64, AtomOrd::Relaxed);
+    MM_GPU_US.fetch_add(gpu as u64, AtomOrd::Relaxed);
+    MM_READ_US.fetch_add(read as u64, AtomOrd::Relaxed);
+    let n = MM_CALLS.fetch_add(1, AtomOrd::Relaxed) + 1;
+    // First call + every 224: stack prefill is often one timed launch.
+    if n == 1 || n.is_multiple_of(224) {
+        eprintln!(
+            "ferrox: mul_mm {n} calls -- setup {:.1} ms, gpu {:.1} ms, readback {:.1} ms",
+            MM_SETUP_US.load(AtomOrd::Relaxed) as f64 / 1000.0,
+            MM_GPU_US.load(AtomOrd::Relaxed) as f64 / 1000.0,
+            MM_READ_US.load(AtomOrd::Relaxed) as f64 / 1000.0,
+        );
+    }
+}
+
+/// GPU-clock accumulators for `FERROX_METAL_GPU_TIMING`, keyed by tag.
+///
+/// Wall-clock (`FERROX_METAL_MM_TIMING`) measures how long the host waited,
+/// which on a loaded host is mostly scheduler noise. `MTLCommandBuffer`'s
+/// `GPUStartTime`/`GPUEndTime` measure the command buffer's own occupancy
+/// and stay usable while the machine is busy, so A/B evidence in
+/// `docs/plans/llama-cpp-parity-push.md` is taken from these.
+static GPU_TIMING: std::sync::Mutex<Vec<TimingSlot>> = std::sync::Mutex::new(Vec::new());
+
+/// One tag's running GPU-time total, plus what the host encoded to
+/// produce it.
+///
+/// The encode counters in [`crate::dispatch`] are process-wide, so a
+/// per-submission figure has to come from the DELTA between consecutive
+/// submissions of the same tag rather than from a total divided by a
+/// count -- otherwise a prefill's dispatches land in the decode average.
+/// GitHub issue #149 is about the host cost of encoding, so this number
+/// belongs next to the GPU time it bought, not in a separate readout
+/// somebody has to line up by hand.
+struct TimingSlot {
+    tag: &'static str,
+    n: u64,
+    acc_ns: u64,
+    /// Counter snapshot at the previous submission under this tag.
+    prev: crate::dispatch::EncodeStats,
+    /// Encode work attributed to this tag, summed over `n` submissions.
+    acc_dispatches: u64,
+    acc_barriers: u64,
+    acc_begin_ops: u64,
+}
+
+/// True when `FERROX_METAL_GPU_TIMING` is set (cached; read once).
+pub(crate) fn gpu_timing_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("FERROX_METAL_GPU_TIMING").is_some())
+}
+
+/// Accumulate one command buffer's GPU-side duration under `tag` and log a
+/// running mean every `every` submissions. No-op unless timing is enabled.
+pub(crate) fn gpu_timing_note(
+    cmd_buf: &ProtocolObject<dyn MTLCommandBuffer>,
+    tag: &'static str,
+    every: u64,
+) {
+    if !gpu_timing_enabled() {
+        return;
+    }
+    let dt_ns = ((cmd_buf.GPUEndTime() - cmd_buf.GPUStartTime()) * 1e9).max(0.0) as u64;
+    let now = crate::dispatch::metal_encode_stats();
+    let Ok(mut slots) = GPU_TIMING.lock() else {
+        return;
+    };
+    let slot = match slots.iter_mut().find(|s| s.tag == tag) {
+        Some(s) => s,
+        None => {
+            slots.push(TimingSlot {
+                tag,
+                n: 0,
+                acc_ns: 0,
+                prev: now,
+                acc_dispatches: 0,
+                acc_barriers: 0,
+                acc_begin_ops: 0,
+            });
+            slots.last_mut().expect("just pushed")
+        }
+    };
+    slot.n += 1;
+    slot.acc_ns += dt_ns;
+    slot.acc_dispatches += now.dispatches.saturating_sub(slot.prev.dispatches);
+    slot.acc_barriers += now.barriers.saturating_sub(slot.prev.barriers);
+    slot.acc_begin_ops += now.begin_ops.saturating_sub(slot.prev.begin_ops);
+    slot.prev = now;
+    let n = slot.n;
+    if n.is_multiple_of(every.max(1)) {
+        let per = |acc: u64| acc as f64 / n as f64;
+        eprintln!(
+            "ferrox: metal gpu[{tag}] {:.3} ms avg over {n} (last {:.3} ms); \
+             encode/submission: {:.1} dispatches, {:.1} barriers, \
+             {:.1} hazard checks ({:.2} bar/op)",
+            (slot.acc_ns as f64 / n as f64) / 1e6,
+            dt_ns as f64 / 1e6,
+            per(slot.acc_dispatches),
+            per(slot.acc_barriers),
+            per(slot.acc_begin_ops),
+            slot.acc_barriers as f64 / slot.acc_begin_ops.max(1) as f64,
+        );
+    }
+}


### PR DESCRIPTION
Part of #149. **No lever was pulled, on purpose**: the arithmetic bound was written down first, as the issue's own rule demands, and it says the two candidate levers (argument packing, encode/execute pipelining) cannot reach the target by an order of magnitude. What this PR ships is the instrument that shows why, the accounting correction, and the parity evidence that the instrument changed nothing.

## The measurement first

#149's "host = wall minus GPU" used the GPU time of ONE command buffer per token, `dense-decode/tok`. A sampled decode token has TWO. The lm_head runs afterwards in `launch_matvec_fused`, which had no timing tag, so its GPU time was booked as host time. Tagging it:

| model | stack GPU ms | lm_head GPU ms | ledger's "host" ms |
|---|---:|---:|---:|
| Llama-3.2-1B Q4_K_M | 4.97 | **1.17** | 1.71 |
| Gemma-2-2B Q4_K_M | 12.03 | **2.78** | 4.67 |

Most of the 26-29% was the GPU. `FERROX_METAL_GPU_TIMING=1` now clocks three phases per submission from one clock: **encode** (`SubmitClock::start` to `commit`), **GPU** (`GPUEnd - GPUStart`), and **latency** (the wait beyond GPU time: submit-to-start plus completion-to-wakeup). `commit_wait_note` is the only way to finish a clock, so a submission cannot be timed with the encode phase left out.

Per token, window means over four runs alternating the two models, one process each (GPU columns are load-immune; this host was not quiet, load1 6-16, so the wall-derived columns are upper bounds and no tok/s is quoted; `benchmarks/RESULTS.md` is untouched):

| phase | Llama-3.2-1B | Gemma-2-2B |
|---|---:|---:|
| stack GPU | 4.97-5.08 | 12.03-12.44 |
| lm_head GPU | 1.17-1.28 | 2.78-2.91 |
| **encode, both buffers** | **0.15-0.24** | **0.42-0.45** |
| submit latency, both buffers | 0.41-0.46 | 0.81-0.88 |
| CPU between buffers | ~0.06 | ~0.89 |
| wall | 6.76-7.07 | 17.00-17.63 |

Gemma's 0.89 ms between buffers is measured separately: `final_logit_softcap` is a scalar `tanh` over 256k logits at **0.645 ms**, plus the bench's own argmax (~0.3 ms).

## The arithmetic bound

Per-dispatch argument binding is INSIDE the encode phase, so packing arguments into one `setBytes` struct is bounded by encode: **0.15-0.24 ms = 2-3% of wall** on the 1B, **0.42-0.45 ms = 2.5%** on Gemma-2, and realistically half of that since llama.cpp still binds several buffers per node. Pipelining encode against execution can hide at most the same 0.15 / 0.42 ms. The target was a 26% host share. Neither lever can get within 10x of it, so neither was built.

Three independent measurements now agree on the encode cost, which is the reason to believe the number: the issue's injection slope (515 dispatches x 0.61 us = 0.31 ms on Gemma-2), #156's removal of 48 ops for 0.04 ms of host time, and this direct clock (0.38-0.42 ms).

## What is actually left on the host, with bounds

- **Submit latency**, ~0.2 ms per command buffer, two buffers per sampled token. Folding the lm_head into the stack's command buffer for sampled decode (the greedy fold already does this) is the one host lever the data supports: at most ~0.25 ms, **4% of wall on the 1B, 1.7% on Gemma-2**. It lives in `ferrox-models`' `FoldedLmHead` invariant (which deliberately forbids a full-logits fold today; `interpret` already caps a vocabulary-shaped result, so it is the permit that would change), not in a Metal seam, so it is not in this PR.
- **Gemma's CPU softcap**, 0.65 ms = 3.8% of its wall, more than its whole encode phase. A GPU epilogue on the lm_head would remove it.

And the GPU column reorders the problem: **Gemma-2-2B's GPU time alone, 14.8 ms, already exceeds llama.cpp's 14.74 ms token.** The worst Metal row is a kernel gap, not a host one. `benchmarks/HISTORY.md` carries the correction; `RESULTS.md`'s #149 row needs the same and is left for a quiet-host run.

## Two accounting defects fixed on the way

- Dispatch attribution was the delta between consecutive submissions of the SAME tag, so with two tags alternating per token the lm_head's line reported the dense stack's 210 dispatches as its own. The ledger now holds one snapshot and attributes work to the next submission noted after it.
- The cumulative mean carried every priming token (fresh KV buffers, ~100 ms events), which is why the phases did not sum to the wall on the first run. A per-report window is printed beside the cumulative figure.

`Ledger` is pure over integers and tested without a device: attribution to the encoding submission, window reset without cumulative reset, latency clamped at zero. Each test was sabotaged once (mutation grep-confirmed) and went red.

## Correctness

The submission path moved into a helper, so the full gate was run even though no kernel changed:

- `ferrox verify --prompt-tokens 64` (Metal vs CPU reference): **token-identical** on Llama-3.2-1B Q8_0, Llama-3.2-3B Q4_K_M, Gemma-2-2B Q4_K_M, OLMoE Q4_0.
- `ferrox parity` against libllama built from `.scratch/llama.cpp`: Llama-3.2-1B Q8_0 **MATCH**, KL 7.219e-4 (identical to #156's figure); Llama-3.2-3B Q4_K_M MATCH, KL 6.409e-4; OLMoE Q4_0 MATCH, KL 4.241e-4; Gemma-2-2B Q4_K_M TIE-FLIP on a 3.2e-3 top-2 margin with KL 1.531e-2, and the SAME verdict and KL with `FERROX_METAL=0`, so it is the known K-quant `vec_dot_type` drift, not Metal and not this branch.
- `cargo test -p ferrox-metal --features metal -- --ignored`: **60 passed** on the GPU.
- The concurrent-request check from #184, `ferrox-server` on port 8399 with Llama-3.2-1B Q8_0: a greedy request is byte-identical alone, while a `temperature 0.8` request runs, and afterwards; the sampled request returns prose.

## Gates

`cargo test --workspace` 3047 passed, 0 failed; clippy `-D warnings` debug and release, workspace and `--features metal` for `ferrox-metal`/`ferrox-cli`/`ferrox-server`; `cargo fmt --all --check`.

## File sizes

First commit is a pure move: `gpu.rs` 8901 -> 8789, `timing.rs` new. Per-token cost of the instrument when disabled: two `Instant::now()` per submission.
