### PR TITLE
release: 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,31 @@ are the ones worth reading twice.
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-09-11
+
 ### Fixed
 
+- **The Metal benchmark ledger booked the lm_head's GPU time as host
+  time.** #149's "host = wall minus GPU" used the GPU time of ONE
+  command buffer per token; a sampled decode token has two, and the
+  lm_head's had no timing tag, so 1.2 ms (Llama-3.2-1B) to 2.8 ms
+  (Gemma-2-2B) of GPU work read as a 26-29% host share that did not
+  exist. `FERROX_METAL_GPU_TIMING=1` clocks encode, GPU and submit
+  latency for every submission from one clock, and a submission cannot
+  be timed with a phase left out. Measured encode is 2-3% of wall, so
+  the argument-packing lever the issue named was retired unbuilt;
+  the correction moved the worst Metal row from "host" to "kernel".
+- **`/v1/rerank` scores from the published `ms-marco-MiniLM-L6-v2` GGUF
+  were fifty times too small.** llama.cpp's converter drops
+  `pooler.dense.*` for every BERT, so the file scores `classifier(cls)`
+  where HuggingFace scores `classifier(tanh(pooler(cls)))`; orderings
+  were right and the scale was not, which is why a threshold copied from
+  another engine never fired. `ferrox splice-pooler -m in.gguf
+  --safetensors model.safetensors -o out.gguf` writes the pooler back
+  under llama.cpp's own tensor names (llama-server loads the result and
+  applies it too), tied to the checkpoint by the classifier both files
+  hold rather than by a name the published file gets wrong. Seventeen
+  pairs within 0.051 of HuggingFace afterwards, orderings identical.
 - **The GLM, MLA and hybrid dedicated loaders would have run a
   checkpoint's MTP block as one more decoder layer.** `glm4moe`,
   `glm-dsa`, `glm4`, `deepseek2`, `qwen3next`, `qwen35` and `qwen35moe`
@@ -57,6 +80,63 @@ are the ones worth reading twice.
 
 ### Added
 
+- **Every one of the 16 comparable Metal `tg128` rows is now faster
+  than llama.cpp** (gap 0.60x-0.96x; prefill 0.99x-1.09x), re-measured
+  on a quiet host with `ferrox 0.20.0` receipts. Gemma-2-2B decode went
+  from 1.11x to 0.94x on three kernel rewrites none of which is
+  Gemma-specific: RoPE (one thread per rotary pair, one templated
+  NORM/NEOX kernel where there were four sources; 61.6 to 3.4 us),
+  RMSNorm (float4 loads, at most two loop trips; 14.2 to 4.7 us),
+  FA-vec decode at d=128/256 (compile-time tile loops so K and V loads
+  overlap; 38.9 to 17.6 us with the softcap), and the final logit
+  softcap moved off the host into the lm_head's command buffer as an
+  epilogue (0.65 ms of scalar `tanh` per Gemma-2 token, gone).
+  `FERROX_METAL_KERNEL_TIMING=1` attributes a token's GPU time per
+  dispatch kind, which is how the three were found: the matvecs, 80% of
+  the stack, were already at parity. `ferrox verify` token-identical and
+  `ferrox parity` unchanged on four models. Closes #149.
+- **The Studio Thinking block times the thought.** A live `Thinking for
+  12 seconds` while the model reasons, collapsing to `Thought for 15
+  seconds` (`1 min 20 s`, `1 h 5 min`) once the answer begins, one click
+  away; a thought cut off with no answer stays open under the Continue
+  banner and a continuation keeps counting. The time is the wall-clock
+  between the first `reasoning_content` delta and the first `content`
+  delta, persisted as `reasoning_ms` beside `reasoning_content`; older
+  records load and show their thought with no time.
+- **`grok` and `dbrx` are audited**, 37 to 39, each by extending a seam
+  from the day before by one column. Grok-1 on the MiniCPM defaults
+  hook: `grok.cpp:5-12` seeds seven hyper-parameters before the file
+  may override them, `logit_scale` is a multiply there and
+  `attention.output_scale` is "pre-scale Q, then softcap", so it
+  resolves into slots that existed; two of the seven are read by
+  llama.cpp and applied nowhere (measured), and ferrox neither applies
+  nor refuses them. DBRX on `NormOp::LayerNorm` (weight, no bias, the
+  variant OLMo-1 deliberately left unwritten until a caller arrived),
+  a REQUIRED `attention.clamp_kqv` (the three QKV-bias loops collapsed
+  onto `decoder/qkv_bias.rs` first, so the clamp is one line rather
+  than three), and `norm_sites.rs`, one table for which tensor feeds
+  which norm site, because `blk.N.attn_output_norm` is DBRX's pre-FFN
+  norm and Grok's post-attention norm. The clamp closed OLMo-1's
+  `clip_qkv` checkpoints with it. KL 4.7e-10 / 1.6e-10 (Grok, at the
+  GeGLU f16-table tolerance, measured), 3.4e-12 (DBRX). Grok-2's
+  parallel dense FFN stays refused by name from a fixture that has it.
+- **`arcee`, `deci` and `openelm` are audited**, 39 to 42. `arcee` is
+  the ungated ReLU-squared FFN, spelled as `GluAct::Reglu` with the gate
+  aliased to the up matrix rather than a fourth expert shape; on the
+  way, six Metal launch sites that derived `gelu = !is_swiglu()` (a
+  third activation would have run as GELU on all of them) now refuse on
+  `None` from one function. `deci` and `openelm` are one seam,
+  `layer_shapes.rs`: llama.cpp reads `head_count`, `head_count_kv` and
+  `feed_forward_length` as scalar-or-array for every architecture and
+  ferrox carried scalars; all 140 graphs were scanned for which honour
+  a per-layer value before a line was written, and the table records
+  each. `AttnShape::{Gqa, Linear, Absent}` is an enum so an
+  attention-less layer cannot be a zero count a loop accepts;
+  `ModelConfig::new_kv_caches` replaced ninety hand-written
+  `KvCache::new(config.n_kv_heads, ..)` sites and `KvCache::push`
+  asserts the width. KL 2.27e-14, 1.44e-13, 7.29e-13, 1.28e-13. `plm`
+  did NOT close with `arcee`: its verdict had been read from one file,
+  and the diff is 150 lines of MLA attention.
 - **`apertus` and `step35` are audited, on ONE seam with TWO
   activation bodies.** An FFN activation whose parameters vary by
   layer had no home: `FfnActivation` was a unit enum and every FFN

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,7 +575,7 @@ in two directories. Each of those splits happened because somebody was
 about to add to the file and split it first. That is the whole
 mechanism, and it is the only one that has ever worked here.
 
