### PR TITLE
fix(studio,server): show a cut-off answer, continue it, and keep the thought

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ Entries name what changed and, where it matters, what was wrong
 before. A fix that closed a silent-wrong-answer class says so — those
 are the ones worth reading twice.
 
+## [Unreleased]
+
+### Fixed
+
+- **A reasoning model that ran out of `max_tokens` inside its thought
+  showed thinking and then nothing.** Studio sent `max_tokens: 512` on
+  every request, DeepSeek-R1-Distill spends about 900 tokens thinking
+  on an ordinary question, the server correctly returned `finish_reason:
+  "length"` with empty content, and the UI rendered that as silence.
+  The default is now no cap (the context is the limit, llama.cpp's
+  `n_predict: -1`), a saved 512 from the old default is migrated away,
+  a `length` finish is shown as a cut-off with the token count, and a
+  **Continue** button carries on from where it stopped.
+- **The conversation store dropped a reasoning model's chain of
+  thought.** An answer that was entirely `reasoning_content` persisted
+  as `content: ""` and reloaded as an empty turn. The store keeps
+  `reasoning_content` beside `content`; records written before the
+  field read back unchanged.
+
+### Added
+
+- `continue_final_message` on `/v1/chat/completions`, llama.cpp's field
+  and value set (`true`, `"reasoning_content"`, `"content"`): the
+  trailing assistant message renders as a turn still being written, its
+  thought re-opened in the family's own markers, so the model continues
+  rather than starting over. Default off; the channel-grammar families
+  and a content continuation for an always-open family are 501 by name.
+- `reasoning_budget_tokens` / `thinking_budget_tokens` are refused by
+  name (501) except `-1`, rather than silently dropped. llama.cpp
+  enforces the budget in its sampler; ferrox has no such sampler yet.
+
 ## [0.20.0] - 2026-09-11
 
 ### Fixed

--- a/crates/ferrox-server/src/anthropic.rs
+++ b/crates/ferrox-server/src/anthropic.rs
@@ -671,6 +671,10 @@ fn prepare_prompt(prompt: &PromptFields, model: String, max_tokens: usize) -> Pr
         thinking: prompt.thinking.clone(),
         // Stateless surface: Claude Code resends the whole conversation.
         session_id: None,
+        // Anthropic's API prefills a trailing assistant turn; this lowering
+        // does not ask for that yet -- see `continuation`.
+        continue_final_message: None,
+        reasoning_budget_tokens: None,
         logprobs: None,
         top_logprobs: None,
         n: None,

