### PR TITLE
feat(ui): the Thinking block times the thought, and says so

### DIFF
--- a/crates/ferrox-server/src/conversations.rs
+++ b/crates/ferrox-server/src/conversations.rs
@@ -219,6 +219,17 @@ pub(crate) struct MessageNode {
     /// key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) reasoning_content: Option<String>,
+    /// How long the model thought, in milliseconds: the wall-clock
+    /// between the first `reasoning_content` delta and the first
+    /// `content` delta, as the client that consumed the stream saw it.
+    /// Stored here rather than derived from `usage` because usage
+    /// measures decode, and a thought's length in seconds is not a
+    /// decode figure. Only ever beside a `reasoning_content`; a
+    /// duration for a turn that did not think is dropped on append.
+    /// Absent on records from before it existed (`default`), which
+    /// then show their thought with no time on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reasoning_ms: Option<u64>,
     /// Stamped by the server on append. A client-supplied time would be
     /// a claim; this is a fact about when the server was told.
     pub(crate) created_at: u64,
@@ -341,6 +352,10 @@ pub(crate) struct NewMessage {
     /// empty thought is no thought.
     #[serde(default)]
     pub(crate) reasoning_content: Option<String>,
+    /// See [`MessageNode::reasoning_ms`]. Kept only when the turn has a
+    /// thought to attach it to.
+    #[serde(default)]
+    pub(crate) reasoning_ms: Option<u64>,
     #[serde(default)]
     pub(crate) metadata: Option<serde_json::Value>,
 }
@@ -839,6 +854,10 @@ fn append_messages(
         // unstorable, and vice versa. The conversation-wide byte
         // ceiling still bounds the two together.
         let reasoning_content = message.reasoning_content.filter(|r| !r.is_empty());
+        // The clock goes with the thought. A duration on a turn with
+        // no reasoning is a number about nothing, and storing it would
+        // make a reload show "Thought for 15 seconds" over no thought.
+        let reasoning_ms = message.reasoning_ms.filter(|_| reasoning_content.is_some());
         if reasoning_content
             .as_ref()
             .is_some_and(|r| r.len() > MAX_CONTENT_BYTES)
@@ -868,6 +887,7 @@ fn append_messages(
             role: message.role,
             content: message.content,
             reasoning_content,
+            reasoning_ms,
             created_at: now,
             metadata: message.metadata,
         });
@@ -1087,6 +1107,7 @@ mod tests {
             role: role.to_string(),
             content: content.to_string(),
             reasoning_content: None,
+            reasoning_ms: None,
             metadata: None,
         }
     }
@@ -1456,6 +1477,55 @@ mod tests {
         );
     }
 
+    /// The thought's clock is stored beside the thought and only there:
+    /// a `reasoning_ms` on a turn with no `reasoning_content` is dropped
+    /// on append rather than stored, and the key is written only where
+    /// there is a duration.
+    #[test]
+    fn a_thoughts_duration_survives_a_restart_and_never_without_a_thought() {
+        let dir = TempDir::new("reasoning-ms");
+        let id = {
+            let store = store(&dir);
+            let mut timed = msg("a1", Some("u1"), "assistant", "answer");
+            timed.reasoning_content = Some("Let me think".to_string());
+            timed.reasoning_ms = Some(15_250);
+            let mut untimed = msg("a2", Some("a1"), "assistant", "again");
+            untimed.reasoning_content = Some("Hmm".to_string());
+            let mut thoughtless = msg("a3", Some("a2"), "assistant", "plain");
+            thoughtless.reasoning_ms = Some(3_000);
+            let mut blank = msg("a4", Some("a3"), "assistant", "blank");
+            blank.reasoning_content = Some(String::new());
+            blank.reasoning_ms = Some(4_000);
+            store
+                .create(created(vec![
+                    msg("u1", None, "user", "why"),
+                    timed,
+                    untimed,
+                    thoughtless,
+                    blank,
+                ]))
+                .unwrap()
+                .id
+        };
+        let conversation = store(&dir).get(&id).unwrap();
+        assert_eq!(conversation.messages[1].reasoning_ms, Some(15_250));
+        assert_eq!(conversation.messages[2].reasoning_ms, None);
+        assert_eq!(
+            conversation.messages[3].reasoning_ms, None,
+            "a duration with no thought beside it is a number about nothing"
+        );
+        assert_eq!(
+            conversation.messages[4].reasoning_ms, None,
+            "an empty thought is no thought, so it has no duration either"
+        );
+        let on_disk = std::fs::read_to_string(dir.0.join(format!("{id}.json"))).unwrap();
+        assert_eq!(
+            on_disk.matches("reasoning_ms").count(),
+            1,
+            "the key is written only where there is a duration: {on_disk}"
+        );
+    }
+
     /// A file written before the field existed carries no
     /// `reasoning_content` at all, and must load as it did then.
     #[test]