-Those files are why llama.cpp has 140 architectures and ferrox has 42
+Those files are why llama.cpp has 140 architectures and ferrox has 47
 proven. Adding a model means editing a 6750-line file, so nobody adds
 one. The same decode layer used to be written out about ELEVEN times
 across `decoder.rs` and `attn.rs`, which has already lost EIGHT model

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-api"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cli"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-cuda"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "cudarc",
  "ferrox-quant",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-gguf"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-inference"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ferrox-api",
  "ferrox-core",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-metal"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ferrox-quant",
  "half",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-models"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-moe"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "ferrox-core",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-quant"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "half",
  "thiserror",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-safetensors"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "byteorder",
  "memmap2",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-server"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "ferrox-vulkan"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ash",
  "ferrox-quant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/antonellof/ferrox"
@@ -57,19 +57,19 @@ minijinja = { version = "2.21", features = ["loop_controls", "json"] }
 libc = "0.2"
 
 # Internal crates — path for local builds, version for crates.io.
-ferrox-api = { version = "0.20.0", path = "crates/ferrox-api" }
-ferrox-gguf = { version = "0.20.0", path = "crates/ferrox-gguf" }
-ferrox-quant = { version = "0.20.0", path = "crates/ferrox-quant" }
-ferrox-safetensors = { version = "0.20.0", path = "crates/ferrox-safetensors" }
-ferrox-cuda = { version = "0.20.0", path = "crates/ferrox-cuda" }
-ferrox-metal = { version = "0.20.0", path = "crates/ferrox-metal" }
-ferrox-vulkan = { version = "0.20.0", path = "crates/ferrox-vulkan" }
-ferrox-core = { version = "0.20.0", path = "crates/ferrox-core" }
-ferrox-moe = { version = "0.20.0", path = "crates/ferrox-moe" }
-ferrox-models = { version = "0.20.0", path = "crates/ferrox-models" }
-ferrox-inference = { version = "0.20.0", path = "crates/ferrox-inference" }
+ferrox-api = { version = "0.21.0", path = "crates/ferrox-api" }
+ferrox-gguf = { version = "0.21.0", path = "crates/ferrox-gguf" }
+ferrox-quant = { version = "0.21.0", path = "crates/ferrox-quant" }
+ferrox-safetensors = { version = "0.21.0", path = "crates/ferrox-safetensors" }
+ferrox-cuda = { version = "0.21.0", path = "crates/ferrox-cuda" }
+ferrox-metal = { version = "0.21.0", path = "crates/ferrox-metal" }
+ferrox-vulkan = { version = "0.21.0", path = "crates/ferrox-vulkan" }
+ferrox-core = { version = "0.21.0", path = "crates/ferrox-core" }
+ferrox-moe = { version = "0.21.0", path = "crates/ferrox-moe" }
+ferrox-models = { version = "0.21.0", path = "crates/ferrox-models" }
+ferrox-inference = { version = "0.21.0", path = "crates/ferrox-inference" }
 # Only ferrox-cli depends on this, and only behind its optional `serve`
 # feature. The server's dependency set is a strict superset of the CLI's
 # (+98 crates, +6 MB), so an unconditional dependency would make
 # `cargo install ferrox-cli` compile an HTTP and TLS stack it never runs.
-ferrox-server = { version = "0.20.0", path = "crates/ferrox-server" }
+ferrox-server = { version = "0.21.0", path = "crates/ferrox-server" }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ kernels, attention and expert routing are written here, in Rust.
   Tokenization is verified against libllama on twenty checkpoints under
   both special-token settings, and every engine number in
   [the speed table](benchmarks/RESULTS.md) was measured against
-  llama.cpp on the same host and the same file. 37 architectures run
+  llama.cpp on the same host and the same file. 47 architectures run
   with a logit comparison to back it; the rest stop and say what is
   missing rather than guess.
 - **OpenAI-compatible server.** On Metal, multiple concurrent clients


### PR DESCRIPTION
Cuts 0.21.0 from main at 2bb7550: PRs #200 through #211.

- Seven of the twelve merged PRs carried no changelog entry; written up here from their PR bodies (Metal ledger correction #202, rerank pooler splice #201, Gemma-2 kernels + quiet-host Metal rows #208/#209, thinking-block clock #210, grok/dbrx #200, arcee/deci/openelm #203).
- Workspace version bumped in lockstep; README and CLAUDE.md say 47 audited architectures.
- Gates run locally: workspace tests, clippy `-D warnings`, fmt, release Metal build (`ferrox 0.21.0`).