### PR TITLE
feat(ui): chats in the sidebar, model search, load and HF URLs on Models

### DIFF
--- a/ui/src/components/app-shell.tsx
+++ b/ui/src/components/app-shell.tsx
@@ -1,26 +1,32 @@
-import { useState } from "react";
-import { NavLink, Outlet } from "react-router";
-import { PanelLeft, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { NavLink, Outlet, useLocation, useNavigate, useParams } from "react-router";
+import { PanelLeft, Search, SquarePen, Trash2, X } from "lucide-react";
 import { SCREENS } from "@/lib/screens";
 import { HealthPill } from "@/components/health-pill";
 import { FerroxWordmark } from "@/components/logo";
 import { useHealth } from "@/lib/use-health";
+import {
+  recencyBucket,
+  useConversationList,
+  type RecencyBucket,
+} from "@/lib/use-conversations";
+import { conversationLabel } from "@/lib/conversations";
 import { cn } from "@/lib/utils";
 
+const BUCKETS: RecencyBucket[] = ["Today", "Yesterday", "Previous 7 days", "Older"];
+
+/** The three management screens; Chat is the sidebar's main body, not a row. */
 function Nav({ onNavigate }: { onNavigate?: () => void }) {
   return (
     <nav aria-label="Screens" className="flex flex-col gap-0.5">
-      {SCREENS.map(({ to, label, icon: Icon, blurb }) => (
+      {SCREENS.filter((s) => s.to !== "/ui/chat").map(({ to, label, icon: Icon }) => (
         <NavLink
           key={to}
           to={to}
           onClick={onNavigate}
-          // Where you are is not news: you clicked it. A neutral fill
-          // plus a weight bump says it without making the loudest thing
-          // on a screen where nothing is wrong be "which tab am I on".
           className={({ isActive }) =>
             cn(
-              "group flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm transition-colors",
+              "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm transition-colors",
               isActive
                 ? "bg-inset font-medium text-fg"
                 : "text-muted hover:bg-inset/60 hover:text-fg",
@@ -36,9 +42,6 @@ function Nav({ onNavigate }: { onNavigate?: () => void }) {
                 )}
               />
               <span className="min-w-0 flex-1 truncate">{label}</span>
-              <span className="hidden text-2xs text-faint lg:group-hover:inline">
-                {blurb}
-              </span>
             </>
           )}
         </NavLink>
@@ -47,12 +50,161 @@ function Nav({ onNavigate }: { onNavigate?: () => void }) {
   );
 }
 
+/** The one action that is not a screen: start over. Lit only on a NEW chat. */
+function NewChatLink({ onNavigate }: { onNavigate?: () => void }) {
+  const location = useLocation();
+  const { conversationId } = useParams();
+  const onNewChat = location.pathname.startsWith("/ui/chat") && !conversationId;
+  return (
+    <NavLink
+      to="/ui/chat"
+      onClick={onNavigate}
+      className={cn(
+        "flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm transition-colors",
+        onNewChat ? "bg-inset font-medium text-fg" : "text-fg hover:bg-inset/60",
+      )}
+    >
+      <SquarePen className="size-4 shrink-0" />
+      <span>New chat</span>
+    </NavLink>
+  );
+}
+
+/**
+ * The chat library: a search box and every saved
+ * conversation grouped by when it was last touched, the way every
+ * chat client lays its left rail out. Lives in the shell rather than
+ * the chat header so it is there on every screen and never competes
+ * with the model picker for the header.
+ *
+ * Deleting the conversation that is open sends the chat back to a new
+ * one: the URL is the only thing that says which conversation is open,
+ * so that is one navigation, not a second piece of state.
+ */
+function ConversationRail({ onNavigate }: { onNavigate?: () => void }) {
+  const list = useConversationList();
+  // `fetchedAt` is the clock the buckets are drawn against: a rail left
+  // open overnight moves "Today" to "Yesterday" on its next refresh
+  // rather than on every keystroke.
+  const { summaries, fetchedAt: now } = list;
+  const { conversationId } = useParams();
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+
+  const groups = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const by = new Map<RecencyBucket, typeof summaries>();
+    for (const entry of summaries) {
+      if (needle && !conversationLabel(entry).toLowerCase().includes(needle)) {
+        continue;
+      }
+      const bucket = recencyBucket(entry.updated_at, now);
+      by.set(bucket, [...(by.get(bucket) ?? []), entry]);
+    }
+    return BUCKETS.filter((b) => by.has(b)).map((b) => ({
+      bucket: b,
+      entries: by.get(b)!,
+    }));
+  }, [summaries, query, now]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      {list.mode === "server" ? (
+        <>
+          <p className="px-2.5 pt-1 text-2xs font-medium tracking-wide text-faint uppercase">
+            Chats
+          </p>
+          <div className="relative px-0.5">
+            <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-faint" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search chats"
+              aria-label="Search chats"
+              className="h-8 w-full rounded-lg border border-line bg-raised pr-2 pl-8 text-xs text-fg placeholder:text-faint focus:border-fg/30 focus:outline-none"
+            />
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto pr-0.5">
+            {list.error ? (
+              <p className="px-2.5 py-2 text-2xs text-err">{list.error}</p>
+            ) : null}
+            {!summaries.length ? (
+              <p className="px-2.5 py-2 text-2xs text-faint">
+                No saved chats yet. One is created the first time you send a
+                message.
+              </p>
+            ) : !groups.length ? (
+              <p className="px-2.5 py-2 text-2xs text-faint">
+                Nothing matches “{query}”.
+              </p>
+            ) : (
+              groups.map(({ bucket, entries }) => (
+                <div key={bucket} className="mb-2">
+                  <p className="px-2.5 pt-2 pb-1 text-2xs font-medium text-faint">
+                    {bucket}
+                  </p>
+                  <ul className="space-y-px">
+                    {entries.map((entry) => {
+                      const isActive = entry.id === conversationId;
+                      return (
+                        <li key={entry.id} className="group relative">
+                          <NavLink
+                            to={`/ui/chat/${encodeURIComponent(entry.id)}`}
+                            onClick={onNavigate}
+                            title={conversationLabel(entry)}
+                            className={cn(
+                              "block truncate rounded-lg py-1.5 pr-8 pl-2.5 text-sm transition-colors",
+                              isActive
+                                ? "bg-inset font-medium text-fg"
+                                : "text-muted hover:bg-inset/60 hover:text-fg",
+                            )}
+                          >
+                            {conversationLabel(entry)}
+                          </NavLink>
+                          <button
+                            type="button"
+                            title="Delete this chat from the server"
+                            aria-label={`Delete ${conversationLabel(entry)}`}
+                            onClick={async () => {
+                              await list.remove(entry.id);
+                              if (isActive) navigate("/ui/chat");
+                            }}
+                            className={cn(
+                              "absolute top-1/2 right-1.5 -translate-y-1/2 rounded-md p-1 text-faint transition-opacity hover:bg-raised hover:text-err",
+                              "opacity-0 focus:opacity-100 group-hover:opacity-100",
+                              isActive && "opacity-100",
+                            )}
+                          >
+                            <Trash2 className="size-3.5" />
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))
+            )}
+          </div>
+        </>
+      ) : list.mode === "unsupported" ? (
+        <p className="px-2.5 py-2 text-2xs text-faint">
+          This server keeps no conversations; the transcript lives in this
+          browser.
+        </p>
+      ) : (
+        <div className="flex-1" />
+      )}
+    </div>
+  );
+}
+
 export function AppShell() {
   const health = useHealth();
   const [drawer, setDrawer] = useState(false);
 
   const sidebar = (
-    <div className="flex h-full flex-col gap-4 p-3">
+    <div className="flex h-full flex-col gap-3 p-3">
       <div className="flex items-center justify-between px-1 pt-1">
         <FerroxWordmark />
         <button
@@ -64,8 +216,11 @@ export function AppShell() {
           <X className="size-4" />
         </button>
       </div>
+      <NewChatLink onNavigate={() => setDrawer(false)} />
       <Nav onNavigate={() => setDrawer(false)} />
-      <div className="mt-auto space-y-2">
+      <div className="border-t border-line" />
+      <ConversationRail onNavigate={() => setDrawer(false)} />
+      <div className="mt-auto border-t border-line pt-3">
         <HealthPill state={health} />
       </div>
     </div>
@@ -81,7 +236,7 @@ export function AppShell() {
       </a>
 
       {/* Desktop sidebar */}
-      <aside className="hidden w-60 shrink-0 border-r border-line bg-sunken md:block">
+      <aside className="hidden w-64 shrink-0 border-r border-line bg-sunken md:block">
         {sidebar}
       </aside>
 
@@ -94,7 +249,7 @@ export function AppShell() {
             className="absolute inset-0 bg-black/40"
             onClick={() => setDrawer(false)}
           />
-          <aside className="animate-in slide-in-from-left absolute inset-y-0 left-0 w-64 border-r border-line bg-sunken shadow-pop">
+          <aside className="animate-in slide-in-from-left absolute inset-y-0 left-0 w-72 border-r border-line bg-sunken shadow-pop">
             {sidebar}
           </aside>
         </div>

--- a/ui/src/lib/conversations.ts
+++ b/ui/src/lib/conversations.ts
@@ -109,8 +109,23 @@ export async function listConversations(): Promise<ConversationSummary[]> {
   return body?.data ?? [];
 }
 
+/**
+ * Fired on `window` after any write to the conversation store succeeds,
+ * so a listing kept somewhere other than the chat (the sidebar) can
+ * re-read without polling the store on a timer. Every write goes
+ * through the three functions below; there is no other writer.
+ */
+export const CONVERSATIONS_CHANGED = "ferrox:conversations-changed";
+
+function notifyChanged<T>(value: T): T {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(CONVERSATIONS_CHANGED));
+  }
+  return value;
+}
+
 export function createConversation(body: CreateBody): Promise<Conversation> {
-  return postJson<Conversation>(routes.conversations, body);
+  return postJson<Conversation>(routes.conversations, body).then(notifyChanged);
 }
 
 export function getConversation(id: string): Promise<Conversation> {
@@ -121,11 +136,13 @@ export function updateConversation(
   id: string,
   body: UpdateBody,
 ): Promise<Conversation> {
-  return postJson<Conversation>(routes.conversation(id), body);
+  return postJson<Conversation>(routes.conversation(id), body).then(
+    notifyChanged,
+  );
 }
 
 export function deleteConversation(id: string): Promise<unknown> {
-  return postJson(routes.conversationDelete(id), {});
+  return postJson(routes.conversationDelete(id), {}).then(notifyChanged);
 }
 
 // ---------------------------------------------------------------------

--- a/ui/src/lib/hf-source.test.ts
+++ b/ui/src/lib/hf-source.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseHfSource } from "./hf-source.ts";
+
+test("an owner/repo identifier takes the fallback file", () => {
+  assert.deepEqual(parseHfSource("unsloth/Llama-3.2-3B-Instruct-GGUF", "*Q4_K_M.gguf"), {
+    repo: "unsloth/Llama-3.2-3B-Instruct-GGUF",
+    file: "*Q4_K_M.gguf",
+  });
+});
+
+test("a :suffix names the file and beats the fallback", () => {
+  assert.deepEqual(parseHfSource("owner/repo:model-q8_0.gguf", "*Q4_K_M.gguf"), {
+    repo: "owner/repo",
+    file: "model-q8_0.gguf",
+  });
+});
+
+test("a repo URL, with or without /tree/main, is the repo", () => {
+  for (const u of [
+    "https://huggingface.co/owner/repo",
+    "https://huggingface.co/owner/repo/",
+    "https://huggingface.co/owner/repo/tree/main",
+    "hf.co/owner/repo",
+    "https://www.huggingface.co/owner/repo?not-for-all-audiences=true",
+  ]) {
+    assert.deepEqual(parseHfSource(u, "*.gguf"), { repo: "owner/repo", file: "*.gguf" }, u);
+  }
+});
+
+test("a file URL names the file, resolve or blob, nested or not", () => {
+  assert.deepEqual(
+    parseHfSource("https://huggingface.co/owner/repo/resolve/main/sub/m-Q4_K_M.gguf?download=true", "*.gguf"),
+    { repo: "owner/repo", file: "sub/m-Q4_K_M.gguf" },
+  );
+  assert.deepEqual(
+    parseHfSource("https://huggingface.co/owner/repo/blob/main/m%20x.gguf", "*.gguf"),
+    { repo: "owner/repo", file: "m x.gguf" },
+  );
+});
+
+test("junk is refused with a reason rather than sent", () => {
+  for (const bad of ["", "just-a-name", "https://huggingface.co/", "https://huggingface.co/owner/repo/discussions/3", "owner/repo:"]) {
+    const out = parseHfSource(bad, "");
+    assert.ok("error" in out, bad);
+  }
+});

--- a/ui/src/lib/hf-source.ts
+++ b/ui/src/lib/hf-source.ts
@@ -1,0 +1,62 @@
+/**
+ * What a user pastes into the download box, resolved to the
+ * `{ repo, file }` pair `POST /admin/download` takes.
+ *
+ * Three spellings are accepted, because those are the three a person
+ * has on their clipboard:
+ *
+ * - a Hugging Face identifier, `owner/repo`, with an optional
+ *   `:file-or-glob` suffix (`unsloth/Llama-3.2-3B-Instruct-GGUF:*Q4_K_M.gguf`);
+ * - a repo URL, `https://huggingface.co/owner/repo` (or `hf.co`, with
+ *   or without `/tree/main`);
+ * - a file URL, `https://huggingface.co/owner/repo/resolve/main/file.gguf`
+ *   (or `/blob/main/`), which names the file too.
+ *
+ * `file` comes from the suffix or the URL when either names one, else
+ * from the caller's pattern box. Nothing here validates that the file
+ * exists: the server resolves a `*` glob against the repo's file list
+ * and refuses anything that is not a plain `.gguf`.
+ */
+export type HfSource = { repo: string; file: string };
+
+export function parseHfSource(
+  input: string,
+  fallbackFile: string,
+): HfSource | { error: string } {
+  const raw = input.trim();
+  if (!raw) return { error: "Paste a Hugging Face repo or URL." };
+
+  let path = raw;
+  let fileFromUrl: string | null = null;
+  const url = /^(?:https?:\/\/)?(?:www\.)?(?:huggingface\.co|hf\.co)\/(.+)$/i.exec(raw);
+  if (url) {
+    path = url[1].replace(/[?#].*$/, "").replace(/\/+$/, "");
+    const parts = path.split("/").filter(Boolean);
+    if (parts.length < 2) return { error: "That URL names no repo." };
+    const [owner, repo, ...rest] = parts;
+    path = `${owner}/${repo}`;
+    // `/resolve/main/<file>` and `/blob/main/<file>` name a file;
+    // `/tree/main` names the repo and nothing more.
+    if ((rest[0] === "resolve" || rest[0] === "blob") && rest.length >= 3) {
+      fileFromUrl = decodeURIComponent(rest.slice(2).join("/"));
+    } else if (rest.length && rest[0] !== "tree") {
+      return { error: `That URL is not a repo or file page (${rest.join("/")}).` };
+    }
+  }
+
+  let repo = path;
+  let fileFromSuffix: string | null = null;
+  const colon = path.indexOf(":");
+  if (colon > 0) {
+    repo = path.slice(0, colon);
+    fileFromSuffix = path.slice(colon + 1).trim() || null;
+  }
+  if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+    return {
+      error: `“${repo}” is not an owner/repo identifier.`,
+    };
+  }
+  const file = (fileFromUrl ?? fileFromSuffix ?? fallbackFile).trim();
+  if (!file) return { error: "Say which file: a name or a glob like *Q4_K_M.gguf." };
+  return { repo, file };
+}

--- a/ui/src/lib/use-conversations.ts
+++ b/ui/src/lib/use-conversations.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from "react";
+import { ApiError } from "./api.ts";
+import {
+  CONVERSATIONS_CHANGED,
+  deleteConversation,
+  listConversations,
+  type ConversationSummary,
+} from "./conversations.ts";
+
+/** Re-read this often even when nothing here wrote: another client may have. */
+const REFRESH_MS = 30_000;
+
+export type ConversationList = {
+  /** `"checking"` until the first answer; `"unsupported"` when the server has no store. */
+  mode: "checking" | "server" | "unsupported";
+  summaries: ConversationSummary[];
+  /** When `summaries` was read (ms); the clock recency buckets are drawn against. */
+  fetchedAt: number;
+  error: string | null;
+  refresh: () => void;
+  remove: (id: string) => Promise<void>;
+};
+
+/**
+ * The saved conversations, for a listing that lives OUTSIDE the chat
+ * screen (the sidebar) and so cannot read the chat's own transcript
+ * state.
+ *
+ * Reads on mount, whenever the store is written to from this tab
+ * (`CONVERSATIONS_CHANGED`), and on a slow timer for writes from other
+ * clients. A 404 on the listing means the server keeps no
+ * conversations at all -- local-transcript mode -- and the section
+ * hides rather than showing an empty library.
+ */
+export function useConversationList(): ConversationList {
+  const [mode, setMode] = useState<ConversationList["mode"]>("checking");
+  const [summaries, setSummaries] = useState<ConversationSummary[]>([]);
+  const [fetchedAt, setFetchedAt] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    listConversations()
+      .then((list) => {
+        setSummaries(list);
+        setFetchedAt(Date.now());
+        setMode("server");
+        setError(null);
+      })
+      .catch((e: unknown) => {
+        if (e instanceof ApiError && e.isMissingEndpoint) {
+          setMode("unsupported");
+          return;
+        }
+        setError((e as Error).message);
+      });
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const onChange = () => refresh();
+    window.addEventListener(CONVERSATIONS_CHANGED, onChange);
+    const timer = setInterval(refresh, REFRESH_MS);
+    return () => {
+      window.removeEventListener(CONVERSATIONS_CHANGED, onChange);
+      clearInterval(timer);
+    };
+  }, [refresh]);
+
+  const remove = useCallback(
+    async (id: string) => {
+      try {
+        await deleteConversation(id);
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    },
+    [],
+  );
+
+  return { mode, summaries, fetchedAt, error, refresh, remove };
+}
+
+/** Sidebar groups, in display order. */
+export type RecencyBucket = "Today" | "Yesterday" | "Previous 7 days" | "Older";
+
+/**
+ * Which bucket a conversation falls in by its `updated_at` (seconds),
+ * against `now` (milliseconds). Local-midnight boundaries, as every
+ * chat client draws them.
+ */
+export function recencyBucket(updatedAtSeconds: number, now: number): RecencyBucket {
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const day = 24 * 60 * 60 * 1000;
+  const at = updatedAtSeconds * 1000;
+  if (at >= startOfToday.getTime()) return "Today";
+  if (at >= startOfToday.getTime() - day) return "Yesterday";
+  if (at >= startOfToday.getTime() - 7 * day) return "Previous 7 days";
+  return "Older";
+}

--- a/ui/src/screens/chat.tsx
+++ b/ui/src/screens/chat.tsx
@@ -7,10 +7,9 @@ import {
   ChevronDown,
   History,
   Loader2,
-  MessagesSquare,
+  Search,
   SlidersHorizontal,
   SquarePen,
-  Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Field, Input, Textarea } from "@/components/ui/field";
@@ -163,9 +162,18 @@ function ModelSwitcher({
   // trigger carries the spinner from there on, and an error re-opens
   // nothing -- it is shown the next time the menu is opened.
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   // The parent disables the composer for the same window; one state,
   // reported outward, so the two cannot disagree about when it ends.
   useEffect(() => onLoadingChange(loading), [loading, onLoadingChange]);
+  const needle = query.trim().toLowerCase();
+  const visible = (inventory?.models ?? []).filter(
+    (m) =>
+      !needle ||
+      m.id.toLowerCase().includes(needle) ||
+      (m.quant ?? "").toLowerCase().includes(needle) ||
+      (m.arch ?? "").toLowerCase().includes(needle),
+  );
 
   const refresh = useCallback(() => {
     return getJson<Inventory>(routes.adminModels)
@@ -266,8 +274,23 @@ function ModelSwitcher({
               .
             </p>
           ) : (
+            <>
+              <div className="relative mb-1">
+                <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-faint" />
+                <input
+                  autoFocus
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search models"
+                  aria-label="Search models"
+                  className="h-8 w-full rounded-lg border border-line bg-inset pr-2 pl-8 text-xs text-fg placeholder:text-faint focus:border-fg/30 focus:outline-none"
+                />
+              </div>
+              {!visible.length ? (
+                <p className="p-2 text-xs text-faint">Nothing matches “{query}”.</p>
+              ) : null}
             <ul className="max-h-72 space-y-0.5 overflow-y-auto">
-              {inventory.models.map((entry) => {
+              {visible.map((entry) => {
                 const isActive = entry.id === inventory.active;
                 // The server's own view, so a load started by another
                 // client shows here too, not only one this menu began.
@@ -310,6 +333,7 @@ function ModelSwitcher({
                 );
               })}
             </ul>
+            </>
           )}
           {error ? (
             <p className="mt-1 rounded-lg bg-err-soft px-2 py-1.5 text-2xs text-err">
@@ -433,95 +457,6 @@ function SamplingPanel({
   );
 }
 
-/**
- * The saved conversations, and the switch between them.
- *
- * Only rendered when the server actually keeps conversations. In local
- * mode there is exactly one transcript and a list of it would be a
- * menu with one entry pretending to be a library.
- */
-function ConversationPicker({ transcript }: { transcript: Transcript }) {
-  const { summaries, current } = transcript;
-
-  return (
-    <Popover.Root
-      onOpenChange={(open) => {
-        if (open) transcript.refresh();
-      }}
-    >
-      <Popover.Trigger asChild>
-        <Button variant="default" size="sm" className="max-w-[14rem]">
-          <MessagesSquare className="text-faint" />
-          <span className="truncate text-2xs">
-            {current ? conversationLabel(current) : "New conversation"}
-          </span>
-          <ChevronDown className="text-faint" />
-        </Button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          align="end"
-          sideOffset={6}
-          collisionPadding={12}
-          className="z-50 w-[min(26rem,calc(100vw-1.5rem))] rounded-xl border border-line bg-raised p-1.5 shadow-pop data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
-        >
-          {!summaries.length ? (
-            <p className="p-2 text-xs text-faint">
-              Nothing saved yet. A conversation is created on this server the
-              first time you send a message.
-            </p>
-          ) : (
-            <ul className="max-h-80 space-y-0.5 overflow-y-auto">
-              {summaries.map((entry) => {
-                const isActive = entry.id === current?.id;
-                return (
-                  <li key={entry.id} className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={() => transcript.open(entry.id)}
-                      className={cn(
-                        "min-w-0 flex-1 rounded-lg px-2 py-1.5 text-left transition-colors",
-                        isActive
-                          ? "bg-inset font-medium text-fg"
-                          : "hover:bg-inset",
-                      )}
-                    >
-                      <span className="block truncate text-xs">
-                        {conversationLabel(entry)}
-                      </span>
-                      <span className="block truncate text-2xs text-faint">
-                        {[
-                          `${entry.message_count} message${entry.message_count === 1 ? "" : "s"}`,
-                          entry.model,
-                        ]
-                          .filter(Boolean)
-                          .join(" · ")}
-                      </span>
-                    </button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      title="Delete this conversation from the server"
-                      onClick={() => transcript.remove(entry.id)}
-                    >
-                      <Trash2 />
-                    </Button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-          <p className="mt-1 border-t border-line px-2 pt-1.5 text-2xs text-faint">
-            Stored on the server, not in this browser. Deleting one deletes it
-            for every client of this server, and nothing is ever deleted to
-            make room.
-          </p>
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
-  );
-}
-
 function ChatInner({
   sampling,
   setSampling,
@@ -554,7 +489,11 @@ function ChatInner({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="flex shrink-0 flex-wrap items-center gap-2 border-b border-line bg-raised/70 px-4 py-2.5 backdrop-blur">
-        <h1 className="text-sm font-semibold tracking-tight">Chat</h1>
+        {/* The conversation's own title, as the sidebar names it; the
+            library itself is the sidebar, not a menu up here. */}
+        <h1 className="min-w-0 max-w-[40%] truncate text-sm font-semibold tracking-tight">
+          {transcript.current ? conversationLabel(transcript.current) : "New chat"}
+        </h1>
         {serving.synthetic ? (
           <Badge tone="err">synthetic weights</Badge>
         ) : null}
@@ -562,18 +501,20 @@ function ChatInner({
           <span className="text-2xs text-faint">saving…</span>
         ) : null}
         <span className="flex-1" />
-        {transcript.mode === "server" ? (
-          <ConversationPicker transcript={transcript} />
-        ) : null}
         <ModelSwitcher
           active={serving.modelId}
           onSwitched={refreshServing}
           onLoadingChange={setLoadingModel}
         />
         <SamplingPanel value={sampling} onChange={setSampling} />
-        <Button variant="ghost" size="sm" onClick={transcript.newChat}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={transcript.newChat}
+          className="md:hidden"
+          title="New chat"
+        >
           <SquarePen />
-          <span className="hidden sm:inline">New chat</span>
         </Button>
       </header>
 

--- a/ui/src/screens/models.tsx
+++ b/ui/src/screens/models.tsx
@@ -1,19 +1,20 @@
-// Models: the library. What is on disk, how to get more, and how to give
-// the memory back.
+// Models: the library. What is on disk, how to get more, which one
+// answers, and how to give the memory back.
 //
-// **Choosing which model answers is not done here.** It is done in the
-// picker in the Chat header, which is the only model selector in this
-// app. This screen used to carry a second one — a `Load` button on every
-// row, posting the same `/admin/models/load` to the same server for the
-// same effect — plus an `Unload` in the header AND an `Unload` in the
-// loaded row, and an `active:` badge restating what the row's own state
-// column already said. Four controls and two badges for two verbs.
+// **Loading is done here AND in the chat header's picker**, and both post
+// the same `/admin/models/load` to the same server. The picker is for
+// the person mid-conversation; this screen is for the person managing a
+// box, who should not have to leave for the chat to switch what is
+// running. One `Load` per row and one `Unload` on the loaded one, so
+// each row carries exactly the verb that applies to it, and the header
+// carries neither.
 //
-// The split it now follows is the one every UI of this shape converged
-// on: a management screen installs, removes and reports; a picker beside
-// the conversation selects. `Unload` stays because it is the one verb
-// the picker cannot express — give the memory back without putting
-// something else in it — and it exists exactly once.
+// **Downloads take what is on the clipboard.** One box accepts an
+// `owner/repo` identifier, `owner/repo:file-or-glob`, a repo URL or a
+// file URL (`lib/hf-source.ts` resolves them); the pattern box beside
+// it is the default when none of those names a file. Progress shows
+// under the box while a task runs and only then: a task list that
+// mostly says "done" is a log, and the Activity screen is the log.
 //
 // Two more rules this screen exists to respect.
 //
@@ -29,7 +30,7 @@
 // explanation rather than as a broken table.
 
 import { useCallback, useEffect, useState } from "react";
-import { Boxes, CloudDownload, RefreshCw, Search } from "lucide-react";
+import { Boxes, CloudDownload, Loader2, RefreshCw, Search } from "lucide-react";
 import { Link } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -62,6 +63,7 @@ import {
   fmtRate,
   isNum,
 } from "@/lib/format";
+import { parseHfSource } from "@/lib/hf-source";
 
 /** Poll fast while something is moving, slowly when nothing is. */
 const BUSY_POLL_MS = 1000;
@@ -161,9 +163,10 @@ export function ModelsScreen() {
   const [unsupported, setUnsupported] = useState(false);
   const [banner, setBanner] = useState<Banner>(null);
   const [filter, setFilter] = useState("");
-  const [repo, setRepo] = useState("");
+  const [source, setSource] = useState("");
   const [file, setFile] = useState("*Q4_K_M.gguf");
   const [queueing, setQueueing] = useState(false);
+  const [loadingId, setLoadingId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -221,21 +224,36 @@ export function ModelsScreen() {
 
   const unloadModel = () =>
     act("Unload", () => postJson(routes.adminModelsUnload));
+  // `202 Accepted` means queued, not loaded; the row's state column,
+  // polled fast while anything moves, is what says when it landed.
+  const loadModel = async (id: string) => {
+    setLoadingId(id);
+    try {
+      await act("Load", () => postJson(routes.adminModelsLoad, { id }));
+    } finally {
+      setLoadingId(null);
+    }
+  };
   const cancelTask = (taskId: string) =>
     act("Cancel", () => postJson(routes.adminTaskCancel(taskId)));
 
   const startDownload = async (event: React.FormEvent) => {
     event.preventDefault();
+    const parsed = parseHfSource(source, file);
+    if ("error" in parsed) {
+      setBanner({ text: parsed.error, tone: "err" });
+      return;
+    }
     setQueueing(true);
     try {
       // The server resolves a `*` glob against the repo's file list and
       // refuses anything that is not a plain `.gguf` child of the model
       // directory, so no validation is duplicated here.
-      await postJson(routes.adminDownload, {
-        repo: repo.trim(),
-        file: file.trim(),
+      await postJson(routes.adminDownload, parsed);
+      setBanner({
+        text: `Download queued: ${parsed.file} from ${parsed.repo}.`,
+        tone: "info",
       });
-      setBanner({ text: `Download queued for ${repo.trim()}.`, tone: "info" });
       await refresh();
     } catch (error) {
       setBanner({
@@ -270,6 +288,12 @@ export function ModelsScreen() {
   }
 
   const active = inventory?.active ?? null;
+  // Only what is moving, plus the most recent failure so a refused or
+  // broken download is not silently a task that vanished.
+  const liveTasks = tasks.filter(
+    (t) => t.status === "queued" || t.status === "running",
+  );
+  const lastFailed = tasks.find((t) => t.status === "error") ?? null;
   const needle = filter.trim().toLowerCase();
   const visible = (inventory?.models ?? []).filter(
     (m) =>
@@ -289,17 +313,10 @@ export function ModelsScreen() {
             : "What is on disk, Hugging Face downloads, and giving the memory back."
         }
         actions={
-          <>
-            {active ? (
-              <Button variant="default" size="sm" onClick={unloadModel}>
-                Unload {active}
-              </Button>
-            ) : null}
-            <Button variant="ghost" size="sm" onClick={() => void refresh()}>
-              <RefreshCw />
-              Refresh
-            </Button>
-          </>
+          <Button variant="ghost" size="sm" onClick={() => void refresh()}>
+            <RefreshCw />
+            Refresh
+          </Button>
         }
       />
 
@@ -308,11 +325,8 @@ export function ModelsScreen() {
       <Card>
         <CardHeader>
           <CardTitle>Inventory</CardTitle>
-          {/* The active checkpoint is stated once on this screen. When
-              there is one it is on the `Unload …` button, which names it
-              and does something about it; only the empty case needs a
-              badge of its own. The `state` column says the same thing
-              per row and is where the eye goes anyway. */}
+          {/* The `state` column and the row's own button say which
+              checkpoint is loaded; only the empty case needs a badge. */}
           {active ? null : <Badge tone="neutral">nothing loaded</Badge>}
           <span className="flex-1" />
           <div className="relative">
@@ -320,9 +334,9 @@ export function ModelsScreen() {
             <Input
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
-              placeholder="Filter by id, quant or arch"
-              aria-label="Filter models"
-              className="h-8 w-56 pl-8 text-xs"
+              placeholder="Search by id, quant or arch"
+              aria-label="Search models"
+              className="h-8 w-64 pl-8 text-xs"
             />
           </div>
         </CardHeader>
@@ -367,6 +381,9 @@ export function ModelsScreen() {
                   <Th numeric>on disk</Th>
                   <Th numeric>resident</Th>
                   <Th>state</Th>
+                  <Th>
+                    <span className="sr-only">actions</span>
+                  </Th>
                 </Tr>
               </thead>
               <tbody>
@@ -399,6 +416,31 @@ export function ModelsScreen() {
                       <Td>
                         <StateBadge entry={entry} activeId={active} />
                       </Td>
+                      <Td className="text-right">
+                        {entry.id === active ? (
+                          <Button
+                            variant="default"
+                            size="sm"
+                            onClick={unloadModel}
+                            title="Give the memory back without loading another"
+                          >
+                            Unload
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="default"
+                            size="sm"
+                            disabled={busy || loadingId !== null}
+                            onClick={() => void loadModel(entry.id)}
+                            title="Load this checkpoint for every client of this server"
+                          >
+                            {loadingId === entry.id || entry.state === "loading" ? (
+                              <Loader2 className="animate-spin" />
+                            ) : null}
+                            Load
+                          </Button>
+                        )}
+                      </Td>
                     </Tr>
                   );
                 })}
@@ -408,12 +450,13 @@ export function ModelsScreen() {
         )}
 
         <CardFooter>
-          Pick which of these answers in the model menu at the top of{" "}
+          Load swaps the checkpoint for every client of this server; an
+          in-flight request finishes on the weights it started on. The
+          same switch is in the model menu at the top of{" "}
           <Link to="/ui/chat" className="link">
             Chat
           </Link>
-          . A swap loads the checkpoint for every client of this server; an
-          in-flight request finishes on the weights it started on.
+          .
         </CardFooter>
       </Card>
 
@@ -427,22 +470,25 @@ export function ModelsScreen() {
             className="flex flex-wrap items-end gap-3"
           >
             <Field
-              label="Hugging Face repo"
-              className="min-w-64 flex-1"
-              htmlFor="repo"
+              label="Hugging Face repo, repo:file, or URL"
+              className="min-w-72 flex-1"
+              htmlFor="source"
             >
               <Input
-                id="repo"
+                id="source"
                 required
-                value={repo}
-                onChange={(e) => setRepo(e.target.value)}
-                placeholder="unsloth/Llama-3.2-3B-Instruct-GGUF"
+                value={source}
+                onChange={(e) => setSource(e.target.value)}
+                placeholder="unsloth/Llama-3.2-3B-Instruct-GGUF  or  https://huggingface.co/…/resolve/main/x.gguf"
               />
             </Field>
-            <Field label="file (name or glob)" className="w-48" htmlFor="file">
+            <Field
+              label="file (name or glob) when the source names none"
+              className="w-56"
+              htmlFor="file"
+            >
               <Input
                 id="file"
-                required
                 value={file}
                 onChange={(e) => setFile(e.target.value)}
                 placeholder="*Q4_K_M.gguf"
@@ -454,21 +500,10 @@ export function ModelsScreen() {
             </Button>
           </form>
         </CardBody>
-        <CardFooter>
-          <code className="font-mono">POST /admin/download</code> starts a task;
-          progress appears below.
-        </CardFooter>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Tasks</CardTitle>
-          {tasks.length ? <Badge>{tasks.length}</Badge> : null}
-        </CardHeader>
-        {tasks.length ? (
-          <CardBody>
+        {liveTasks.length ? (
+          <CardBody className="border-t border-line">
             <ul className="space-y-2">
-              {tasks.map((task) => (
+              {liveTasks.map((task) => (
                 <TaskCard
                   key={task.task_id}
                   task={task}
@@ -477,15 +512,23 @@ export function ModelsScreen() {
               ))}
             </ul>
           </CardBody>
-        ) : (
-          <EmptyState
-            icon={CloudDownload}
-            title="No downloads or loads have run yet"
-          >
-            A rate appears only once the server's estimator calls it stable —
-            until then the progress line says so instead of guessing.
-          </EmptyState>
-        )}
+        ) : null}
+        {lastFailed ? (
+          <CardBody className="border-t border-line">
+            <Notice tone="err">
+              {lastFailed.label} failed: {lastFailed.error ?? "no reason given"}
+            </Notice>
+          </CardBody>
+        ) : null}
+        <CardFooter>
+          A rate appears only once the server's estimator calls it stable;
+          until then the progress line says so instead of guessing. Finished
+          tasks are in{" "}
+          <Link to="/ui/activity" className="link">
+            Activity
+          </Link>
+          .
+        </CardFooter>
       </Card>
     </Page>
   );


### PR DESCRIPTION
- Sidebar: New chat, the three screens, then a searchable chat library grouped by recency with in-place delete (`lib/use-conversations.ts`; re-reads on every store write via `CONVERSATIONS_CHANGED` and on a slow timer). The header's conversation picker is gone; the header shows the open conversation's title.
- Model picker: search box (id / quant / arch).
- Models page: `Load` per row, `Unload` on the loaded row; the download box accepts `owner/repo`, `owner/repo:file`, a repo URL or a file URL (`lib/hf-source.ts`, tested); the Tasks card is replaced by inline progress for running downloads plus the last failure.

`npm run check` green; verified against a running server.

https://claude.ai/code/session_01NktiVMMsiFztKa741hmKZv