@@ -1473,6 +1543,7 @@ mod tests {
         assert_eq!(conversation.messages.len(), 2);
         assert_eq!(conversation.messages[1].content, "hello");
         assert_eq!(conversation.messages[1].reasoning_content, None);
+        assert_eq!(conversation.messages[1].reasoning_ms, None);
     }
 
     #[test]

--- a/ui/README.md
+++ b/ui/README.md
@@ -66,7 +66,7 @@ npm run check       # typecheck + lint + test
 
 `npm test` runs `node --test` over `src/lib/*.test.ts`, node strips the
 types itself, so there is no test framework in the dependency tree and
-nothing for the licence check to weigh. It covers three things a browser
+nothing for the licence check to weigh. It covers four things a browser
 cannot show you:
 
 - the stream recovery paths in `lib/api.ts`, the half of SSE hardening
@@ -79,7 +79,18 @@ cannot show you:
   getting "which nodes are new" wrong duplicates or drops a message;
 - the entry rule in `lib/entry-state.ts` (below), where being too eager
   throws away the conversation you were in and being too lazy resurrects
-  one for ever. Both failures are silent.
+  one for ever. Both failures are silent;
+- the thought clock in `lib/thought.ts`: the words a duration turns
+  into ("Thought for 15 seconds", "1 min 20 s"), that a running clock
+  ticks from its stamp rather than freezing at the last delta, and
+  that the duration is stored ONCE, as `reasoning_ms` beside
+  `reasoning_content`, rather than twice -- once as that column and
+  once inside the opaque `metadata` blob the server hands back
+  byte-identical. This is the one client-side stopwatch in the app:
+  every speed under an answer is the server's `usage`, but how long
+  the model THOUGHT is the gap between the first reasoning delta and
+  the first content delta, which `usage` does not measure and only the
+  stream's consumer can.
 
 CI runs `npm run licenses`, `npm run typecheck`, `npm run lint` and
 `npm run build`. It does not run `npm test`, so run `npm run check`

--- a/ui/src/lib/conversations.test.ts
+++ b/ui/src/lib/conversations.test.ts
@@ -389,3 +389,105 @@ test("a stored thought reloads above its answer, and a cut-off turn offers the w
     reason: "stop",
   });
 });
+
+test("the thought's duration is stored once, as a column, and comes back where it was", () => {
+  // The runtime carries the clock as `metadata.custom.thought`, and the
+  // server stores `metadata` byte-identical. Left there, the duration
+  // would be stored twice and a reload would have two numbers to pick
+  // from; it is lifted out into `reasoning_ms` and put back on load.
+  const pending = pendingAppend(
+    repo([
+      {
+        parentId: null,
+        message: {
+          id: "a1",
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "Let me think" },
+            { type: "text", text: "hello" },
+          ],
+          status: { type: "complete", reason: "stop" },
+          metadata: {
+            custom: {
+              stats: { outcome: "ok" },
+              thought: { state: "done", ms: 15_250 },
+            },
+          },
+        },
+      },
+      {
+        // A thought whose clock never stopped is not a duration.
+        parentId: "a1",
+        message: {
+          id: "a2",
+          role: "assistant",
+          content: [{ type: "reasoning", text: "Hmm" }],
+          status: { type: "incomplete", reason: "cancelled" },
+          metadata: { custom: { thought: { state: "thinking", startedAt: 5 } } },
+        },
+      },
+      {
+        // A duration with no thought beside it is not stored either:
+        // the column means "this turn thought for", and there was none.
+        parentId: "a2",
+        message: {
+          id: "a3",
+          role: "assistant",
+          content: [{ type: "text", text: "plain" }],
+          status: { type: "complete", reason: "stop" },
+          metadata: { custom: { thought: { state: "done", ms: 3_000 } } },
+        },
+      },
+    ]),
+    new Set(),
+  );
+  const [thought, running, plain] = pending.messages;
+  assert.equal(thought.reasoning_ms, 15_250);
+  assert.deepEqual(thought.metadata, { custom: { stats: { outcome: "ok" } } });
+  assert.equal("reasoning_ms" in running, false);
+  assert.deepEqual(running.metadata, { custom: {} });
+  assert.equal("reasoning_ms" in plain, false);
+
+  const { items } = toBranchable({
+    ...CONVERSATION,
+    messages: [
+      {
+        id: "a1",
+        parent_id: null,
+        role: "assistant",
+        content: "hello",
+        reasoning_content: "Let me think",
+        reasoning_ms: 15_250,
+        created_at: 1,
+        metadata: { custom: { stats: { outcome: "ok" } } },
+      },
+      {
+        // Written before the column existed: the thought shows, with
+        // no time on it, rather than as "Thought for 0 seconds".
+        id: "a2",
+        parent_id: "a1",
+        role: "assistant",
+        content: "",
+        reasoning_content: "Hmm",
+        created_at: 2,
+        metadata: { custom: { stats: { outcome: "length" } } },
+      },
+    ],
+  });
+  assert.deepEqual(items[0].message.metadata, {
+    custom: { stats: { outcome: "ok" }, thought: { state: "done", ms: 15_250 } },
+  });
+  assert.deepEqual(items[1].message.metadata, {
+    custom: { stats: { outcome: "length" } },
+  });
+
+  // And the round trip is closed: what came back is not written again.
+  const again = pendingAppend(
+    repo(items.map((i) => ({ parentId: i.parentId, message: i.message }))),
+    new Set(),
+  );
+  assert.equal(again.messages[0].reasoning_ms, 15_250);
+  assert.deepEqual(again.messages[0].metadata, {
+    custom: { stats: { outcome: "ok" } },
+  });
+});

