### PR TITLE
bench(metal): re-measure after #208; every Metal decode row is now faster than llama.cpp

### DIFF
--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -109,7 +109,9 @@ fix that outlived its cause, so they ran with no dispatch overlap.
 
 Output is byte-identical to `main`. That predicted Gemma-2-2B decode
 would move from 1.23× to about 1.12×, and the 2026-09-09 re-measurement
-confirms it at **1.11×**, still the worst Metal row.
+confirmed it at **1.11×**, then the worst Metal row. After the kernel
+work in #208 the 2026-09-11 re-measurement reads **0.94×**, and no
+Metal decode row is slower than llama.cpp any more.
 
 **Metal, where the rest of the gap is** (quiet host, GPU-clock and wall
 from one process; [#149](https://github.com/antonellof/ferrox/issues/149)).
@@ -208,8 +210,10 @@ token, ms (the lm_head buffer is unchanged within noise on all three):
 Gemma-2 prefill (`pp512`, GPU clock) 569.6 -> 565.9 ms, within noise.
 Against #202's quiet-host figures that is 12.03 -> ~10.2 ms of stack
 plus 0.65 ms of host removed, about 2.5 ms of a 17.3 ms token, which
-is the size of the 1.11x gap; the row needs a quiet-host `ferrox
-bench --compare` before `RESULTS.md` moves.
+is the size of the 1.11x gap. Measured on 2026-09-11 on a quiet host:
+Gemma-2-2B decode **1.11× to 0.94×**, Llama-3.2-3B **1.03× to 0.94×**,
+and every other Metal decode row moved the same direction; the summary
+line is now 0.60× to 0.96× on decode.
 
 ## Open
 
@@ -217,7 +221,7 @@ bench --compare` before `RESULTS.md` moves.
 |---|---|---|
 | [#133](https://github.com/antonellof/ferrox/issues/133) | CUDA prefill, 22× to 34× | ~4× is tensor cores (`mul_mm` has none), ~5× is undiagnosed kernel efficiency. #148 bought 20–26% and ruled out dequant redundancy and occupancy |
 | [#133](https://github.com/antonellof/ferrox/issues/133) | CUDA decode, 2.2× to 5.0× | memory-bound: 17–22% of card bandwidth against llama.cpp's ~60%. Coalescing closed 9–19× to 2–5×. What limits the rest is not diagnosed — the access pattern was a real cost and was not the last one |
-| [#149](https://github.com/antonellof/ferrox/issues/149) | Metal decode, 1.11× worst row | the "26% host" was an accounting error: the lm_head runs in a second, untimed command buffer, and its GPU time was booked as host. Encoding, argument binding included, is ~2% of wall (three measurements agree), so packing and pipelining are retired unbuilt. The kernel gap was then attributed per kind: RoPE, the norms and d=128/256 attention were 3x to 18x llama.cpp's per-dispatch cost, all memory-latency chains, and are fixed (stack GPU -15.5% on Gemma-2-2B, -9.6% on Llama-3B); the CPU softcap is a GPU epilogue. Left: ~0.2 ms submit latency per command buffer, two per sampled token; the quiet-host re-measure |
+| [#149](https://github.com/antonellof/ferrox/issues/149) | Metal decode, **closed**, worst row 0.96× | the "26% host" was an accounting error: the lm_head runs in a second, untimed command buffer, and its GPU time was booked as host. Encoding, argument binding included, is ~2% of wall (three measurements agree), so packing and pipelining are retired unbuilt. The kernel gap was then attributed per kind: RoPE, the norms and d=128/256 attention were 3x to 18x llama.cpp's per-dispatch cost, all memory-latency chains, and are fixed (stack GPU -15.5% on Gemma-2-2B, -9.6% on Llama-3B); the CPU softcap is a GPU epilogue. Left: ~0.2 ms submit latency per command buffer, two per sampled token; the quiet-host re-measure |
 | [#127](https://github.com/antonellof/ferrox/issues/127) | x86 CPU prefill, 6.3× to 10.1× | was a missing kernel tier. [#159](https://github.com/antonellof/ferrox/pull/159) added AVX2 GEMMs for all five interleaved kinds and a per-workload dispatch rule, verified by execution on real AVX2 but **not yet benchmarked**, so this gap number still describes the code before it |
 | [#27](https://github.com/antonellof/ferrox/issues/27) | CPU decode default | the size rule landed in [#155](https://github.com/antonellof/ferrox/pull/155); the crossover constant is bracketed by the published numbers, not swept, and no before/after on a quiet host has been run. `MIN_TASK_MACS` is still there, which the issue asks to delete |
 | [#128](https://github.com/antonellof/ferrox/issues/128) | CPU decode dispatch, **closed** | The condvar wait was real and the cause was rayon's two-armed `join`: from a non-worker thread it injects and blocks on a mutex, ~150 times per token. [#167](https://github.com/antonellof/ferrox/pull/167) runs a whole forward in one `rayon::scope`. Note the trap: #128 had computed scheduling at 6.7% of a token and ruled it out, against a **stale denominator** taken before #155 removed the repack that inflated the token to 17 ms. At ~5 ms the same fixed cost is a much larger share |

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -14,7 +14,7 @@ Measured on **3 machines**, one section each. A gap only means something against
 | Machine | Backend | Prefill | Decode |
 |---|---|---|---|
 | AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic | CPU | 🔴 **6.26×** to 🔴 **10.14×** | 🔴 **1.06×** to 🔴 **1.92×** |
-| Apple M2 Pro (10c/6p) macOS 26.6.2 + Apple M2 Pro | METAL | ⚪ **1.01×** to 🔴 **1.10×** | 🟢 **0.64×** to 🔴 **1.11×** |
+| Apple M2 Pro (10c/6p) macOS 26.6.2 + Apple M2 Pro | METAL | ⚪ **0.99×** to 🔴 **1.09×** | 🟢 **0.60×** to ⚪ **0.96×** |
 | Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz (10c) Linux 5.15.0-186-generic + NVIDIA GeForce RTX 3060 | CUDA | 🔴 **22.55×** to 🔴 **33.79×** | 🔴 **2.18×** to 🔴 **5.04×** |
 
 ### AMD Ryzen 9 7945HX with Radeon Graphics (16c) Linux 6.17.0-23-generic
@@ -40,21 +40,22 @@ Measured on **3 machines**, one section each. A gap only means something against
 
 | Model | Prefill | Decode | ferrox pp512 | llama.cpp pp512 | ferrox tg128 | llama.cpp tg128 |
 |---|---|---|---:|---:|---:|---:|
-| Gemma-2-2B-IT Q4_K_M | ⚪ **1.05×** | 🔴 **1.11×** | 876 | 917 | 61.6 | 68.2 |
-| Gemma-3-1B-IT Q8_0 | ⚪ **1.04×** | 🟢 **0.80×** | 2685 | 2785 | 103 | 83.1 |
-| Gemma-4-E2B-IT Q4_K_M | — | — | 14.3 | — | 16.2 | — |
-| Llama-3.2-1B-Instruct IQ4_XS | ⚪ **1.03×** | 🟢 **0.94×** | 1852 | 1908 | 157 | 147 |
-| Llama-3.2-1B-Instruct Q4_K_M | ⚪ **1.04×** | ⚪ **0.98×** | 1815 | 1890 | 151 | 149 |
-| Llama-3.2-1B-Instruct Q5_K_M | ⚪ **1.02×** | 🟢 **0.90×** | 1659 | 1695 | 129 | 117 |
-| Llama-3.2-1B-Instruct Q6_K | 🔴 **1.08×** | ⚪ **0.97×** | 1712 | 1847 | 136 | 132 |
-| Llama-3.2-3B-Instruct Q4_K_M | ⚪ **1.02×** | ⚪ **1.03×** | 647 | 663 | 62.7 | 64.3 |
-| Meta-Llama-3.1-8B-Instruct Q4_K_M | ⚪ **1.03×** | ⚪ **0.98×** | 272 | 279 | 30.7 | 30.1 |
-| OLMoE-1B-7B-0924 Q4_0 | 🔴 **1.09×** | ⚪ **0.96×** | 1424 | 1552 | 160 | 153 |
-| Phi-4-mini-Instruct Q4_K_M | ⚪ **1.02×** | ⚪ **0.98×** | 551 | 561 | 51.2 | 50.0 |
-| Qwen2.5-0.5B-Instruct Q8_0 | 🔴 **1.10×** | 🟢 **0.65×** | 4485 | 4925 | 202 | 131 |
-| Qwen3-0.6B Q8_0 | ⚪ **1.02×** | 🟢 **0.76×** | 3450 | 3511 | 152 | 116 |
-| SmolLM2-135M-Instruct Q8_0 | ⚪ **1.02×** | 🟢 **0.64×** | 12004 | 12184 | 317 | 203 |
-| TinyLlama-1.1B-Chat-v1.0 Q8_0 | ⚪ **1.01×** | 🟢 **0.86×** | 2018 | 2036 | 128 | 109 |
+| Gemma-2-2B-IT Q4_K_M | ⚪ **1.02×** | 🟢 **0.94×** | 882 | 897 | 71.6 | 67.0 |
+| Gemma-3-1B-IT Q8_0 | ⚪ **1.03×** | 🟢 **0.68×** | 2691 | 2779 | 122 | 83.2 |
+| Gemma-4-E2B-IT Q4_K_M | — | — | 14.6 | — | 16.3 | — |
+| Llama-3.2-1B-Instruct IQ4_XS | ⚪ **1.03×** | 🟢 **0.90×** | 1847 | 1906 | 163 | 147 |
+| Llama-3.2-1B-Instruct Q4_K_M | ⚪ **1.04×** | 🟢 **0.95×** | 1814 | 1888 | 158 | 149 |
+| Llama-3.2-1B-Instruct Q5_K_M | ⚪ **1.02×** | 🟢 **0.86×** | 1654 | 1691 | 136 | 117 |
+| Llama-3.2-1B-Instruct Q6_K | 🔴 **1.08×** | 🟢 **0.94×** | 1709 | 1848 | 140 | 131 |
+| Llama-3.2-3B-Instruct Q4_K_M | ⚪ **1.03×** | 🟢 **0.94×** | 646 | 662 | 68.5 | 64.5 |
+| Meta-Llama-3.1-8B-Instruct Q4_K_M | ⚪ **1.03×** | 🟢 **0.95×** | 271 | 279 | 32.0 | 30.4 |
+| Mistral-7B-Instruct-v0.2 Q4_K_M | ⚪ **1.03×** | 🟢 **0.95×** | 273 | 280 | 34.3 | 32.4 |
+| OLMoE-1B-7B-0924 Q4_0 | 🔴 **1.08×** | ⚪ **0.96×** | 1441 | 1556 | 174 | 168 |
+| Phi-4-mini-Instruct Q4_K_M | ⚪ **1.02×** | 🟢 **0.88×** | 543 | 556 | 53.9 | 47.6 |
+| Qwen2.5-0.5B-Instruct Q8_0 | 🔴 **1.09×** | 🟢 **0.60×** | 4511 | 4935 | 218 | 131 |
+| Qwen3-0.6B Q8_0 | ⚪ **0.99×** | 🟢 **0.61×** | 3535 | 3500 | 191 | 116 |
+| SmolLM2-135M-Instruct Q8_0 | ⚪ **1.02×** | 🟢 **0.60×** | 11878 | 12161 | 363 | 217 |
+| TinyLlama-1.1B-Chat-v1.0 Q8_0 | ⚪ **1.00×** | 🟢 **0.83×** | 2032 | 2034 | 132 | 110 |
 
 ### Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz (10c) Linux 5.15.0-186-generic + NVIDIA GeForce RTX 3060
 

--- a/benchmarks/receipts/engine/gemma2_2b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/gemma2_2b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.41,
-  "host_load_1min_start": 1.62,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 2.04,
+  "host_load_1min_start": 1.97,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "gemma2_2b_q4km",
   "kind": "engine",
-  "load_s": 0.03393725,
+  "load_s": 0.036797958,
   "model_path": "models/gemma-2-2b-it-Q4_K_M.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        875.0572374169901,
-        876.1174375260376,
-        876.733346347344
+        867.9565318960497,
+        884.5318783474976,
+        882.3948868676948
       ],
-      "ferrox_stddev": 0.6922354363300297,
-      "ferrox_tps": 876.1174375260376,
-      "gap": 1.046686164116836,
-      "llama_tps": 917.02,
+      "ferrox_stddev": 7.361875794007228,
+      "ferrox_tps": 882.3948868676948,
+      "gap": 1.0164156811739062,
+      "llama_tps": 896.88,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        59.19909179639321,
-        61.586263700821235,
-        61.95766621444831
+        72.30485082178132,
+        71.5817144749725,
+        67.86070431717374
       ],
-      "ferrox_stddev": 1.222304851425601,
-      "ferrox_tps": 61.586263700821235,
-      "gap": 1.1067403005824998,
-      "llama_tps": 68.16,
+      "ferrox_stddev": 1.9470570648754681,
+      "ferrox_tps": 71.5817144749725,
+      "gap": 0.9352947256300782,
+      "llama_tps": 66.95,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/gemma3_1b_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/gemma3_1b_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.76,
-  "host_load_1min_start": 1.83,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.89,
+  "host_load_1min_start": 1.97,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "gemma3_1b_q8",
   "kind": "engine",
-  "load_s": 0.037404459,
+  "load_s": 0.049336333,
   "model_path": "models/hf_test/gemma-3-1b-it-Q8_0.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        2685.484880266424,
-        2667.5807576729626,
-        2697.9915855544305
+        2670.634952014219,
+        2690.765597807156,
+        2721.40904269903
       ],
-      "ferrox_stddev": 12.480178664314996,
-      "ferrox_tps": 2685.484880266424,
-      "gap": 1.0370827333511914,
-      "llama_tps": 2785.07,
+      "ferrox_stddev": 20.876014678603582,
+      "ferrox_tps": 2690.765597807156,
+      "gap": 1.0328956198432815,
+      "llama_tps": 2779.28,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        103.32923635063895,
-        103.78582438139246,
-        103.23982150715626
+        122.46500524683137,
+        121.0422541118737,
+        122.02863061090467
       ],
-      "ferrox_stddev": 0.23911568161238173,
-      "ferrox_tps": 103.32923635063895,
-      "gap": 0.8038383223712501,
-      "llama_tps": 83.06,
+      "ferrox_stddev": 0.5951267103869625,
+      "ferrox_tps": 122.02863061090467,
+      "gap": 0.6821350004771874,
+      "llama_tps": 83.24,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/gemma4_e2b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/gemma4_e2b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 2.94,
-  "host_load_1min_start": 1.65,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.08,
+  "host_load_1min_start": 1.76,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "gemma4_e2b_q4km",
   "kind": "engine",
-  "load_s": 0.378213458,
+  "load_s": 0.367138208,
   "model_path": "models/gemma-4-E2B-it-Q4_K_M.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,12 +45,12 @@
   "tests": [
     {
       "ferrox_samples": [
-        14.108957017886553,
-        14.269410054600762,
-        14.741923818250983
+        14.619363091912685,
+        14.604244512590613,
+        14.544481056892895
       ],
-      "ferrox_stddev": 0.26867191975701793,
-      "ferrox_tps": 14.269410054600762,
+      "ferrox_stddev": 0.03233086115352395,
+      "ferrox_tps": 14.604244512590613,
       "gap": null,
       "llama_tps": null,
       "test": "pp512",
@@ -58,12 +58,12 @@
     },
     {
       "ferrox_samples": [
-        16.232315719649616,
-        16.252487643056835,
-        16.17773227347935
+        16.2978847598255,
+        16.29265131773213,
+        16.205686455784434
       ],
-      "ferrox_stddev": 0.03157816469657364,
-      "ferrox_tps": 16.232315719649616,
+      "ferrox_stddev": 0.04228317684608439,
+      "ferrox_tps": 16.29265131773213,
       "gap": null,
       "llama_tps": null,
       "test": "tg128",

--- a/benchmarks/receipts/engine/iq4_xs_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/iq4_xs_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.49,
-  "host_load_1min_start": 1.62,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.27,
+  "host_load_1min_start": 1.27,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "iq4_xs",
   "kind": "engine",
-  "load_s": 0.036125375,
+  "load_s": 0.034933083,
   "model_path": "models/Llama-3.2-1B-Instruct-IQ4_XS.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        1844.0214237688692,
-        1853.9599198850326,
-        1852.1122716455448
+        1837.9925121262006,
+        1846.7109646699776,
+        1854.6314848145257
       ],
-      "ferrox_stddev": 4.315982293643295,
-      "ferrox_tps": 1852.1122716455448,
-      "gap": 1.0301265367163086,
-      "llama_tps": 1907.91,
+      "ferrox_stddev": 6.795435283589787,
+      "ferrox_tps": 1846.7109646699776,
+      "gap": 1.0322839017424021,
+      "llama_tps": 1906.33,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        156.23063480088018,
-        156.68655279757886,
-        156.8486252618695
+        162.37788879889504,
+        162.8898524920908,
+        163.46444146575055
       ],
-      "ferrox_stddev": 0.2616275795156085,
-      "ferrox_tps": 156.68655279757886,
-      "gap": 0.9358812060243749,
-      "llama_tps": 146.64,
+      "ferrox_stddev": 0.4438287970293689,
+      "ferrox_tps": 162.8898524920908,
+      "gap": 0.9003016317859375,
+      "llama_tps": 146.65,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/llama31_8b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/llama31_8b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.45,
-  "host_load_1min_start": 1.78,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.46,
+  "host_load_1min_start": 1.83,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "llama31_8b_q4km",
   "kind": "engine",
-  "load_s": 0.0433665,
+  "load_s": 0.042051083,
   "model_path": "models/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        271.1977945000386,
-        271.88978874342905,
-        272.08254410464014
+        270.063862587076,
+        271.19730365258937,
+        271.95138201065976
       ],
-      "ferrox_stddev": 0.3798819297570942,
-      "ferrox_tps": 271.88978874342905,
-      "gap": 1.0277326018436328,
-      "llama_tps": 279.43,
+      "ferrox_stddev": 0.7757471232809532,
+      "ferrox_tps": 271.19730365258937,
+      "gap": 1.0296562548339845,
+      "llama_tps": 279.24,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        30.6687558775847,
-        30.65170065453354,
-        30.627918698728674
+        31.895130469562858,
+        32.070540155275914,
+        32.034005762885606
       ],
-      "ferrox_stddev": 0.016746930837050342,
-      "ferrox_tps": 30.65170065453354,
-      "gap": 0.9826534696875001,
-      "llama_tps": 30.12,
+      "ferrox_stddev": 0.07556429695208171,
+      "ferrox_tps": 32.034005762885606,
+      "gap": 0.9493036938649999,
+      "llama_tps": 30.41,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/llama32_1b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/llama32_1b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.35,
-  "host_load_1min_start": 1.47,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.62,
+  "host_load_1min_start": 1.41,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "llama32_1b_q4km",
   "kind": "engine",
-  "load_s": 0.03670375,
+  "load_s": 0.037102292,
   "model_path": "models/Llama-3.2-1B-Instruct-Q4_K_M.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        1813.3171698774104,
-        1818.5108937433356,
-        1814.8611250189417
+        1819.4751380680457,
+        1811.0516640476808,
+        1814.0270906097107
       ],
-      "ferrox_stddev": 2.177648497707409,
-      "ferrox_tps": 1814.8611250189417,
-      "gap": 1.0413579165625,
-      "llama_tps": 1889.92,
+      "ferrox_stddev": 3.4879044792295413,
+      "ferrox_tps": 1814.0270906097107,
+      "gap": 1.0408499463838672,
+      "llama_tps": 1888.13,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        153.4667447641346,
-        151.4586548193656,
-        151.09622239364742
+        157.66411586081568,
+        156.15373023410046,
+        158.08158121101604
       ],
-      "ferrox_stddev": 1.0426013832116987,
-      "ferrox_tps": 151.4586548193656,
-      "gap": 0.9819841604785156,
-      "llama_tps": 148.73,
+      "ferrox_stddev": 0.8281271674487485,
+      "ferrox_tps": 157.66411586081568,
+      "gap": 0.9464423733028124,
+      "llama_tps": 149.22,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/llama32_1b_q5km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/llama32_1b_q5km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.55,
-  "host_load_1min_start": 1.68,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.76,
+  "host_load_1min_start": 1.74,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "llama32_1b_q5km",
   "kind": "engine",
-  "load_s": 0.038263083,
+  "load_s": 0.036690834,
   "model_path": "models/Llama-3.2-1B-Instruct-Q5_K_M.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        1648.793333658047,
-        1659.3709064968575,
-        1658.6387095337304
+        1649.7606956056152,
+        1653.7877247754711,
+        1658.3956075189776
       ],
-      "ferrox_stddev": 4.82300719568477,
-      "ferrox_tps": 1658.6387095337304,
-      "gap": 1.0219163403442384,
-      "llama_tps": 1694.99,
+      "ferrox_stddev": 3.5278455979110586,
+      "ferrox_tps": 1653.7877247754711,
+      "gap": 1.0222775116011524,
+      "llama_tps": 1690.63,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        129.3187713634484,
-        129.2953127671293,
-        129.2866771720509
+        135.6649748951063,
+        134.46306228875721,
+        135.51445744141256
       ],
-      "ferrox_stddev": 0.013560221094069392,
-      "ferrox_tps": 129.2953127671293,
-      "gap": 0.9018115003906249,
-      "llama_tps": 116.6,
+      "ferrox_stddev": 0.5346526581908057,
+      "ferrox_tps": 135.51445744141256,
+      "gap": 0.86131031480875,
+      "llama_tps": 116.72,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/llama32_1b_q6k_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/llama32_1b_q6k_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.76,
-  "host_load_1min_start": 1.91,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.56,
+  "host_load_1min_start": 1.7,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "llama32_1b_q6k",
   "kind": "engine",
-  "load_s": 0.037645208,
+  "load_s": 0.038315833,
   "model_path": "models/Llama-3.2-1B-Instruct-Q6_K.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        1711.86359924337,
-        1712.8428926637969,
-        1711.4933174308862
+        1700.1651839981023,
+        1709.2126813899872,
+        1715.4195951509241
       ],
-      "ferrox_stddev": 0.5693541695283217,
-      "ferrox_tps": 1711.86359924337,
-      "gap": 1.0790287268310546,
-      "llama_tps": 1847.15,
+      "ferrox_stddev": 6.26347478207502,
+      "ferrox_tps": 1709.2126813899872,
+      "gap": 1.0813926318969727,
+      "llama_tps": 1848.33,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        137.2637595524987,
-        135.4221792574669,
-        135.97249212747155
+        139.19117962893588,
+        140.45286722732598,
+        139.79652602531092
       ],
-      "ferrox_stddev": 0.7718400669740405,
-      "ferrox_tps": 135.97249212747155,
-      "gap": 0.9685782612304686,
-      "llama_tps": 131.7,
+      "ferrox_stddev": 0.5152220264656336,
+      "ferrox_tps": 139.79652602531092,
+      "gap": 0.9403667153803125,
+      "llama_tps": 131.46,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/mistral_7b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/mistral_7b_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -1,6 +1,6 @@
 {
   "accelerator": "Apple M2 Pro",
-  "approx_params": 3958898688,
+  "approx_params": 8046772224,
   "arch": "llama",
   "backend": "metal",
   "backend_active": "Metal",
@@ -8,7 +8,7 @@
     "FERROX_CPU_INT_DOT": "1"
   },
   "ferrox_version": "0.20.0",
-  "host_load_1min_end": 1.95,
+  "host_load_1min_end": 1.73,
   "host_load_1min_start": 1.93,
   "host_spec": {
     "arch": "aarch64",
@@ -33,39 +33,39 @@
     "pressure": "nominal",
     "source": "NSProcessInfo.thermalState"
   },
-  "id": "llama32_3b_q4km",
+  "id": "mistral_7b_q4km",
   "kind": "engine",
-  "load_s": 0.042647875,
-  "model_path": "models/Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+  "load_s": 0.015069958,
+  "model_path": "models/Mistral-7B-Instruct-v0.2-Q4_K_M.gguf",
   "quant": "quantized",
   "quiet_host": true,
   "reps": 3,
   "schema": 2,
-  "size_bytes": 2019377696,
+  "size_bytes": 4368439584,
   "tests": [
     {
       "ferrox_samples": [
-        640.6328251125565,
-        645.5926822513312,
-        646.6116371284852
+        272.53045391424195,
+        272.6572989979511,
+        272.4520813221656
       ],
-      "ferrox_stddev": 2.6116117841615725,
-      "ferrox_tps": 645.5926822513312,
-      "gap": 1.025832569369453,
-      "llama_tps": 662.27,
+      "ferrox_stddev": 0.08455519755674742,
+      "ferrox_tps": 272.53045391424195,
+      "gap": 1.0266375591479493,
+      "llama_tps": 279.79,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        68.52402158533876,
-        68.54300618576855,
-        68.47194098093144
+        34.40107267124232,
+        34.30759840433173,
+        34.3216313304973
       ],
-      "ferrox_stddev": 0.03004268768020193,
-      "ferrox_tps": 68.52402158533876,
-      "gap": 0.9414216869869532,
-      "llama_tps": 64.51,
+      "ferrox_stddev": 0.04115727046694998,
+      "ferrox_tps": 34.3216313304973,
+      "gap": 0.9451765182028125,
+      "llama_tps": 32.44,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/olmoe_q4_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/olmoe_q4_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.61,
-  "host_load_1min_start": 1.41,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 4.81,
+  "host_load_1min_start": 1.49,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "olmoe_q4",
   "kind": "engine",
-  "load_s": 0.030430875,
+  "load_s": 0.030822166,
   "model_path": "models/olmoe-1b-7b-0924-q4_0.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        1390.601489464564,
-        1424.3904610351312,
-        1426.8583585102072
+        1411.6819927355948,
+        1441.027466543599,
+        1446.214486692098
       ],
-      "ferrox_stddev": 16.540676026548034,
-      "ferrox_tps": 1424.3904610351312,
-      "gap": 1.0899047996093751,
-      "llama_tps": 1552.45,
+      "ferrox_stddev": 15.204367610412808,
+      "ferrox_tps": 1441.027466543599,
+      "gap": 1.079896140864375,
+      "llama_tps": 1556.16,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        160.0857709544692,
-        160.24429743908019,
-        159.78525520814202
+        173.30979517323635,
+        176.59762929106336,
+        174.4692631045189
       ],
-      "ferrox_stddev": 0.19036810245719915,
-      "ferrox_tps": 160.0857709544692,
-      "gap": 0.9581738532128905,
-      "llama_tps": 153.39,
+      "ferrox_stddev": 1.3615416790472694,
+      "ferrox_tps": 174.4692631045189,
+      "gap": 0.9609715603576563,
+      "llama_tps": 167.66,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/phi4_mini_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/phi4_mini_q4km_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.32,
-  "host_load_1min_start": 1.52,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 2.85,
+  "host_load_1min_start": 1.08,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "phi4_mini_q4km",
   "kind": "engine",
-  "load_s": 0.051981958,
+  "load_s": 0.048400459,
   "model_path": "models/Phi-4-mini-instruct-Q4_K_M.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        549.181191116554,
-        550.7524817673257,
-        555.4312525001865
+        548.5333495822053,
+        542.9945595084325,
+        502.616731670815
       ],
-      "ferrox_stddev": 2.6546210689841447,
-      "ferrox_tps": 550.7524817673257,
-      "gap": 1.0191329473429882,
-      "llama_tps": 561.29,
+      "ferrox_stddev": 20.46510031135993,
+      "ferrox_tps": 542.9945595084325,
+      "gap": 1.024835314195,
+      "llama_tps": 556.48,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        51.139323193031466,
-        51.22041645800016,
-        51.24516919346674
+        54.281479999496554,
+        53.0560134198554,
+        53.90764346684899
       ],
-      "ferrox_stddev": 0.04520593784068695,
-      "ferrox_tps": 51.22041645800016,
-      "gap": 0.9761732421875,
-      "llama_tps": 50.0,
+      "ferrox_stddev": 0.512813137713237,
+      "ferrox_tps": 53.90764346684899,
+      "gap": 0.8835481749316406,
+      "llama_tps": 47.63,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/qwen25_05b_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/qwen25_05b_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.26,
-  "host_load_1min_start": 1.26,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.69,
+  "host_load_1min_start": 1.84,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "qwen25_05b_q8",
   "kind": "engine",
-  "load_s": 0.040750958,
+  "load_s": 0.052323959,
   "model_path": "models/hf_test/qwen2.5-0.5b-instruct-q8_0.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        4204.251056194907,
-        4485.455682173506,
-        4523.759136403071
+        4225.353588853174,
+        4511.223554141397,
+        4546.345894022759
       ],
-      "ferrox_stddev": 142.45022896748003,
-      "ferrox_tps": 4485.455682173506,
-      "gap": 1.098073495536875,
-      "llama_tps": 4925.36,
+      "ferrox_stddev": 143.7556861834672,
+      "ferrox_tps": 4511.223554141397,
+      "gap": 1.0940335677821094,
+      "llama_tps": 4935.43,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        202.30035000979254,
-        202.04778587985894,
-        201.26553567490586
+        217.71705091327863,
+        218.42456717896445,
+        212.56857360467106
       ],
-      "ferrox_stddev": 0.4405230137215932,
-      "ferrox_tps": 202.04778587985894,
-      "gap": 0.6468766753906249,
-      "llama_tps": 130.7,
+      "ferrox_stddev": 2.6098117983576805,
+      "ferrox_tps": 217.71705091327863,
+      "gap": 0.6018361880723437,
+      "llama_tps": 131.03,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/qwen3_06b_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/qwen3_06b_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.38,
-  "host_load_1min_start": 1.32,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.8,
+  "host_load_1min_start": 1.69,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "qwen3_06b_q8",
   "kind": "engine",
-  "load_s": 0.040841583,
+  "load_s": 0.0399685,
   "model_path": "models/hf_test/Qwen3-0.6B-Q8_0.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        3204.2731987110938,
-        3449.8955099421273,
-        3484.1269369244956
+        3371.6364847470786,
+        3564.1534569939113,
+        3534.841531466227
       ],
-      "ferrox_stddev": 124.64180909030625,
-      "ferrox_tps": 3449.8955099421273,
-      "gap": 1.0178134351839843,
-      "llama_tps": 3511.35,
+      "ferrox_stddev": 84.69412996570374,
+      "ferrox_tps": 3534.841531466227,
+      "gap": 0.9901094487107813,
+      "llama_tps": 3499.88,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        151.75678485467287,
-        153.16242261670521,
-        151.69452706127376
+        192.05483175049218,
+        190.62077519953186,
+        187.54648607057524
       ],
-      "ferrox_stddev": 0.6777750292559089,
-      "ferrox_tps": 151.75678485467287,
-      "gap": 0.7626018178417969,
-      "llama_tps": 115.73,
+      "ferrox_stddev": 1.8806899623217135,
+      "ferrox_tps": 190.62077519953186,
+      "gap": 0.609272519631875,
+      "llama_tps": 116.14,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/smollm2_135m_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/smollm2_135m_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.37,
-  "host_load_1min_start": 1.37,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.94,
+  "host_load_1min_start": 1.94,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "smollm2_135m_q8",
   "kind": "engine",
-  "load_s": 0.023222625,
+  "load_s": 0.021486667,
   "model_path": "models/hf_test/SmolLM2-135M-Instruct-Q8_0.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        12004.032698516163,
-        12182.825666025205,
-        11562.48853207772
+        12110.4365850234,
+        10012.719674082846,
+        11878.420193314329
       ],
-      "ferrox_stddev": 260.7140485284147,
-      "ferrox_tps": 12004.032698516163,
-      "gap": 1.015002233499922,
-      "llama_tps": 12184.12,
+      "ferrox_stddev": 938.976172454061,
+      "ferrox_tps": 11878.420193314329,
+      "gap": 1.023761561057129,
+      "llama_tps": 12160.67,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        317.17591167297104,
-        317.3998996966723,
-        325.2600651155404
+        348.62612707694694,
+        362.6650076555892,
+        363.3282138306437
       ],
-      "ferrox_stddev": 3.7592243279363537,
-      "ferrox_tps": 317.3998996966723,
-      "gap": 0.6390676247656251,
-      "llama_tps": 202.84,
+      "ferrox_stddev": 6.77971947342656,
+      "ferrox_tps": 362.6650076555892,
+      "gap": 0.5986516355782031,
+      "llama_tps": 217.11,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/benchmarks/receipts/engine/tinyllama_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
+++ b/benchmarks/receipts/engine/tinyllama_q8_metal__apple-m2-pro-10c-6p-macos-26-6-2.json
@@ -7,9 +7,9 @@
   "engine_env": {
     "FERROX_CPU_INT_DOT": "1"
   },
-  "ferrox_version": "0.17.1",
-  "host_load_1min_end": 1.47,
-  "host_load_1min_start": 1.57,
+  "ferrox_version": "0.20.0",
+  "host_load_1min_end": 1.63,
+  "host_load_1min_start": 1.78,
   "host_spec": {
     "arch": "aarch64",
     "cores": 10,
@@ -35,7 +35,7 @@
   },
   "id": "tinyllama_q8",
   "kind": "engine",
-  "load_s": 0.018174583,
+  "load_s": 0.018764875,
   "model_path": "models/tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
   "quant": "quantized",
   "quiet_host": true,
@@ -45,27 +45,27 @@
   "tests": [
     {
       "ferrox_samples": [
-        1991.0383829035131,
-        2017.6355931410242,
-        2022.735355767386
+        2032.1929287124224,
+        2016.7825615492493,
+        2035.4214293755733
       ],
-      "ferrox_stddev": 13.896911167580802,
-      "ferrox_tps": 2017.6355931410242,
-      "gap": 1.0088689984057617,
-      "llama_tps": 2035.53,
+      "ferrox_stddev": 8.13299197700976,
+      "ferrox_tps": 2032.1929287124224,
+      "gap": 1.0008055688337696,
+      "llama_tps": 2033.83,
       "test": "pp512",
       "workload_digest": "b8d417040110e751"
     },
     {
       "ferrox_samples": [
-        127.83683226322003,
-        127.64779840701271,
-        127.51511840662383
+        131.66265195353813,
+        132.3446088182867,
+        132.37943142008262
       ],
-      "ferrox_stddev": 0.13200908505006895,
-      "ferrox_tps": 127.64779840701271,
-      "gap": 0.8577507905846093,
-      "llama_tps": 109.49,
+      "ferrox_stddev": 0.32999168047313426,
+      "ferrox_tps": 132.3446088182867,
+      "gap": 0.8285188265625001,
+      "llama_tps": 109.65,
       "test": "tg128",
       "workload_digest": "044655d19aa3baa5"
     }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -11,13 +11,14 @@ Measured against llama.cpp on the same host and the same GGUF with
 is faster.
 
 - **Dense GQA**: TinyLlama, Llama 3.2, SmolLM2, Qwen2.5/Qwen3,
-  Gemma-2/3/4, Phi-4-mini. Re-measured on 2026-09-09 on a quiet M2 Pro:
-  **12 of 14 comparable Metal `tg128` rows are faster than llama.cpp**
-  (SmolLM2-135M **0.64×**, Qwen2.5-0.5B **0.65×**, Qwen3-0.6B **0.76×**,
-  Gemma-3-1B **0.80×**, TinyLlama **0.86×**, down to Llama-3.1-8B and
-  Phi-4-mini at **0.98×**). The two that are not: Llama-3.2-3B at 1.03×
-  and Gemma-2-2B at **1.11×**, which is the worst Metal row. Dense Metal
-  prefill spans **1.01× to 1.10×**. **CPU is a different story and is
+  Gemma-2/3/4, Phi-4-mini, Mistral-7B. Re-measured on 2026-09-11 on a
+  quiet M2 Pro after the Metal kernel work in #208: **every one of the
+  16 comparable Metal `tg128` rows is faster than llama.cpp**, from
+  SmolLM2-135M and Qwen2.5-0.5B at **0.60×** through Qwen3-0.6B
+  **0.61×**, Gemma-3-1B **0.68×**, TinyLlama **0.83×**, Phi-4-mini
+  **0.88×**, up to OLMoE at **0.96×** as the closest row. Gemma-2-2B,
+  the worst row two days earlier at 1.11×, reads **0.94×**. Dense Metal
+  prefill spans **0.99× to 1.09×**. **CPU is a different story and is
   behind on every row**: prefill 6.3× to 10.1× and decode 1.06× to
   1.92× on x86, though the AVX2 GEMM tier that closes the prefill half
   landed unmeasured.
@@ -435,8 +436,8 @@ checked against the code rather than asserted. The gap is the roadmap.
 
 Two honest notes. Ferrox runs on Apple Metal, which that description
 does not cover, and Metal is where it is fastest: every `pp512` row is
-1.01x to 1.10x against llama.cpp and **12 of 14** comparable `tg128`
-rows are faster. And the single largest gap is not on this table:
+0.99x to 1.09x against llama.cpp and **every one of the 16** comparable
+`tg128` rows is faster. And the single largest gap is not on this table:
 running a model that does not fit in memory works as policy and not as
 execution.
 


### PR DESCRIPTION
Sixteen Metal entries re-measured on a quiet M2 Pro after the kernel work in #208. Every receipt records `quiet_host: true` and `backend_active: Metal` on 0.20.0. Four entries the guard skipped mid-run when load crept up were re-run afterwards rather than published from the busy window. Mistral-7B is back in the table because closing the browser freed the memory `--fit-host` needs.

**Decode moved on every row.** Gemma-2-2B, the worst Metal row at 1.11x two days ago, reads **0.94x**. Llama-3.2-3B went 1.03x to **0.94x**. The summary line is now **0.60x to 0.96x** on decode, so no Metal decode row is slower than llama.cpp. Prefill 0.99x to 1.09x.

`docs/FEATURES.md` and `benchmarks/HISTORY.md` corrected to match, and the #149 row marked closed.

Docs and receipts only; `cargo test -p ferrox-cli` green including the committed-receipt checks.