--- a/crates/ferrox-server/src/continuation.rs
+++ b/crates/ferrox-server/src/continuation.rs
@@ -1,0 +1,487 @@
+//! Continuing a partial assistant turn: llama.cpp's
+//! `continue_final_message`.
+//!
+//! A reasoning model that runs out of `max_tokens` inside its chain of
+//! thought returns `finish_reason: "length"`, `reasoning_content` and
+//! no content at all. The natural next request is "carry on from
+//! there" -- and a trailing assistant message on this server rendered
+//! as a CLOSED turn followed by a fresh generation prompt, so the model
+//! started over instead of continuing. This module renders the
+//! continuation llama.cpp renders (`common/chat-auto-parser-generator
+//! .cpp:54-71`), under llama.cpp's own field and value set:
+//!
+//! - `true` -- **auto**: continue the reasoning when the message has a
+//!   thought and no content, otherwise continue the content;
+//! - `"reasoning_content"` -- continue INSIDE the reasoning block;
+//! - `"content"` -- the thought is closed and the answer continues.
+//!
+//! The rendering is `messages[..n-1]` through the template with the
+//! generation prompt, then the partial turn appended RAW: the family's
+//! opener, the replayed thought, and for a content continuation the
+//! closer and the text. An opener the template put into the generation
+//! prompt itself (R1 distills end theirs with `<think>\n`) is cut off
+//! first, so the block is opened exactly once. Nothing is re-tokenized
+//! specially: the appended text is prompt like any other, and
+//! `OutputPosture::resolve` reads the resulting prompt to learn whether
+//! the model is inside the block, which is the same fact it reads for
+//! every other request.
+//!
+//! **Default off.** llama.cpp's server treats ANY trailing assistant
+//! message as a continuation unless `--no-prefill-assistant` is given.
+//! OpenAI's API does not (a trailing assistant message there gets a new
+//! turn), and `/v1/responses` and `/v1/messages` render through the
+//! same function this one wraps, so flipping that default is a change
+//! to what three routes mean and is not made here. A caller asks for it
+//! by name.
+//!
+//! **Refused by name, not approximated:** a channel grammar (harmony,
+//! ATEM) has no marker pair to write a thought back between; an
+//! always-open family (`deepseekv32`, `minimax`) cannot be told by the
+//! prompt that its block is closed, so its content continuation would
+//! be parsed as reasoning; a turn carrying tool calls is refused the
+//! way llama.cpp refuses it.
+
+use serde::Deserialize;
+
+use crate::policy::parser::ReasoningFormat;
+use crate::{chat_template, invalid_request, unsupported_feature, ApiError, ChatMessage, ToolDef};
+
+/// The wire value: `true`, `"reasoning_content"` or `"content"`.
+///
+/// `false` deserializes to the same thing as absence, because a client
+/// that spells "do not continue" explicitly meant exactly that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Continuation {
+    Auto,
+    Reasoning,
+    Content,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ContinueWire {
+    Flag(bool),
+    Mode(String),
+}
+
+/// An `Option<Continuation>` field: `false` and absent both mean none,
+/// so the outer `Option` cannot deserialize `false` to `Some`.
+pub(crate) fn deserialize_optional<'de, D>(
+    deserializer: D,
+) -> Result<Option<Continuation>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(wire) = Option::<ContinueWire>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    match wire {
+        ContinueWire::Flag(false) => Ok(None),
+        wire => Continuation::try_from(wire)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
+}
+
+impl TryFrom<ContinueWire> for Continuation {
+    type Error = String;
+
+    fn try_from(wire: ContinueWire) -> Result<Self, String> {
+        match wire {
+            ContinueWire::Flag(true) => Ok(Continuation::Auto),
+            ContinueWire::Flag(false) => Err(
+                "continue_final_message: false is the same as omitting it; pass true, \
+                 \"reasoning_content\" or \"content\""
+                    .to_string(),
+            ),
+            ContinueWire::Mode(mode) => match mode.as_str() {
+                "reasoning_content" => Ok(Continuation::Reasoning),
+                "content" => Ok(Continuation::Content),
+                other => Err(format!(
+                    "continue_final_message must be true, \"reasoning_content\" or \
+                     \"content\", not {other:?}"
+                )),
+            },
+        }
+    }
+}
+
+impl Continuation {
+    /// llama.cpp's `auto` rule: a thought with nothing after it is
+    /// continued as a thought; anything else continues the content.
+    fn resolve(self, reasoning: &str, content: &str) -> Continuation {
+        match self {
+            Continuation::Auto if !reasoning.is_empty() && content.is_empty() => {
+                Continuation::Reasoning
+            }
+            Continuation::Auto => Continuation::Content,
+            explicit => explicit,
+        }
+    }
+}
+
+/// Render `messages` so the model continues the last one.
+///
+/// Every refusal is decided BEFORE the template runs, so a request that
+/// cannot be continued costs no render. `format` is the served
+/// checkpoint's reasoning family, the same value `OutputPosture` will
+/// read the result with.
+pub(crate) fn prompt_continuing_final_message(
+    messages: &[ChatMessage],
+    template: &chat_template::PromptTemplate,
+    tools: &[ToolDef],
+    extra: serde_json::Map<String, serde_json::Value>,
+    format: Option<ReasoningFormat>,
+    mode: Continuation,
+) -> Result<String, ApiError> {
+    let Some((last, head)) = messages.split_last() else {
+        return Err(invalid_request(
+            "continue_final_message needs a message to continue",
+            "messages",
+        ));
+    };
+    if last.role != "assistant" {
+        return Err(invalid_request(
+            "continue_final_message: the last message must be an assistant message",
+            "messages",
+        ));
+    }
+    if head.last().is_some_and(|m| m.role == "assistant") {
+        // llama.cpp's rule too: a template may fold two adjacent
+        // assistant turns into one, and which of them is being
+        // continued would then depend on the template.
+        return Err(invalid_request(
+            "continue_final_message: cannot have 2 or more assistant messages at the end of \
+             the list",
+            "messages",
+        ));
+    }
+    if last
+        .tool_calls
+        .as_ref()
+        .is_some_and(|calls| !calls.is_empty())
+    {
+        return Err(unsupported_feature(
+            "continue_final_message: continuing an assistant message that contains tool calls \
+             is not implemented",
+        ));
+    }
+
+    let reasoning = last.reasoning_content.as_deref().unwrap_or("");
+    let content = last
+        .content
+        .as_ref()
+        .map(crate::MessageContent::as_text)
+        .unwrap_or_default();
+    let mode = mode.resolve(reasoning, &content);
+
+    // Whether the thought can be written back at all, decided from the
+    // family alone: a plain checkpoint has no block and continues its
+    // content; a marker family writes the block; a channel grammar
+    // cannot be given text to continue by concatenation.
+    let markers = match format {
+        None => None,
+        Some(format) => match format.continuation_markers() {
+            Some(pair) => Some((format, pair)),
+            None => {
+                return Err(unsupported_feature(&format!(
+                    "continue_final_message is not implemented for the {} reasoning format: \
+                     its chain of thought is a channel grammar, not a marker pair a replayed \
+                     thought can be written between",
+                    format.as_str()
+                )))
+            }
+        },
+    };
+    if markers.is_none() && !reasoning.is_empty() {
+        return Err(unsupported_feature(
+            "continue_final_message: the served model has no reasoning format, so a \
+             reasoning_content on the message to continue cannot be rendered back into a prompt",
+        ));
+    }
+    if let (Some((format, _)), Continuation::Content) = (markers, mode) {
+        if format.always_open() {
+            return Err(unsupported_feature(&format!(
+                "continue_final_message: \"content\" is not implemented for the {} reasoning \
+                 format, whose parser reads every generation as starting inside the thinking \
+                 block; only a reasoning continuation can be rendered for it",
+                format.as_str()
+            )));
+        }
+    }
+
+    let mut prompt = crate::prompt_from_messages(head, template, tools, extra)?;
+    if let Some((format, (start, end))) = markers {
+        // The template may already have opened the block in its
+        // generation prompt. Cut it off and open it once, here, with the
+        // thought inside -- what llama.cpp's generator does with its
+        // `generation_prompt.find(reasoning.start)`.
+        if format.prompt_opens_reasoning(&prompt) {
+            if let Some(at) = prompt.rfind(start) {
+                prompt.truncate(at);
+            }
+        }
+        prompt.push_str(start);
+        prompt.push_str(reasoning);
+        if mode == Continuation::Content {
+            prompt.push_str(end);
+        }
+    }
+    if mode == Continuation::Content {
+        prompt.push_str(&content);
+    }
+    Ok(prompt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chat_template::PromptTemplate;
+    use crate::output::OutputPosture;
+    use crate::MessageContent;
+
+    /// An R1-distill-shaped template: closes a replayed assistant turn,
+    /// strips its thinking, and opens the block in the generation
+    /// prompt -- the exact shape a naive trailing-assistant render gets
+    /// wrong.
+    const R1: &str = "{% for m in messages %}{% if m.role == 'user' %}<|User|>{{ m.content }}{% else %}<|Assistant|>{{ m.content }}<|end▁of▁sentence|>{% endif %}{% endfor %}{% if add_generation_prompt %}<|Assistant|><think>\n{% endif %}";
+
+    /// ChatML with no notion of thinking.
+    const CHATML: &str = "{% for m in messages %}<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}";
+
+    fn template(source: &str) -> PromptTemplate {
+        PromptTemplate::from_gguf_metadata(Some(source), Some("llama"), false, true, None, None)
+    }
+
+    fn msg(role: &str, content: &str, reasoning: Option<&str>) -> ChatMessage {
+        ChatMessage {
+            role: role.to_string(),
+            content: Some(MessageContent::Text(content.to_string())),
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: reasoning.map(str::to_string),
+        }
+    }
+
+    fn render(
+        source: &str,
+        messages: &[ChatMessage],
+        format: Option<ReasoningFormat>,
+        mode: Continuation,
+    ) -> Result<String, ApiError> {
+        prompt_continuing_final_message(
+            messages,
+            &template(source),
+            &[],
+            serde_json::Map::new(),
+            format,
+            mode,
+        )
+    }
+
+    fn parse(value: serde_json::Value) -> Result<Option<Continuation>, String> {
+        #[derive(Deserialize)]
+        struct Body {
+            #[serde(default, deserialize_with = "deserialize_optional")]
+            continue_final_message: Option<Continuation>,
+        }
+        serde_json::from_value::<Body>(serde_json::json!({ "continue_final_message": value }))
+            .map(|b| b.continue_final_message)
+            .map_err(|e| e.to_string())
+    }
+
+    /// The user's case: a thought cut off by `max_tokens`, sent back.
+    /// The block is opened ONCE -- the template's own `<think>\n` is
+    /// gone -- and left open, so the parser reads the continuation as
+    /// reasoning.
+    #[test]
+    fn a_cut_off_thought_is_continued_inside_an_open_block() {
+        let prompt = render(
+            R1,
+            &[
+                msg("user", "why", None),
+                msg("assistant", "", Some("Let me think about")),
+            ],
+            Some(ReasoningFormat::Think),
+            Continuation::Auto,
+        )
+        .expect("renders");
+        assert_eq!(
+            prompt, "<|User|>why<|Assistant|><think>Let me think about",
+            "the template's own opener must not be doubled"
+        );
+        // The parser the server will read the stream with is built off
+        // this prompt: the continuation's first tokens are reasoning.
+        let split = OutputPosture::resolve("DeepSeek-R1-Distill-Qwen-1.5B", &prompt)
+            .reasoning_parser()
+            .expect("R1 has a format")
+            .parse_complete(" this.</think>Because.");
+        assert_eq!(
+            split.reasoning, "this.",
+            "the parser must pick up inside the block"
+        );
+        assert_eq!(split.content, "Because.");
+    }
+
+    /// A finished thought with a cut-off answer: the block is closed and
+    /// the answer text follows it, so the parser reads the rest as
+    /// content.
+    #[test]
+    fn a_cut_off_answer_is_continued_after_a_closed_block() {
+        let prompt = render(
+            R1,
+            &[
+                msg("user", "why", None),
+                msg("assistant", "Because", Some("thought")),
+            ],
+            Some(ReasoningFormat::Think),
+            Continuation::Auto,
+        )
+        .expect("renders");
+        assert_eq!(
+            prompt,
+            "<|User|>why<|Assistant|><think>thought</think>Because"
+        );
+        let split = OutputPosture::resolve("DeepSeek-R1-Distill-Qwen-1.5B", &prompt)
+            .reasoning_parser()
+            .expect("R1 has a format")
+            .parse_complete(" it is so.");
+        assert_eq!(
+            split.reasoning, "",
+            "the block is closed; nothing is reasoning"
+        );
+        assert_eq!(split.content, "it is so.");
+    }
+
+    /// The explicit modes override auto's rule.
+    #[test]
+    fn an_explicit_mode_wins_over_the_auto_rule() {
+        let messages = [
+            msg("user", "why", None),
+            msg("assistant", "Because", Some("thought")),
+        ];
+        let reasoning = render(
+            R1,
+            &messages,
+            Some(ReasoningFormat::Think),
+            Continuation::Reasoning,
+        )
+        .expect("renders");
+        assert_eq!(reasoning, "<|User|>why<|Assistant|><think>thought");
+        let content = render(
+            R1,
+            &[
+                msg("user", "why", None),
+                msg("assistant", "", Some("thought")),
+            ],
+            Some(ReasoningFormat::Think),
+            Continuation::Content,
+        )
+        .expect("renders");
+        assert_eq!(content, "<|User|>why<|Assistant|><think>thought</think>");
+    }
+
+    /// A model with no reasoning format continues its text and nothing
+    /// else is written.
+    #[test]
+    fn a_plain_model_continues_its_content() {
+        let prompt = render(
+            CHATML,
+            &[msg("user", "hi", None), msg("assistant", "Hello, I", None)],
+            None,
+            Continuation::Auto,
+        )
+        .expect("renders");
+        assert_eq!(
+            prompt,
+            "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\nHello, I"
+        );
+    }
+
+    /// A thought for a model that cannot have written one is refused,
+    /// not folded into the content.
+    #[test]
+    fn reasoning_for_a_model_with_no_format_is_refused() {
+        let err = render(
+            CHATML,
+            &[
+                msg("user", "hi", None),
+                msg("assistant", "", Some("thought")),
+            ],
+            None,
+            Continuation::Auto,
+        )
+        .expect_err("refused");
+        assert_eq!(err.0, axum::http::StatusCode::NOT_IMPLEMENTED);
+    }
+
+    /// The families that cannot be continued by concatenation say so.
+    #[test]
+    fn channel_grammars_and_always_open_content_are_refused_by_name() {
+        let messages = [msg("user", "hi", None), msg("assistant", "x", Some("t"))];
+        for format in [ReasoningFormat::GptOss, ReasoningFormat::MuseGlimmer] {
+            let err =
+                render(CHATML, &messages, Some(format), Continuation::Auto).expect_err("refused");
+            assert_eq!(err.0, axum::http::StatusCode::NOT_IMPLEMENTED, "{format:?}");
+        }
+        let err = render(
+            CHATML,
+            &messages,
+            Some(ReasoningFormat::DeepSeekV32),
+            Continuation::Content,
+        )
+        .expect_err("refused");
+        assert_eq!(err.0, axum::http::StatusCode::NOT_IMPLEMENTED);
+        // ...but the same family's THOUGHT can be continued.
+        render(
+            CHATML,
+            &[msg("user", "hi", None), msg("assistant", "", Some("t"))],
+            Some(ReasoningFormat::DeepSeekV32),
+            Continuation::Auto,
+        )
+        .expect("a reasoning continuation renders");
+    }
+
+    #[test]
+    fn the_last_message_must_be_a_lone_assistant_turn_without_tool_calls() {
+        let bad_role = render(CHATML, &[msg("user", "hi", None)], None, Continuation::Auto)
+            .expect_err("refused");
+        assert_eq!(bad_role.0, axum::http::StatusCode::BAD_REQUEST);
+        let two = render(
+            CHATML,
+            &[
+                msg("user", "hi", None),
+                msg("assistant", "a", None),
+                msg("assistant", "b", None),
+            ],
+            None,
+            Continuation::Auto,
+        )
+        .expect_err("refused");
+        assert_eq!(two.0, axum::http::StatusCode::BAD_REQUEST);
+        let empty = render(CHATML, &[], None, Continuation::Auto).expect_err("refused");
+        assert_eq!(empty.0, axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    /// llama.cpp's value set, and nothing else: `false` is absence, an
+    /// unknown mode is a parse error rather than a guess.
+    #[test]
+    fn the_wire_value_set_is_llama_cpps() {
+        assert_eq!(
+            parse(serde_json::json!(true)).unwrap(),
+            Some(Continuation::Auto)
+        );
+        assert_eq!(parse(serde_json::json!(false)).unwrap(), None);
+        assert_eq!(parse(serde_json::json!(null)).unwrap(), None);
+        assert_eq!(
+            parse(serde_json::json!("reasoning_content")).unwrap(),
+            Some(Continuation::Reasoning)
+        );
+        assert_eq!(
+            parse(serde_json::json!("content")).unwrap(),
+            Some(Continuation::Content)
+        );
+        assert!(parse(serde_json::json!("auto")).is_err());
+        assert!(parse(serde_json::json!(1)).is_err());
+    }
+}

--- a/crates/ferrox-server/src/conversations.rs
+++ b/crates/ferrox-server/src/conversations.rs
@@ -207,6 +207,18 @@ pub(crate) struct MessageNode {
     pub(crate) role: String,
     #[serde(default)]
     pub(crate) content: String,
+    /// A reasoning model's chain of thought, kept BESIDE `content` the
+    /// way `/v1/chat/completions` returns it, never folded in.
+    ///
+    /// An R1 answer that ran out of `max_tokens` while thinking is
+    /// entirely `reasoning_content`; stored as `content: ""` it came
+    /// back from a reload as an empty assistant turn, with the thinking
+    /// gone. Absent on the wire and on disk when there is none, so a
+    /// record written before this field existed reads back unchanged
+    /// (`default`), and a client that does not think never sees the
+    /// key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reasoning_content: Option<String>,
     /// Stamped by the server on append. A client-supplied time would be
     /// a claim; this is a fact about when the server was told.
     pub(crate) created_at: u64,
@@ -324,6 +336,11 @@ pub(crate) struct NewMessage {
     pub(crate) role: String,
     #[serde(default)]
     pub(crate) content: String,
+    /// See [`MessageNode::reasoning_content`]. An empty string is
+    /// stored as absent: the field means "this turn thought", and an
+    /// empty thought is no thought.
+    #[serde(default)]
+    pub(crate) reasoning_content: Option<String>,
     #[serde(default)]
     pub(crate) metadata: Option<serde_json::Value>,
 }
@@ -817,6 +834,20 @@ fn append_messages(
                 format!("a message holds at most {MAX_CONTENT_BYTES} bytes of content"),
             ));
         }
+        // The same ceiling, applied to the thought on its own rather
+        // than to the sum: a long thought must not make a short answer
+        // unstorable, and vice versa. The conversation-wide byte
+        // ceiling still bounds the two together.
+        let reasoning_content = message.reasoning_content.filter(|r| !r.is_empty());
+        if reasoning_content
+            .as_ref()
+            .is_some_and(|r| r.len() > MAX_CONTENT_BYTES)
+        {
+            return Err(StoreError::too_large(
+                "message_too_large",
+                format!("a message holds at most {MAX_CONTENT_BYTES} bytes of reasoning_content"),
+            ));
+        }
         if let Some(parent) = message.parent_id.as_deref() {
             if !existing.contains(parent) && !staged_ids.contains(parent) {
                 return Err(StoreError::invalid(
@@ -836,6 +867,7 @@ fn append_messages(
             parent_id: message.parent_id,
             role: message.role,
             content: message.content,
+            reasoning_content,
             created_at: now,
             metadata: message.metadata,
         });
@@ -1054,6 +1086,7 @@ mod tests {
             parent_id: parent.map(str::to_string),
             role: role.to_string(),
             content: content.to_string(),
+            reasoning_content: None,
             metadata: None,
         }
     }
@@ -1381,6 +1414,81 @@ mod tests {
             store.list().is_empty(),
             "memory must not hold a conversation that never reached disk"
         );
+    }
+
+    /// The defect: an R1 answer cut off inside its thought is ALL
+    /// `reasoning_content`, and a store with no such field kept an
+    /// empty assistant turn. The thought now survives a restart, and
+    /// an empty one is stored as nothing rather than as `""`.
+    #[test]
+    fn a_chain_of_thought_survives_a_restart_beside_its_answer() {
+        let dir = TempDir::new("reasoning");
+        let id = {
+            let store = store(&dir);
+            let mut thought = msg("a1", Some("u1"), "assistant", "");
+            thought.reasoning_content = Some("Let me think about".to_string());
+            let mut blank = msg("a2", Some("a1"), "assistant", "answer");
+            blank.reasoning_content = Some(String::new());
+            store
+                .create(created(vec![
+                    msg("u1", None, "user", "why"),
+                    thought,
+                    blank,
+                ]))
+                .unwrap()
+                .id
+        };
+        let conversation = store(&dir).get(&id).unwrap();
+        assert_eq!(
+            conversation.messages[1].reasoning_content.as_deref(),
+            Some("Let me think about")
+        );
+        assert_eq!(conversation.messages[1].content, "");
+        assert_eq!(
+            conversation.messages[2].reasoning_content, None,
+            "an empty thought is no thought"
+        );
+        let on_disk = std::fs::read_to_string(dir.0.join(format!("{id}.json"))).unwrap();
+        assert_eq!(
+            on_disk.matches("reasoning_content").count(),
+            1,
+            "the key is written only where there is a thought: {on_disk}"
+        );
+    }
+
+    /// A file written before the field existed carries no
+    /// `reasoning_content` at all, and must load as it did then.
+    #[test]
+    fn a_record_from_before_reasoning_was_stored_loads_unchanged() {
+        let dir = TempDir::new("pre-reasoning");
+        std::fs::create_dir_all(&dir.0).unwrap();
+        std::fs::write(
+            dir.0.join("conv_0000000000000000.json"),
+            br#"{"id":"conv_0000000000000000","created_at":1,"updated_at":1,"head_id":"a1",
+                "messages":[{"id":"u1","parent_id":null,"role":"user","content":"hi","created_at":1},
+                {"id":"a1","parent_id":"u1","role":"assistant","content":"hello","created_at":1}]}"#,
+        )
+        .unwrap();
+        let conversation = store(&dir).get("conv_0000000000000000").unwrap();
+        assert_eq!(conversation.messages.len(), 2);
+        assert_eq!(conversation.messages[1].content, "hello");
+        assert_eq!(conversation.messages[1].reasoning_content, None);
+    }
+
+    #[test]
+    fn an_oversized_thought_is_refused_like_an_oversized_answer() {
+        let dir = TempDir::new("big-thought");
+        let store = store(&dir);
+        let mut thought = msg("m1", None, "assistant", "short");
+        thought.reasoning_content = Some("x".repeat(MAX_CONTENT_BYTES + 1));
+        let err = store.create(created(vec![thought])).unwrap_err();
+        assert!(matches!(
+            err,
+            StoreError::TooLarge {
+                code: "message_too_large",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/ferrox-server/src/lib.rs
+++ b/crates/ferrox-server/src/lib.rs
@@ -41,6 +41,7 @@ mod cancel;
 mod chat_template;
 mod cli;
 mod completion;
+mod continuation;
 mod conversations;
 mod decode_task;
 mod embeddings;
@@ -957,6 +958,20 @@ struct ChatCompletionRequest {
     /// history, not the whole conversation.
     #[serde(default)]
     session_id: Option<String>,
+    /// llama.cpp's `continue_final_message`: render the LAST message,
+    /// which must be an assistant turn, as a turn still being written
+    /// rather than a closed one, so the model carries on from where
+    /// it stopped. `true`, `"reasoning_content"` or `"content"`; the
+    /// whole rule, its refusals included, is [`continuation`].
+    #[serde(default, deserialize_with = "continuation::deserialize_optional")]
+    continue_final_message: Option<continuation::Continuation>,
+    /// llama.cpp's reasoning budget, declared ONLY so it can be refused
+    /// by name -- see
+    /// [`crate::unsupported_sampling::refuse_reasoning_budget`].
+    /// Undeclared, serde would drop it and a caller who asked for a
+    /// 2,000-token thought would get an unbounded one with a 200.
+    #[serde(default, alias = "thinking_budget_tokens")]
+    reasoning_budget_tokens: Option<serde_json::Value>,
     /// OpenAI fields we explicitly reject rather than silently ignore.
     #[serde(default)]
     logprobs: Option<bool>,
@@ -1096,6 +1111,35 @@ impl ChatCompletionRequest {
     /// the client hasn't explicitly disabled it via `tool_choice:
     /// "none"` -- see `ToolChoice`'s doc comment for what the other
     /// values do (nothing different from `"auto"`).
+    /// The prompt this request decodes from: the history rendered
+    /// whole, or continued from its last message when the caller asked
+    /// for that. ONE call for both the buffered and the streaming
+    /// handler, so the two cannot disagree about what a trailing
+    /// assistant message means.
+    ///
+    /// `served_model` is the name `OutputPosture::resolve` will read the
+    /// output with, so the continuation is written in the same family's
+    /// markers the parser will look for.
+    fn render_prompt(
+        &self,
+        history: &[ChatMessage],
+        template: &chat_template::PromptTemplate,
+        kwargs: serde_json::Map<String, serde_json::Value>,
+        served_model: &str,
+    ) -> Result<String, ApiError> {
+        match self.continue_final_message {
+            None => prompt_from_messages(history, template, &self.tools, kwargs),
+            Some(mode) => continuation::prompt_continuing_final_message(
+                history,
+                template,
+                &self.tools,
+                kwargs,
+                crate::policy::parser::ReasoningFormat::infer(served_model),
+                mode,
+            ),
+        }
+    }
+
     fn tools_active(&self) -> bool {
         !self.tools.is_empty()
             && !matches!(&self.tool_choice, Some(ToolChoice::Mode(m)) if m == "none")
@@ -1313,6 +1357,10 @@ impl ChatCompletionRequest {
             ));
         }
         unsupported_sampling::refuse_logit_bias(self.logit_bias.as_ref(), "/v1/chat/completions")?;
+        unsupported_sampling::refuse_reasoning_budget(
+            self.reasoning_budget_tokens.as_ref(),
+            "/v1/chat/completions",
+        )?;
         // Parsed here as well as in `sampling_knobs` so a bad chain is
         // a 400/501 before any prompt is rendered. The same function
         // both times, so there is no second opinion to drift from.
@@ -2756,7 +2804,7 @@ async fn chat_completions_full(
     let history = resolve_history(&state, &req);
     let template = active.generative()?.chat_template();
     let kwargs = req.resolve_template_kwargs(&template);
-    let prompt = prompt_from_messages(&history, &template, &req.tools, kwargs)?;
+    let prompt = req.render_prompt(&history, &template, kwargs, active.name())?;
     // Resolved BEFORE the lookup, because the constraint is part of the
     // key: a grammar, JSON mode and `ignore_eos` all change the answer
     // and none of them changes the prompt, so a cache consulted first
@@ -2881,7 +2929,7 @@ async fn chat_completions_stream(
     let history = resolve_history(&state, &req);
     let template = active.generative()?.chat_template();
     let kwargs = req.resolve_template_kwargs(&template);
-    let prompt = prompt_from_messages(&history, &template, &req.tools, kwargs)?;
+    let prompt = req.render_prompt(&history, &template, kwargs, active.name())?;
     let model_name = req.model.clone();
     let session_id = req.session_id.clone();
     let sessions = state.sessions.clone();
@@ -8448,6 +8496,77 @@ mod tests {
             "stop",
         );
         assert_eq!(message.reasoning_content, None);
+    }
+
+    /// The request-level half of `continuation`: the field reaches the
+    /// render, and the family is taken from the SERVED model, the same
+    /// name the output parser reads. A trailing assistant turn without
+    /// the field still renders as history plus a fresh turn.
+    #[test]
+    fn continue_final_message_reaches_the_render_under_the_served_models_family() {
+        let r1 = chat_template::PromptTemplate::from_gguf_metadata(
+            Some("{% for m in messages %}<|{{ m.role }}|>{{ m.content }}{% endfor %}{% if add_generation_prompt %}<|assistant|><think>\n{% endif %}"),
+            Some("qwen2"),
+            false,
+            true,
+            None,
+            None,
+        );
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "why"},
+                {"role": "assistant", "content": "", "reasoning_content": "Let me"},
+            ],
+        });
+        let plain = chat_request(body.clone());
+        let prompt = plain
+            .render_prompt(
+                &plain.messages,
+                &r1,
+                serde_json::Map::new(),
+                "DeepSeek-R1-Distill",
+            )
+            .expect("renders");
+        assert_eq!(prompt, "<|user|>why<|assistant|><|assistant|><think>\n");
+
+        let mut continued = body;
+        continued["continue_final_message"] = serde_json::json!(true);
+        let req = chat_request(continued);
+        let prompt = req
+            .render_prompt(
+                &req.messages,
+                &r1,
+                serde_json::Map::new(),
+                "DeepSeek-R1-Distill",
+            )
+            .expect("renders");
+        assert_eq!(prompt, "<|user|>why<|assistant|><think>Let me");
+        // Under a served model with no reasoning family the same body
+        // is a refusal, not a guess.
+        let (status, _) = req
+            .render_prompt(&req.messages, &r1, serde_json::Map::new(), "Llama-3.2-3B")
+            .expect_err("no family to write the thought in");
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+    }
+
+    /// llama.cpp's budget field, under both of its spellings, is a 501
+    /// before any prompt is rendered.
+    #[test]
+    fn a_reasoning_budget_is_refused_by_name_under_both_spellings() {
+        for key in ["reasoning_budget_tokens", "thinking_budget_tokens"] {
+            let req = chat_request(serde_json::json!({
+                "model": "m",
+                "messages": [{"role": "user", "content": "hi"}],
+                key: 2000,
+            }));
+            let (status, body) = req.validate_supported_fields().expect_err(key);
+            assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{key}");
+            assert!(body.0["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("reasoning_budget_tokens"));
+        }
     }
 
     #[test]

--- a/crates/ferrox-server/src/policy/parser/reasoning.rs
+++ b/crates/ferrox-server/src/policy/parser/reasoning.rs
@@ -184,6 +184,40 @@ impl ReasoningFormat {
         }
     }
 
+    /// The opener and closer a chain of thought can be *written back*
+    /// between, for a prompt that continues one.
+    ///
+    /// `None` for the channel grammars (harmony, ATEM): their reasoning
+    /// is not a marker pair around text, so there is nothing a caller
+    /// could concatenate a replayed thought into. A continuation for
+    /// those families has to be refused rather than rendered, and this
+    /// is the one place that says which families those are.
+    pub fn continuation_markers(self) -> Option<(&'static str, &'static str)> {
+        match self {
+            // Harmony has no markers at all; ATEM's pair is a channel
+            // HEADER (`<|start|>` ... `<|message|>`), which the parser
+            // uses for `prompt_opens_reasoning` and which is not a pair
+            // a thought can be written between.
+            ReasoningFormat::GptOss | ReasoningFormat::MuseGlimmer => None,
+            ReasoningFormat::DeepSeekV32
+            | ReasoningFormat::Think
+            | ReasoningFormat::ThinkAlwaysOpen
+            | ReasoningFormat::MiniMaxM3
+            | ReasoningFormat::Gemma4 => {
+                let m = self.markers();
+                Some((m.start, m.end))
+            }
+        }
+    }
+
+    /// Whether the parser reads every generation as starting INSIDE the
+    /// block regardless of what the prompt says. A prompt that closes
+    /// the block itself cannot tell such a parser so, which is why a
+    /// content continuation is refused for these families.
+    pub fn always_open(self) -> bool {
+        self.markers().always_open
+    }
+
     fn markers(self) -> Markers {
         match self {
             ReasoningFormat::DeepSeekV32 => Markers {

--- a/crates/ferrox-server/src/responses.rs
+++ b/crates/ferrox-server/src/responses.rs
@@ -652,6 +652,8 @@ fn to_chat_request(req: &ResponsesRequest) -> Result<ChatCompletionRequest, ApiE
         // Stateless surface: history comes in `input`, in full, on every
         // turn.
         session_id: None,
+        continue_final_message: None,
+        reasoning_budget_tokens: None,
         logprobs: None,
         top_logprobs: None,
         n: None,

--- a/crates/ferrox-server/src/unsupported_sampling.rs
+++ b/crates/ferrox-server/src/unsupported_sampling.rs
@@ -141,10 +141,77 @@ pub(crate) fn refuse_logit_bias(value: Option<&Value>, route: &str) -> Result<()
     )))
 }
 
+/// Refuse llama.cpp's `reasoning_budget_tokens` (alias
+/// `thinking_budget_tokens`) BY NAME.
+///
+/// llama.cpp enforces it in the sampler (`common/reasoning-budget.cpp`):
+/// once N generated tokens have followed the thinking opener, the
+/// closer -- optionally preceded by `reasoning_budget_message` -- is
+/// force-fed one token per step, so the answer always gets what is
+/// left of `max_tokens`. ferrox has one sampler hook both decode loops
+/// share (`sample_step::sample_next`) and no budget state in it, so a
+/// budget here would be dropped; a caller who asked for a 2,000-token
+/// thought and got an unbounded one with a 200 could not tell.
+///
+/// `-1` is llama.cpp's "unrestricted" and is exactly what this server
+/// does, so it is accepted; `null` likewise. `0` is llama.cpp's "end
+/// thinking immediately", which this server spells `reasoning_effort:
+/// "none"` or `thinking: {"type": "disabled"}`, and the refusal says
+/// so rather than sending the caller to read the source.
+pub(crate) fn refuse_reasoning_budget(value: Option<&Value>, route: &str) -> Result<(), ApiError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if value.is_null() || value.as_i64() == Some(-1) {
+        return Ok(());
+    }
+    if value.as_i64() == Some(0) {
+        return Err(unsupported_feature(&format!(
+            "`reasoning_budget_tokens: 0` (end thinking immediately) is not implemented on \
+             {route}; to serve the request without a chain of thought send `reasoning_effort: \
+             \"none\"` or `thinking: {{\"type\": \"disabled\"}}` instead."
+        )));
+    }
+    Err(unsupported_feature(&format!(
+        "`reasoning_budget_tokens` (a token budget for the chain of thought, enforced by \
+         llama.cpp in its sampler) is not implemented on {route}; only -1, unrestricted, is \
+         accepted. It is refused rather than ignored: a dropped budget is indistinguishable \
+         from an honoured one. Bound the whole completion with `max_tokens`, or continue a \
+         cut-off answer with `continue_final_message`."
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::http::StatusCode;
+
+    /// The value llama.cpp calls unrestricted is what this server does
+    /// anyway; every other value would be dropped, so it is refused.
+    #[test]
+    fn a_reasoning_budget_is_refused_unless_it_is_unrestricted() {
+        for accepted in [serde_json::json!(-1), serde_json::Value::Null] {
+            refuse_reasoning_budget(Some(&accepted), "/v1/chat/completions")
+                .expect("unrestricted is what ferrox does");
+        }
+        refuse_reasoning_budget(None, "/v1/chat/completions").expect("absent");
+        for refused in [
+            serde_json::json!(0),
+            serde_json::json!(2000),
+            serde_json::json!("x"),
+        ] {
+            let (status, body) = refuse_reasoning_budget(Some(&refused), "/v1/chat/completions")
+                .expect_err("refused");
+            assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{refused}");
+            assert!(
+                body.0["error"]["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("reasoning_budget_tokens"),
+                "{refused}: the refusal must name the field"
+            );
+        }
+    }
 
     #[test]
     fn a_real_bias_is_refused_by_name() {

--- a/docs/API.md
+++ b/docs/API.md
@@ -79,6 +79,8 @@ conversation or a large `/v1/embeddings` batch past that comes back
 | `thinking: {"type": …}` | Supported (DeepSeek wire): `enabled`/`disabled`, anything else is a 400 |
 | `ignore_eos` | Ferrox extension: run past the model's own end-of-generation tokens so the request produces exactly `max_tokens`. A serving-benchmark knob. Suppresses the model's set only. A caller's own `stop` strings still end the answer |
 | `reasoning_content` (both ways) | Ferrox extension: a reasoning model's chain of thought, split out of `content` on the way out and replayable on the way in (`reasoning` is accepted as an alias) |
+| `continue_final_message` | Supported, llama.cpp's field and value set: `true` (auto), `"reasoning_content"` or `"content"`. The trailing assistant message is rendered as a turn still being written, thought included, so the model carries on from where it stopped. **Default off**, where llama.cpp's server defaults to continuing any trailing assistant message (`--prefill-assistant`); the harmony and ATEM channel formats, a content continuation for an always-open family, and a turn with tool calls are **501 by name** |
+| `reasoning_budget_tokens` / `thinking_budget_tokens` | **501 by name** except `-1` (llama.cpp's "unrestricted", which is what this server does). llama.cpp enforces the budget in its sampler by force-feeding the closing tag; there is no such sampler here yet, and a budget silently dropped would be indistinguishable from one honoured. `0` says to use `reasoning_effort: "none"` instead |
 
 ### Where a completion stops
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -243,6 +243,26 @@ Nothing here ever presents a partial answer as a finished one: if the
 reconnect and the poll both fail, or the replay window has moved past
 where the client stopped, it surfaces as a truncation error.
 
+## A cut-off answer says so, and can be continued
+
+`max_tokens` defaults to **no cap**: the request carries none, and the
+server bounds the answer by the context window alone, which is
+llama.cpp's `n_predict: -1` and its own web UI's default. It used to be
+512, and a reasoning model spends more than that thinking on an ordinary
+question, so the budget ran out inside the thought, the server correctly
+answered `finish_reason: "length"` with no content, and the transcript
+showed a Thinking block and then nothing. A saved 512 from that default
+is dropped on load; any other saved value is kept as the choice it was.
+
+A `length` finish now renders as a cut-off under the message, with the
+token count, and a **Continue** button. Continue is assistant-ui's own
+regenerate carrying the partial parts in its run config: the adapter
+sends the cut-off turn back as the trailing assistant message with
+`continue_final_message: true` (llama.cpp's field), seeds the new message
+with what was already there, and the server renders the turn as one
+still being written, thought re-opened, so the model carries on rather
+than starting over. The cut-off version stays as the previous branch.
+
 ## Three things not to undo
 
 - **No client stopwatch.** Every number under an answer comes from the

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -330,14 +330,31 @@ export type Usage = {
   cached_tokens?: number | null;
 };
 
-export type ChatMessage = { role: string; content: string };
+export type ChatMessage = {
+  role: string;
+  content: string;
+  /**
+   * A replayed assistant turn's chain of thought, in the server's own
+   * field. Sent only on the one turn being CONTINUED: for ordinary
+   * history the template strips it anyway, and the DeepSeek guidance
+   * is not to replay it.
+   */
+  reasoning_content?: string;
+};
 
 export type ChatRequest = {
   model: string;
   messages: ChatMessage[];
   temperature?: number;
   top_p?: number;
+  /** Omitted, the server bounds the answer by the context alone. */
   max_tokens?: number;
+  /**
+   * llama.cpp's field: render the trailing assistant message as a turn
+   * still being written, so the model carries on from where it stopped
+   * rather than starting a new one.
+   */
+  continue_final_message?: boolean;
 };
 
 /** One SSE frame's payload, as far as this client reads it. */

--- a/ui/src/lib/conversations.test.ts
+++ b/ui/src/lib/conversations.test.ts
@@ -14,6 +14,7 @@ import {
   isStorable,
   pendingAppend,
   plainText,
+  restoredStatus,
   storedIds,
   toBranchable,
   type Conversation,
@@ -308,4 +309,83 @@ test("a reloaded conversation is immediately in sync", () => {
     false,
     "opening a conversation must not write it straight back",
   );
+});
+
+test("thinking is stored beside the answer, never inside it", () => {
+  // The user's case: an R1 turn cut off inside its thought is ALL
+  // reasoning. Stored as `content: ""` alone it reloaded as an empty
+  // bubble with the thinking gone.
+  const pending = pendingAppend(
+    repo([
+      item("u1", null, "user", "why"),
+      {
+        parentId: "u1",
+        message: {
+          id: "a1",
+          role: "assistant",
+          content: [{ type: "reasoning", text: "Let me think" }],
+          status: { type: "incomplete", reason: "length" },
+        },
+      },
+    ]),
+    new Set(),
+  );
+  assert.equal(pending.messages.length, 2, "a cut-off turn is stored");
+  assert.equal(pending.messages[1].content, "");
+  assert.equal(pending.messages[1].reasoning_content, "Let me think");
+  // A turn that never thought carries no key at all.
+  assert.equal("reasoning_content" in pending.messages[0], false);
+});
+
+test("a stored thought reloads above its answer, and a cut-off turn offers the way out", () => {
+  const conversation: Conversation = {
+    ...CONVERSATION,
+    messages: [
+      CONVERSATION.messages[0],
+      {
+        id: "a1",
+        parent_id: "u1",
+        role: "assistant",
+        content: "",
+        reasoning_content: "Let me think",
+        created_at: 1_700_000_001,
+        metadata: { custom: { stats: { outcome: "length" } } },
+      },
+      {
+        id: "a2",
+        parent_id: "u1",
+        role: "assistant",
+        content: "hello",
+        created_at: 1_700_000_002,
+        metadata: { custom: { stats: { outcome: "stopped-by-you" } } },
+      },
+    ],
+  };
+  const { items } = toBranchable(conversation);
+  assert.deepEqual(items[1].message.content, [
+    { type: "reasoning", text: "Let me think" },
+    { type: "text", text: "" },
+  ]);
+  // The status comes back from the outcome the runtime recorded, so
+  // Continue is offered after a reload exactly where it was before.
+  assert.deepEqual(items[1].message.status, {
+    type: "incomplete",
+    reason: "length",
+  });
+  assert.deepEqual(items[2].message.status, {
+    type: "incomplete",
+    reason: "cancelled",
+  });
+  assert.deepEqual(
+    items[2].message.content,
+    [{ type: "text", text: "hello" }],
+    "a turn that never thought grows no empty reasoning part",
+  );
+  // A record from before the field existed, or with no outcome at all,
+  // is complete: the old shape reads exactly as it did.
+  assert.deepEqual(restoredStatus(undefined), { type: "complete", reason: "stop" });
+  assert.deepEqual(restoredStatus({ custom: { stats: { outcome: "ok" } } }), {
+    type: "complete",
+    reason: "stop",
+  });
 });

--- a/ui/src/lib/conversations.ts
+++ b/ui/src/lib/conversations.ts
@@ -24,6 +24,12 @@ export type StoredMessage = {
   parent_id: string | null;
   role: ConversationRole;
   content: string;
+  /**
+   * A reasoning model's chain of thought, beside the answer rather
+   * than inside it. Absent on records written before the store had the
+   * field, and on every turn that did not think.
+   */
+  reasoning_content?: string | null;
   created_at: number;
   metadata?: Record<string, unknown> | null;
 };
@@ -64,6 +70,7 @@ export type NewMessage = {
   parent_id: string | null;
   role: ConversationRole;
   content: string;
+  reasoning_content?: string;
   metadata?: Record<string, unknown>;
 };
 
@@ -141,15 +148,37 @@ export type ExportedRepository = {
 
 const ROLES: ReadonlySet<string> = new Set(["user", "assistant", "system"]);
 
+/** Parts of one kind, concatenated. */
+function textOfKind(
+  content: readonly { type: string; text?: string }[],
+  kind: "text" | "reasoning",
+): string {
+  return content
+    .filter((part) => part.type === kind && typeof part.text === "string")
+    .map((part) => part.text as string)
+    .join("");
+}
+
 /** Text parts, concatenated. Anything else in the message is not text
- * and is not what a transcript stores. */
+ * and is not what a transcript stores as the answer. */
 export function plainText(
   content: readonly { type: string; text?: string }[],
 ): string {
-  return content
-    .filter((part) => part.type === "text" && typeof part.text === "string")
-    .map((part) => part.text as string)
-    .join("");
+  return textOfKind(content, "text");
+}
+
+/**
+ * Reasoning parts, concatenated.
+ *
+ * Stored in its own field, never folded into the answer. An R1 turn cut
+ * off inside its thinking is ALL reasoning; stored as `content: ""` it
+ * came back from a reload as an empty bubble with the thinking gone,
+ * which is the defect this exists to close.
+ */
+export function plainReasoning(
+  content: readonly { type: string; text?: string }[],
+): string {
+  return textOfKind(content, "reasoning");
 }
 
 /**
@@ -209,11 +238,13 @@ export function pendingAppend(
     const parentId = item.parentId;
     if (parentId !== null && !reachable.has(parentId)) continue;
     reachable.add(message.id);
+    const reasoning = plainReasoning(message.content);
     messages.push({
       id: message.id,
       parent_id: parentId,
       role: message.role as ConversationRole,
       content: plainText(message.content),
+      ...(reasoning ? { reasoning_content: reasoning } : {}),
       ...(message.metadata ? { metadata: message.metadata } : {}),
     });
   }
@@ -235,14 +266,38 @@ export function hasWork(pending: Pending, storedHead: string | null): boolean {
   return pending.headId !== null && pending.headId !== storedHead;
 }
 
+/** The status an assistant node gets back, from the outcome its own
+ * metadata recorded. */
+export type RestoredStatus =
+  | { type: "complete"; reason: "stop" }
+  | { type: "incomplete"; reason: "length" | "cancelled" };
+
+/**
+ * `status` is reconstructed rather than stored: the store has no
+ * business keeping a copy of a fact that is already in the metadata it
+ * carries. The outcome is what the runtime wrote under
+ * `metadata.custom.stats`, and it is what decides whether a reloaded
+ * answer offers Continue -- a cut-off turn restored as complete would
+ * lose the way out of it.
+ */
+export function restoredStatus(
+  metadata: Record<string, unknown> | null | undefined,
+): RestoredStatus {
+  const outcome = (
+    metadata as { custom?: { stats?: { outcome?: unknown } } } | undefined
+  )?.custom?.stats?.outcome;
+  if (outcome === "length") return { type: "incomplete", reason: "length" };
+  if (outcome === "stopped-by-you" || outcome === "stopped-by-server")
+    return { type: "incomplete", reason: "cancelled" };
+  return { type: "complete", reason: "stop" };
+}
+
 /**
  * The stored tree, in the shape `ExportedMessageRepository
  * .fromBranchableArray` takes.
  *
- * `status` is reconstructed rather than stored: an assistant node is
- * complete unless its own metadata says the run was stopped, and the
- * store has no business keeping a copy of a fact that is already in the
- * metadata it carries.
+ * Thinking comes back as a reasoning part ABOVE the text, the order it
+ * was shown in; a turn that never thought grows no empty part.
  */
 export function toBranchable(conversation: Conversation): {
   items: {
@@ -250,9 +305,12 @@ export function toBranchable(conversation: Conversation): {
     message: {
       id: string;
       role: ConversationRole;
-      content: { type: "text"; text: string }[];
+      content: (
+        | { type: "text"; text: string }
+        | { type: "reasoning"; text: string }
+      )[];
       createdAt: Date;
-      status?: { type: "complete"; reason: "stop" };
+      status?: RestoredStatus;
       metadata?: Record<string, unknown>;
     };
   }[];
@@ -264,10 +322,15 @@ export function toBranchable(conversation: Conversation): {
       message: {
         id: node.id,
         role: node.role,
-        content: [{ type: "text" as const, text: node.content }],
+        content: [
+          ...(node.reasoning_content
+            ? [{ type: "reasoning" as const, text: node.reasoning_content }]
+            : []),
+          { type: "text" as const, text: node.content },
+        ],
         createdAt: new Date(node.created_at * 1000),
         ...(node.role === "assistant"
-          ? { status: { type: "complete" as const, reason: "stop" as const } }
+          ? { status: restoredStatus(node.metadata) }
           : {}),
         ...(node.metadata ? { metadata: node.metadata } : {}),
       },

--- a/ui/src/screens/chat.tsx
+++ b/ui/src/screens/chat.tsx
@@ -30,6 +30,7 @@ import { cn } from "@/lib/utils";
 import { Thread } from "@/screens/chat/thread";
 import {
   DEFAULT_SAMPLING,
+  LEGACY_MAX_TOKENS,
   useFerroxRuntime,
   type Sampling,
 } from "@/screens/chat/runtime";
@@ -41,14 +42,23 @@ import { conversationLabel } from "@/lib/conversations";
 import { describeAway, RESUME_WINDOW_MS } from "@/lib/entry-state";
 import { useTabActivity } from "@/lib/use-tab-activity";
 
-const SETTINGS_KEY = "ferrox.studio.sampling.v1";
+const SETTINGS_KEY = "ferrox.studio.sampling.v2";
+/** The shape whose default `maxTokens` was 512. */
+const LEGACY_SETTINGS_KEY = "ferrox.studio.sampling.v1";
 
 function loadSampling(): Sampling {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
-    return raw
-      ? { ...DEFAULT_SAMPLING, ...JSON.parse(raw) }
-      : { ...DEFAULT_SAMPLING };
+    if (raw) return { ...DEFAULT_SAMPLING, ...JSON.parse(raw) };
+    // A v1 blob was written on every change, so nearly every one of
+    // them carries the old default of 512 without the user ever having
+    // chosen it. That number is the bug this migration exists for: it
+    // is dropped, and any other value is kept as the choice it was.
+    const legacy = localStorage.getItem(LEGACY_SETTINGS_KEY);
+    if (!legacy) return { ...DEFAULT_SAMPLING };
+    const parsed = JSON.parse(legacy) as Partial<Sampling>;
+    if (parsed.maxTokens === LEGACY_MAX_TOKENS) delete parsed.maxTokens;
+    return { ...DEFAULT_SAMPLING, ...parsed };
   } catch {
     return { ...DEFAULT_SAMPLING };
   }
@@ -289,21 +299,27 @@ function SamplingPanel({
               />
             </Field>
             <Field label="max_tokens">
+              {/* Empty is a value: no cap, the context is the limit. A
+                  reasoning model counts its thinking against this
+                  number, and a cap that fits an answer rarely fits the
+                  thought that precedes it. */}
               <Input
                 type="number"
                 min="1"
-                max="32768"
                 step="1"
-                value={value.maxTokens}
-                onChange={(e) =>
-                  set(
-                    "maxTokens",
-                    Math.max(1, Math.round(Number(e.target.value) || 1)),
-                  )
-                }
+                placeholder="no cap"
+                value={value.maxTokens ?? ""}
+                onChange={(e) => {
+                  const n = Math.round(Number(e.target.value));
+                  set("maxTokens", e.target.value === "" || n < 1 ? null : n);
+                }}
               />
             </Field>
           </div>
+          <p className="text-2xs text-faint">
+            With no cap, an answer runs until the model stops or the context
+            fills; Stop cancels it on the server. A cap counts thinking too.
+          </p>
           <Field
             label="system prompt"
             hint="Sent as the first message of every request, not stored on the server."

--- a/ui/src/screens/chat/runtime.ts
+++ b/ui/src/screens/chat/runtime.ts
@@ -12,6 +12,7 @@ import { useState } from "react";
 import {
   useLocalRuntime,
   type ChatModelAdapter,
+  type ChatModelRunOptions,
   type ChatModelRunResult,
   type ThreadMessage,
 } from "@assistant-ui/react";
@@ -27,33 +28,106 @@ import {
 import { fmtInt, fmtMs, fmtNum, isNum } from "@/lib/format";
 import { useLatest } from "@/lib/use-latest";
 
+/** Not re-exported by the react package under its own name. */
+type RunConfig = ChatModelRunOptions["runConfig"];
+
 export type Sampling = {
   system: string;
   temperature: number;
   topP: number;
-  maxTokens: number;
+  /**
+   * `null` sends no `max_tokens` at all, and the server then bounds the
+   * answer by the context window alone -- llama.cpp's `n_predict: -1`,
+   * and what its own web UI defaults to.
+   *
+   * This used to be 512. That is a decode-era number: a reasoning model
+   * spends more than that THINKING on an ordinary question, the budget
+   * runs out inside the thought, and the server correctly returns
+   * `finish_reason: "length"` with no answer at all. OpenAI's semantics
+   * count reasoning inside the completion budget, so the accounting was
+   * right and the number was wrong. There is no number that is right
+   * for every model, which is why the default is now no number: the
+   * context is the only limit that is always true.
+   */
+  maxTokens: number | null;
 };
 
 export const DEFAULT_SAMPLING: Sampling = {
   system: "",
   temperature: 0.7,
   topP: 0.95,
-  maxTokens: 512,
+  maxTokens: null,
 };
+
+/** The `max_tokens` the previous default sent. A saved settings blob
+ * still carrying it was never a choice, so it is not kept. */
+export const LEGACY_MAX_TOKENS = 512;
 
 /**
  * What the UI prints under an answer.
  *
  * `line` is the server's `usage`, formatted. `outcome` says how the
- * generation ended when that is not simply "it finished" — a short
- * answer and a truncated one look identical otherwise.
+ * generation ended when that is not simply "it finished" -- a short
+ * answer and a truncated one look identical otherwise, and `length` is
+ * the one that used to render as silence: the model was cut off, most
+ * often inside its own thinking, and nothing said so.
  */
 export type AnswerStats = {
   line: string;
   requestId: string | null;
-  outcome: "ok" | "stopped-by-you" | "stopped-by-server" | "error";
+  outcome: "ok" | "length" | "stopped-by-you" | "stopped-by-server" | "error";
   usage: Usage | null;
 };
+
+/** Whether an answer with this outcome can be picked up where it stopped. */
+export function canContinue(outcome: AnswerStats["outcome"]): boolean {
+  return (
+    outcome === "length" ||
+    outcome === "stopped-by-you" ||
+    outcome === "stopped-by-server"
+  );
+}
+
+/**
+ * A partial turn to carry on from: what the cut-off message already
+ * holds, so the continuation starts from it rather than from nothing.
+ */
+export type ContinueFrom = { reasoning: string; text: string };
+
+const CONTINUE_KEY = "continueFrom";
+
+/**
+ * The run config that turns a reload into a continuation.
+ *
+ * The parts ride in `runConfig.custom` because that is the one channel
+ * assistant-ui carries from the button that starts a run to the adapter
+ * that serves it. Written here and read by `readContinuation` below, so
+ * the key is spelled once.
+ */
+export function continuationRun(from: ContinueFrom): RunConfig {
+  return { custom: { [CONTINUE_KEY]: from } };
+}
+
+function readContinuation(runConfig: RunConfig): ContinueFrom | null {
+  const value = runConfig.custom?.[CONTINUE_KEY] as Partial<ContinueFrom> | undefined;
+  if (!value || typeof value !== "object") return null;
+  return {
+    reasoning: typeof value.reasoning === "string" ? value.reasoning : "",
+    text: typeof value.text === "string" ? value.text : "",
+  };
+}
+
+/** The reasoning and text parts of a message, concatenated by kind. */
+export function partsText(
+  content: readonly { type: string; text?: string }[],
+): ContinueFrom {
+  const pick = (kind: string) =>
+    content
+      .filter((part) => part.type === kind && typeof part.text === "string")
+      .map((part) => part.text as string)
+      .join("");
+  return { reasoning: pick("reasoning"), text: pick("text") };
+}
 
 /** Turns the server's `usage` into one line, omitting anything absent. */
 export function statLine(
@@ -93,10 +167,10 @@ function toWire(messages: readonly ThreadMessage[]): ChatMessage[] {
     // A message that failed carries no answer worth replaying.
     if (message.status?.type === "incomplete" && message.status.reason === "error")
       continue;
-    const text = message.content
-      .filter((part): part is { type: "text"; text: string } => part.type === "text")
-      .map((part) => part.text)
-      .join("");
+    // History carries the answer only. A turn that was cut off inside
+    // its thought has no answer and is not replayed; `Continue` on that
+    // turn is the path that sends the thought back.
+    const { text } = partsText(message.content);
     if (!text) continue;
     wire.push({ role: message.role, content: text });
   }
@@ -148,12 +222,26 @@ export type ChatDeps = {
 
 function makeAdapter(deps: ChatDeps): ChatModelAdapter {
   return {
-    async *run({ messages, abortSignal }) {
+    async *run({ messages, abortSignal, runConfig }) {
       const sampling = deps.sampling();
       const wire: ChatMessage[] = [];
       if (sampling.system.trim())
         wire.push({ role: "system", content: sampling.system.trim() });
       wire.push(...toWire(messages));
+
+      // A continuation: the cut-off turn goes back as the trailing
+      // assistant message, thought and all, and the server is asked to
+      // keep writing it rather than to open a new one. The new message
+      // starts out holding what the old one had, so the stream appends
+      // to a visible answer rather than replaying it.
+      const resume = readContinuation(runConfig);
+      if (resume) {
+        wire.push({
+          role: "assistant",
+          content: resume.text,
+          ...(resume.reasoning ? { reasoning_content: resume.reasoning } : {}),
+        });
+      }
 
       // ONE pump, carrying tagged chunks, rather than one per kind.
       // Two queues drained in sequence would be two structures that
@@ -178,7 +266,10 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
           messages: wire,
           temperature: sampling.temperature,
           top_p: sampling.topP,
-          max_tokens: sampling.maxTokens,
+          ...(sampling.maxTokens !== null
+            ? { max_tokens: sampling.maxTokens }
+            : {}),
+          ...(resume ? { continue_final_message: true } : {}),
         },
         {
           signal: abortSignal,
@@ -207,8 +298,8 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
           tokens.end();
         });
 
-      let text = "";
-      let reasoning = "";
+      let text = resume?.text ?? "";
+      let reasoning = resume?.reasoning ?? "";
       // Thinking is shown ABOVE the answer, which is also the order it
       // arrives in. An empty part is never emitted: a model that does
       // not think must not grow an empty block, and an answer that has
@@ -238,10 +329,16 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
         // than as an AbortError. Saying so is the difference between a
         // short answer and a truncated one, which look identical.
         const cancelled = finished?.finishReason === "cancelled";
+        // `length` is the server saying the budget ran out, not the
+        // model saying it was done. For a reasoning model that most
+        // often happens INSIDE the thought, so the message has thinking
+        // and no answer -- which, marked complete, looked like a model
+        // that chose to say nothing.
+        const cutOff = finished?.finishReason === "length";
         const stats: AnswerStats = {
           line: statLine(finished?.usage, id),
           requestId: id,
-          outcome: cancelled ? "stopped-by-server" : "ok",
+          outcome: cancelled ? "stopped-by-server" : cutOff ? "length" : "ok",
           usage: finished?.usage ?? null,
         };
         yield {
@@ -251,7 +348,9 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
           content: parts(),
           status: cancelled
             ? { type: "incomplete", reason: "cancelled" }
-            : { type: "complete", reason: "stop" },
+            : cutOff
+              ? { type: "incomplete", reason: "length" }
+              : { type: "complete", reason: "stop" },
           metadata: { custom: { stats } },
         } satisfies ChatModelRunResult;
         return;

--- a/ui/src/screens/chat/thread.tsx
+++ b/ui/src/screens/chat/thread.tsx
@@ -6,6 +6,7 @@ import {
   ErrorPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
+  useAui,
   useAuiState,
 } from "@assistant-ui/react";
 import {
@@ -16,15 +17,22 @@ import {
   CircleAlert,
   Copy,
   Pencil,
+  Play,
   RefreshCw,
   Square,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FerroxMark } from "@/components/logo";
+import { fmtInt } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { MarkdownText } from "@/screens/chat/markdown";
 import { ReasoningPart } from "@/screens/chat/reasoning";
-import type { AnswerStats } from "@/screens/chat/runtime";
+import {
+  canContinue,
+  continuationRun,
+  partsText,
+  type AnswerStats,
+} from "@/screens/chat/runtime";
 
 // The transcript, the composer, autoscroll, branching and the abort
 // signal are assistant-ui's. What is written here is presentation plus
@@ -47,10 +55,64 @@ function useStats(): AnswerStats | undefined {
 
 const OUTCOME_LABEL: Record<AnswerStats["outcome"], string | null> = {
   ok: null,
+  length: "cut off at the token limit",
   "stopped-by-you": "stopped by you",
   "stopped-by-server": "stopped",
   error: "failed",
 };
+
+/**
+ * The state that used to be silence, and the way out of it.
+ *
+ * A reasoning model that runs out of `max_tokens` inside its thought
+ * returns thinking and no answer, and the transcript showed exactly
+ * that: a "Thinking" block and then nothing, with no indication that
+ * anything had been cut. This says so, and offers to carry on.
+ *
+ * Continue is a reload -- assistant-ui's own regenerate -- carrying the
+ * partial parts in its run config, so the adapter sends them back as
+ * the trailing assistant turn with `continue_final_message` and seeds
+ * the new message with them. The cut-off version stays reachable as
+ * the previous branch, the same way a regenerated answer does; nothing
+ * is overwritten.
+ */
+function CutOff() {
+  const aui = useAui();
+  const stats = useStats();
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const content = useAuiState((s) => s.message.content);
+  if (!stats || !canContinue(stats.outcome)) return null;
+
+  const from = partsText(content);
+  const generated = stats.usage?.completion_tokens;
+  const detail =
+    stats.outcome === "length"
+      ? `The token limit ran out${
+          typeof generated === "number"
+            ? ` after ${fmtInt(generated)} tokens`
+            : ""
+        }${
+          from.reasoning && !from.text
+            ? ", inside the model's thinking, so there is no answer yet"
+            : ", so this answer is incomplete"
+        }. Raise max_tokens in Sampling, or carry on from here.`
+      : "This answer was stopped before it finished.";
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-warn/35 bg-warn-soft px-3 py-2 text-xs text-warn">
+      <span className="min-w-0 flex-1">{detail}</span>
+      <Button
+        variant="default"
+        size="sm"
+        disabled={isRunning}
+        onClick={() => aui.message.reload({ runConfig: continuationRun(from) })}
+      >
+        <Play />
+        Continue
+      </Button>
+    </div>
+  );
+}
 
 function StatLine() {
   const stats = useStats();
@@ -159,6 +221,7 @@ const AssistantMessage: FC = () => (
           </div>
         </MessagePrimitive.Error>
 
+        <CutOff />
         <StatLine />
 
         <div className="mt-1 flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">


### PR DESCRIPTION
## The bug

With DeepSeek-R1-Distill-Qwen-1.5B loaded, "Give me a Python snippet that streams from this server." showed the model thinking and then stopped with no answer.

Reproduced against `/v1/chat/completions` at `max_tokens: 512`, temperature 0: `finish_reason: length`, 2180 chars of `reasoning_content`, 0 of `content`. The model and the reasoning parser were fine. Studio sent `max_tokens: 512` on every request, the model spends about 900 tokens thinking on that prompt, the budget died inside the thought, and the UI rendered `length` as silence. OpenAI's semantics count reasoning inside the completion budget, so the accounting was right and the number was wrong.

Underneath it, the conversation store had no `reasoning_content` field, so a turn that was entirely thinking persisted as `content: ""` and reloaded as an empty bubble.

## What changed

**The default became no cap.** Studio sends no `max_tokens`; the server bounds the answer by the context window alone (its own `DEFAULT_CHAT_MAX_TOKENS` clamped to the context ceiling), which is llama.cpp's `n_predict: -1` and what llama.cpp's own web UI defaults to. 4096 would fit this model on this prompt and not the next one; there is no number that is right for every reasoning model, so the default is no number and the context is the only limit that is always true. Settings moved to a `v2` key; a `v1` blob still carrying 512 (which nearly every one does, since it was written on every change) drops it, and any other saved value is kept as the choice it was. The field accepts empty and says what empty means.

**The cut-off is visible.** `finish_reason: "length"` is now `status: incomplete/length` and outcome `length`: a warning under the message with the token count and, when the thought was what got cut, the words "inside the model's thinking, so there is no answer yet", plus the stat line "cut off at the token limit".

**Continue.** A `Continue` button on any cut-off or stopped answer. It is assistant-ui's own `message.reload()` carrying the partial parts in `runConfig.custom`; the adapter sends the cut-off turn back as the trailing assistant message with `continue_final_message: true`, seeds the new message with what was already there, and the stream appends in place. The cut-off version stays as the previous branch (the picker reads 2 / 2), the way a regenerate does, so nothing is overwritten.

**`continue_final_message` on the server**, llama.cpp's field and value set (`true` / `"reasoning_content"` / `"content"`), rendered the way `common/chat-auto-parser-generator.cpp:54-71` renders it: `messages[..n-1]` through the template with the generation prompt, an opener the template already put there (R1 distills end theirs with `<think>\n`) cut off, then opener + thought, and for a content continuation the closer and the text. `OutputPosture::resolve` reads the resulting prompt as it reads every other, so the parser picks up inside or outside the block by the same rule. New module `crates/ferrox-server/src/continuation.rs`; one `render_prompt()` for both chat handlers. **Default off**: llama.cpp continues any trailing assistant message by default (`--prefill-assistant`), but OpenAI's API does not, and `/v1/responses` and `/v1/messages` render through the same function, so flipping that default is a change to what three routes mean and is not made here. Refused by name (501): the harmony and ATEM channel grammars (no marker pair to write a thought between), a content continuation for an always-open family (`deepseekv32`, `minimax`, whose parser cannot be told the block is closed), a turn with tool calls, two trailing assistant turns.

**Reasoning budget: not built, refused by name.** llama.cpp's `reasoning_budget_tokens` (alias `thinking_budget_tokens`, server flag `--reasoning-budget N`, plus `reasoning_budget_message`) is enforced in its sampler (`common/reasoning-budget.cpp`): once N generated tokens follow the thinking opener, the closer is force-fed one token per step. ferrox's single sampler hook (`sample_step::sample_next`) has no budget state, so it would need a token-level state machine that recognises the opener sequence, counts, and forces the closer sequence, plus request plumbing into `GenerationParams`. That is a real module and a separate PR. Until then the field is a 501 naming it, except `-1` (unrestricted, which is what this server does); `0` points the caller at `reasoning_effort: "none"`. Undeclared, serde would have dropped it and a caller asking for a 2,000-token thought would have got an unbounded one with a 200.

**Persistence.** `MessageNode` and `NewMessage` carry `reasoning_content`, bounded by the same ceiling as `content` on its own, absent on the wire and on disk when empty (`skip_serializing_if`), and `#[serde(default)]` so a record written before the field reads back unchanged. The UI stores the reasoning parts in it, restores them as a reasoning part above the text on reload, and reconstructs the message status from the recorded outcome, so a reloaded cut-off turn still offers Continue.

## Verified in a real browser

Own server on port 8401 with the R1 distill, Vite on 5199, scratch conversations dir.

1. `max_tokens` 512, the user's prompt: thinking, then the answer cut mid-code at 512 tokens, warning + Continue shown, stat line "cut off at the token limit". Continue: the code resumed mid-line, prefill 526 tok (14 prompt + 512 partial), 283 new tokens, finished; branch picker 2 / 2.
2. `max_tokens` 200: the cut landed inside the thought (942 chars), the warning said so. Continue extended the thought in place to 1,871 chars (prefill 214 = 14 + 200), hit the cap again, Continue again to 2,802 (prefill 414); 3 / 3.
3. Seeded a `v1` settings blob carrying 512: the panel loaded as "no cap". Same prompt with the default: the whole answer arrived, 1,068 tokens, no cut-off.
4. Reload of each: the Thinking block (1,843 / 2,678 chars) and the answer both render; the cut-off conversation reloads with its warning and Continue. On disk both branch nodes carry `reasoning_content` and the cut-off node records `outcome: length`.

The user's server on 8383 was not touched.

## Tests

- `continuation.rs`: 8 tests (R1-shaped template: opener stripped once and left open, closed for a content continuation, explicit modes, plain model, every refusal, the wire value set; the posture is checked behaviourally through `parse_complete`).
- `lib.rs`: the field reaches the render under the served model's family; both budget spellings are 501 before rendering.
- `unsupported_sampling.rs`: `-1`/`null`/absent accepted, everything else refused naming the field.
- `conversations.rs`: a thought survives a restart and an empty one is stored as nothing; a pre-field record loads unchanged; an oversized thought is refused.
- `ui/src/lib/conversations.test.ts`: thinking stored beside the answer; restored status from outcome.

Every new test was sabotaged once with the mutation grep-confirmed before the red run (17 mutations, 17 red). `cargo clippy --all-targets -- -D warnings` in dev and release, `cargo fmt --check`, `cargo test -p ferrox-server` (874 pass), `npm run check`, `npm run build`, `npm run licenses`.

## Follow-ups named, not built

- A reasoning budget sampler (above).
- Flipping `continue_final_message` to llama.cpp's default-on, and `/v1/messages` using it (Anthropic's own API prefills a trailing assistant turn).

https://claude.ai/code/session_01M5Meu19B6yUK24hFe5R7BN