--- a/ui/src/lib/conversations.ts
+++ b/ui/src/lib/conversations.ts
@@ -15,6 +15,7 @@
 // byte-identical.
 
 import { getJson, postJson, routes } from "./api.ts";
+import { readThought, THOUGHT_KEY, type Thought } from "./thought.ts";
 
 export type ConversationRole = "user" | "assistant" | "system";
 
@@ -30,6 +31,14 @@ export type StoredMessage = {
    * field, and on every turn that did not think.
    */
   reasoning_content?: string | null;
+  /**
+   * How long the model thought, in milliseconds, measured by the
+   * client between the first reasoning delta and the first content
+   * delta. Beside `reasoning_content` and never without it. Absent on
+   * records from before it was stored, which then show their thought
+   * with no time.
+   */
+  reasoning_ms?: number | null;
   created_at: number;
   metadata?: Record<string, unknown> | null;
 };
@@ -71,6 +80,7 @@ export type NewMessage = {
   role: ConversationRole;
   content: string;
   reasoning_content?: string;
+  reasoning_ms?: number;
   metadata?: Record<string, unknown>;
 };
 
@@ -239,13 +249,15 @@ export function pendingAppend(
     if (parentId !== null && !reachable.has(parentId)) continue;
     reachable.add(message.id);
     const reasoning = plainReasoning(message.content);
+    const { metadata, thoughtMs } = liftThought(message.metadata);
     messages.push({
       id: message.id,
       parent_id: parentId,
       role: message.role as ConversationRole,
       content: plainText(message.content),
       ...(reasoning ? { reasoning_content: reasoning } : {}),
-      ...(message.metadata ? { metadata: message.metadata } : {}),
+      ...(reasoning && thoughtMs !== undefined ? { reasoning_ms: thoughtMs } : {}),
+      ...(metadata ? { metadata } : {}),
     });
   }
 
@@ -264,6 +276,33 @@ export function pendingAppend(
 export function hasWork(pending: Pending, storedHead: string | null): boolean {
   if (pending.messages.length > 0) return true;
   return pending.headId !== null && pending.headId !== storedHead;
+}
+
+/**
+ * The thought's duration, taken OUT of the metadata it rides on.
+ *
+ * The store keeps `metadata` byte-identical, so leaving
+ * `custom.thought` in it would store the duration twice -- once as
+ * the typed `reasoning_ms` column and once inside an opaque blob --
+ * and a reload would then have two numbers to choose between. It is
+ * stored once, as the column, and `toBranchable` puts it back under
+ * the same key. A thought still marked as running is not a duration
+ * and is dropped rather than stored.
+ */
+function liftThought(metadata: Record<string, unknown> | undefined): {
+  metadata: Record<string, unknown> | undefined;
+  thoughtMs: number | undefined;
+} {
+  const thought = metadata && readThought(metadata);
+  if (!metadata || !thought) return { metadata, thoughtMs: undefined };
+  const { [THOUGHT_KEY]: _thought, ...custom } = metadata.custom as Record<
+    string,
+    unknown
+  >;
+  return {
+    metadata: { ...metadata, custom },
+    thoughtMs: thought.state === "done" ? thought.ms : undefined,
+  };
 }
 
 /** The status an assistant node gets back, from the outcome its own
@@ -293,6 +332,31 @@ export function restoredStatus(
 }
 
 /**
+ * The metadata a restored node carries: what was stored, with the
+ * thought's duration put back where the runtime writes it, so the
+ * Thinking block reads one shape whether the turn is fresh or
+ * reloaded. `null` when there is nothing to carry.
+ */
+export function restoredMetadata(
+  node: Pick<StoredMessage, "metadata" | "reasoning_content" | "reasoning_ms">,
+): Record<string, unknown> | null {
+  const ms = node.reasoning_ms;
+  const thought: Thought | undefined =
+    node.reasoning_content && typeof ms === "number" && Number.isFinite(ms)
+      ? { state: "done", ms: Math.max(0, ms) }
+      : undefined;
+  if (!thought) return node.metadata ?? null;
+  const custom = node.metadata?.custom;
+  return {
+    ...node.metadata,
+    custom: {
+      ...(custom && typeof custom === "object" ? custom : {}),
+      [THOUGHT_KEY]: thought,
+    },
+  };
+}
+
+/**
  * The stored tree, in the shape `ExportedMessageRepository
  * .fromBranchableArray` takes.
  *
@@ -317,24 +381,27 @@ export function toBranchable(conversation: Conversation): {
   headId: string | null;
 } {
   return {
-    items: conversation.messages.map((node) => ({
-      parentId: node.parent_id,
-      message: {
-        id: node.id,
-        role: node.role,
-        content: [
-          ...(node.reasoning_content
-            ? [{ type: "reasoning" as const, text: node.reasoning_content }]
-            : []),
-          { type: "text" as const, text: node.content },
-        ],
-        createdAt: new Date(node.created_at * 1000),
-        ...(node.role === "assistant"
-          ? { status: restoredStatus(node.metadata) }
-          : {}),
-        ...(node.metadata ? { metadata: node.metadata } : {}),
-      },
-    })),
+    items: conversation.messages.map((node) => {
+      const metadata = restoredMetadata(node);
+      return {
+        parentId: node.parent_id,
+        message: {
+          id: node.id,
+          role: node.role,
+          content: [
+            ...(node.reasoning_content
+              ? [{ type: "reasoning" as const, text: node.reasoning_content }]
+              : []),
+            { type: "text" as const, text: node.content },
+          ],
+          createdAt: new Date(node.created_at * 1000),
+          ...(node.role === "assistant"
+            ? { status: restoredStatus(node.metadata) }
+            : {}),
+          ...(metadata ? { metadata } : {}),
+        },
+      };
+    }),
     headId: conversation.head_id,
   };
 }

--- a/ui/src/lib/thought.test.ts
+++ b/ui/src/lib/thought.test.ts
@@ -1,0 +1,58 @@
+// The thought clock's pure half.
+//
+// What is worth pinning: the words a duration turns into (the summary
+// line is the feature), that a running clock ticks from its stamp
+// rather than freezing at the last delta, and that a stored shape the
+// module did not write is refused rather than rendered as NaN seconds.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { fmtThought, readThought, thoughtMs } from "./thought.ts";
+
+test("seconds under a minute, minutes and seconds above it", () => {
+  assert.equal(fmtThought(0), "under a second");
+  assert.equal(fmtThought(499), "under a second");
+  assert.equal(fmtThought(500), "1 second");
+  assert.equal(fmtThought(1_000), "1 second");
+  assert.equal(fmtThought(15_000), "15 seconds");
+  assert.equal(fmtThought(59_400), "59 seconds");
+  assert.equal(fmtThought(59_600), "1 min");
+  assert.equal(fmtThought(80_000), "1 min 20 s");
+  assert.equal(fmtThought(3_600_000), "1 h");
+  assert.equal(fmtThought(3_900_000), "1 h 5 min");
+});
+
+test("a thought in progress is measured from its stamp, never negative", () => {
+  assert.equal(thoughtMs({ state: "thinking", startedAt: 1_000 }, 16_000), 15_000);
+  // A clock that went backwards (a resumed laptop) reads zero, not a
+  // negative number of seconds.
+  assert.equal(thoughtMs({ state: "thinking", startedAt: 5_000 }, 4_000), 0);
+  assert.equal(thoughtMs({ state: "done", ms: 12_345 }, 0), 12_345);
+});
+
+test("the metadata round-trips, and anything else reads as no thought", () => {
+  assert.deepEqual(readThought({ custom: { thought: { state: "done", ms: 15_000 } } }), {
+    state: "done",
+    ms: 15_000,
+  });
+  assert.deepEqual(
+    readThought({ custom: { thought: { state: "thinking", startedAt: 7 } } }),
+    { state: "thinking", startedAt: 7 },
+  );
+  for (const bad of [
+    undefined,
+    null,
+    {},
+    { custom: {} },
+    { custom: { thought: null } },
+    { custom: { thought: "15s" } },
+    { custom: { thought: { state: "done" } } },
+    { custom: { thought: { state: "done", ms: -1 } } },
+    { custom: { thought: { state: "done", ms: "15000" } } },
+    { custom: { thought: { state: "thinking", ms: 1 } } },
+    { custom: { thought: { state: "paused", startedAt: 1 } } },
+  ]) {
+    assert.equal(readThought(bad as never), undefined, JSON.stringify(bad));
+  }
+});

--- a/ui/src/lib/thought.ts
+++ b/ui/src/lib/thought.ts
@@ -1,0 +1,87 @@
+// How long a reasoning model thought, as the stream saw it.
+//
+// This is the ONE client-side stopwatch in the UI, and it is here on
+// purpose. Every other number under an answer is the server's `usage`,
+// because a browser cannot tell prefill from decode. But "how long did
+// the model think" is not a decode figure at all: the server's usage
+// counts tokens and their rate, and a thought's length in seconds is
+// the wall-clock between the first `reasoning_content` delta and the
+// first `content` delta -- which only the consumer of the stream can
+// see. That measurement is taken in `screens/chat/runtime.ts`, carried
+// on the message as `metadata.custom.thought`, shown by
+// `screens/chat/reasoning.tsx`, and stored beside `reasoning_content`
+// as `reasoning_ms` by `lib/conversations.ts`. The shape is spelled
+// here so those four agree by import rather than by convention.
+
+/** Under `metadata.custom`, on an assistant message. */
+export const THOUGHT_KEY = "thought";
+
+export type Thought =
+  /**
+   * Still thinking. `startedAt` is an epoch-millisecond stamp so the
+   * elapsed time can tick locally between deltas -- a stalled stream
+   * must not show a frozen clock. A continuation resumed inside a
+   * thought sets it BACK by the earlier portion, so the running total
+   * counts both halves without a second field.
+   */
+  | { state: "thinking"; startedAt: number }
+  /** The thought ended, either because the answer began or because
+   * the stream did (cut off, stopped) with no answer after it. */
+  | { state: "done"; ms: number };
+
+/** Milliseconds thought so far, at `now`. */
+export function thoughtMs(thought: Thought, now: number): number {
+  return thought.state === "done"
+    ? thought.ms
+    : Math.max(0, now - thought.startedAt);
+}
+
+/**
+ * The `Thought` carried on a message's metadata, or `undefined` when
+ * there is none or it is not the shape this module writes.
+ *
+ * Validated field by field because metadata comes back from the store
+ * and from `localStorage`, neither of which the type system reaches.
+ */
+export function readThought(
+  metadata: Record<string, unknown> | null | undefined,
+): Thought | undefined {
+  const custom = metadata?.custom;
+  if (!custom || typeof custom !== "object") return undefined;
+  return parseThought((custom as Record<string, unknown>)[THOUGHT_KEY]);
+}
+
+/** The slot's value alone, for a reader that already has it in hand. */
+export function parseThought(value: unknown): Thought | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const { state, startedAt, ms } = value as Record<string, unknown>;
+  if (state === "thinking" && isFiniteNumber(startedAt))
+    return { state: "thinking", startedAt };
+  if (state === "done" && isFiniteNumber(ms) && ms >= 0)
+    return { state: "done", ms };
+  return undefined;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * A thought's length in words: "15 seconds" under a minute, "1 min
+ * 20 s" above it, "1 h 5 min" above an hour. Whole seconds: a tenth
+ * of a second is not a fact about a thought, and a live clock that
+ * ticks in tenths is noise.
+ */
+export function fmtThought(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 1) return "under a second";
+  if (s < 60) return s === 1 ? "1 second" : `${s} seconds`;
+  if (s < 3600) {
+    const m = Math.floor(s / 60);
+    const rest = s % 60;
+    return rest ? `${m} min ${rest} s` : `${m} min`;
+  }
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  return m ? `${h} h ${m} min` : `${h} h`;
+}

--- a/ui/src/screens/chat/reasoning.tsx
+++ b/ui/src/screens/chat/reasoning.tsx
@@ -1,6 +1,16 @@
-import { useState } from "react";
-import type { ReasoningMessagePartComponent } from "@assistant-ui/react";
+import { useEffect, useRef, useState } from "react";
+import {
+  useAuiState,
+  type ReasoningMessagePartComponent,
+} from "@assistant-ui/react";
 import { ChevronRight } from "lucide-react";
+import {
+  fmtThought,
+  parseThought,
+  THOUGHT_KEY,
+  thoughtMs,
+  type Thought,
+} from "@/lib/thought";
 import { cn } from "@/lib/utils";
 
 /**
@@ -14,13 +24,48 @@ import { cn } from "@/lib/utils";
  * answer arrived whole, which reads as "streaming is broken" rather
  * than "thinking is hidden".
  *
- * Collapsed by default, because it is working-out and not the answer.
+ * Three states, told apart by the clock the runtime carries on the
+ * message (`lib/thought.ts`), not by the part's own status:
+ *
+ * - THINKING: open, the text streaming in and pinned to its last line,
+ *   the header a live "Thinking for 12 seconds". A model that thinks
+ *   for a minute on CPU is not frozen, and the clock is what says so.
+ * - DONE, with an answer under it: collapsed to "Thought for 15
+ *   seconds". The thought is working-out, secondary once the answer
+ *   exists, and one click away.
+ * - DONE, with NO answer: still open. This is the cut-off case from
+ *   the Continue banner -- the budget ran out inside the thought, so
+ *   the thought is all there is, and folding it would leave a banner
+ *   over nothing.
+ *
+ * A record stored before the clock existed has a thought and no time;
+ * it reads "Thought" with the length in characters, as it did.
+ *
  * It is deliberately NOT markdown: thinking is where a model emits
  * half-open code fences and unbalanced brackets, and a renderer that
  * reflows them makes the text harder to read, not easier.
  */
 export const ReasoningPart: ReasoningMessagePartComponent = ({ text }) => {
-  const [open, setOpen] = useState(false);
+  // The raw slot is selected and decoded outside the selector: a
+  // selector that returned a fresh object would re-render on every
+  // store update, and `useSyncExternalStore` would then loop on it.
+  const thought = parseThought(
+    useAuiState((s) => s.message.metadata.custom?.[THOUGHT_KEY]),
+  );
+  const running = useAuiState((s) => s.message.status?.type === "running");
+  const answered = useAuiState((s) =>
+    s.message.content.some(
+      (part) => part.type === "text" && part.text.trim().length > 0,
+    ),
+  );
+  const thinking = thought?.state === "thinking" && running;
+  // Until the user has clicked, the block follows the state above; one
+  // click and it is theirs. `null` is "not clicked yet", so a thought
+  // the user opened after it finished does not snap shut on the next
+  // render, and one they closed while it streamed stays closed.
+  const [chosen, setChosen] = useState<boolean | null>(null);
+  const open = chosen ?? (thinking || !answered);
+
   const trimmed = text.trim();
   // A part that exists but has not been written to yet would otherwise
   // render an empty, clickable box under every answer.
@@ -29,7 +74,7 @@ export const ReasoningPart: ReasoningMessagePartComponent = ({ text }) => {
     <div className="mb-2 rounded-lg border border-line bg-inset">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setChosen(!open)}
         aria-expanded={open}
         className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-muted transition-colors hover:text-fg"
       >
@@ -40,16 +85,89 @@ export const ReasoningPart: ReasoningMessagePartComponent = ({ text }) => {
             open && "rotate-90",
           )}
         />
-        <span>Thinking</span>
-        <span className="text-muted/70">
-          {trimmed.length.toLocaleString()} chars
-        </span>
+        <Summary thought={thought} thinking={thinking} chars={trimmed.length} />
       </button>
-      {open && (
-        <div className="max-h-80 overflow-y-auto whitespace-pre-wrap border-t border-line px-2.5 py-2 text-xs leading-relaxed text-muted">
-          {trimmed}
-        </div>
-      )}
+      {open && <Body text={trimmed} thinking={thinking} />}
     </div>
   );
 };
+
+/**
+ * The header line. A live clock while thinking, a total once done.
+ *
+ * The interval runs ONLY while thinking: a finished thought is a fixed
+ * number and a transcript of fifty of them must not hold fifty timers.
+ */
+function Summary({
+  thought,
+  thinking,
+  chars,
+}: {
+  thought: Thought | undefined;
+  thinking: boolean;
+  chars: number;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!thinking) return;
+    // Half-second ticks so the displayed second is never more than
+    // half a second stale, which reads as a clock rather than a lag.
+    const timer = window.setInterval(() => setNow(Date.now()), 500);
+    return () => window.clearInterval(timer);
+  }, [thinking]);
+
+  if (!thought) {
+    return (
+      <>
+        <span>{thinking ? "Thinking" : "Thought"}</span>
+        <span className="text-muted/70">{chars.toLocaleString()} chars</span>
+      </>
+    );
+  }
+  const elapsed = fmtThought(thoughtMs(thought, now));
+  return thinking ? (
+    <>
+      {/* The pulse is the "still alive" signal: a clock alone could be
+          a stopped one that happens to show the right number. */}
+      <span className="relative grid size-2.5 shrink-0 place-items-center">
+        <span className="absolute inset-0 animate-ping rounded-full bg-muted/40" />
+        <span className="size-1.5 rounded-full bg-muted" />
+      </span>
+      <span>
+        Thinking for <span className="tabular-nums">{elapsed}</span>
+      </span>
+    </>
+  ) : (
+    <span>
+      Thought for <span className="tabular-nums">{elapsed}</span>
+    </span>
+  );
+}
+
+/**
+ * The thought itself. While streaming it follows its own last line,
+ * the way the transcript follows the answer -- but only while the
+ * reader is at the bottom. Scrolling up to reread something is a
+ * choice, and a box that yanks back on every token overrides it.
+ */
+function Body({ text, thinking }: { text: string; thinking: boolean }) {
+  const box = useRef<HTMLDivElement>(null);
+  const pinned = useRef(true);
+  useEffect(() => {
+    const el = box.current;
+    if (!el || !thinking || !pinned.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [text, thinking]);
+  return (
+    <div
+      ref={box}
+      onScroll={(e) => {
+        const el = e.currentTarget;
+        pinned.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+      }}
+      className="max-h-80 overflow-y-auto whitespace-pre-wrap border-t border-line px-2.5 py-2 text-xs leading-relaxed text-muted"
+    >
+      {text}
+    </div>
+  );
+}

--- a/ui/src/screens/chat/runtime.ts
+++ b/ui/src/screens/chat/runtime.ts
@@ -4,9 +4,12 @@
 // assistant-ui owns the transcript, the composer, autoscroll, branching
 // and the abort signal. This file owns exactly one thing: turning a run
 // into an SSE request and turning the server's answer back into message
-// parts. Nothing here measures time — every number the UI prints comes
-// from the server's own `usage` block, carried on the message as
-// `metadata.custom`.
+// parts. Every speed the UI prints comes from the server's own `usage`
+// block, carried on the message as `metadata.custom.stats`. The one
+// clock this file holds is the thought's (`lib/thought.ts`): how long
+// the model reasoned before it began to answer is the gap between two
+// deltas of the stream, which `usage` does not measure and only the
+// stream's consumer can.
 
 import { useState } from "react";
 import {
@@ -27,6 +30,7 @@ import {
 } from "@/lib/api";
 import { fmtInt, fmtMs, fmtNum, isNum } from "@/lib/format";
 import { samplingToWire } from "@/lib/sampling-wire";
+import { THOUGHT_KEY, type Thought } from "@/lib/thought";
 import { useLatest } from "@/lib/use-latest";
 
 /** Not re-exported by the react package under its own name. */
@@ -102,8 +106,17 @@ export function canContinue(outcome: AnswerStats["outcome"]): boolean {
 /**
  * A partial turn to carry on from: what the cut-off message already
  * holds, so the continuation starts from it rather than from nothing.
+ *
+ * `thoughtMs` is how long the first attempt thought. A continuation
+ * that resumes inside the thought adds to it rather than restarting
+ * the clock, so the summary at the end counts the whole thought and
+ * not the second half of it.
  */
-export type ContinueFrom = { reasoning: string; text: string };
+export type ContinueFrom = {
+  reasoning: string;
+  text: string;
+  thoughtMs?: number;
+};
 
 const CONTINUE_KEY = "continueFrom";
 
@@ -125,6 +138,7 @@ function readContinuation(runConfig: RunConfig): ContinueFrom | null {
   return {
     reasoning: typeof value.reasoning === "string" ? value.reasoning : "",
     text: typeof value.text === "string" ? value.text : "",
+    ...(isNum(value.thoughtMs) ? { thoughtMs: value.thoughtMs } : {}),
   };
 }
 
@@ -315,14 +329,47 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
         ...(reasoning ? [{ type: "reasoning" as const, text: reasoning }] : []),
         ...(text ? [{ type: "text" as const, text }] : []),
       ];
+
+      // The thought clock. It starts on the first reasoning delta and
+      // stops on the first content delta, or on the end of the stream
+      // when no answer ever came (cut off inside the thought, or
+      // stopped). A continuation inherits the earlier attempt's time
+      // and, if it is still thinking, resumes the clock BEHIND `now` by
+      // that much, so one running total covers both halves.
+      let thought: Thought | undefined = isNum(resume?.thoughtMs)
+        ? { state: "done", ms: resume.thoughtMs }
+        : undefined;
+      const thoughtStarts = () => {
+        if (thought?.state === "thinking") return;
+        const before = thought?.ms ?? 0;
+        thought = { state: "thinking", startedAt: Date.now() - before };
+      };
+      const thoughtEnds = () => {
+        if (thought?.state !== "thinking") return;
+        thought = { state: "done", ms: Math.max(0, Date.now() - thought.startedAt) };
+      };
+      // Every yield carries the whole `custom` block: assistant-ui
+      // replaces it per yield rather than merging key by key, so a
+      // yield that named only `stats` would drop the thought.
+      const custom = (rest: Record<string, unknown> = {}) => ({
+        ...(thought ? { [THOUGHT_KEY]: thought } : {}),
+        ...rest,
+      });
+
       try {
         for await (const chunk of tokens.drain()) {
-          if (chunk.kind === "reasoning") reasoning += chunk.text;
-          else text += chunk.text;
-          yield { content: parts() };
+          if (chunk.kind === "reasoning") {
+            reasoning += chunk.text;
+            thoughtStarts();
+          } else {
+            text += chunk.text;
+            thoughtEnds();
+          }
+          yield { content: parts(), metadata: { custom: custom() } };
         }
         await task;
       } finally {
+        thoughtEnds();
         abortSignal.removeEventListener("abort", onAbort);
       }
 
@@ -358,7 +405,7 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
             : cutOff
               ? { type: "incomplete", reason: "length" }
               : { type: "complete", reason: "stop" },
-          metadata: { custom: { stats } },
+          metadata: { custom: custom({ stats }) },
         } satisfies ChatModelRunResult;
         return;
       }
@@ -378,14 +425,14 @@ function makeAdapter(deps: ChatDeps): ChatModelAdapter {
           ],
           status: { type: "incomplete", reason: "cancelled" },
           metadata: {
-            custom: {
+            custom: custom({
               stats: {
                 line: "",
                 requestId,
                 outcome: "stopped-by-you",
                 usage: null,
               } satisfies AnswerStats,
-            },
+            }),
           },
         } satisfies ChatModelRunResult;
         return;

--- a/ui/src/screens/chat/thread.tsx
+++ b/ui/src/screens/chat/thread.tsx
@@ -24,6 +24,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { FerroxMark } from "@/components/logo";
 import { fmtInt } from "@/lib/format";
+import { parseThought, THOUGHT_KEY } from "@/lib/thought";
 import { cn } from "@/lib/utils";
 import { MarkdownText } from "@/screens/chat/markdown";
 import { ReasoningPart } from "@/screens/chat/reasoning";
@@ -42,8 +43,10 @@ import {
 // Note what is NOT used: `useMessageTiming()`. assistant-ui measures its
 // own stream client-side and would happily hand over a `tokensPerSecond`.
 // That number cannot separate prefill from decode and would read a
-// 50 tok/s model as 5 on a long prompt. There is no client stopwatch in
-// this UI, by construction.
+// 50 tok/s model as 5 on a long prompt. No speed printed here comes from
+// a client clock, by construction. The one client clock there is
+// measures something `usage` cannot: how long the model THOUGHT, which
+// is the gap between two deltas of the stream (`lib/thought.ts`).
 
 function useStats(): AnswerStats | undefined {
   return useAuiState(
@@ -81,9 +84,17 @@ function CutOff() {
   const stats = useStats();
   const isRunning = useAuiState((s) => s.thread.isRunning);
   const content = useAuiState((s) => s.message.content);
+  // The clock goes with the thought: a continuation that resumes
+  // inside it keeps counting from here rather than from zero.
+  const thought = parseThought(
+    useAuiState((s) => s.message.metadata.custom?.[THOUGHT_KEY]),
+  );
   if (!stats || !canContinue(stats.outcome)) return null;
 
-  const from = partsText(content);
+  const from = {
+    ...partsText(content),
+    ...(thought?.state === "done" ? { thoughtMs: thought.ms } : {}),
+  };
   const generated = stats.usage?.completion_tokens;
   const detail =
     stats.outcome === "length"


### PR DESCRIPTION
## What

The Studio Thinking block (#204, #205) now carries a clock.

- **While thinking**: open, the thought streaming in and pinned to its last line (only while the reader is at the bottom), the header a live `Thinking for 12 seconds` with a neutral pulse. A model that thinks for a minute on CPU is not frozen, and the clock is what says so.
- **Once the answer begins**: collapses to `Thought for 15 seconds` (`1 min 20 s` above a minute, `1 h 5 min` above an hour), one click away. Once the user has clicked, the block is theirs and stops following the state.
- **Cut off with no answer**: stays open, because the thought is all there is and the Continue banner from #204 needs something to sit over. Continue carries the elapsed time along, so a continuation resumed inside a thought keeps counting rather than restarting.
- A non-reasoning model shows no thinking chrome at all (unchanged, verified).

## Where the time comes from

The stream, not `usage`. `usage` measures decode; how long the model THOUGHT is the wall-clock between the first `reasoning_content` delta and the first `content` delta, and only the stream's consumer can see it. `ui/src/lib/thought.ts` is the one shape the runtime writes (`metadata.custom.thought`), the block reads, the Continue path carries and the store persists, so the four agree by import rather than by convention. The two comments that said "no client stopwatch, by construction" now say what the one exception is and why.

## Persisted field

`reasoning_ms: Option<u64>` on `MessageNode` and `NewMessage` in `crates/ferrox-server/src/conversations.rs`, beside `reasoning_content`, `#[serde(default, skip_serializing_if = "Option::is_none")]` so older records load and show their thought with no time. The server drops a duration on a turn with no thought (a number about nothing). The client lifts the clock OUT of `metadata.custom` before storing and puts it back on load, so the number lives once as a typed column rather than twice: the server hands `metadata` back byte-identical, and a reload would otherwise have had two numbers to choose from.

## Tests

- `ui/src/lib/thought.test.ts`: the words a duration turns into, a running clock measured from its stamp and never negative, and every stored shape the module did not write reading as no thought.
- `ui/src/lib/conversations.test.ts`: the duration stored once as the column with `metadata.custom` stripped of it, a still-running clock and a duration with no thought both dropped, the restore putting it back, and the round trip closed.
- `conversations.rs`: `a_thoughts_duration_survives_a_restart_and_never_without_a_thought`, plus the pre-field record test asserting `reasoning_ms: None`.

Each new test sabotaged once with the mutation grep-confirmed in the file first: the Rust `filter` removed (red on "a number about nothing"), the client `reasoning &&` guard removed (red), the `1 min` / `1 min 0 s` branch collapsed (red on `'1 min 0 s'`).

## Verified in Chrome

Own `ferrox-server` (release, Metal) on 8404 with `DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M`, Vite on 5190, prompt "Give me a Python snippet that streams from this server."

- clock ran during the thought: 3 s, 8 s, 44 s, 1 min 51 s, 2 min 27 s on a debug build; 3 s, 11 s on release;
- collapsed to `Thought for 26 seconds` the moment the answer began (`Thought for 5 min 4 s` and `1 min 39 s` on two other runs), pulse gone, chevron closed;
- stored record: `reasoning_ms: 26187`, `metadata.custom` holds only `stats`;
- reload of the conversation shows the same `Thought for 26 seconds`, collapsed; clicking expands it;
- Llama-3.2-1B-Instruct-Q4_K_M on the same server: answer, stat line, no thinking chrome.

Gates: `npm run check`, `npm run build`, `npm run licenses`, `npm test` (46 pass); `cargo test -p ferrox-server` (891 pass); clippy `-D warnings` debug and release; `cargo fmt --all -- --check`.
